### PR TITLE
Fix mount daemon trusting mount_path over localhost TCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   `discover_heddle_root` path other inspect commands use) and never
   bootstraps a `.heddle` sidecar or rewrites Git excludes (heddle#1487).
 
+- **Mount daemon rejects unauthenticated localhost TCP.** `heddled`
+  binds a mode-0600 Unix socket and checks same-uid `SO_PEERCRED`
+  before honoring a client-supplied `mount_path`. Loopback is not an
+  authz boundary; a TCP-only `endpoint.json` is treated as stale
+  (heddle#901).
+
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now
   prints the same capture actor first and hosted authentication as a second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   binds a mode-0600 Unix socket and checks same-uid `SO_PEERCRED`
   before honoring a client-supplied `mount_path`. Loopback is not an
   authz boundary; a TCP-only `endpoint.json` is treated as stale
-  (heddle#901).
+  (heddle#901). A live socket is not unlinked, and a leftover v2 TCP
+  daemon is shut down before a replacement is spawned.
 
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,9 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   binds a mode-0600 Unix socket and checks same-uid `SO_PEERCRED`
   before honoring a client-supplied `mount_path`. Loopback is not an
   authz boundary; a TCP-only `endpoint.json` is treated as stale
-  (heddle#901). A live socket is not unlinked, and a leftover v2 TCP
-  daemon is shut down before a replacement is spawned.
+  (heddle#901). A live socket is not unlinked, including when connect
+  returns permission denied on a shared state dir, and a leftover v2
+  TCP daemon is shut down before a replacement is spawned.
 
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   authz boundary; a TCP-only `endpoint.json` is treated as stale
   (heddle#901). A live socket is not unlinked, including when connect
   returns permission denied on a shared state dir, and a leftover v2
-  TCP daemon is shut down before a replacement is spawned.
+  TCP daemon is shut down before a replacement is spawned. The client
+  checks same-uid `SO_PEERCRED` before trusting a UDS reply.
 
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now

--- a/crates/cli/src/cli/commands/daemon/client.rs
+++ b/crates/cli/src/cli/commands/daemon/client.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Result, anyhow};
 use repo::daemon::{
     ERR_MOUNT_UNSUPPORTED, EndpointState, MOUNT_PROTOCOL_VERSION, MountDaemonRequest,
     MountDaemonResponse, MountRegistryFile, load_endpoint, mount_daemon_endpoint_path,
-    mount_daemon_registry_path, pid_alive, remove_endpoint, send_json_request,
+    mount_daemon_registry_path, pid_alive, remove_endpoint, send_mount_daemon_request,
 };
 use tracing::{debug, warn};
 
@@ -136,6 +136,10 @@ fn read_live_endpoint(endpoint_path: &Path) -> Result<Option<EndpointState>> {
         );
         return Ok(None);
     }
+    if endpoint.socket_path.is_none() {
+        warn!("daemon endpoint has no authenticated socket; treating as stale");
+        return Ok(None);
+    }
     if let Some(pid) = endpoint.pid
         && !pid_alive(pid)
     {
@@ -239,7 +243,7 @@ pub fn rpc(
     let Some(endpoint) = ensure_daemon_endpoint(repo_root, spawn_if_missing)? else {
         return Ok(None);
     };
-    let response: MountDaemonResponse = match send_json_request(&endpoint, request) {
+    let response: MountDaemonResponse = match send_mount_daemon_request(&endpoint, request) {
         Ok(response) => response,
         Err(error) => {
             // The send/decode failed. Re-read the endpoint file before
@@ -283,10 +287,12 @@ fn refine_rpc_error(
             MOUNT_PROTOCOL_VERSION,
         ));
     }
-    anyhow!(error).context(format!(
-        "RPC to daemon at {}:{}",
-        endpoint.host, endpoint.port
-    ))
+    let target = endpoint
+        .socket_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| format!("{}:{}", endpoint.host, endpoint.port));
+    anyhow!(error).context(format!("RPC to daemon at {target}"))
 }
 
 /// Convenience helper used by the per-thread mount path. Classifies
@@ -328,12 +334,16 @@ pub fn mount_via_daemon_classified(
         mount_path: mount_path.to_path_buf(),
         repo_root: repo_root.to_path_buf(),
     };
-    let response: MountDaemonResponse = match send_json_request(&endpoint, &request) {
+    let response: MountDaemonResponse = match send_mount_daemon_request(&endpoint, &request) {
         Ok(response) => response,
         Err(error) => {
+            let target = endpoint
+                .socket_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| format!("{}:{}", endpoint.host, endpoint.port));
             return Err(DaemonMountError::Unavailable(format!(
-                "RPC to daemon at {}:{} failed: {error}",
-                endpoint.host, endpoint.port
+                "RPC to daemon at {target} failed: {error}"
             )));
         }
     };
@@ -398,7 +408,7 @@ mod tests {
     //! covered by the existing virtualized-mount integration test in
     //! `crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs`.
 
-    use std::{io::Write, net::TcpListener, path::PathBuf};
+    use std::{io::Write, os::unix::net::UnixListener, path::PathBuf};
 
     use repo::daemon::{
         EndpointState, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountRegistryFile,
@@ -428,9 +438,10 @@ mod tests {
             tmp.path(),
             &EndpointState {
                 version: MOUNT_PROTOCOL_VERSION + 99,
-                host: "127.0.0.1".to_string(),
-                port: 1,
+                host: "unix".to_string(),
+                port: 0,
                 pid: Some(1),
+                socket_path: Some(tmp.path().join("heddled.sock")),
             },
         );
         let endpoint_path = mount_daemon_endpoint_path(tmp.path());
@@ -452,9 +463,10 @@ mod tests {
             tmp.path(),
             &EndpointState {
                 version: MOUNT_PROTOCOL_VERSION,
-                host: "127.0.0.1".to_string(),
-                port: 9999,
+                host: "unix".to_string(),
+                port: 0,
                 pid: Some(1),
+                socket_path: Some(tmp.path().join("heddled.sock")),
             },
         );
         let endpoint_path = mount_daemon_endpoint_path(tmp.path());
@@ -472,14 +484,38 @@ mod tests {
             tmp.path(),
             &EndpointState {
                 version: MOUNT_PROTOCOL_VERSION,
-                host: "127.0.0.1".to_string(),
-                port: 9999,
+                host: "unix".to_string(),
+                port: 0,
                 pid: Some(0x7fff_fffe),
+                socket_path: Some(tmp.path().join("heddled.sock")),
             },
         );
         let endpoint_path = mount_daemon_endpoint_path(tmp.path());
         let result = read_live_endpoint(&endpoint_path).unwrap();
         assert!(result.is_none(), "endpoint with dead PID must be stale");
+    }
+
+    /// A v2 TCP endpoint (no socket_path) is stale. Loopback is not
+    /// an authz boundary (heddle#901).
+    #[test]
+    fn read_live_endpoint_treats_tcp_only_endpoint_as_stale() {
+        let tmp = TempDir::new().unwrap();
+        write_endpoint(
+            tmp.path(),
+            &EndpointState {
+                version: MOUNT_PROTOCOL_VERSION,
+                host: "127.0.0.1".to_string(),
+                port: 9999,
+                pid: Some(1),
+                socket_path: None,
+            },
+        );
+        let endpoint_path = mount_daemon_endpoint_path(tmp.path());
+        let result = read_live_endpoint(&endpoint_path).unwrap();
+        assert!(
+            result.is_none(),
+            "TCP-only endpoint must be treated as stale"
+        );
     }
 
     /// A missing endpoint file is silently treated as "no daemon
@@ -531,49 +567,28 @@ mod tests {
         sweep_stale_mounts(tmp.path()); // must not panic
     }
 
-    /// A v1 daemon binary that survived a CLI upgrade is observable
-    /// only as a successful TCP connect followed by an undecodable
-    /// response. After the decode failure the client must re-read the
-    /// endpoint file, notice the recorded version is below
-    /// `MOUNT_PROTOCOL_VERSION`, and surface a "stop the daemon" hint
-    /// rather than a raw `decode helper response: ...` line.
-    ///
-    /// We simulate the race in the realistic order: the endpoint file
-    /// initially advertises the current version (so
-    /// `ensure_daemon_endpoint` accepts it), then the fake daemon
-    /// "downgrades" the on-disk record to v1 just before sending a
-    /// garbage reply — exactly what a v1 binary would have written
-    /// had it been the one to claim the port.
+    /// A leftover older daemon that still answers on the socket but
+    /// writes an older endpoint version must surface a "stop the
+    /// daemon" hint instead of a raw decode error.
     #[test]
     fn rpc_hints_at_stale_daemon_when_endpoint_version_is_older() {
         let tmp = TempDir::new().unwrap();
         let repo_root: PathBuf = tmp.path().to_path_buf();
-
-        // Bind a real listener on a free port. A single accept loop
-        // serves the one request the test sends — we don't validate
-        // the bytes, we just write garbage back so JSON decoding
-        // fails, which is exactly what a v1 daemon's reply looks like
-        // to a v2-speaking CLI in the worst case.
-        let listener =
-            TcpListener::bind("127.0.0.1:0").expect("bind loopback listener for daemon RPC test");
-        let port = listener.local_addr().unwrap().port();
+        let socket_path = repo_root.join("heddled.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind uds for daemon RPC test");
         let server_repo = repo_root.clone();
+        let server_socket = socket_path.clone();
         let server = std::thread::spawn(move || {
             if let Ok((mut stream, _)) = listener.accept() {
-                // Stamp the on-disk endpoint with the version a real
-                // v1 daemon would have written, then send back
-                // something that is not parseable as a
-                // `MountDaemonResponse`. The client's decode failure
-                // must therefore consult an endpoint file that
-                // already reads as stale.
                 let endpoint_path = mount_daemon_endpoint_path(&server_repo);
                 persist_endpoint(
                     &endpoint_path,
                     &EndpointState {
                         version: MOUNT_PROTOCOL_VERSION - 1,
-                        host: "127.0.0.1".to_string(),
-                        port,
+                        host: "unix".to_string(),
+                        port: 0,
                         pid: Some(1),
+                        socket_path: Some(server_socket),
                     },
                 )
                 .unwrap();
@@ -585,16 +600,17 @@ mod tests {
             &repo_root,
             &EndpointState {
                 version: MOUNT_PROTOCOL_VERSION,
-                host: "127.0.0.1".to_string(),
-                port,
+                host: "unix".to_string(),
+                port: 0,
                 // Use init's PID (1) so `read_live_endpoint` accepts
                 // the file as live and we exercise the decode path.
                 pid: Some(1),
+                socket_path: Some(socket_path),
             },
         );
 
         let err = rpc(&repo_root, &MountDaemonRequest::Health {}, false)
-            .expect_err("v1 daemon reply must surface as an error");
+            .expect_err("older daemon reply must surface as an error");
         let _ = server.join();
 
         // The hint must reference both the recorded daemon version

--- a/crates/cli/src/cli/commands/daemon/client.rs
+++ b/crates/cli/src/cli/commands/daemon/client.rs
@@ -24,7 +24,8 @@ use anyhow::{Context, Result, anyhow};
 use repo::daemon::{
     ERR_MOUNT_UNSUPPORTED, EndpointState, MOUNT_PROTOCOL_VERSION, MountDaemonRequest,
     MountDaemonResponse, MountRegistryFile, load_endpoint, mount_daemon_endpoint_path,
-    mount_daemon_registry_path, pid_alive, remove_endpoint, send_mount_daemon_request,
+    mount_daemon_registry_path, pid_alive, remove_endpoint, retire_live_tcp_predecessor,
+    send_mount_daemon_request,
 };
 use tracing::{debug, warn};
 
@@ -83,21 +84,31 @@ pub fn ensure_daemon_endpoint(
     repo_root: &Path,
     spawn_if_missing: bool,
 ) -> Result<Option<EndpointState>> {
+    ensure_daemon_endpoint_with(repo_root, spawn_if_missing, spawn_daemon_detached)
+}
+
+fn ensure_daemon_endpoint_with(
+    repo_root: &Path,
+    spawn_if_missing: bool,
+    spawn: impl FnOnce(&Path) -> Result<()>,
+) -> Result<Option<EndpointState>> {
     let endpoint_path = mount_daemon_endpoint_path(repo_root);
 
     if let Some(endpoint) = read_live_endpoint(&endpoint_path)? {
         return Ok(Some(endpoint));
     }
-    // Endpoint absent or stale. Sweep before respawning so we don't
-    // leave a wedged FUSE mount behind from the dead daemon.
-    sweep_stale_mounts(repo_root);
-    remove_endpoint(&endpoint_path);
-
     if !spawn_if_missing {
         return Ok(None);
     }
+    // A live v2 TCP daemon still owns mounts. Retire it before we
+    // sweep and spawn, or two daemons race the same FUSE sessions.
+    if let Ok(recorded) = load_endpoint(&endpoint_path) {
+        retire_live_tcp_predecessor(&recorded)?;
+    }
+    sweep_stale_mounts(repo_root);
+    remove_endpoint(&endpoint_path);
 
-    spawn_daemon_detached(repo_root)?;
+    spawn(repo_root)?;
     for _ in 0..SPAWN_RETRIES {
         if let Some(endpoint) = read_live_endpoint(&endpoint_path)? {
             return Ok(Some(endpoint));
@@ -408,11 +419,22 @@ mod tests {
     //! covered by the existing virtualized-mount integration test in
     //! `crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs`.
 
-    use std::{io::Write, os::unix::net::UnixListener, path::PathBuf};
+    use std::{
+        io::{BufRead, BufReader, Write},
+        net::TcpListener,
+        os::unix::net::UnixListener,
+        path::PathBuf,
+        process::{Command, Stdio},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
 
     use repo::daemon::{
-        EndpointState, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountRegistryFile,
-        PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path, persist_endpoint,
+        EndpointState, MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonRequest,
+        MountDaemonResponse, MountRegistryFile, PersistedMount, mount_daemon_endpoint_path,
+        mount_daemon_registry_path, persist_endpoint,
     };
     use tempfile::TempDir;
 
@@ -631,6 +653,70 @@ mod tests {
         assert!(
             chain.contains(&format!("v{MOUNT_PROTOCOL_VERSION}")),
             "expected CLI version in error chain, got: {chain}"
+        );
+    }
+
+    /// After upgrade, a still-running v2 TCP daemon must receive
+    /// `Shutdown` before `ensure` is allowed to spawn a replacement.
+    #[test]
+    fn ensure_retires_live_v2_before_spawn() {
+        let tmp = TempDir::new().unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind v2 stand-in");
+        let port = listener.local_addr().unwrap().port();
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("stand-in v2 pid");
+        let pid = child.id();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&shutdown);
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut line = String::new();
+                let _ = BufReader::new(stream.try_clone().expect("clone")).read_line(&mut line);
+                if line.contains("shutdown") {
+                    flag.store(true, Ordering::Release);
+                    let reply = MountDaemonResponse::Shutdown {
+                        version: MOUNT_PROTOCOL_V2,
+                        ok: true,
+                    };
+                    let _ = serde_json::to_writer(&mut stream, &reply);
+                    let _ = stream.write_all(b"\n");
+                }
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+        });
+
+        write_endpoint(
+            tmp.path(),
+            &EndpointState {
+                version: MOUNT_PROTOCOL_V2,
+                host: "127.0.0.1".to_string(),
+                port,
+                pid: Some(pid),
+                socket_path: None,
+            },
+        );
+
+        let spawned = Arc::new(AtomicBool::new(false));
+        let spawned_flag = Arc::clone(&spawned);
+        let err = ensure_daemon_endpoint_with(tmp.path(), true, move |_| {
+            assert!(
+                shutdown.load(Ordering::Acquire),
+                "spawn must not run until the live v2 daemon is retired"
+            );
+            spawned_flag.store(true, Ordering::Release);
+            Ok(())
+        })
+        .expect_err("no v3 endpoint was written");
+        let _ = server.join();
+        assert!(
+            spawned.load(Ordering::Acquire),
+            "replacement spawn must run after retire: {err:#}"
         );
     }
 }

--- a/crates/cli/src/cli/commands/daemon/client.rs
+++ b/crates/cli/src/cli/commands/daemon/client.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Result, anyhow};
 use repo::daemon::{
     ERR_MOUNT_UNSUPPORTED, EndpointState, MOUNT_PROTOCOL_VERSION, MountDaemonRequest,
     MountDaemonResponse, MountRegistryFile, load_endpoint, mount_daemon_endpoint_path,
-    mount_daemon_registry_path, pid_alive, remove_endpoint, retire_live_tcp_predecessor,
+    mount_daemon_registry_path, pid_alive, refuse_live_legacy_tcp_endpoint, remove_endpoint,
     send_mount_daemon_request,
 };
 use tracing::{debug, warn};
@@ -100,10 +100,10 @@ fn ensure_daemon_endpoint_with(
     if !spawn_if_missing {
         return Ok(None);
     }
-    // A live v2 TCP daemon still owns mounts. Retire it before we
-    // sweep and spawn, or two daemons race the same FUSE sessions.
+    // A live v2 TCP daemon still owns mounts. v3 does not speak
+    // that protocol — fail closed so we do not spawn a second owner.
     if let Ok(recorded) = load_endpoint(&endpoint_path) {
-        retire_live_tcp_predecessor(&recorded)?;
+        refuse_live_legacy_tcp_endpoint(&recorded)?;
     }
     sweep_stale_mounts(repo_root);
     remove_endpoint(&endpoint_path);
@@ -420,8 +420,7 @@ mod tests {
     //! `crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs`.
 
     use std::{
-        io::{BufRead, BufReader, Write},
-        net::TcpListener,
+        io::Write,
         os::unix::net::UnixListener,
         path::PathBuf,
         process::{Command, Stdio},
@@ -433,8 +432,8 @@ mod tests {
 
     use repo::daemon::{
         EndpointState, MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonRequest,
-        MountDaemonResponse, MountRegistryFile, PersistedMount, mount_daemon_endpoint_path,
-        mount_daemon_registry_path, persist_endpoint,
+        MountRegistryFile, PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path,
+        persist_endpoint,
     };
     use tempfile::TempDir;
 
@@ -656,13 +655,11 @@ mod tests {
         );
     }
 
-    /// After upgrade, a still-running v2 TCP daemon must receive
-    /// `Shutdown` before `ensure` is allowed to spawn a replacement.
+    /// After upgrade, a still-running v2 TCP daemon must fail closed
+    /// before `ensure` is allowed to spawn a replacement.
     #[test]
-    fn ensure_retires_live_v2_before_spawn() {
+    fn ensure_refuses_live_v2_without_spawn() {
         let tmp = TempDir::new().unwrap();
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind v2 stand-in");
-        let port = listener.local_addr().unwrap().port();
         let mut child = Command::new("sleep")
             .arg("30")
             .stdin(Stdio::null())
@@ -671,32 +668,13 @@ mod tests {
             .spawn()
             .expect("stand-in v2 pid");
         let pid = child.id();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let flag = Arc::clone(&shutdown);
-        let server = std::thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut line = String::new();
-                let _ = BufReader::new(stream.try_clone().expect("clone")).read_line(&mut line);
-                if line.contains("shutdown") {
-                    flag.store(true, Ordering::Release);
-                    let reply = MountDaemonResponse::Shutdown {
-                        version: MOUNT_PROTOCOL_V2,
-                        ok: true,
-                    };
-                    let _ = serde_json::to_writer(&mut stream, &reply);
-                    let _ = stream.write_all(b"\n");
-                }
-            }
-            let _ = child.kill();
-            let _ = child.wait();
-        });
 
         write_endpoint(
             tmp.path(),
             &EndpointState {
                 version: MOUNT_PROTOCOL_V2,
                 host: "127.0.0.1".to_string(),
-                port,
+                port: 9,
                 pid: Some(pid),
                 socket_path: None,
             },
@@ -705,18 +683,24 @@ mod tests {
         let spawned = Arc::new(AtomicBool::new(false));
         let spawned_flag = Arc::clone(&spawned);
         let err = ensure_daemon_endpoint_with(tmp.path(), true, move |_| {
-            assert!(
-                shutdown.load(Ordering::Acquire),
-                "spawn must not run until the live v2 daemon is retired"
-            );
             spawned_flag.store(true, Ordering::Release);
             Ok(())
         })
-        .expect_err("no v3 endpoint was written");
-        let _ = server.join();
+        .expect_err("live v2 must fail closed");
+        let chain = format!("{err:#}");
         assert!(
-            spawned.load(Ordering::Acquire),
-            "replacement spawn must run after retire: {err:#}"
+            !spawned.load(Ordering::Acquire),
+            "replacement must not spawn over a live v2 daemon: {chain}"
         );
+        assert!(
+            chain.contains("refusing to spawn a replacement"),
+            "expected fail-closed message, got: {chain}"
+        );
+        assert!(
+            chain.contains("Stop or upgrade the leftover process"),
+            "expected recovery guidance, got: {chain}"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }

--- a/crates/cli/src/cli/commands/daemon/dispatch.rs
+++ b/crates/cli/src/cli/commands/daemon/dispatch.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Mount-daemon request dispatch. Auth is decided before any
+//! `mount_path` is honored (heddle#901).
+
+use std::{
+    path::PathBuf,
+    sync::{
+        Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
+
+use objects::sync::LockExt;
+use repo::daemon::{
+    MOUNT_PROTOCOL_VERSION, MountClientAuth, MountDaemonRequest, MountDaemonResponse, MountStatus,
+    authorize_mount_request, trusted_mount_path,
+};
+
+use super::registry::{MountOutcome, MountRegistry};
+
+pub(super) fn dispatch(
+    registry: &Mutex<MountRegistry>,
+    started: Instant,
+    shutdown_requested: &AtomicBool,
+    auth: MountClientAuth,
+    request: MountDaemonRequest,
+) -> MountDaemonResponse {
+    if let Err(denied) = authorize_mount_request(auth, &request) {
+        return error_response(denied.code, denied.message);
+    }
+    match request {
+        MountDaemonRequest::Mount {
+            thread_id,
+            mount_path,
+            repo_root: _,
+        } => dispatch_mount(registry, auth, thread_id, mount_path),
+        MountDaemonRequest::Unmount { thread_id } => dispatch_unmount(registry, &thread_id),
+        MountDaemonRequest::ListMounts {} => {
+            let guard = registry.lock_or_poisoned();
+            MountDaemonResponse::ListMounts {
+                version: MOUNT_PROTOCOL_VERSION,
+                mounts: guard.snapshot(),
+            }
+        }
+        MountDaemonRequest::Health {} => {
+            let guard = registry.lock_or_poisoned();
+            MountDaemonResponse::Health {
+                version: MOUNT_PROTOCOL_VERSION,
+                ok: true,
+                uptime_s: started.elapsed().as_secs(),
+                mount_count: guard.len(),
+            }
+        }
+        MountDaemonRequest::Shutdown {} => {
+            shutdown_requested.store(true, Ordering::Release);
+            MountDaemonResponse::Shutdown {
+                version: MOUNT_PROTOCOL_VERSION,
+                ok: true,
+            }
+        }
+        MountDaemonRequest::Unknown => error_response(
+            "unknown_command",
+            "daemon received an unrecognized command (likely client/server skew)",
+        ),
+    }
+}
+
+fn dispatch_mount(
+    registry: &Mutex<MountRegistry>,
+    auth: MountClientAuth,
+    thread_id: String,
+    supplied: PathBuf,
+) -> MountDaemonResponse {
+    let mount_path = match trusted_mount_path(auth, &supplied) {
+        Ok(path) => path.to_path_buf(),
+        Err(denied) => return error_response(denied.code, denied.message),
+    };
+    let mut guard = registry.lock_or_poisoned();
+    match guard.mount(&thread_id, &mount_path) {
+        Ok(MountOutcome::Created) => MountDaemonResponse::Mount {
+            version: MOUNT_PROTOCOL_VERSION,
+            ok: true,
+            mount_path,
+            status: MountStatus::Created,
+        },
+        Ok(MountOutcome::Existing) => MountDaemonResponse::Mount {
+            version: MOUNT_PROTOCOL_VERSION,
+            ok: true,
+            mount_path,
+            status: MountStatus::AlreadyMounted,
+        },
+        Err(error) => MountDaemonResponse::Error {
+            version: MOUNT_PROTOCOL_VERSION,
+            code: repo::daemon::ERR_MOUNT_CONFLICT.to_string(),
+            message: error.to_string(),
+        },
+    }
+}
+
+fn dispatch_unmount(registry: &Mutex<MountRegistry>, thread_id: &str) -> MountDaemonResponse {
+    let mut guard = registry.lock_or_poisoned();
+    match guard.unmount(thread_id) {
+        Ok(was_mounted) => MountDaemonResponse::Unmount {
+            version: MOUNT_PROTOCOL_VERSION,
+            ok: true,
+            was_mounted,
+        },
+        Err(error) => MountDaemonResponse::Error {
+            version: MOUNT_PROTOCOL_VERSION,
+            code: "unmount_failed".to_string(),
+            message: error.to_string(),
+        },
+    }
+}
+
+fn error_response(code: impl Into<String>, message: impl Into<String>) -> MountDaemonResponse {
+    MountDaemonResponse::Error {
+        version: MOUNT_PROTOCOL_VERSION,
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        sync::{Mutex, atomic::AtomicBool},
+        time::Instant,
+    };
+
+    use repo::daemon::{ERR_UNAUTHORIZED, MountClientAuth, MountDaemonRequest};
+
+    use super::dispatch;
+    use crate::cli::commands::daemon::registry::MountRegistry;
+
+    #[test]
+    fn unauthenticated_tcp_mount_is_rejected_without_touching_registry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let registry = Mutex::new(MountRegistry::new(tmp.path().to_path_buf()));
+        let response = dispatch(
+            &registry,
+            Instant::now(),
+            &AtomicBool::new(false),
+            MountClientAuth::Unauthenticated,
+            MountDaemonRequest::Mount {
+                thread_id: "agent-7".to_string(),
+                mount_path: PathBuf::from("/tmp/evil"),
+                repo_root: tmp.path().to_path_buf(),
+            },
+        );
+        match response {
+            repo::daemon::MountDaemonResponse::Error { code, .. } => {
+                assert_eq!(code, ERR_UNAUTHORIZED);
+            }
+            other => panic!("expected unauthorized, got {other:?}"),
+        }
+        assert_eq!(registry.lock().unwrap().len(), 0);
+    }
+}

--- a/crates/cli/src/cli/commands/daemon/mod.rs
+++ b/crates/cli/src/cli/commands/daemon/mod.rs
@@ -2,11 +2,11 @@
 //! Long-lived mount daemon (`heddle daemon serve`).
 //!
 //! Reuses the helper-subprocess scaffolding in `repo::daemon` —
-//! endpoint file, JSON-over-TCP framing, idle-exit loop — but
-//! layers a `MountRegistry` on top so a single daemon process can
-//! own multiple FUSE sessions across CLI invocations. See
-//! `docs/design/mount-daemon.md` for the full lifecycle and
-//! failure-mode analysis.
+//! endpoint file, JSON-over-UDS framing with same-uid `SO_PEERCRED`,
+//! idle-exit loop — but layers a `MountRegistry` on top so a single
+//! daemon process can own multiple FUSE sessions across CLI
+//! invocations. See `docs/design/mount-daemon.md` for the full
+//! lifecycle and failure-mode analysis.
 //!
 //! Three CLI verbs hang off this module:
 //!
@@ -28,6 +28,8 @@
 
 pub mod client;
 
+#[cfg(all(target_os = "linux", feature = "mount"))]
+mod dispatch;
 #[cfg(all(target_os = "linux", feature = "mount"))]
 pub mod registry;
 #[cfg(all(target_os = "linux", feature = "mount"))]

--- a/crates/cli/src/cli/commands/daemon/server.rs
+++ b/crates/cli/src/cli/commands/daemon/server.rs
@@ -3,7 +3,7 @@
 //! loop to a `MountRegistry`. Linux + `--features mount` only.
 
 use std::{
-    net::{TcpListener, TcpStream},
+    os::unix::net::UnixStream,
     path::Path,
     sync::{
         Arc, Mutex,
@@ -15,17 +15,18 @@ use std::{
 use anyhow::{Context, Result};
 use objects::{error::HeddleError, sync::LockExt};
 use repo::daemon::{
-    EndpointState, HELPER_HOST, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
-    MountStatus, mount_daemon_endpoint_path, mount_idle_policy, persist_endpoint, remove_endpoint,
-    server::{DaemonHandler, IdleDecision, handle_json_connection},
+    EndpointState, IdleDecision, MOUNT_PROTOCOL_VERSION, MountClientAuth, MountDaemonRequest,
+    UnixDaemonHandler, bind_unix_socket, handle_authenticated_unix_connection,
+    mount_daemon_endpoint_path, mount_daemon_socket_path, mount_idle_policy, persist_endpoint,
+    remove_endpoint, run_unix_server_loop,
 };
 use tracing::info;
 
-use super::registry::{MountOutcome, MountRegistry};
+use super::{dispatch::dispatch, registry::MountRegistry};
 
 /// Run the mount daemon for `repo_root` until idle. Binds a
-/// localhost TCP port, writes the endpoint file, listens for
-/// connections. Exits when both:
+/// mode-0600 Unix socket, writes the endpoint file, listens for
+/// same-uid peers. Exits when both:
 ///
 /// * no RPC has arrived for `HELPER_IDLE_TIMEOUT_SECS` (default
 ///   300s, mirrors fsmonitor),
@@ -41,20 +42,24 @@ pub fn run_mount_daemon(repo_root: &Path) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
 
-    let listener = TcpListener::bind((HELPER_HOST, 0))?;
-    listener.set_nonblocking(true)?;
-    let port = listener.local_addr()?.port();
+    let socket_path = mount_daemon_socket_path(repo_root);
+    let listener = bind_unix_socket(&socket_path).context("bind mount daemon socket")?;
     persist_endpoint(
         &endpoint_path,
         &EndpointState {
             version: MOUNT_PROTOCOL_VERSION,
-            host: HELPER_HOST.to_string(),
-            port,
+            host: "unix".to_string(),
+            port: 0,
             pid: Some(std::process::id()),
+            socket_path: Some(socket_path.clone()),
         },
     )
     .context("persist daemon endpoint")?;
-    info!(port, pid = std::process::id(), "heddle daemon serving");
+    info!(
+        socket = %socket_path.display(),
+        pid = std::process::id(),
+        "heddle daemon serving"
+    );
 
     let registry = Arc::new(Mutex::new(MountRegistry::new(repo_root.to_path_buf())));
     let started = Instant::now();
@@ -65,7 +70,7 @@ pub fn run_mount_daemon(repo_root: &Path) -> Result<()> {
         started,
         shutdown_requested: Arc::clone(&shutdown_requested),
     };
-    let result = repo::daemon::run_server_loop(&listener, &mut handler);
+    let result = run_unix_server_loop(&listener, &mut handler);
 
     // Cleanup ordering — load-bearing for the `cmd_daemon_stop`
     // post-condition documented on that function:
@@ -87,6 +92,7 @@ pub fn run_mount_daemon(repo_root: &Path) -> Result<()> {
         guard.shutdown_all();
     }
     remove_endpoint(&endpoint_path);
+    let _ = std::fs::remove_file(&socket_path);
     info!("heddle daemon exiting");
     result.map_err(Into::into)
 }
@@ -97,15 +103,21 @@ struct MountDaemonHandler {
     shutdown_requested: Arc<AtomicBool>,
 }
 
-impl DaemonHandler for MountDaemonHandler {
-    fn handle(&mut self, stream: TcpStream) -> Result<(), HeddleError> {
+impl UnixDaemonHandler for MountDaemonHandler {
+    fn handle(&mut self, stream: UnixStream) -> Result<(), HeddleError> {
         // Capture state before the move so the closure body can
         // borrow them without lifetime headaches.
         let registry = Arc::clone(&self.registry);
         let started = self.started;
         let shutdown_requested = Arc::clone(&self.shutdown_requested);
-        handle_json_connection(stream, move |request: MountDaemonRequest| {
-            dispatch(&registry, started, &shutdown_requested, request)
+        handle_authenticated_unix_connection(stream, move |request: MountDaemonRequest| {
+            dispatch(
+                &registry,
+                started,
+                &shutdown_requested,
+                MountClientAuth::SameUid,
+                request,
+            )
         })
     }
 
@@ -119,86 +131,6 @@ impl DaemonHandler for MountDaemonHandler {
         let shutdown = self.shutdown_requested.load(Ordering::Acquire);
         let live_count = self.registry.lock_or_poisoned().len();
         mount_idle_policy(shutdown, live_count, idle_for)
-    }
-}
-
-fn dispatch(
-    registry: &Mutex<MountRegistry>,
-    started: Instant,
-    shutdown_requested: &AtomicBool,
-    request: MountDaemonRequest,
-) -> MountDaemonResponse {
-    match request {
-        MountDaemonRequest::Mount {
-            thread_id,
-            mount_path,
-            repo_root: _,
-        } => {
-            let mut guard = registry.lock_or_poisoned();
-            match guard.mount(&thread_id, &mount_path) {
-                Ok(MountOutcome::Created) => MountDaemonResponse::Mount {
-                    version: MOUNT_PROTOCOL_VERSION,
-                    ok: true,
-                    mount_path,
-                    status: MountStatus::Created,
-                },
-                Ok(MountOutcome::Existing) => MountDaemonResponse::Mount {
-                    version: MOUNT_PROTOCOL_VERSION,
-                    ok: true,
-                    mount_path,
-                    status: MountStatus::AlreadyMounted,
-                },
-                Err(error) => MountDaemonResponse::Error {
-                    version: MOUNT_PROTOCOL_VERSION,
-                    code: repo::daemon::ERR_MOUNT_CONFLICT.to_string(),
-                    message: error.to_string(),
-                },
-            }
-        }
-        MountDaemonRequest::Unmount { thread_id } => {
-            let mut guard = registry.lock_or_poisoned();
-            match guard.unmount(&thread_id) {
-                Ok(was_mounted) => MountDaemonResponse::Unmount {
-                    version: MOUNT_PROTOCOL_VERSION,
-                    ok: true,
-                    was_mounted,
-                },
-                Err(error) => MountDaemonResponse::Error {
-                    version: MOUNT_PROTOCOL_VERSION,
-                    code: "unmount_failed".to_string(),
-                    message: error.to_string(),
-                },
-            }
-        }
-        MountDaemonRequest::ListMounts {} => {
-            let guard = registry.lock_or_poisoned();
-            MountDaemonResponse::ListMounts {
-                version: MOUNT_PROTOCOL_VERSION,
-                mounts: guard.snapshot(),
-            }
-        }
-        MountDaemonRequest::Health {} => {
-            let guard = registry.lock_or_poisoned();
-            MountDaemonResponse::Health {
-                version: MOUNT_PROTOCOL_VERSION,
-                ok: true,
-                uptime_s: started.elapsed().as_secs(),
-                mount_count: guard.len(),
-            }
-        }
-        MountDaemonRequest::Shutdown {} => {
-            shutdown_requested.store(true, Ordering::Release);
-            MountDaemonResponse::Shutdown {
-                version: MOUNT_PROTOCOL_VERSION,
-                ok: true,
-            }
-        }
-        MountDaemonRequest::Unknown => MountDaemonResponse::Error {
-            version: MOUNT_PROTOCOL_VERSION,
-            code: "unknown_command".to_string(),
-            message: "daemon received an unrecognized command (likely client/server skew)"
-                .to_string(),
-        },
     }
 }
 

--- a/crates/repo/src/daemon/endpoint.rs
+++ b/crates/repo/src/daemon/endpoint.rs
@@ -32,6 +32,11 @@ pub struct EndpointState {
     /// existed; treated as "unknown, assume alive" when absent.
     #[serde(default)]
     pub pid: Option<u32>,
+    /// Unix-domain socket the mount daemon binds. Absent for the
+    /// fsmonitor TCP helper. Mount clients refuse host:port when
+    /// this is missing (heddle#901).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub socket_path: Option<PathBuf>,
 }
 
 /// Default state directory under a Heddle repo root:
@@ -135,6 +140,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 9999,
             pid: Some(12345),
+            socket_path: None,
         };
         persist_endpoint(&path, &original).unwrap();
         let loaded = load_endpoint(&path).unwrap();
@@ -167,6 +173,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 8001,
             pid: Some(100),
+            socket_path: None,
         };
         let replacement = EndpointState {
             port: 8002,

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Long-lived helper-daemon scaffolding.
 //!
-//! Heddle's local helper subprocesses (today: the fsmonitor change
-//! watcher; tomorrow: the FUSE mount daemon) all share the same
-//! plumbing — a JSON-over-TCP protocol on `127.0.0.1`, an endpoint
-//! file at `.heddle/state/<name>.endpoint.json` that the spawning
-//! CLI uses for discovery, atomic write-on-bind, idle-timeout exit,
-//! crashed-PID detection via `kill -0`. The fsmonitor invented this
-//! pattern; the mount daemon reuses it.
+//! Heddle's local helper subprocesses share endpoint discovery
+//! (`.heddle/state/<name>.endpoint.json`), idle-timeout exit, and
+//! crashed-PID detection via `kill -0`. Transports differ:
 //!
-//! Threat model: the endpoint file binds to localhost with no auth.
-//! That matches the existing fsmonitor posture and assumes a
-//! single-user dev workstation. Anyone with a shell on the box can
-//! talk to the helper anyway; we are not a security boundary.
+//! * fsmonitor still speaks JSON-over-TCP on `127.0.0.1`.
+//! * the mount daemon binds a mode-0600 Unix socket and checks
+//!   same-uid `SO_PEERCRED`. Localhost TCP is not an authz
+//!   boundary (heddle#901).
 //!
 //! What lives here:
 //!
@@ -36,18 +32,34 @@
 pub mod endpoint;
 pub mod mount_auth;
 pub mod mount_proto;
+#[cfg(unix)]
+pub mod peer;
 pub mod protocol;
 pub mod server;
+#[cfg(unix)]
+pub mod unix_server;
 
 pub use endpoint::{
     EndpointState, default_state_dir, endpoint_path_for, load_endpoint, persist_endpoint,
     pid_alive, remove_endpoint, remove_endpoint_if_owned,
 };
-pub use mount_auth::{MountAuthDenied, MountClientAuth, authorize_mount_request, trusted_mount_path};
+pub use mount_auth::{
+    MountAuthDenied, MountClientAuth, authorize_mount_request, trusted_mount_path,
+};
 pub use mount_proto::{
     ERR_MOUNT_CONFLICT, ERR_MOUNT_UNSUPPORTED, ERR_UNAUTHORIZED, ERR_VERSION_MISMATCH,
-    MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse, MountRegistryFile, MountStatus,
-    PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path,
+    MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse, MountRegistryFile,
+    MountStatus, PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path,
+    mount_daemon_socket_path,
 };
-pub use protocol::{HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request};
+#[cfg(unix)]
+pub use peer::check_peer_uid_matches_self;
+pub use protocol::{
+    HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request,
+    send_json_request_unix, send_mount_daemon_request,
+};
 pub use server::{IdleDecision, mount_idle_policy, run_server_loop};
+#[cfg(unix)]
+pub use unix_server::{
+    UnixDaemonHandler, bind_unix_socket, handle_authenticated_unix_connection, run_unix_server_loop,
+};

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -52,13 +52,12 @@ pub use mount_auth::{
 pub use mount_proto::{
     ERR_MOUNT_CONFLICT, ERR_MOUNT_UNSUPPORTED, ERR_UNAUTHORIZED, ERR_VERSION_MISMATCH,
     MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
-    MountEndpointDisposition, MountRegistryFile, MountStatus, PersistedMount,
-    mount_daemon_endpoint_path, mount_daemon_registry_path, mount_daemon_socket_path,
-    mount_endpoint_disposition,
+    MountRegistryFile, MountStatus, PersistedMount, mount_daemon_endpoint_path,
+    mount_daemon_registry_path, mount_daemon_socket_path,
 };
 #[cfg(unix)]
 pub use peer::check_peer_uid_matches_self;
-pub use predecessor::retire_live_tcp_predecessor;
+pub use predecessor::refuse_live_legacy_tcp_endpoint;
 pub use protocol::{
     HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request,
     send_json_request_unix, send_mount_daemon_request,

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -34,6 +34,7 @@ pub mod mount_auth;
 pub mod mount_proto;
 #[cfg(unix)]
 pub mod peer;
+pub mod predecessor;
 pub mod protocol;
 pub mod server;
 #[cfg(unix)]
@@ -48,12 +49,14 @@ pub use mount_auth::{
 };
 pub use mount_proto::{
     ERR_MOUNT_CONFLICT, ERR_MOUNT_UNSUPPORTED, ERR_UNAUTHORIZED, ERR_VERSION_MISMATCH,
-    MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse, MountRegistryFile,
-    MountStatus, PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path,
-    mount_daemon_socket_path,
+    MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
+    MountEndpointDisposition, MountRegistryFile, MountStatus, PersistedMount,
+    mount_daemon_endpoint_path, mount_daemon_registry_path, mount_daemon_socket_path,
+    mount_endpoint_disposition,
 };
 #[cfg(unix)]
 pub use peer::check_peer_uid_matches_self;
+pub use predecessor::retire_live_tcp_predecessor;
 pub use protocol::{
     HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request,
     send_json_request_unix, send_mount_daemon_request,

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -38,6 +38,8 @@ pub mod predecessor;
 pub mod protocol;
 pub mod server;
 #[cfg(unix)]
+mod unix_probe;
+#[cfg(unix)]
 pub mod unix_server;
 
 pub use endpoint::{

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -34,6 +34,7 @@
 //! consumer of this module.
 
 pub mod endpoint;
+pub mod mount_auth;
 pub mod mount_proto;
 pub mod protocol;
 pub mod server;
@@ -42,10 +43,11 @@ pub use endpoint::{
     EndpointState, default_state_dir, endpoint_path_for, load_endpoint, persist_endpoint,
     pid_alive, remove_endpoint, remove_endpoint_if_owned,
 };
+pub use mount_auth::{MountAuthDenied, MountClientAuth, authorize_mount_request, trusted_mount_path};
 pub use mount_proto::{
-    ERR_MOUNT_CONFLICT, ERR_MOUNT_UNSUPPORTED, ERR_VERSION_MISMATCH, MOUNT_PROTOCOL_VERSION,
-    MountDaemonRequest, MountDaemonResponse, MountRegistryFile, MountStatus, PersistedMount,
-    mount_daemon_endpoint_path, mount_daemon_registry_path,
+    ERR_MOUNT_CONFLICT, ERR_MOUNT_UNSUPPORTED, ERR_UNAUTHORIZED, ERR_VERSION_MISMATCH,
+    MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse, MountRegistryFile, MountStatus,
+    PersistedMount, mount_daemon_endpoint_path, mount_daemon_registry_path,
 };
 pub use protocol::{HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request};
 pub use server::{IdleDecision, mount_idle_policy, run_server_loop};

--- a/crates/repo/src/daemon/mount_auth.rs
+++ b/crates/repo/src/daemon/mount_auth.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fail-closed authorization for mount-daemon RPCs.
+//!
+//! Localhost TCP is not an authz boundary. A client-supplied
+//! `mount_path` is honored only when the peer has the same uid the
+//! UDS `SO_PEERCRED` path proves. Unauthenticated transports
+//! (including the historical `127.0.0.1` listener) must refuse.
+
+use std::path::Path;
+
+use objects::error::HeddleError;
+
+use super::mount_proto::MountDaemonRequest;
+
+/// How the daemon authenticated the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountClientAuth {
+    /// `SO_PEERCRED` / `getpeereid` proved the peer uid matches this process.
+    SameUid,
+    /// No peer identity. Localhost TCP is this. Fail closed.
+    Unauthenticated,
+}
+
+/// Why a mount-daemon request was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountAuthDenied {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl MountAuthDenied {
+    pub fn unauthorized(message: impl Into<String>) -> Self {
+        Self {
+            code: super::mount_proto::ERR_UNAUTHORIZED,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<MountAuthDenied> for HeddleError {
+    fn from(denied: MountAuthDenied) -> Self {
+        HeddleError::Config(format!("{}: {}", denied.code, denied.message))
+    }
+}
+
+/// Honor a client-supplied `mount_path` only for same-uid peers.
+///
+/// Intentionally still accepts unauthenticated paths so the first
+/// commit stays red (heddle#901). The follow-up flips this closed.
+pub fn trusted_mount_path<'a>(
+    auth: MountClientAuth,
+    supplied: &'a Path,
+) -> Result<&'a Path, MountAuthDenied> {
+    let _ = auth;
+    Ok(supplied)
+}
+
+/// Every mount-daemon verb needs same-uid proof. Health and list leak
+/// mount paths; mount/unmount/shutdown are filesystem primitives.
+pub fn authorize_mount_request(
+    auth: MountClientAuth,
+    request: &MountDaemonRequest,
+) -> Result<(), MountAuthDenied> {
+    match auth {
+        MountClientAuth::SameUid => Ok(()),
+        MountClientAuth::Unauthenticated => Err(MountAuthDenied::unauthorized(format!(
+            "refusing {:?} over an unauthenticated transport; same-uid UDS is required",
+            request_verb(request)
+        ))),
+    }
+}
+
+fn request_verb(request: &MountDaemonRequest) -> &'static str {
+    match request {
+        MountDaemonRequest::Mount { .. } => "mount",
+        MountDaemonRequest::Unmount { .. } => "unmount",
+        MountDaemonRequest::ListMounts {} => "list_mounts",
+        MountDaemonRequest::Health {} => "health",
+        MountDaemonRequest::Shutdown {} => "shutdown",
+        MountDaemonRequest::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{MountClientAuth, authorize_mount_request, trusted_mount_path};
+    use crate::daemon::MountDaemonRequest;
+
+    fn mount_request() -> MountDaemonRequest {
+        MountDaemonRequest::Mount {
+            thread_id: "agent-7".to_string(),
+            mount_path: PathBuf::from("/tmp/evil"),
+            repo_root: PathBuf::from("/tmp/repo"),
+        }
+    }
+
+    #[test]
+    fn unauthenticated_tcp_must_not_honor_client_mount_path() {
+        let denied = trusted_mount_path(
+            MountClientAuth::Unauthenticated,
+            Path::new("/tmp/evil"),
+        );
+        assert!(
+            denied.is_err(),
+            "localhost TCP must not honor a client-supplied mount_path"
+        );
+    }
+
+    #[test]
+    fn same_uid_peer_may_supply_mount_path() {
+        let path = Path::new("/tmp/ok");
+        let accepted = trusted_mount_path(MountClientAuth::SameUid, path)
+            .expect("same-uid UDS may honor mount_path");
+        assert_eq!(accepted, path);
+    }
+
+    #[test]
+    fn unauthenticated_tcp_must_not_drive_mount_or_unmount() {
+        let mount = authorize_mount_request(MountClientAuth::Unauthenticated, &mount_request());
+        assert!(mount.is_err(), "unauthenticated mount must fail closed");
+
+        let unmount = authorize_mount_request(
+            MountClientAuth::Unauthenticated,
+            &MountDaemonRequest::Unmount {
+                thread_id: "agent-7".to_string(),
+            },
+        );
+        assert!(unmount.is_err(), "unauthenticated unmount must fail closed");
+    }
+
+    #[test]
+    fn same_uid_peer_is_authorized() {
+        authorize_mount_request(MountClientAuth::SameUid, &mount_request())
+            .expect("same-uid mount is allowed");
+    }
+}

--- a/crates/repo/src/daemon/mount_auth.rs
+++ b/crates/repo/src/daemon/mount_auth.rs
@@ -44,15 +44,16 @@ impl From<MountAuthDenied> for HeddleError {
 }
 
 /// Honor a client-supplied `mount_path` only for same-uid peers.
-///
-/// Intentionally still accepts unauthenticated paths so the first
-/// commit stays red (heddle#901). The follow-up flips this closed.
-pub fn trusted_mount_path<'a>(
+pub fn trusted_mount_path(
     auth: MountClientAuth,
-    supplied: &'a Path,
-) -> Result<&'a Path, MountAuthDenied> {
-    let _ = auth;
-    Ok(supplied)
+    supplied: &Path,
+) -> Result<&Path, MountAuthDenied> {
+    match auth {
+        MountClientAuth::SameUid => Ok(supplied),
+        MountClientAuth::Unauthenticated => Err(MountAuthDenied::unauthorized(
+            "refusing client-supplied mount_path over an unauthenticated transport; same-uid UDS is required",
+        )),
+    }
 }
 
 /// Every mount-daemon verb needs same-uid proof. Health and list leak
@@ -64,8 +65,8 @@ pub fn authorize_mount_request(
     match auth {
         MountClientAuth::SameUid => Ok(()),
         MountClientAuth::Unauthenticated => Err(MountAuthDenied::unauthorized(format!(
-            "refusing {:?} over an unauthenticated transport; same-uid UDS is required",
-            request_verb(request)
+            "refusing {verb} over an unauthenticated transport; same-uid UDS is required",
+            verb = request_verb(request)
         ))),
     }
 }
@@ -98,10 +99,7 @@ mod tests {
 
     #[test]
     fn unauthenticated_tcp_must_not_honor_client_mount_path() {
-        let denied = trusted_mount_path(
-            MountClientAuth::Unauthenticated,
-            Path::new("/tmp/evil"),
-        );
+        let denied = trusted_mount_path(MountClientAuth::Unauthenticated, Path::new("/tmp/evil"));
         assert!(
             denied.is_err(),
             "localhost TCP must not honor a client-supplied mount_path"

--- a/crates/repo/src/daemon/mount_proto.rs
+++ b/crates/repo/src/daemon/mount_proto.rs
@@ -15,12 +15,11 @@
 //!
 //! Versioning: `MOUNT_PROTOCOL_VERSION` is bumped together with the
 //! daemon binary. The endpoint file under
-//! `.heddle/state/heddled.endpoint.json` records this number; CLI
-//! clients that read a version they don't recognize remove the
-//! file and respawn. fsmonitor's protocol stays at v1 on a
-//! separate endpoint file (`monitor-helper.json`) — bumping there
-//! is reserved for future breaking changes to the change-monitor
-//! verbs.
+//! `.heddle/state/heddled.endpoint.json` records this number. A live
+//! older TCP daemon (v2) is retired with `Shutdown` before the CLI
+//! removes the file and respawns — otherwise two daemons own mounts.
+//! fsmonitor's protocol stays at v1 on a separate endpoint file
+//! (`monitor-helper.json`).
 //!
 //! Endpoint file path: `.heddle/state/heddled.endpoint.json`
 //! (resolved by [`mount_daemon_endpoint_path`]).
@@ -29,13 +28,47 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::endpoint::default_state_dir;
+use super::endpoint::{EndpointState, default_state_dir};
 
 /// Wire-protocol version for the mount daemon. Bump in lockstep with
 /// any breaking change to the request/response enums below. CLI
-/// clients that find a different version on the endpoint file
-/// remove the file and respawn the daemon at their version.
+/// clients that find a live older version retire that daemon before
+/// respawning at this version.
 pub const MOUNT_PROTOCOL_VERSION: u32 = 3;
+
+/// Last protocol that spoke unauthenticated localhost TCP.
+pub const MOUNT_PROTOCOL_V2: u32 = 2;
+
+/// How a recorded endpoint relates to this CLI's protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountEndpointDisposition {
+    /// Current version and an authenticated socket. Safe to use.
+    Current,
+    /// Older TCP daemon whose PID is still alive. Must `Shutdown`
+    /// before spawning a replacement.
+    LiveTcpPredecessor,
+    /// Missing socket, dead PID, or otherwise not a live predecessor.
+    Stale,
+}
+
+/// Classify an on-disk mount-daemon endpoint. `pid_is_alive` is
+/// supplied by the caller so tests can exercise the v2-upgrade
+/// branch without forking.
+pub fn mount_endpoint_disposition(
+    endpoint: &EndpointState,
+    pid_is_alive: bool,
+) -> MountEndpointDisposition {
+    if endpoint.version == MOUNT_PROTOCOL_VERSION && endpoint.socket_path.is_some() {
+        if endpoint.pid.is_some() && !pid_is_alive {
+            return MountEndpointDisposition::Stale;
+        }
+        return MountEndpointDisposition::Current;
+    }
+    if endpoint.version < MOUNT_PROTOCOL_VERSION && endpoint.socket_path.is_none() && pid_is_alive {
+        return MountEndpointDisposition::LiveTcpPredecessor;
+    }
+    MountEndpointDisposition::Stale
+}
 
 /// The endpoint file the mount daemon writes (and CLI clients read)
 /// to discover its UDS path + PID.

--- a/crates/repo/src/daemon/mount_proto.rs
+++ b/crates/repo/src/daemon/mount_proto.rs
@@ -185,6 +185,10 @@ pub const ERR_MOUNT_CONFLICT: &str = "mount_conflict";
 /// builds, or a Linux build without `--features mount`).
 pub const ERR_MOUNT_UNSUPPORTED: &str = "mount_unsupported";
 
+/// Standard error code when the caller has no same-uid proof.
+/// Localhost TCP is unauthenticated; the daemon fails closed.
+pub const ERR_UNAUTHORIZED: &str = "unauthorized";
+
 #[cfg(test)]
 mod tests {
     //! Wire-protocol round-trip tests. These verify that:

--- a/crates/repo/src/daemon/mount_proto.rs
+++ b/crates/repo/src/daemon/mount_proto.rs
@@ -9,8 +9,9 @@
 //! CLI client side and tests can decode it without pulling the
 //! mount stack in.
 //!
-//! Wire posture: localhost TCP, no auth — same threat model as
-//! fsmonitor. Single-user dev workstation.
+//! Wire posture: Unix-domain socket, mode 0600, same-uid
+//! `SO_PEERCRED`. Localhost TCP is not an authz boundary and is
+//! refused (heddle#901).
 //!
 //! Versioning: `MOUNT_PROTOCOL_VERSION` is bumped together with the
 //! daemon binary. The endpoint file under
@@ -34,12 +35,18 @@ use super::endpoint::default_state_dir;
 /// any breaking change to the request/response enums below. CLI
 /// clients that find a different version on the endpoint file
 /// remove the file and respawn the daemon at their version.
-pub const MOUNT_PROTOCOL_VERSION: u32 = 2;
+pub const MOUNT_PROTOCOL_VERSION: u32 = 3;
 
 /// The endpoint file the mount daemon writes (and CLI clients read)
-/// to discover its TCP port + PID.
+/// to discover its UDS path + PID.
 pub fn mount_daemon_endpoint_path(repo_root: &Path) -> PathBuf {
     default_state_dir(repo_root).join("heddled.endpoint.json")
+}
+
+/// Unix-domain socket the mount daemon binds. Mode 0600 + same-uid
+/// `SO_PEERCRED`. Not the historical localhost TCP port.
+pub fn mount_daemon_socket_path(repo_root: &Path) -> PathBuf {
+    default_state_dir(repo_root).join("heddled.sock")
 }
 
 /// File where the daemon persists the list of currently-active
@@ -70,7 +77,7 @@ pub struct MountRegistryFile {
     pub mounts: Vec<PersistedMount>,
 }
 
-/// Mount-daemon request envelope. Single-line JSON over TCP. Adding
+/// Mount-daemon request envelope. Single-line JSON over UDS. Adding
 /// a new verb is additive; every existing client can ignore unknown
 /// verbs and the daemon sees the version mismatch first anyway.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,6 +282,8 @@ mod tests {
         let registry = mount_daemon_registry_path(tmp.path());
         assert!(endpoint.ends_with(".heddle/state/heddled.endpoint.json"));
         assert!(registry.ends_with(".heddle/state/mounts.json"));
+        let socket = mount_daemon_socket_path(tmp.path());
+        assert!(socket.ends_with(".heddle/state/heddled.sock"));
     }
 
     #[test]

--- a/crates/repo/src/daemon/mount_proto.rs
+++ b/crates/repo/src/daemon/mount_proto.rs
@@ -16,10 +16,10 @@
 //! Versioning: `MOUNT_PROTOCOL_VERSION` is bumped together with the
 //! daemon binary. The endpoint file under
 //! `.heddle/state/heddled.endpoint.json` records this number. A live
-//! older TCP daemon (v2) is retired with `Shutdown` before the CLI
-//! removes the file and respawns — otherwise two daemons own mounts.
-//! fsmonitor's protocol stays at v1 on a separate endpoint file
-//! (`monitor-helper.json`).
+//! older TCP daemon (v2) fails closed: v3 does not speak that
+//! protocol. The operator must stop or upgrade the leftover process
+//! before a replacement can spawn. fsmonitor's protocol stays at v1
+//! on a separate endpoint file (`monitor-helper.json`).
 //!
 //! Endpoint file path: `.heddle/state/heddled.endpoint.json`
 //! (resolved by [`mount_daemon_endpoint_path`]).
@@ -28,47 +28,15 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::endpoint::{EndpointState, default_state_dir};
+use super::endpoint::default_state_dir;
 
 /// Wire-protocol version for the mount daemon. Bump in lockstep with
-/// any breaking change to the request/response enums below. CLI
-/// clients that find a live older version retire that daemon before
-/// respawning at this version.
+/// any breaking change to the request/response enums below. A live
+/// older TCP endpoint fails closed; this CLI does not operate it.
 pub const MOUNT_PROTOCOL_VERSION: u32 = 3;
 
 /// Last protocol that spoke unauthenticated localhost TCP.
 pub const MOUNT_PROTOCOL_V2: u32 = 2;
-
-/// How a recorded endpoint relates to this CLI's protocol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MountEndpointDisposition {
-    /// Current version and an authenticated socket. Safe to use.
-    Current,
-    /// Older TCP daemon whose PID is still alive. Must `Shutdown`
-    /// before spawning a replacement.
-    LiveTcpPredecessor,
-    /// Missing socket, dead PID, or otherwise not a live predecessor.
-    Stale,
-}
-
-/// Classify an on-disk mount-daemon endpoint. `pid_is_alive` is
-/// supplied by the caller so tests can exercise the v2-upgrade
-/// branch without forking.
-pub fn mount_endpoint_disposition(
-    endpoint: &EndpointState,
-    pid_is_alive: bool,
-) -> MountEndpointDisposition {
-    if endpoint.version == MOUNT_PROTOCOL_VERSION && endpoint.socket_path.is_some() {
-        if endpoint.pid.is_some() && !pid_is_alive {
-            return MountEndpointDisposition::Stale;
-        }
-        return MountEndpointDisposition::Current;
-    }
-    if endpoint.version < MOUNT_PROTOCOL_VERSION && endpoint.socket_path.is_none() && pid_is_alive {
-        return MountEndpointDisposition::LiveTcpPredecessor;
-    }
-    MountEndpointDisposition::Stale
-}
 
 /// The endpoint file the mount daemon writes (and CLI clients read)
 /// to discover its UDS path + PID.

--- a/crates/repo/src/daemon/peer.rs
+++ b/crates/repo/src/daemon/peer.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Same-uid peer identity for Unix-domain sockets.
+//!
+//! The mount daemon used to bind unauthenticated localhost TCP.
+//! `SO_PEERCRED` (Linux) / `getpeereid` (other Unix) is the uid
+//! check the documented UDS path uses. Fail closed when credentials
+//! cannot be read or the peer uid differs.
+
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
+
+use objects::error::HeddleError;
+
+/// True when `peer_uid` is this process's effective uid.
+pub fn peer_uids_match(peer_uid: u32, self_uid: u32) -> bool {
+    peer_uid == self_uid
+}
+
+/// Effective uid of this process. Used as the daemon-side identity.
+pub fn current_euid() -> u32 {
+    // SAFETY: `geteuid` is always successful and has no memory effects.
+    unsafe { libc::geteuid() }
+}
+
+/// Fail closed unless the Unix-socket peer is the same effective uid.
+pub fn check_peer_uid_matches_self(stream: &UnixStream) -> Result<(), HeddleError> {
+    let peer_uid = peer_uid(stream)?;
+    let self_uid = current_euid();
+    if !peer_uids_match(peer_uid, self_uid) {
+        return Err(HeddleError::Config(format!(
+            "peer uid {peer_uid} does not match daemon uid {self_uid}"
+        )));
+    }
+    Ok(())
+}
+
+fn peer_uid(stream: &UnixStream) -> Result<u32, HeddleError> {
+    peer_uid_from_fd(stream.as_raw_fd())
+}
+
+#[cfg(target_os = "linux")]
+fn peer_uid_from_fd(fd: libc::c_int) -> Result<u32, HeddleError> {
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: `fd` is a live Unix socket; `cred`/`len` match SO_PEERCRED.
+    let ret = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut libc::ucred as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if ret != 0 {
+        return Err(HeddleError::Config(format!(
+            "SO_PEERCRED unavailable: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(cred.uid)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn peer_uid_from_fd(fd: libc::c_int) -> Result<u32, HeddleError> {
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    // SAFETY: `fd` is a live Unix socket; getpeereid writes the two out-params.
+    let ret = unsafe { libc::getpeereid(fd, &mut uid, &mut gid) };
+    if ret != 0 {
+        return Err(HeddleError::Config(format!(
+            "getpeereid unavailable: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::UnixStream;
+
+    use super::{check_peer_uid_matches_self, current_euid, peer_uid, peer_uids_match};
+
+    #[test]
+    fn peer_uids_match_is_strict_equality() {
+        assert!(peer_uids_match(1000, 1000));
+        assert!(!peer_uids_match(0, 1000));
+    }
+
+    #[test]
+    fn connected_pair_has_matching_self_uid() {
+        let (left, right) = UnixStream::pair().expect("unix socket pair");
+        let left_uid = peer_uid(&left).expect("peer uid on left");
+        let right_uid = peer_uid(&right).expect("peer uid on right");
+        let self_uid = current_euid();
+        assert_eq!(left_uid, self_uid);
+        assert_eq!(right_uid, self_uid);
+        check_peer_uid_matches_self(&left).expect("same process is same uid");
+        check_peer_uid_matches_self(&right).expect("same process is same uid");
+    }
+}

--- a/crates/repo/src/daemon/peer.rs
+++ b/crates/repo/src/daemon/peer.rs
@@ -24,11 +24,16 @@ pub fn current_euid() -> u32 {
 
 /// Fail closed unless the Unix-socket peer is the same effective uid.
 pub fn check_peer_uid_matches_self(stream: &UnixStream) -> Result<(), HeddleError> {
+    check_peer_uid(stream, current_euid())
+}
+
+/// Same `SO_PEERCRED` / `getpeereid` read as
+/// [`check_peer_uid_matches_self`], compared to `expected_uid`.
+pub(crate) fn check_peer_uid(stream: &UnixStream, expected_uid: u32) -> Result<(), HeddleError> {
     let peer_uid = peer_uid(stream)?;
-    let self_uid = current_euid();
-    if !peer_uids_match(peer_uid, self_uid) {
+    if !peer_uids_match(peer_uid, expected_uid) {
         return Err(HeddleError::Config(format!(
-            "peer uid {peer_uid} does not match daemon uid {self_uid}"
+            "peer uid {peer_uid} does not match daemon uid {expected_uid}"
         )));
     }
     Ok(())

--- a/crates/repo/src/daemon/predecessor.rs
+++ b/crates/repo/src/daemon/predecessor.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Retire a live older mount daemon before spawning a replacement.
+//!
+//! A v2 TCP daemon is still a process that owns FUSE mounts. Classifying
+//! its endpoint as stale and respawning without `Shutdown` leaves two
+//! daemons. Fail closed if the predecessor does not exit.
+
+use std::{
+    net::TcpStream,
+    time::{Duration, Instant},
+};
+
+use objects::error::HeddleError;
+
+use super::{
+    endpoint::{EndpointState, pid_alive},
+    mount_proto::{
+        MountDaemonRequest, MountDaemonResponse, MountEndpointDisposition,
+        mount_endpoint_disposition,
+    },
+    protocol::send_json_request,
+};
+
+const RETIRE_POLL_MS: u64 = 50;
+const RETIRE_WAIT: Duration = Duration::from_secs(2);
+
+/// Stop a live v2 TCP predecessor. Current and already-stale endpoints
+/// are no-ops. If the process is still alive after the wait, return
+/// `Err` so the caller does not spawn a second daemon.
+pub fn retire_live_tcp_predecessor(endpoint: &EndpointState) -> Result<(), HeddleError> {
+    let pid_is_alive = endpoint.pid.is_some_and(pid_alive);
+    match mount_endpoint_disposition(endpoint, pid_is_alive) {
+        MountEndpointDisposition::Current | MountEndpointDisposition::Stale => Ok(()),
+        MountEndpointDisposition::LiveTcpPredecessor => stop_tcp_predecessor(endpoint),
+    }
+}
+
+fn stop_tcp_predecessor(endpoint: &EndpointState) -> Result<(), HeddleError> {
+    match send_json_request::<_, MountDaemonResponse>(endpoint, &MountDaemonRequest::Shutdown {}) {
+        Ok(MountDaemonResponse::Shutdown { .. }) => {}
+        Ok(other) => {
+            return Err(HeddleError::Config(format!(
+                "live v{} mount daemon refused shutdown: {other:?}",
+                endpoint.version
+            )));
+        }
+        Err(_) => {
+            // Connection refused means the process already exited; still
+            // wait so we do not race a dying PID.
+        }
+    }
+    if !wait_until_predecessor_gone(endpoint) {
+        return Err(HeddleError::Config(format!(
+            "live v{} mount daemon did not exit after shutdown; refusing to spawn a second daemon",
+            endpoint.version
+        )));
+    }
+    Ok(())
+}
+
+fn wait_until_predecessor_gone(endpoint: &EndpointState) -> bool {
+    let deadline = Instant::now() + RETIRE_WAIT;
+    loop {
+        if predecessor_is_gone(endpoint) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return predecessor_is_gone(endpoint);
+        }
+        std::thread::sleep(Duration::from_millis(RETIRE_POLL_MS));
+    }
+}
+
+fn predecessor_is_gone(endpoint: &EndpointState) -> bool {
+    if let Some(pid) = endpoint.pid
+        && pid_alive(pid)
+    {
+        return false;
+    }
+    !tcp_endpoint_accepts(endpoint)
+}
+
+fn tcp_endpoint_accepts(endpoint: &EndpointState) -> bool {
+    let address = format!("{}:{}", endpoint.host, endpoint.port);
+    let Ok(addr) = address.parse() else {
+        return false;
+    };
+    TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{BufRead, BufReader, Write},
+        net::TcpListener,
+        process::{Command, Stdio},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+    };
+
+    use super::{mount_endpoint_disposition, retire_live_tcp_predecessor};
+    use crate::daemon::{
+        EndpointState, MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonResponse,
+        MountEndpointDisposition, pid_alive,
+    };
+
+    fn v2_tcp(host: &str, port: u16, pid: u32) -> EndpointState {
+        EndpointState {
+            version: MOUNT_PROTOCOL_V2,
+            host: host.to_string(),
+            port,
+            pid: Some(pid),
+            socket_path: None,
+        }
+    }
+
+    #[test]
+    fn live_v2_tcp_is_a_predecessor() {
+        let endpoint = v2_tcp("127.0.0.1", 9, 1);
+        assert_eq!(
+            mount_endpoint_disposition(&endpoint, true),
+            MountEndpointDisposition::LiveTcpPredecessor
+        );
+    }
+
+    #[test]
+    fn dead_v2_tcp_is_stale() {
+        let endpoint = v2_tcp("127.0.0.1", 9, 0x7fff_fffe);
+        assert_eq!(
+            mount_endpoint_disposition(&endpoint, false),
+            MountEndpointDisposition::Stale
+        );
+    }
+
+    #[test]
+    fn current_uds_is_not_a_predecessor() {
+        let endpoint = EndpointState {
+            version: MOUNT_PROTOCOL_VERSION,
+            host: "unix".to_string(),
+            port: 0,
+            pid: Some(1),
+            socket_path: Some("/tmp/heddled.sock".into()),
+        };
+        assert_eq!(
+            mount_endpoint_disposition(&endpoint, true),
+            MountEndpointDisposition::Current
+        );
+    }
+
+    fn spawn_sleep() -> std::process::Child {
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep as stand-in daemon pid")
+    }
+
+    fn serve_v2_shutdown(
+        listener: TcpListener,
+        shutdown: Arc<AtomicBool>,
+        mut child: std::process::Child,
+    ) {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut line = String::new();
+            let _ = BufReader::new(stream.try_clone().expect("clone")).read_line(&mut line);
+            if line.contains("shutdown") {
+                shutdown.store(true, Ordering::Release);
+                let reply = MountDaemonResponse::Shutdown {
+                    version: MOUNT_PROTOCOL_V2,
+                    ok: true,
+                };
+                let _ = serde_json::to_writer(&mut stream, &reply);
+                let _ = stream.write_all(b"\n");
+            }
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn upgrade_retires_live_v2_before_returning() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind v2 stand-in");
+        let port = listener.local_addr().expect("port").port();
+        let child = spawn_sleep();
+        let pid = child.id();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&shutdown);
+        let server = thread::spawn(move || serve_v2_shutdown(listener, flag, child));
+
+        let endpoint = v2_tcp("127.0.0.1", port, pid);
+        retire_live_tcp_predecessor(&endpoint).expect("live v2 must retire");
+        assert!(
+            shutdown.load(Ordering::Acquire),
+            "v2 Shutdown must be sent before the caller may respawn"
+        );
+        assert!(
+            !pid_alive(pid),
+            "retired v2 pid must be gone before respawn"
+        );
+        let _ = server.join();
+    }
+
+    #[test]
+    fn upgrade_fails_closed_when_live_v2_stays_alive() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stubborn v2");
+        let port = listener.local_addr().expect("port").port();
+        let mut child = spawn_sleep();
+        let pid = child.id();
+        let server = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut line = String::new();
+                let _ = BufReader::new(&stream).read_line(&mut line);
+                let reply = MountDaemonResponse::Shutdown {
+                    version: MOUNT_PROTOCOL_V2,
+                    ok: true,
+                };
+                let _ = serde_json::to_writer(&mut stream, &reply);
+                let _ = stream.write_all(b"\n");
+                // Leave `child` alive on purpose.
+            }
+        });
+
+        let endpoint = v2_tcp("127.0.0.1", port, pid);
+        let error = retire_live_tcp_predecessor(&endpoint)
+            .expect_err("a still-alive v2 daemon must block respawn");
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to spawn a second daemon"),
+            "got {error}"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = server.join();
+    }
+}

--- a/crates/repo/src/daemon/predecessor.rs
+++ b/crates/repo/src/daemon/predecessor.rs
@@ -1,111 +1,46 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Retire a live older mount daemon before spawning a replacement.
+//! Refuse to spawn over a live older TCP mount daemon.
 //!
-//! A v2 TCP daemon is still a process that owns FUSE mounts. Classifying
-//! its endpoint as stale and respawning without `Shutdown` leaves two
-//! daemons. Fail closed if the predecessor does not exit.
-
-use std::{
-    net::TcpStream,
-    time::{Duration, Instant},
-};
+//! A leftover v2 process still owns FUSE mounts. v3 does not speak
+//! that protocol. Fail closed and tell the operator to stop or
+//! upgrade the leftover process.
 
 use objects::error::HeddleError;
 
 use super::{
     endpoint::{EndpointState, pid_alive},
-    mount_proto::{
-        MountDaemonRequest, MountDaemonResponse, MountEndpointDisposition,
-        mount_endpoint_disposition,
-    },
-    protocol::send_json_request,
+    mount_proto::MOUNT_PROTOCOL_VERSION,
 };
 
-const RETIRE_POLL_MS: u64 = 50;
-const RETIRE_WAIT: Duration = Duration::from_secs(2);
-
-/// Stop a live v2 TCP predecessor. Current and already-stale endpoints
-/// are no-ops. If the process is still alive after the wait, return
-/// `Err` so the caller does not spawn a second daemon.
-pub fn retire_live_tcp_predecessor(endpoint: &EndpointState) -> Result<(), HeddleError> {
-    let pid_is_alive = endpoint.pid.is_some_and(pid_alive);
-    match mount_endpoint_disposition(endpoint, pid_is_alive) {
-        MountEndpointDisposition::Current | MountEndpointDisposition::Stale => Ok(()),
-        MountEndpointDisposition::LiveTcpPredecessor => stop_tcp_predecessor(endpoint),
+/// Fail closed when a live older TCP daemon still owns this repo.
+/// Current and already-stale endpoints are no-ops.
+pub fn refuse_live_legacy_tcp_endpoint(endpoint: &EndpointState) -> Result<(), HeddleError> {
+    if !is_live_legacy_tcp(endpoint) {
+        return Ok(());
     }
+    let pid = endpoint
+        .pid
+        .map(|pid| pid.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    Err(HeddleError::Config(format!(
+        "live v{} TCP mount daemon (pid {pid} at {}:{}) still owns this repo; \
+         refusing to spawn a replacement. Stop or upgrade the leftover process, then retry",
+        endpoint.version, endpoint.host, endpoint.port
+    )))
 }
 
-fn stop_tcp_predecessor(endpoint: &EndpointState) -> Result<(), HeddleError> {
-    match send_json_request::<_, MountDaemonResponse>(endpoint, &MountDaemonRequest::Shutdown {}) {
-        Ok(MountDaemonResponse::Shutdown { .. }) => {}
-        Ok(other) => {
-            return Err(HeddleError::Config(format!(
-                "live v{} mount daemon refused shutdown: {other:?}",
-                endpoint.version
-            )));
-        }
-        Err(_) => {
-            // Connection refused means the process already exited; still
-            // wait so we do not race a dying PID.
-        }
-    }
-    if !wait_until_predecessor_gone(endpoint) {
-        return Err(HeddleError::Config(format!(
-            "live v{} mount daemon did not exit after shutdown; refusing to spawn a second daemon",
-            endpoint.version
-        )));
-    }
-    Ok(())
-}
-
-fn wait_until_predecessor_gone(endpoint: &EndpointState) -> bool {
-    let deadline = Instant::now() + RETIRE_WAIT;
-    loop {
-        if predecessor_is_gone(endpoint) {
-            return true;
-        }
-        if Instant::now() >= deadline {
-            return predecessor_is_gone(endpoint);
-        }
-        std::thread::sleep(Duration::from_millis(RETIRE_POLL_MS));
-    }
-}
-
-fn predecessor_is_gone(endpoint: &EndpointState) -> bool {
-    if let Some(pid) = endpoint.pid
-        && pid_alive(pid)
-    {
-        return false;
-    }
-    !tcp_endpoint_accepts(endpoint)
-}
-
-fn tcp_endpoint_accepts(endpoint: &EndpointState) -> bool {
-    let address = format!("{}:{}", endpoint.host, endpoint.port);
-    let Ok(addr) = address.parse() else {
-        return false;
-    };
-    TcpStream::connect_timeout(&addr, Duration::from_millis(100)).is_ok()
+fn is_live_legacy_tcp(endpoint: &EndpointState) -> bool {
+    endpoint.version < MOUNT_PROTOCOL_VERSION
+        && endpoint.socket_path.is_none()
+        && endpoint.pid.is_some_and(pid_alive)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        io::{BufRead, BufReader, Write},
-        net::TcpListener,
-        process::{Command, Stdio},
-        sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-        },
-        thread,
-    };
+    use std::process::{Command, Stdio};
 
-    use super::{mount_endpoint_disposition, retire_live_tcp_predecessor};
-    use crate::daemon::{
-        EndpointState, MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, MountDaemonResponse,
-        MountEndpointDisposition, pid_alive,
-    };
+    use super::refuse_live_legacy_tcp_endpoint;
+    use crate::daemon::{EndpointState, MOUNT_PROTOCOL_V2, MOUNT_PROTOCOL_VERSION, pid_alive};
 
     fn v2_tcp(host: &str, port: u16, pid: u32) -> EndpointState {
         EndpointState {
@@ -115,39 +50,6 @@ mod tests {
             pid: Some(pid),
             socket_path: None,
         }
-    }
-
-    #[test]
-    fn live_v2_tcp_is_a_predecessor() {
-        let endpoint = v2_tcp("127.0.0.1", 9, 1);
-        assert_eq!(
-            mount_endpoint_disposition(&endpoint, true),
-            MountEndpointDisposition::LiveTcpPredecessor
-        );
-    }
-
-    #[test]
-    fn dead_v2_tcp_is_stale() {
-        let endpoint = v2_tcp("127.0.0.1", 9, 0x7fff_fffe);
-        assert_eq!(
-            mount_endpoint_disposition(&endpoint, false),
-            MountEndpointDisposition::Stale
-        );
-    }
-
-    #[test]
-    fn current_uds_is_not_a_predecessor() {
-        let endpoint = EndpointState {
-            version: MOUNT_PROTOCOL_VERSION,
-            host: "unix".to_string(),
-            port: 0,
-            pid: Some(1),
-            socket_path: Some("/tmp/heddled.sock".into()),
-        };
-        assert_eq!(
-            mount_endpoint_disposition(&endpoint, true),
-            MountEndpointDisposition::Current
-        );
     }
 
     fn spawn_sleep() -> std::process::Child {
@@ -160,82 +62,43 @@ mod tests {
             .expect("spawn sleep as stand-in daemon pid")
     }
 
-    fn serve_v2_shutdown(
-        listener: TcpListener,
-        shutdown: Arc<AtomicBool>,
-        mut child: std::process::Child,
-    ) {
-        if let Ok((mut stream, _)) = listener.accept() {
-            let mut line = String::new();
-            let _ = BufReader::new(stream.try_clone().expect("clone")).read_line(&mut line);
-            if line.contains("shutdown") {
-                shutdown.store(true, Ordering::Release);
-                let reply = MountDaemonResponse::Shutdown {
-                    version: MOUNT_PROTOCOL_V2,
-                    ok: true,
-                };
-                let _ = serde_json::to_writer(&mut stream, &reply);
-                let _ = stream.write_all(b"\n");
-            }
-        }
-        let _ = child.kill();
-        let _ = child.wait();
-    }
-
     #[test]
-    fn upgrade_retires_live_v2_before_returning() {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind v2 stand-in");
-        let port = listener.local_addr().expect("port").port();
-        let child = spawn_sleep();
-        let pid = child.id();
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let flag = Arc::clone(&shutdown);
-        let server = thread::spawn(move || serve_v2_shutdown(listener, flag, child));
-
-        let endpoint = v2_tcp("127.0.0.1", port, pid);
-        retire_live_tcp_predecessor(&endpoint).expect("live v2 must retire");
-        assert!(
-            shutdown.load(Ordering::Acquire),
-            "v2 Shutdown must be sent before the caller may respawn"
-        );
-        assert!(
-            !pid_alive(pid),
-            "retired v2 pid must be gone before respawn"
-        );
-        let _ = server.join();
-    }
-
-    #[test]
-    fn upgrade_fails_closed_when_live_v2_stays_alive() {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stubborn v2");
-        let port = listener.local_addr().expect("port").port();
+    fn live_v2_tcp_fails_closed_with_recovery() {
         let mut child = spawn_sleep();
         let pid = child.id();
-        let server = thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut line = String::new();
-                let _ = BufReader::new(&stream).read_line(&mut line);
-                let reply = MountDaemonResponse::Shutdown {
-                    version: MOUNT_PROTOCOL_V2,
-                    ok: true,
-                };
-                let _ = serde_json::to_writer(&mut stream, &reply);
-                let _ = stream.write_all(b"\n");
-                // Leave `child` alive on purpose.
-            }
-        });
-
-        let endpoint = v2_tcp("127.0.0.1", port, pid);
-        let error = retire_live_tcp_predecessor(&endpoint)
-            .expect_err("a still-alive v2 daemon must block respawn");
+        assert!(pid_alive(pid), "stand-in pid must be live");
+        let error = refuse_live_legacy_tcp_endpoint(&v2_tcp("127.0.0.1", 9, pid))
+            .expect_err("live v2 must fail closed");
+        let message = error.to_string();
         assert!(
-            error
-                .to_string()
-                .contains("refusing to spawn a second daemon"),
+            message.contains("refusing to spawn a replacement"),
             "got {error}"
         );
+        assert!(
+            message.contains("Stop or upgrade the leftover process"),
+            "got {error}"
+        );
+        assert!(message.contains(&format!("pid {pid}")), "got {error}");
+        assert!(message.contains("v2"), "got {error}");
         let _ = child.kill();
         let _ = child.wait();
-        let _ = server.join();
+    }
+
+    #[test]
+    fn dead_v2_tcp_is_not_a_live_predecessor() {
+        refuse_live_legacy_tcp_endpoint(&v2_tcp("127.0.0.1", 9, 0x7fff_fffe))
+            .expect("dead v2 must not block spawn");
+    }
+
+    #[test]
+    fn current_uds_is_not_a_legacy_tcp_endpoint() {
+        let endpoint = EndpointState {
+            version: MOUNT_PROTOCOL_VERSION,
+            host: "unix".to_string(),
+            port: 0,
+            pid: Some(1),
+            socket_path: Some("/tmp/heddled.sock".into()),
+        };
+        refuse_live_legacy_tcp_endpoint(&endpoint).expect("current UDS must be usable");
     }
 }

--- a/crates/repo/src/daemon/protocol.rs
+++ b/crates/repo/src/daemon/protocol.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! JSON-over-TCP framing for helper subprocess RPCs.
+//! JSON-over-TCP / JSON-over-UDS framing for helper subprocess RPCs.
 //!
 //! One line in, one line out. Each connection is dedicated to a
 //! single request/response pair — same shape the fsmonitor has
@@ -9,6 +9,7 @@
 use std::{
     io::{BufRead, BufReader, Write},
     net::{Shutdown, TcpStream},
+    path::Path,
     time::Duration,
 };
 
@@ -23,7 +24,7 @@ pub const HELPER_IDLE_TIMEOUT_SECS: u64 = 300;
 pub const HELPER_IDLE_POLL_MS: u64 = 5;
 
 /// Send a single JSON request to a helper and decode its single-line
-/// JSON reply. Used by both the fsmonitor and mount daemon clients.
+/// JSON reply. Used by the fsmonitor TCP helper.
 pub fn send_json_request<Req, Resp>(
     endpoint: &EndpointState,
     request: &Req,
@@ -41,13 +42,102 @@ where
     )?;
     stream.set_read_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
     stream.set_write_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
-    serde_json::to_writer(&mut stream, request)
-        .map_err(|error| HeddleError::Config(format!("encode helper request: {error}")))?;
-    stream.write_all(b"\n")?;
+    write_json_line(&mut stream, request)?;
     stream.shutdown(Shutdown::Write)?;
-    let mut reader = BufReader::new(stream);
+    read_json_line(stream)
+}
+
+/// Mount-daemon RPC. Refuses localhost TCP: only a same-uid UDS path
+/// is accepted (heddle#901).
+pub fn send_mount_daemon_request<Req, Resp>(
+    endpoint: &EndpointState,
+    request: &Req,
+) -> Result<Resp, HeddleError>
+where
+    Req: Serialize,
+    Resp: DeserializeOwned,
+{
+    let Some(socket_path) = endpoint.socket_path.as_ref() else {
+        return Err(HeddleError::Config(
+            "mount daemon endpoint has no authenticated socket; refusing localhost TCP".into(),
+        ));
+    };
+    send_json_request_unix(socket_path, request)
+}
+
+/// Send one JSON line over a Unix-domain socket and read the reply.
+pub fn send_json_request_unix<Req, Resp>(
+    socket_path: &Path,
+    request: &Req,
+) -> Result<Resp, HeddleError>
+where
+    Req: Serialize,
+    Resp: DeserializeOwned,
+{
+    #[cfg(unix)]
+    {
+        use std::os::unix::net::UnixStream;
+        let mut stream = UnixStream::connect(socket_path)?;
+        stream.set_read_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
+        stream.set_write_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
+        write_json_line(&mut stream, request)?;
+        stream.shutdown(std::net::Shutdown::Write)?;
+        read_json_line(stream)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (socket_path, request);
+        Err(HeddleError::Config(
+            "mount daemon unix socket is unsupported on this host".into(),
+        ))
+    }
+}
+
+fn write_json_line<W, Req>(writer: &mut W, request: &Req) -> Result<(), HeddleError>
+where
+    W: Write,
+    Req: Serialize,
+{
+    serde_json::to_writer(&mut *writer, request)
+        .map_err(|error| HeddleError::Config(format!("encode helper request: {error}")))?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn read_json_line<R, Resp>(reader: R) -> Result<Resp, HeddleError>
+where
+    R: std::io::Read,
+    Resp: DeserializeOwned,
+{
+    let mut reader = BufReader::new(reader);
     let mut line = String::new();
     reader.read_line(&mut line)?;
     serde_json::from_str(&line)
         .map_err(|error| HeddleError::Config(format!("decode helper response: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::send_mount_daemon_request;
+    use crate::daemon::{EndpointState, MountDaemonRequest};
+
+    #[test]
+    fn mount_client_refuses_tcp_endpoint_without_socket() {
+        let endpoint = EndpointState {
+            version: 3,
+            host: "127.0.0.1".to_string(),
+            port: 9,
+            pid: Some(1),
+            socket_path: None,
+        };
+        let error = send_mount_daemon_request::<_, serde_json::Value>(
+            &endpoint,
+            &MountDaemonRequest::Health {},
+        )
+        .expect_err("TCP-only endpoint must fail closed");
+        assert!(
+            error.to_string().contains("refusing localhost TCP"),
+            "got {error}"
+        );
+    }
 }

--- a/crates/repo/src/daemon/protocol.rs
+++ b/crates/repo/src/daemon/protocol.rs
@@ -12,11 +12,15 @@ use std::{
     path::Path,
     time::Duration,
 };
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 
 use objects::error::HeddleError;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::endpoint::EndpointState;
+#[cfg(unix)]
+use super::peer::check_peer_uid_matches_self;
 
 pub const HELPER_HOST: &str = "127.0.0.1";
 pub const HELPER_CONNECT_TIMEOUT_MS: u64 = 1000;
@@ -76,13 +80,7 @@ where
 {
     #[cfg(unix)]
     {
-        use std::os::unix::net::UnixStream;
-        let mut stream = UnixStream::connect(socket_path)?;
-        stream.set_read_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
-        stream.set_write_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
-        write_json_line(&mut stream, request)?;
-        stream.shutdown(std::net::Shutdown::Write)?;
-        read_json_line(stream)
+        send_json_request_unix_with(socket_path, request, check_peer_uid_matches_self)
     }
     #[cfg(not(unix))]
     {
@@ -91,6 +89,25 @@ where
             "mount daemon unix socket is unsupported on this host".into(),
         ))
     }
+}
+
+#[cfg(unix)]
+fn send_json_request_unix_with<Req, Resp>(
+    socket_path: &Path,
+    request: &Req,
+    authorize: impl FnOnce(&UnixStream) -> Result<(), HeddleError>,
+) -> Result<Resp, HeddleError>
+where
+    Req: Serialize,
+    Resp: DeserializeOwned,
+{
+    let mut stream = UnixStream::connect(socket_path)?;
+    authorize(&stream)?;
+    stream.set_read_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
+    stream.set_write_timeout(Some(Duration::from_millis(HELPER_CONNECT_TIMEOUT_MS)))?;
+    write_json_line(&mut stream, request)?;
+    stream.shutdown(std::net::Shutdown::Write)?;
+    read_json_line(stream)
 }
 
 fn write_json_line<W, Req>(writer: &mut W, request: &Req) -> Result<(), HeddleError>
@@ -121,6 +138,14 @@ mod tests {
     use super::send_mount_daemon_request;
     use crate::daemon::{EndpointState, MountDaemonRequest};
 
+    #[cfg(unix)]
+    use super::{send_json_request_unix, send_json_request_unix_with};
+    #[cfg(unix)]
+    use crate::daemon::{
+        MOUNT_PROTOCOL_VERSION, MountDaemonResponse, MountStatus,
+        peer::{check_peer_uid, current_euid},
+    };
+
     #[test]
     fn mount_client_refuses_tcp_endpoint_without_socket() {
         let endpoint = EndpointState {
@@ -139,5 +164,64 @@ mod tests {
             error.to_string().contains("refusing localhost TCP"),
             "got {error}"
         );
+    }
+
+    /// A replacement socket that answers with a forged successful
+    /// Mount must not be trusted when SO_PEERCRED disagrees. The
+    /// same listener's reply is readable after a same-uid check, so
+    /// the mismatch path is what rejects it — not a missing reply.
+    #[cfg(unix)]
+    #[test]
+    fn peer_uid_mismatch_is_rejected_before_mount_reply_is_trusted() {
+        use std::{io::Write, os::unix::net::UnixListener, path::PathBuf, thread};
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("heddled.sock");
+        let listener = UnixListener::bind(&path).expect("bind stand-in daemon");
+        let server = thread::spawn(move || {
+            for _ in 0..2 {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let reply = MountDaemonResponse::Mount {
+                        version: MOUNT_PROTOCOL_VERSION,
+                        ok: true,
+                        mount_path: PathBuf::from("/forged"),
+                        status: MountStatus::Created,
+                    };
+                    let _ = serde_json::to_writer(&mut stream, &reply);
+                    let _ = stream.write_all(b"\n");
+                }
+            }
+        });
+
+        let request = MountDaemonRequest::Mount {
+            thread_id: "agent-1".into(),
+            mount_path: PathBuf::from("/workspace"),
+            repo_root: PathBuf::from("/repo"),
+        };
+        let trusted: MountDaemonResponse =
+            send_json_request_unix(&path, &request).expect("same-uid reply is readable");
+        assert!(
+            matches!(
+                trusted,
+                MountDaemonResponse::Mount {
+                    ok: true,
+                    ref mount_path,
+                    ..
+                } if mount_path == PathBuf::from("/forged").as_path()
+            ),
+            "control reply must be the forged Mount, got {trusted:?}"
+        );
+
+        let other_uid = current_euid().wrapping_add(1);
+        let error =
+            send_json_request_unix_with::<_, MountDaemonResponse>(&path, &request, |stream| {
+                check_peer_uid(stream, other_uid)
+            })
+            .expect_err("peer-uid mismatch must not trust a Mount reply");
+        assert!(
+            error.to_string().contains("does not match daemon uid"),
+            "got {error}"
+        );
+        let _ = server.join();
     }
 }

--- a/crates/repo/src/daemon/server.rs
+++ b/crates/repo/src/daemon/server.rs
@@ -114,9 +114,35 @@ pub fn mount_idle_policy(
     default_idle_policy(idle_for)
 }
 
+/// Read a newline-terminated JSON request from `reader`, hand it to
+/// `respond`, and write the JSON response to `writer`.
+pub fn handle_json_rw<R, W, Req, Resp, Respond>(
+    reader: R,
+    writer: &mut W,
+    respond: Respond,
+) -> Result<(), HeddleError>
+where
+    R: std::io::Read,
+    W: Write,
+    Req: serde::de::DeserializeOwned,
+    Resp: serde::Serialize,
+    Respond: FnOnce(Req) -> Resp,
+{
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let request: Req = serde_json::from_str(&line)
+        .map_err(|error| HeddleError::Config(format!("decode helper request: {error}")))?;
+    let response = respond(request);
+    serde_json::to_writer(&mut *writer, &response)
+        .map_err(|error| HeddleError::Config(format!("encode helper response: {error}")))?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
 /// Read a newline-terminated JSON request from `stream`, hand it to
-/// `respond`, and write the JSON response back. Used by both the
-/// fsmonitor and mount handler dispatchers.
+/// `respond`, and write the JSON response back. Used by the
+/// fsmonitor TCP helper.
 pub fn handle_json_connection<Req, Resp, Respond>(
     mut stream: TcpStream,
     respond: Respond,
@@ -126,16 +152,8 @@ where
     Resp: serde::Serialize,
     Respond: FnOnce(Req) -> Resp,
 {
-    let mut reader = BufReader::new(stream.try_clone()?);
-    let mut line = String::new();
-    reader.read_line(&mut line)?;
-    let request: Req = serde_json::from_str(&line)
-        .map_err(|error| HeddleError::Config(format!("decode helper request: {error}")))?;
-    let response = respond(request);
-    serde_json::to_writer(&mut stream, &response)
-        .map_err(|error| HeddleError::Config(format!("encode helper response: {error}")))?;
-    stream.write_all(b"\n")?;
-    Ok(())
+    let reader = stream.try_clone()?;
+    handle_json_rw(reader, &mut stream, respond)
 }
 
 #[cfg(test)]

--- a/crates/repo/src/daemon/unix_probe.rs
+++ b/crates/repo/src/daemon/unix_probe.rs
@@ -14,10 +14,6 @@ pub(crate) enum UnixSocketProbe {
     Inaccessible,
 }
 
-pub(crate) fn unix_socket_is_live(path: &Path) -> bool {
-    matches!(probe_unix_socket(path), UnixSocketProbe::Live)
-}
-
 pub(crate) fn probe_unix_socket(path: &Path) -> UnixSocketProbe {
     match UnixStream::connect(path) {
         Ok(_) => UnixSocketProbe::Live,
@@ -45,7 +41,7 @@ pub(crate) fn classify_unix_socket_connect(path: &Path, error: &std::io::Error) 
 mod tests {
     use std::{io::ErrorKind, path::Path};
 
-    use super::{classify_unix_socket_connect, UnixSocketProbe};
+    use super::{UnixSocketProbe, classify_unix_socket_connect};
 
     #[test]
     fn permission_denied_probe_is_not_dead() {

--- a/crates/repo/src/daemon/unix_probe.rs
+++ b/crates/repo/src/daemon/unix_probe.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Liveness probe for the mount-daemon Unix socket.
+//!
+//! Mode-0600 makes `connect` return `PermissionDenied` to every
+//! non-owner. That is not proof the daemon is dead — the parent
+//! dir may still allow unlink.
+
+use std::{io::ErrorKind, os::unix::net::UnixStream, path::Path};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnixSocketProbe {
+    Live,
+    Dead,
+    Inaccessible,
+}
+
+pub(crate) fn unix_socket_is_live(path: &Path) -> bool {
+    matches!(probe_unix_socket(path), UnixSocketProbe::Live)
+}
+
+pub(crate) fn probe_unix_socket(path: &Path) -> UnixSocketProbe {
+    match UnixStream::connect(path) {
+        Ok(_) => UnixSocketProbe::Live,
+        Err(error) => classify_unix_socket_connect(path, &error),
+    }
+}
+
+/// Unlink only when the probe proves the path is dead.
+pub(crate) fn classify_unix_socket_connect(path: &Path, error: &std::io::Error) -> UnixSocketProbe {
+    use std::os::unix::fs::FileTypeExt;
+
+    match error.kind() {
+        ErrorKind::PermissionDenied => UnixSocketProbe::Inaccessible,
+        ErrorKind::ConnectionRefused | ErrorKind::NotFound => UnixSocketProbe::Dead,
+        _ => match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.file_type().is_socket() => UnixSocketProbe::Inaccessible,
+            Ok(_) => UnixSocketProbe::Dead,
+            Err(meta_error) if meta_error.kind() == ErrorKind::NotFound => UnixSocketProbe::Dead,
+            Err(_) => UnixSocketProbe::Inaccessible,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::ErrorKind, path::Path};
+
+    use super::{classify_unix_socket_connect, UnixSocketProbe};
+
+    #[test]
+    fn permission_denied_probe_is_not_dead() {
+        assert_eq!(
+            classify_unix_socket_connect(
+                Path::new("/unused"),
+                &std::io::Error::from(ErrorKind::PermissionDenied),
+            ),
+            UnixSocketProbe::Inaccessible
+        );
+        assert_eq!(
+            classify_unix_socket_connect(
+                Path::new("/unused"),
+                &std::io::Error::from(ErrorKind::ConnectionRefused),
+            ),
+            UnixSocketProbe::Dead
+        );
+    }
+}

--- a/crates/repo/src/daemon/unix_server.rs
+++ b/crates/repo/src/daemon/unix_server.rs
@@ -17,11 +17,11 @@ use std::{
 use objects::error::HeddleError;
 
 use super::{
-    mount_proto::{MountDaemonResponse, ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION},
+    mount_proto::{ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonResponse},
     peer::check_peer_uid_matches_self,
     protocol::HELPER_IDLE_POLL_MS,
-    server::{handle_json_rw, IdleDecision},
-    unix_probe::{probe_unix_socket, UnixSocketProbe},
+    server::{IdleDecision, handle_json_rw},
+    unix_probe::{UnixSocketProbe, probe_unix_socket},
 };
 
 /// Per-connection hook for a Unix-domain helper daemon.
@@ -165,9 +165,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{bind_unix_socket, handle_authenticated_unix_connection};
-    use crate::daemon::unix_probe::unix_socket_is_live;
+    use crate::daemon::unix_probe::{UnixSocketProbe, probe_unix_socket};
     use crate::daemon::{
-        MountDaemonRequest, MountDaemonResponse, ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION,
+        ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
     };
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
             "got {error}"
         );
         assert!(
-            unix_socket_is_live(&path),
+            matches!(probe_unix_socket(&path), UnixSocketProbe::Live),
             "original listener must still own the socket name"
         );
         drop(first);
@@ -214,7 +214,7 @@ mod tests {
         restore.set_mode(0o600);
         std::fs::set_permissions(&path, restore).unwrap();
         assert!(
-            unix_socket_is_live(&path),
+            matches!(probe_unix_socket(&path), UnixSocketProbe::Live),
             "original listener must still own the socket name"
         );
         drop(first);
@@ -228,7 +228,7 @@ mod tests {
         drop(first);
         let replacement = bind_unix_socket(&path).expect("stale leftover socket may be replaced");
         assert!(
-            unix_socket_is_live(&path),
+            matches!(probe_unix_socket(&path), UnixSocketProbe::Live),
             "replacement listener must be reachable"
         );
         drop(replacement);

--- a/crates/repo/src/daemon/unix_server.rs
+++ b/crates/repo/src/daemon/unix_server.rs
@@ -17,10 +17,11 @@ use std::{
 use objects::error::HeddleError;
 
 use super::{
-    mount_proto::{ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonResponse},
+    mount_proto::{MountDaemonResponse, ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION},
     peer::check_peer_uid_matches_self,
     protocol::HELPER_IDLE_POLL_MS,
-    server::{IdleDecision, handle_json_rw},
+    server::{handle_json_rw, IdleDecision},
+    unix_probe::{probe_unix_socket, UnixSocketProbe},
 };
 
 /// Per-connection hook for a Unix-domain helper daemon.
@@ -30,25 +31,30 @@ pub trait UnixDaemonHandler {
 }
 
 /// Bind `path` as a mode-0600 Unix socket. A leftover socket from a
-/// crashed daemon may be replaced. A live, connectable socket is
-/// left intact — fail closed so a second `daemon serve` cannot steal
-/// the endpoint from a running daemon.
+/// crashed daemon may be replaced. A live or permission-denied
+/// socket is left intact — fail closed so a second `daemon serve`
+/// cannot steal the endpoint (unlink is authorized by the parent
+/// dir, which may be shared across OS users).
 pub fn bind_unix_socket(path: &Path) -> Result<UnixListener, HeddleError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     match bind_mode_0600(path) {
         Ok(listener) => Ok(listener),
-        Err(error) if is_addr_in_use(&error) => {
-            if unix_socket_is_live(path) {
-                return Err(HeddleError::Config(format!(
-                    "refusing to replace live mount daemon socket {}",
-                    path.display()
-                )));
+        Err(error) if is_addr_in_use(&error) => match probe_unix_socket(path) {
+            UnixSocketProbe::Live => Err(HeddleError::Config(format!(
+                "refusing to replace live mount daemon socket {}",
+                path.display()
+            ))),
+            UnixSocketProbe::Inaccessible => Err(HeddleError::Config(format!(
+                "refusing to replace mount daemon socket {}: connect permission denied",
+                path.display()
+            ))),
+            UnixSocketProbe::Dead => {
+                remove_stale_unix_socket(path)?;
+                bind_mode_0600(path).map_err(Into::into)
             }
-            remove_stale_unix_socket(path)?;
-            bind_mode_0600(path).map_err(Into::into)
-        }
+        },
         Err(error) => Err(error.into()),
     }
 }
@@ -67,12 +73,6 @@ fn is_addr_in_use(error: &std::io::Error) -> bool {
         error.kind(),
         ErrorKind::AddrInUse | ErrorKind::AlreadyExists
     )
-}
-
-/// True when something is accepting on `path`. Used to distinguish a
-/// crashed leftover from a live daemon before unlinking.
-pub fn unix_socket_is_live(path: &Path) -> bool {
-    UnixStream::connect(path).is_ok()
 }
 
 fn remove_stale_unix_socket(path: &Path) -> Result<(), HeddleError> {
@@ -158,15 +158,16 @@ fn write_unauthorized(stream: &mut UnixStream, message: &str) {
 #[cfg(test)]
 mod tests {
     use std::{
-        io::{BufRead, BufReader, Write},
-        os::unix::net::UnixStream,
+        io::{BufRead, BufReader, ErrorKind, Write},
+        os::unix::{fs::PermissionsExt, net::UnixStream},
     };
 
     use tempfile::TempDir;
 
-    use super::{bind_unix_socket, handle_authenticated_unix_connection, unix_socket_is_live};
+    use super::{bind_unix_socket, handle_authenticated_unix_connection};
+    use crate::daemon::unix_probe::unix_socket_is_live;
     use crate::daemon::{
-        ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
+        MountDaemonRequest, MountDaemonResponse, ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION,
     };
 
     #[test]
@@ -179,6 +180,39 @@ mod tests {
             error.to_string().contains("live mount daemon socket"),
             "got {error}"
         );
+        assert!(
+            unix_socket_is_live(&path),
+            "original listener must still own the socket name"
+        );
+        drop(first);
+    }
+
+    #[test]
+    fn bind_unix_socket_does_not_unlink_on_permission_denied() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("heddled.sock");
+        let first = bind_unix_socket(&path).expect("first bind");
+
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o000);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        assert_eq!(
+            UnixStream::connect(&path)
+                .expect_err("mode 000 must deny connect")
+                .kind(),
+            ErrorKind::PermissionDenied
+        );
+
+        let error = bind_unix_socket(&path).expect_err("must not steal a permission-denied socket");
+        assert!(
+            error.to_string().contains("permission denied"),
+            "got {error}"
+        );
+        assert!(path.exists(), "permission-denied live socket must stay");
+
+        let mut restore = std::fs::metadata(&path).unwrap().permissions();
+        restore.set_mode(0o600);
+        std::fs::set_permissions(&path, restore).unwrap();
         assert!(
             unix_socket_is_live(&path),
             "original listener must still own the socket name"

--- a/crates/repo/src/daemon/unix_server.rs
+++ b/crates/repo/src/daemon/unix_server.rs
@@ -29,19 +29,50 @@ pub trait UnixDaemonHandler {
     fn on_tick(&mut self, idle_for: Duration) -> IdleDecision;
 }
 
-/// Bind `path` as a mode-0600 Unix socket, replacing a leftover socket
-/// from a crashed daemon. Regular files at that path fail closed.
+/// Bind `path` as a mode-0600 Unix socket. A leftover socket from a
+/// crashed daemon may be replaced. A live, connectable socket is
+/// left intact — fail closed so a second `daemon serve` cannot steal
+/// the endpoint from a running daemon.
 pub fn bind_unix_socket(path: &Path) -> Result<UnixListener, HeddleError> {
-    remove_stale_unix_socket(path)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    match bind_mode_0600(path) {
+        Ok(listener) => Ok(listener),
+        Err(error) if is_addr_in_use(&error) => {
+            if unix_socket_is_live(path) {
+                return Err(HeddleError::Config(format!(
+                    "refusing to replace live mount daemon socket {}",
+                    path.display()
+                )));
+            }
+            remove_stale_unix_socket(path)?;
+            bind_mode_0600(path).map_err(Into::into)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn bind_mode_0600(path: &Path) -> std::io::Result<UnixListener> {
     let listener = UnixListener::bind(path)?;
     let mut permissions = std::fs::metadata(path)?.permissions();
     permissions.set_mode(0o600);
     std::fs::set_permissions(path, permissions)?;
     listener.set_nonblocking(true)?;
     Ok(listener)
+}
+
+fn is_addr_in_use(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        ErrorKind::AddrInUse | ErrorKind::AlreadyExists
+    )
+}
+
+/// True when something is accepting on `path`. Used to distinguish a
+/// crashed leftover from a live daemon before unlinking.
+pub fn unix_socket_is_live(path: &Path) -> bool {
+    UnixStream::connect(path).is_ok()
 }
 
 fn remove_stale_unix_socket(path: &Path) -> Result<(), HeddleError> {
@@ -71,7 +102,12 @@ pub fn run_unix_server_loop<H: UnixDaemonHandler>(
         match listener.accept() {
             Ok((stream, _)) => {
                 last_activity = Instant::now();
-                handler.handle(stream)?;
+                // A dropped connect (liveness probe) or a bad request
+                // must not take the daemon down. Fail that connection
+                // only.
+                if let Err(error) = handler.handle(stream) {
+                    tracing::debug!(%error, "mount daemon dropped a connection");
+                }
             }
             Err(error) if error.kind() == ErrorKind::WouldBlock => {
                 match handler.on_tick(last_activity.elapsed()) {
@@ -128,10 +164,41 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{bind_unix_socket, handle_authenticated_unix_connection};
+    use super::{bind_unix_socket, handle_authenticated_unix_connection, unix_socket_is_live};
     use crate::daemon::{
         ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
     };
+
+    #[test]
+    fn bind_unix_socket_refuses_to_unlink_a_live_socket() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("heddled.sock");
+        let first = bind_unix_socket(&path).expect("first bind");
+        let error = bind_unix_socket(&path).expect_err("live socket must not be stolen");
+        assert!(
+            error.to_string().contains("live mount daemon socket"),
+            "got {error}"
+        );
+        assert!(
+            unix_socket_is_live(&path),
+            "original listener must still own the socket name"
+        );
+        drop(first);
+    }
+
+    #[test]
+    fn bind_unix_socket_replaces_a_dead_leftover_socket() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("heddled.sock");
+        let first = bind_unix_socket(&path).expect("first bind");
+        drop(first);
+        let replacement = bind_unix_socket(&path).expect("stale leftover socket may be replaced");
+        assert!(
+            unix_socket_is_live(&path),
+            "replacement listener must be reachable"
+        );
+        drop(replacement);
+    }
 
     #[test]
     fn bind_unix_socket_rejects_a_regular_file() {

--- a/crates/repo/src/daemon/unix_server.rs
+++ b/crates/repo/src/daemon/unix_server.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Unix-domain listener loop for the mount daemon.
+//!
+//! Parallel to the TCP helper loop, plus a same-uid peer check on
+//! every accept. The mount daemon binds only this path.
+
+use std::{
+    io::{ErrorKind, Write},
+    os::unix::{
+        fs::PermissionsExt,
+        net::{UnixListener, UnixStream},
+    },
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use objects::error::HeddleError;
+
+use super::{
+    mount_proto::{ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonResponse},
+    peer::check_peer_uid_matches_self,
+    protocol::HELPER_IDLE_POLL_MS,
+    server::{IdleDecision, handle_json_rw},
+};
+
+/// Per-connection hook for a Unix-domain helper daemon.
+pub trait UnixDaemonHandler {
+    fn handle(&mut self, stream: UnixStream) -> Result<(), HeddleError>;
+    fn on_tick(&mut self, idle_for: Duration) -> IdleDecision;
+}
+
+/// Bind `path` as a mode-0600 Unix socket, replacing a leftover socket
+/// from a crashed daemon. Regular files at that path fail closed.
+pub fn bind_unix_socket(path: &Path) -> Result<UnixListener, HeddleError> {
+    remove_stale_unix_socket(path)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let listener = UnixListener::bind(path)?;
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(0o600);
+    std::fs::set_permissions(path, permissions)?;
+    listener.set_nonblocking(true)?;
+    Ok(listener)
+}
+
+fn remove_stale_unix_socket(path: &Path) -> Result<(), HeddleError> {
+    use std::os::unix::fs::FileTypeExt;
+
+    match std::fs::symlink_metadata(path) {
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+        Ok(meta) if meta.file_type().is_socket() => {
+            std::fs::remove_file(path)?;
+            Ok(())
+        }
+        Ok(_) => Err(HeddleError::Config(format!(
+            "refusing to reuse {}: not a unix socket",
+            path.display()
+        ))),
+    }
+}
+
+/// Drive `listener` until the handler returns [`IdleDecision::Exit`].
+pub fn run_unix_server_loop<H: UnixDaemonHandler>(
+    listener: &UnixListener,
+    handler: &mut H,
+) -> Result<(), HeddleError> {
+    let mut last_activity = Instant::now();
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                last_activity = Instant::now();
+                handler.handle(stream)?;
+            }
+            Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                match handler.on_tick(last_activity.elapsed()) {
+                    IdleDecision::Continue => {
+                        std::thread::sleep(Duration::from_millis(HELPER_IDLE_POLL_MS));
+                    }
+                    IdleDecision::Exit => return Ok(()),
+                }
+            }
+            Err(error) => return Err(HeddleError::Io(error)),
+        }
+    }
+}
+
+/// Same-uid gate, then one JSON request/response. Fail closed before
+/// reading a client-supplied `mount_path` when peer identity is missing.
+pub fn handle_authenticated_unix_connection<Req, Resp, Respond>(
+    mut stream: UnixStream,
+    respond: Respond,
+) -> Result<(), HeddleError>
+where
+    Req: serde::de::DeserializeOwned,
+    Resp: serde::Serialize,
+    Respond: FnOnce(Req) -> Resp,
+{
+    if let Err(error) = stream.set_nonblocking(false) {
+        return Err(HeddleError::Io(error));
+    }
+    if let Err(error) = check_peer_uid_matches_self(&stream) {
+        write_unauthorized(&mut stream, &error.to_string());
+        return Ok(());
+    }
+    let reader = stream.try_clone()?;
+    handle_json_rw(reader, &mut stream, respond)
+}
+
+fn write_unauthorized(stream: &mut UnixStream, message: &str) {
+    let response = MountDaemonResponse::Error {
+        version: MOUNT_PROTOCOL_VERSION,
+        code: ERR_UNAUTHORIZED.to_string(),
+        message: message.to_string(),
+    };
+    if serde_json::to_writer(&mut *stream, &response).is_ok() {
+        let _ = stream.write_all(b"\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{BufRead, BufReader, Write},
+        os::unix::net::UnixStream,
+    };
+
+    use tempfile::TempDir;
+
+    use super::{bind_unix_socket, handle_authenticated_unix_connection};
+    use crate::daemon::{
+        ERR_UNAUTHORIZED, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
+    };
+
+    #[test]
+    fn bind_unix_socket_rejects_a_regular_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("not-a-socket");
+        std::fs::write(&path, b"nope").unwrap();
+        let error = bind_unix_socket(&path).expect_err("regular file must fail closed");
+        assert!(
+            error.to_string().contains("not a unix socket"),
+            "got {error}"
+        );
+    }
+
+    #[test]
+    fn authenticated_pair_serves_health() {
+        let (server, mut client) = UnixStream::pair().unwrap();
+        let worker = std::thread::spawn(move || {
+            handle_authenticated_unix_connection(server, |request: MountDaemonRequest| {
+                assert!(matches!(request, MountDaemonRequest::Health {}));
+                MountDaemonResponse::Health {
+                    version: MOUNT_PROTOCOL_VERSION,
+                    ok: true,
+                    uptime_s: 1,
+                    mount_count: 0,
+                }
+            })
+        });
+        serde_json::to_writer(&mut client, &MountDaemonRequest::Health {}).unwrap();
+        client.write_all(b"\n").unwrap();
+        let mut line = String::new();
+        BufReader::new(&client).read_line(&mut line).unwrap();
+        let decoded: MountDaemonResponse = serde_json::from_str(&line).unwrap();
+        assert!(matches!(
+            decoded,
+            MountDaemonResponse::Health { ok: true, .. }
+        ));
+        worker.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn unauthorized_error_uses_stable_code() {
+        let response = MountDaemonResponse::Error {
+            version: MOUNT_PROTOCOL_VERSION,
+            code: ERR_UNAUTHORIZED.to_string(),
+            message: "peer uid mismatch".to_string(),
+        };
+        let raw = serde_json::to_string(&response).unwrap();
+        assert!(raw.contains(r#""code":"unauthorized""#));
+    }
+}

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -450,6 +450,7 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
         host: HELPER_HOST.to_string(),
         port,
         pid: Some(std::process::id()),
+        socket_path: None,
     };
     persist_endpoint(&endpoint_path, &endpoint)?;
     remove_starting_helper_if_owned(&state_path, std::process::id());
@@ -1594,6 +1595,7 @@ mod tests {
                             host: HELPER_HOST.to_string(),
                             port: 9911,
                             pid: Some(std::process::id()),
+                            socket_path: None,
                         },
                     )
                 })
@@ -1685,6 +1687,7 @@ mod tests {
                 // A stale endpoint can outlive its worker and its PID can be
                 // reused, so liveness alone cannot prove the socket is live.
                 pid: Some(std::process::id()),
+                socket_path: None,
             },
         )
         .unwrap();

--- a/docs/design/mount-daemon.md
+++ b/docs/design/mount-daemon.md
@@ -36,13 +36,15 @@ that the daemon process is gone and both `heddled.endpoint.json` and
 
 State lives under `.heddle/state/`:
 
-- `heddled.endpoint.json` — host, port, PID, protocol version.
+- `heddled.endpoint.json` — socket path, PID, protocol version.
 - `mounts.json` — atomic mirror of the live mount registry. Used by
   the stale-endpoint sweep in CLI clients to recover from a daemon
   crash.
 
-Threat model: localhost TCP, no auth — same posture as the existing
-fsmonitor helper. Single-user dev workstation.
+Threat model: Unix-domain socket at `.heddle/state/heddled.sock`,
+mode 0600, same-uid `SO_PEERCRED`. Localhost TCP is not an authz
+boundary; the daemon does not bind it and refuses a client-supplied
+`mount_path` without that uid proof (heddle#901).
 
 ## Problem
 
@@ -110,12 +112,13 @@ or returns the same "thread is set, mount is gone" message it returns today.
 We don't need a launchd/systemd unit for v1; we need a clean re-attach flow.
 
 **Discovery.** Endpoint file at `.heddle/state/heddled.endpoint.json`
-(host/port, plus a PID we can `kill -0` to detect crashed daemons). Same
-shape as `HelperEndpointState` today.
+(UDS path plus a PID we can `kill -0` to detect crashed daemons). Same
+shape as `HelperEndpointState` today, with `socket_path` required for
+the mount daemon.
 
 ## Protocol sketch
 
-JSON-over-TCP, line-delimited, identical framing to `MonitorHelperRequest`/
+JSON-over-UDS, line-delimited, identical framing to `MonitorHelperRequest`/
 `Response`. New commands, additive:
 
 ```text
@@ -129,10 +132,9 @@ health      {}                                      -> { ok, version, uptime_s, 
 `HELPER_PROTOCOL_VERSION` from 1 to 2 lets old CLIs fall back to spawning a
 new helper rather than mis-parsing.
 
-JSON over TCP is good enough. A Unix domain socket would be cleaner on
-posix and avoid persisting a dynamic port, but the existing helper has
-shipped on TCP; switching transport here adds platform branching for no
-measurable user benefit.
+JSON over a mode-0600 Unix socket with same-uid `SO_PEERCRED`. The
+historical localhost TCP listener is gone: any local user could read
+`endpoint.json` and drive mount/unmount (heddle#901).
 
 ## Failure modes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Close **heddle#901**: the mount daemon no longer binds unauthenticated localhost TCP. Any local user could read `heddled.endpoint.json` and drive mount/unmount at an arbitrary `mount_path`.
- `heddled` now listens on a mode-0600 Unix socket (`.heddle/state/heddled.sock`) and checks same-uid `SO_PEERCRED` before reading a request. Fail closed if peer credentials are missing or the uid differs.
- A client-supplied `mount_path` is honored only for `MountClientAuth::SameUid`. `send_mount_daemon_request` refuses a TCP-only endpoint. Protocol version is 3 so leftover TCP-only `endpoint.json` stays stale.
- Live daemon sockets are not unlinked. `PermissionDenied` on the connect probe is not treated as stale.
- Bounce-fix: the client runs `check_peer_uid_matches_self` after UDS connect and before send/recv, so a replacement socket that forges a successful `Mount` is not trusted when the server uid differs.
- Bounce-fix (this HEAD): a live leftover v2 TCP daemon fails closed. v3 does not speak the obsolete protocol (no Shutdown RPC, no PID polling). Recovery guidance tells the operator to stop or upgrade the leftover process. Dead v2 endpoints stay stale and can respawn.

## Closes

Closes HeddleCo/heddle#901

## Red commit
`78fed949`

## Test evidence

```
$ cargo test -p heddle-repo --lib daemon:: -- --test-threads=1
    Finished `test` profile [unoptimized + debuginfo] target(s) in 55.65s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 37 tests
test daemon::endpoint::tests::endpoint_path_uses_state_dir_convention ... ok
test daemon::endpoint::tests::endpoint_round_trips_through_disk ... ok
test daemon::endpoint::tests::owned_removal_preserves_a_replacement_endpoint ... ok
test daemon::endpoint::tests::pid_alive_recognises_init ... ok
test daemon::endpoint::tests::pid_alive_returns_false_for_dead_pid ... ok
test daemon::endpoint::tests::remove_endpoint_is_idempotent ... ok
test daemon::mount_auth::tests::same_uid_peer_is_authorized ... ok
test daemon::mount_auth::tests::same_uid_peer_may_supply_mount_path ... ok
test daemon::mount_auth::tests::unauthenticated_tcp_must_not_drive_mount_or_unmount ... ok
test daemon::mount_auth::tests::unauthenticated_tcp_must_not_honor_client_mount_path ... ok
test daemon::mount_proto::tests::endpoint_and_registry_paths_are_under_state_dir ... ok
test daemon::mount_proto::tests::error_response_round_trips_with_code ... ok
test daemon::mount_proto::tests::health_response_round_trips ... ok
test daemon::mount_proto::tests::list_mounts_request_has_no_payload ... ok
test daemon::mount_proto::tests::mount_registry_file_round_trips_through_disk ... ok
test daemon::mount_proto::tests::mount_request_serialises_with_command_tag ... ok
test daemon::mount_proto::tests::response_with_unknown_version_still_decodes ... ok
test daemon::mount_proto::tests::unmount_request_serialises ... ok
test daemon::peer::tests::connected_pair_has_matching_self_uid ... ok
test daemon::peer::tests::peer_uids_match_is_strict_equality ... ok
test daemon::predecessor::tests::current_uds_is_not_a_legacy_tcp_endpoint ... ok
test daemon::predecessor::tests::dead_v2_tcp_is_not_a_live_predecessor ... ok
test daemon::predecessor::tests::live_v2_tcp_fails_closed_with_recovery ... ok
test daemon::protocol::tests::mount_client_refuses_tcp_endpoint_without_socket ... ok
test daemon::protocol::tests::peer_uid_mismatch_is_rejected_before_mount_reply_is_trusted ... ok
test daemon::server::tests::fsmonitor_idle_policy_exits_at_timeout ... ok
test daemon::server::tests::mount_idle_policy_continues_when_registry_is_empty_below_timeout ... ok
test daemon::server::tests::mount_idle_policy_exits_on_explicit_shutdown_even_with_live_mounts ... ok
test daemon::server::tests::mount_idle_policy_exits_when_registry_is_empty_after_timeout ... ok
test daemon::server::tests::mount_idle_policy_keeps_alive_while_mount_is_live ... ok
test daemon::unix_probe::tests::permission_denied_probe_is_not_dead ... ok
test daemon::unix_server::tests::authenticated_pair_serves_health ... ok
test daemon::unix_server::tests::bind_unix_socket_does_not_unlink_on_permission_denied ... ok
test daemon::unix_server::tests::bind_unix_socket_refuses_to_unlink_a_live_socket ... ok
test daemon::unix_server::tests::bind_unix_socket_rejects_a_regular_file ... ok
test daemon::unix_server::tests::bind_unix_socket_replaces_a_dead_leftover_socket ... ok
test daemon::unix_server::tests::unauthorized_error_uses_stable_code ... ok

test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 660 filtered out; finished in 0.01s

$ cargo test -p heddle-cli --lib daemon::client -- --test-threads=1
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 39s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 9 tests
test cli::commands::daemon::client::tests::ensure_refuses_live_v2_without_spawn ... ok
test cli::commands::daemon::client::tests::read_live_endpoint_detects_dead_pid ... ok
test cli::commands::daemon::client::tests::read_live_endpoint_handles_missing_file ... ok
test cli::commands::daemon::client::tests::read_live_endpoint_returns_alive_endpoint ... ok
test cli::commands::daemon::client::tests::read_live_endpoint_treats_tcp_only_endpoint_as_stale ... ok
test cli::commands::daemon::client::tests::read_live_endpoint_treats_version_skew_as_stale ... ok
test cli::commands::daemon::client::tests::rpc_hints_at_stale_daemon_when_endpoint_version_is_older ... ok
test cli::commands::daemon::client::tests::sweep_stale_mounts_clears_registry_file ... ok
test cli::commands::daemon::client::tests::sweep_stale_mounts_is_noop_when_registry_absent ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 743 filtered out; finished in 0.02s

$ cargo clippy -p heddle-repo --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.21s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2743dc0-9293-494d-b955-5175c4057d57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2743dc0-9293-494d-b955-5175c4057d57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789831594&installation_model_id=21489&pr_number=1524&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1524&signature=682979996eb895e9aa131b712bf0ae2488974d3e5589ec02619c304e66c2b3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->