### PR TITLE
Reserve heddle/ refs and type advertised refs by RefKind

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1814,7 +1814,13 @@ async fn clone_network_connected(
         }
         persist_advertised_synthetic_refs(&local_repo, &remote_refs)?;
         client
-            .publish_clone_markers(&local_repo, repo_path, &result.checkpoint)
+            .publish_clone_markers(
+                &local_repo,
+                repo_path,
+                &result.checkpoint,
+                depth,
+                materialization,
+            )
             .await?;
         // Lazy clone: persist the hydrator metadata so future
         // `Repository::open` calls (in any process) can reconstruct
@@ -2033,7 +2039,13 @@ async fn recover_interrupted_clone_connected(
     }
     persist_advertised_synthetic_refs(&repo, &remote_refs)?;
     client
-        .publish_clone_markers(&repo, &intent.repository, &result.checkpoint)
+        .publish_clone_markers(
+            &repo,
+            &intent.repository,
+            &result.checkpoint,
+            intent.depth,
+            materialization,
+        )
         .await?;
     if intent.lazy {
         publish_attached_clone_thread(&repo, &track_name, &final_state)?;
@@ -2996,7 +3008,8 @@ mod tests {
                 None,
             ),
         ];
-        persist_advertised_synthetic_refs(&repo, &remote_refs).expect("persist after objects exist");
+        persist_advertised_synthetic_refs(&repo, &remote_refs)
+            .expect("persist after objects exist");
         assert!(
             repo.store()
                 .has_state(&snapshot.state_id)

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1728,6 +1728,15 @@ async fn clone_network_connected(
             verify_hosted_clone(&local_repo, final_state, depth, lazy)
                 .context("clone remained incomplete after targeted remote repair")?;
         }
+        client
+            .fetch_advertised_synthetic_frontier_objects(
+                &local_repo,
+                repo_path,
+                &remote_refs,
+                depth,
+                materialization,
+            )
+            .await?;
 
         let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
             .context("decode hosted clone bootstrap")?
@@ -1803,6 +1812,7 @@ async fn clone_network_connected(
             )
             .into());
         }
+        persist_advertised_synthetic_refs(&local_repo, &remote_refs)?;
         client
             .publish_clone_markers(&local_repo, repo_path, &result.checkpoint)
             .await?;
@@ -1959,6 +1969,15 @@ async fn recover_interrupted_clone_connected(
             .context("clone repair retry completed without a final state")?;
         verify_hosted_clone(&repo, final_state, intent.depth, intent.lazy)?;
     }
+    client
+        .fetch_advertised_synthetic_frontier_objects(
+            &repo,
+            &intent.repository,
+            &remote_refs,
+            intent.depth,
+            materialization,
+        )
+        .await?;
 
     if intent.lazy {
         use repo::lazy_hydrator::LazyHydratorConfig;
@@ -2012,6 +2031,7 @@ async fn recover_interrupted_clone_connected(
         )
         .into());
     }
+    persist_advertised_synthetic_refs(&repo, &remote_refs)?;
     client
         .publish_clone_markers(&repo, &intent.repository, &result.checkpoint)
         .await?;
@@ -2520,10 +2540,6 @@ fn initialize_hosted_clone_repository(
     Repository::init_clone(root, source_authority)
         .map(Repository::without_fsmonitor)
         .map_err(wire::ProtocolError::from)
-        .and_then(|repo| {
-            persist_advertised_synthetic_refs(&repo, remote_refs)?;
-            Ok(repo)
-        })
 }
 
 #[cfg(feature = "client")]
@@ -2534,6 +2550,13 @@ fn persist_advertised_synthetic_refs(
     for entry in remote_refs {
         match entry.to_wire_entry().advertised() {
             Ok(wire::AdvertisedRef::SyntheticFrontier(name)) => {
+                if !repo.store().has_state(&entry.state_id)? {
+                    return Err(wire::ProtocolError::InvalidState(format!(
+                        "synthetic frontier {} advertised {} but the target state is absent",
+                        name.as_name(),
+                        entry.state_id.to_string_full()
+                    )));
+                }
                 repo.refs()
                     .set_synthetic_frontier(&name, &entry.state_id)
                     .map_err(wire::ProtocolError::from)?;
@@ -2947,7 +2970,44 @@ mod tests {
             repo.refs()
                 .get_synthetic_frontier(&frontier)
                 .expect("read synthetic"),
-            Some(frontier_state)
+            None,
+            "initialize must not publish a synthetic ref before its objects exist"
+        );
+        persist_advertised_synthetic_refs(&repo, &remote_refs)
+            .expect_err("persist must fail closed when the advertised state is absent");
+
+        std::fs::write(root.join("README"), "frontier\n").expect("seed worktree");
+        let snapshot = repo
+            .snapshot(Some("frontier".to_string()), None)
+            .expect("seed state");
+        let remote_refs = vec![
+            HostedRefEntry::from_advertised(
+                "main".to_string(),
+                snapshot.state_id,
+                true,
+                "heddle:main".to_string(),
+                Some("thread-main".to_string()),
+            ),
+            HostedRefEntry::from_advertised(
+                frontier.as_name(),
+                snapshot.state_id,
+                true,
+                "heddle:frontier".to_string(),
+                None,
+            ),
+        ];
+        persist_advertised_synthetic_refs(&repo, &remote_refs).expect("persist after objects exist");
+        assert!(
+            repo.store()
+                .has_state(&snapshot.state_id)
+                .expect("has_state"),
+            "clone must store the synthetic target state, not only the ref"
+        );
+        assert_eq!(
+            repo.refs()
+                .get_synthetic_frontier(&frontier)
+                .expect("read synthetic"),
+            Some(snapshot.state_id)
         );
         assert!(
             repo.refs()

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1672,7 +1672,7 @@ async fn clone_network_connected(
                     intent,
                     refs.refs
                         .iter()
-                        .filter(|entry| entry.is_thread)
+                        .filter(|entry| entry.is_user_thread())
                         .map(|entry| entry.name.as_str()),
                 )
                 .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
@@ -1907,7 +1907,7 @@ async fn recover_interrupted_clone_connected(
         intent,
         remote_refs
             .iter()
-            .filter(|entry| entry.is_thread)
+            .filter(|entry| entry.is_user_thread())
             .map(|entry| entry.name.as_str()),
     )?;
     let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
@@ -2494,7 +2494,7 @@ fn hosted_clone_thread_revision_address<'a>(
 ) -> Option<&'a str> {
     remote_refs
         .iter()
-        .find(|entry| entry.name == thread && entry.is_thread)
+        .find(|entry| entry.name == thread && entry.is_user_thread())
         .map(|entry| entry.revision_address.as_str())
 }
 
@@ -2520,6 +2520,28 @@ fn initialize_hosted_clone_repository(
     Repository::init_clone(root, source_authority)
         .map(Repository::without_fsmonitor)
         .map_err(wire::ProtocolError::from)
+        .and_then(|repo| {
+            persist_advertised_synthetic_refs(&repo, remote_refs)?;
+            Ok(repo)
+        })
+}
+
+#[cfg(feature = "client")]
+fn persist_advertised_synthetic_refs(
+    repo: &Repository,
+    remote_refs: &[HostedRefEntry],
+) -> std::result::Result<(), wire::ProtocolError> {
+    for entry in remote_refs {
+        match entry.to_wire_entry().advertised() {
+            Ok(wire::AdvertisedRef::SyntheticFrontier(name)) => {
+                repo.refs()
+                    .set_synthetic_frontier(&name, &entry.state_id)
+                    .map_err(wire::ProtocolError::from)?;
+            }
+            Ok(wire::AdvertisedRef::Thread(_) | wire::AdvertisedRef::Marker(_)) | Err(_) => {}
+        }
+    }
+    Ok(())
 }
 
 #[cfg(feature = "client")]
@@ -2820,13 +2842,13 @@ mod tests {
         }
         .create(&root)
         .expect("create clone intent");
-        let remote_refs = vec![HostedRefEntry {
-            name: "main".to_string(),
-            state_id: objects::object::StateId::from_bytes([1; 32]),
-            is_thread: true,
-            revision_address: "git:5b2471720c93ee30e5764a19f3d3b3ae9ec9712a".to_string(),
-            thread_id: Some("thread-main".to_string()),
-        }];
+        let remote_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            objects::object::StateId::from_bytes([1; 32]),
+            true,
+            "git:5b2471720c93ee30e5764a19f3d3b3ae9ec9712a".to_string(),
+            Some("thread-main".to_string()),
+        )];
 
         let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
             .expect("initialize Git-lane clone");
@@ -2854,19 +2876,85 @@ mod tests {
         }
         .create(&root)
         .expect("create clone intent");
-        let remote_refs = vec![HostedRefEntry {
-            name: "main".to_string(),
-            state_id: objects::object::StateId::from_bytes([2; 32]),
-            is_thread: true,
-            revision_address: "heddle:0123456789abcdef".to_string(),
-            thread_id: Some("thread-main".to_string()),
-        }];
+        let remote_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            objects::object::StateId::from_bytes([2; 32]),
+            true,
+            "heddle:0123456789abcdef".to_string(),
+            Some("thread-main".to_string()),
+        )];
 
         let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
             .expect("initialize native clone");
 
         assert_eq!(repo.source_authority(), RepositorySourceAuthority::Native);
         assert!(!root.join(".git").exists());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_persists_synthetic_frontier_and_does_not_treat_it_as_a_thread() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("clone");
+        CloneIntent {
+            origin: "heddle://127.0.0.1:8421/owner/repo".to_string(),
+            endpoint: "127.0.0.1:8421".to_string(),
+            repository: "owner/repo".to_string(),
+            thread: Some("main".to_string()),
+            advertised_head: Some("main".to_string()),
+            depth: None,
+            lazy: false,
+        }
+        .create(&root)
+        .expect("create clone intent");
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let frontier = objects::object::SyntheticFrontierName::new("main", change).unwrap();
+        let frontier_state = objects::object::StateId::from_bytes([3; 32]);
+        let remote_refs = vec![
+            HostedRefEntry::from_advertised(
+                "main".to_string(),
+                objects::object::StateId::from_bytes([2; 32]),
+                true,
+                "heddle:main".to_string(),
+                Some("thread-main".to_string()),
+            ),
+            HostedRefEntry::from_advertised(
+                frontier.as_name(),
+                frontier_state,
+                true,
+                "heddle:frontier".to_string(),
+                None,
+            ),
+        ];
+
+        assert!(!remote_refs[1].is_user_thread());
+        assert!(!remote_refs[1].is_marker());
+        let selected = select_hosted_clone_thread(
+            None,
+            remote_refs
+                .iter()
+                .filter(|entry| entry.is_user_thread())
+                .map(|entry| entry.name.as_str()),
+            Some("main"),
+            "owner/repo",
+        )
+        .expect("thread selected");
+        assert_eq!(selected, "main");
+
+        let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
+            .expect("initialize clone with synthetic root");
+        assert_eq!(
+            repo.refs()
+                .get_synthetic_frontier(&frontier)
+                .expect("read synthetic"),
+            Some(frontier_state)
+        );
+        assert!(
+            repo.refs()
+                .get_thread(&objects::object::ThreadName::new(frontier.as_name()))
+                .is_err(),
+            "a synthetic root must not be readable as a ThreadName"
+        );
     }
 
     // weft#633: the hosted ListRefs response for a git-overlay repo carries

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -1605,13 +1605,8 @@ impl HostedClient {
             .await
             .map(|exchange| exchange.result)?;
         if options.publish_refs {
-            self.sync_synthetic_frontiers(
-                repo,
-                repo_path,
-                options.depth,
-                options.materialization,
-            )
-            .await?;
+            self.sync_synthetic_frontiers(repo, repo_path, options.depth, options.materialization)
+                .await?;
         }
         Ok(result)
     }
@@ -2375,7 +2370,7 @@ impl HostedClient {
                     self.fetch_synthetic_frontier_root(
                         repo,
                         repo_path,
-                        &entry.name,
+                        &name,
                         entry.state_id,
                         depth,
                         materialization,
@@ -2398,16 +2393,14 @@ impl HostedClient {
         materialization: PullMaterialization,
     ) -> Result<(), ProtocolError> {
         for entry in advertised {
-            if !matches!(
-                entry.to_wire_entry().advertised(),
-                Ok(AdvertisedRef::SyntheticFrontier(_))
-            ) {
+            let Ok(AdvertisedRef::SyntheticFrontier(name)) = entry.to_wire_entry().advertised()
+            else {
                 continue;
-            }
+            };
             self.fetch_synthetic_frontier_root(
                 repo,
                 repo_path,
-                &entry.name,
+                &name,
                 entry.state_id,
                 depth,
                 materialization,
@@ -2421,7 +2414,7 @@ impl HostedClient {
         &mut self,
         repo: &Repository,
         repo_path: &str,
-        remote_thread: &str,
+        name: &objects::object::SyntheticFrontierName,
         state_id: StateId,
         depth: Option<u32>,
         materialization: PullMaterialization,
@@ -2429,14 +2422,15 @@ impl HostedClient {
         if repo.store().has_state(&state_id)? {
             return Ok(());
         }
+        let address = synthetic_frontier_pull_address(name, state_id);
         self.pull_exchange(
             repo,
             repo_path,
-            remote_thread,
+            address.remote_thread.as_str(),
             PullOptions {
                 local_thread: None,
                 depth,
-                target_state: Some(state_id),
+                target_state: Some(address.target_state),
                 materialization,
                 publish_refs: false,
                 wanted_hashes: None,
@@ -2445,7 +2439,8 @@ impl HostedClient {
         .await?;
         if !repo.store().has_state(&state_id)? {
             return Err(ProtocolError::InvalidState(format!(
-                "synthetic frontier {remote_thread} advertised {} but the target state is still absent after pull",
+                "synthetic frontier {} advertised {} but the target state is still absent after pull",
+                name.as_name(),
                 state_id.to_string_full()
             )));
         }
@@ -2457,13 +2452,35 @@ impl HostedClient {
         repo: &Repository,
         repo_path: &str,
         checkpoint: &[u8],
+        depth: Option<u32>,
+        materialization: PullMaterialization,
     ) -> Result<(), ProtocolError> {
         if !apply_marker_snapshot(repo, checkpoint)? {
             self.sync_local_markers(repo, repo_path).await?;
         }
-        self.sync_synthetic_frontiers(repo, repo_path, None, PullMaterialization::Full)
+        self.sync_synthetic_frontiers(repo, repo_path, depth, materialization)
             .await?;
         Ok(())
+    }
+}
+
+struct SyntheticFrontierPullAddress {
+    remote_thread: ThreadName,
+    target_state: StateId,
+}
+
+/// Address a synthetic-root pull through the owning user thread.
+///
+/// Synthetic names are absent from ListThreads and have no thread identity.
+/// The exchange must use [`SyntheticFrontierName::owning_thread`]; the
+/// synthetic state stays the pull `target_state`.
+fn synthetic_frontier_pull_address(
+    name: &objects::object::SyntheticFrontierName,
+    target_state: StateId,
+) -> SyntheticFrontierPullAddress {
+    SyntheticFrontierPullAddress {
+        remote_thread: name.owning_thread(),
+        target_state,
     }
 }
 
@@ -3242,6 +3259,22 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert_eq!(decoded.refs[1].kind, RefKind::Marker);
+    }
+
+    #[test]
+    fn synthetic_frontier_pull_uses_owning_thread_and_keeps_synthetic_target() {
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let name = objects::object::SyntheticFrontierName::new("feature/auth", change)
+            .expect("fixture synthetic name");
+        let state = StateId::from_bytes([7; 32]);
+        let address = synthetic_frontier_pull_address(&name, state);
+        assert_eq!(address.remote_thread.as_str(), "feature/auth");
+        assert_eq!(
+            address.remote_thread.as_str(),
+            name.owning_thread().as_str()
+        );
+        assert_ne!(address.remote_thread.as_str(), name.as_name());
+        assert_eq!(address.target_state, state);
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -3355,14 +3355,11 @@ mod pull_bootstrap_tests {
     }
 
     #[test]
-    #[test]
     fn synthetic_frontier_root_skips_only_when_requested_closure_is_complete() {
         let temp = TempDir::new().expect("temp repo");
         let repo = Repository::init_default(temp.path()).expect("init repo");
         let blob = Blob::from("frontier blob\n");
-        let tree = Tree::from_entries(vec![
-            TreeEntry::file("README", blob.hash(), false).unwrap(),
-        ]);
+        let tree = Tree::from_entries(vec![TreeEntry::file("README", blob.hash(), false).unwrap()]);
         let tree_hash = repo.store().put_tree(&tree).unwrap();
         let state = State::new(
             tree_hash,
@@ -3415,9 +3412,7 @@ mod pull_bootstrap_tests {
         let repo = Repository::init_default(temp.path()).expect("init repo");
         let blob = Blob::from("child\n");
         repo.store().put_blob(&blob).unwrap();
-        let tree = Tree::from_entries(vec![
-            TreeEntry::file("README", blob.hash(), false).unwrap(),
-        ]);
+        let tree = Tree::from_entries(vec![TreeEntry::file("README", blob.hash(), false).unwrap()]);
         let tree_hash = repo.store().put_tree(&tree).unwrap();
         let parent = State::new(
             tree_hash,

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -26,7 +26,7 @@ use objects::{
     Progress,
     object::{
         AnnotationStatus, ContentHash, ContextBlob, ContextTarget, Discussion, DiscussionsBlob,
-        MarkerName, StateAttachmentBody, StateAttachmentKind, StateId, ThreadName,
+        MarkerName, StateAttachmentBody, StateAttachmentKind, StateId, ThreadName, TreeEntryTarget,
     },
     store::{AnyStore, ObjectStore, PackObjectId, SnapshotCommitDescriptor},
 };
@@ -2419,7 +2419,7 @@ impl HostedClient {
         depth: Option<u32>,
         materialization: PullMaterialization,
     ) -> Result<(), ProtocolError> {
-        if repo.store().has_state(&state_id)? {
+        if synthetic_frontier_root_locally_complete(repo, state_id, depth, materialization)? {
             return Ok(());
         }
         let address = synthetic_frontier_pull_address(name, state_id);
@@ -2437,9 +2437,9 @@ impl HostedClient {
             },
         )
         .await?;
-        if !repo.store().has_state(&state_id)? {
+        if !synthetic_frontier_root_locally_complete(repo, state_id, depth, materialization)? {
             return Err(ProtocolError::InvalidState(format!(
-                "synthetic frontier {} advertised {} but the target state is still absent after pull",
+                "synthetic frontier {} advertised {} but the requested object closure is still incomplete after pull",
                 name.as_name(),
                 state_id.to_string_full()
             )));
@@ -2482,6 +2482,95 @@ fn synthetic_frontier_pull_address(
         remote_thread: name.owning_thread(),
         target_state,
     }
+}
+
+/// True when the requested synthetic-root closure is already present locally.
+///
+/// `has_state` is not enough: a prior lazy or shallow pull can leave the State
+/// while blobs or ancestors are still absent. Full materialization uses the
+/// pull planner's [`wire::enumerate_state_closure_with_options`] walk; lazy
+/// requires the state/tree graph at `depth` and permits missing blobs.
+fn synthetic_frontier_root_locally_complete(
+    repo: &Repository,
+    state_id: StateId,
+    depth: Option<u32>,
+    materialization: PullMaterialization,
+) -> Result<bool, ProtocolError> {
+    if !repo.store().has_state(&state_id)? {
+        return Ok(false);
+    }
+    let options = wire::StateClosureOptions {
+        depth,
+        exclude_states: Vec::new(),
+    };
+    match wire::enumerate_state_closure_with_options(repo.store(), state_id, options) {
+        Ok(_) => Ok(true),
+        Err(ProtocolError::ObjectNotFound(_)) => {
+            if materialization.allows_partial_fetch() {
+                lazy_synthetic_frontier_graph_present(repo, state_id, depth)
+            } else {
+                Ok(false)
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn lazy_synthetic_frontier_graph_present(
+    repo: &Repository,
+    state_id: StateId,
+    depth: Option<u32>,
+) -> Result<bool, ProtocolError> {
+    let mut seen_states = HashSet::new();
+    let mut seen_trees = HashSet::new();
+    let mut pending = vec![(state_id, 0u32)];
+    while let Some((id, generation)) = pending.pop() {
+        if !seen_states.insert(id) {
+            continue;
+        }
+        let Some(state) = repo.store().get_state(&id)? else {
+            return Ok(false);
+        };
+        if !tree_closure_present(repo, state.tree, &mut seen_trees)? {
+            return Ok(false);
+        }
+        if let Some(provenance) = state.provenance
+            && !tree_closure_present(repo, provenance, &mut seen_trees)?
+        {
+            return Ok(false);
+        }
+        if depth.map(|max| generation < max).unwrap_or(true) {
+            pending.extend(
+                state
+                    .parents
+                    .iter()
+                    .copied()
+                    .map(|parent| (parent, generation + 1)),
+            );
+        }
+    }
+    Ok(true)
+}
+
+fn tree_closure_present(
+    repo: &Repository,
+    tree_hash: ContentHash,
+    seen: &mut HashSet<ContentHash>,
+) -> Result<bool, ProtocolError> {
+    if !seen.insert(tree_hash) {
+        return Ok(true);
+    }
+    let Some(tree) = repo.store().get_tree(&tree_hash)? else {
+        return Ok(false);
+    };
+    for entry in tree.entries() {
+        if let TreeEntryTarget::Tree { hash } = entry.target()
+            && !tree_closure_present(repo, *hash, seen)?
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 fn persist_synthetic_frontier(
@@ -3156,9 +3245,13 @@ fn apply_marker_entry(
 #[cfg(test)]
 mod pull_bootstrap_tests {
     use chrono::Utc;
-    use objects::object::{
-        Annotation, AnnotationKind, AnnotationScope, Attribution, Blob, DiscussionResolution,
-        DiscussionTurn, Principal, StateAttachment, SymbolAnchor, VisibilityTier,
+    use objects::{
+        object::{
+            Annotation, AnnotationKind, AnnotationScope, Attribution, Blob, DiscussionResolution,
+            DiscussionTurn, Principal, State, StateAttachment, SymbolAnchor, Tree, TreeEntry,
+            VisibilityTier,
+        },
+        store::ObjectStore,
     };
     use tempfile::TempDir;
     use wire::{AdvertisedRef, RefKind};
@@ -3259,6 +3352,114 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert_eq!(decoded.refs[1].kind, RefKind::Marker);
+    }
+
+    #[test]
+    #[test]
+    fn synthetic_frontier_root_skips_only_when_requested_closure_is_complete() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        let blob = Blob::from("frontier blob\n");
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("README", blob.hash(), false).unwrap(),
+        ]);
+        let tree_hash = repo.store().put_tree(&tree).unwrap();
+        let state = State::new(
+            tree_hash,
+            Vec::new(),
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        let state_id = state.id();
+
+        assert!(
+            repo.store().has_state(&state_id).unwrap(),
+            "has_state alone must not skip an incomplete eager pull"
+        );
+        assert!(
+            !synthetic_frontier_root_locally_complete(
+                &repo,
+                state_id,
+                None,
+                PullMaterialization::Full,
+            )
+            .unwrap(),
+            "missing blobs must force an eager upgrade"
+        );
+        assert!(
+            synthetic_frontier_root_locally_complete(
+                &repo,
+                state_id,
+                None,
+                PullMaterialization::Lazy,
+            )
+            .unwrap(),
+            "lazy materialization may leave blobs absent"
+        );
+
+        repo.store().put_blob(&blob).unwrap();
+        assert!(
+            synthetic_frontier_root_locally_complete(
+                &repo,
+                state_id,
+                None,
+                PullMaterialization::Full,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn synthetic_frontier_root_upgrades_when_ancestors_are_missing() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        let blob = Blob::from("child\n");
+        repo.store().put_blob(&blob).unwrap();
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("README", blob.hash(), false).unwrap(),
+        ]);
+        let tree_hash = repo.store().put_tree(&tree).unwrap();
+        let parent = State::new(
+            tree_hash,
+            Vec::new(),
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        let child = State::new(
+            tree_hash,
+            vec![parent.id()],
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        repo.store().put_state(&child).unwrap();
+
+        assert!(
+            synthetic_frontier_root_locally_complete(
+                &repo,
+                child.id(),
+                Some(0),
+                PullMaterialization::Full,
+            )
+            .unwrap(),
+            "depth 0 is the tip only"
+        );
+        assert!(
+            !synthetic_frontier_root_locally_complete(
+                &repo,
+                child.id(),
+                None,
+                PullMaterialization::Full,
+            )
+            .unwrap(),
+            "a deeper pull must see the missing parent"
+        );
+        assert!(
+            !synthetic_frontier_root_locally_complete(
+                &repo,
+                child.id(),
+                None,
+                PullMaterialization::Lazy,
+            )
+            .unwrap()
+        );
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -1314,21 +1314,24 @@ impl HostedClient {
         remote_thread: &str,
         local_thread: Option<&str>,
     ) -> Result<(PullComplete, PullProfile), ProtocolError> {
-        self.pull_exchange(
-            repo,
-            repo_path,
-            remote_thread,
-            PullOptions {
-                local_thread,
-                depth: None,
-                target_state: None,
-                materialization: PullMaterialization::Full,
-                publish_refs: true,
-                wanted_hashes: None,
-            },
-        )
-        .await
-        .map(|exchange| (exchange.result, exchange.profile))
+        let exchange = self
+            .pull_exchange(
+                repo,
+                repo_path,
+                remote_thread,
+                PullOptions {
+                    local_thread,
+                    depth: None,
+                    target_state: None,
+                    materialization: PullMaterialization::Full,
+                    publish_refs: true,
+                    wanted_hashes: None,
+                },
+            )
+            .await?;
+        self.sync_synthetic_frontiers(repo, repo_path, None, PullMaterialization::Full)
+            .await?;
+        Ok((exchange.result, exchange.profile))
     }
 
     pub async fn pull_with_depth_and_materialization(
@@ -1597,9 +1600,20 @@ impl HostedClient {
         remote_thread: &str,
         options: PullOptions<'_>,
     ) -> Result<PullComplete, ProtocolError> {
-        self.pull_exchange(repo, repo_path, remote_thread, options)
+        let result = self
+            .pull_exchange(repo, repo_path, remote_thread, options)
             .await
-            .map(|exchange| exchange.result)
+            .map(|exchange| exchange.result)?;
+        if options.publish_refs {
+            self.sync_synthetic_frontiers(
+                repo,
+                repo_path,
+                options.depth,
+                options.materialization,
+            )
+            .await?;
+        }
+        Ok(result)
     }
 
     async fn pull_exchange(
@@ -2341,11 +2355,99 @@ impl HostedClient {
                         None => repo.create_marker_recorded(&marker_name, &entry.state_id)?,
                     }
                 }
-                Ok(AdvertisedRef::SyntheticFrontier(name)) => {
-                    repo.refs().set_synthetic_frontier(&name, &entry.state_id)?;
-                }
-                Ok(AdvertisedRef::Thread(_)) | Err(_) => {}
+                Ok(AdvertisedRef::SyntheticFrontier(_) | AdvertisedRef::Thread(_)) | Err(_) => {}
             }
+        }
+        Ok(())
+    }
+
+    async fn sync_synthetic_frontiers(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        depth: Option<u32>,
+        materialization: PullMaterialization,
+    ) -> Result<(), ProtocolError> {
+        let remote_refs = self.list_refs(repo_path).await?;
+        for entry in remote_refs {
+            match entry.advertised() {
+                Ok(AdvertisedRef::SyntheticFrontier(name)) => {
+                    self.fetch_synthetic_frontier_root(
+                        repo,
+                        repo_path,
+                        &entry.name,
+                        entry.state_id,
+                        depth,
+                        materialization,
+                    )
+                    .await?;
+                    persist_synthetic_frontier(repo, &name, entry.state_id)?;
+                }
+                Ok(AdvertisedRef::Marker(_) | AdvertisedRef::Thread(_)) | Err(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn fetch_advertised_synthetic_frontier_objects(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        advertised: &[HostedRefEntry],
+        depth: Option<u32>,
+        materialization: PullMaterialization,
+    ) -> Result<(), ProtocolError> {
+        for entry in advertised {
+            if !matches!(
+                entry.to_wire_entry().advertised(),
+                Ok(AdvertisedRef::SyntheticFrontier(_))
+            ) {
+                continue;
+            }
+            self.fetch_synthetic_frontier_root(
+                repo,
+                repo_path,
+                &entry.name,
+                entry.state_id,
+                depth,
+                materialization,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn fetch_synthetic_frontier_root(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        state_id: StateId,
+        depth: Option<u32>,
+        materialization: PullMaterialization,
+    ) -> Result<(), ProtocolError> {
+        if repo.store().has_state(&state_id)? {
+            return Ok(());
+        }
+        self.pull_exchange(
+            repo,
+            repo_path,
+            remote_thread,
+            PullOptions {
+                local_thread: None,
+                depth,
+                target_state: Some(state_id),
+                materialization,
+                publish_refs: false,
+                wanted_hashes: None,
+            },
+        )
+        .await?;
+        if !repo.store().has_state(&state_id)? {
+            return Err(ProtocolError::InvalidState(format!(
+                "synthetic frontier {remote_thread} advertised {} but the target state is still absent after pull",
+                state_id.to_string_full()
+            )));
         }
         Ok(())
     }
@@ -2359,8 +2461,26 @@ impl HostedClient {
         if !apply_marker_snapshot(repo, checkpoint)? {
             self.sync_local_markers(repo, repo_path).await?;
         }
+        self.sync_synthetic_frontiers(repo, repo_path, None, PullMaterialization::Full)
+            .await?;
         Ok(())
     }
+}
+
+fn persist_synthetic_frontier(
+    repo: &Repository,
+    name: &objects::object::SyntheticFrontierName,
+    state_id: StateId,
+) -> Result<(), ProtocolError> {
+    if !repo.store().has_state(&state_id)? {
+        return Err(ProtocolError::InvalidState(format!(
+            "synthetic frontier {} advertised {} but the target state is absent",
+            name.as_name(),
+            state_id.to_string_full()
+        )));
+    }
+    repo.refs().set_synthetic_frontier(name, &state_id)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -3156,6 +3276,45 @@ mod pull_bootstrap_tests {
             Ok(AdvertisedRef::SyntheticFrontier(name)) => assert_eq!(name.as_name(), frontier),
             other => panic!("synthetic must stay synthetic, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn folded_synthetic_frontier_survives_marker_snapshot() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("README.md"), "frontier\n").expect("write fixture");
+        let snapshot = repo
+            .snapshot(Some("seed".to_string()), None)
+            .expect("snapshot");
+        let checkpoint = format!(
+            "heddle-markers-v1\nrelease\t{}\n",
+            snapshot.state_id.to_string_full()
+        );
+        assert!(
+            apply_marker_snapshot(&repo, checkpoint.as_bytes()).expect("apply snapshot"),
+            "a folded marker snapshot must still leave room for synthetic sync"
+        );
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let frontier = objects::object::SyntheticFrontierName::new("main", change).unwrap();
+        persist_synthetic_frontier(&repo, &frontier, snapshot.state_id)
+            .expect("synthetic persist is independent of the marker snapshot");
+        assert!(
+            repo.store()
+                .has_state(&snapshot.state_id)
+                .expect("has_state")
+        );
+        assert_eq!(
+            repo.refs()
+                .get_marker(&MarkerName::from("release"))
+                .expect("read marker"),
+            Some(snapshot.state_id)
+        );
+        assert_eq!(
+            repo.refs()
+                .get_synthetic_frontier(&frontier)
+                .expect("read synthetic"),
+            Some(snapshot.state_id)
+        );
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -40,9 +40,9 @@ use sley::{
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc;
 use wire::{
-    GitLaneTransferIntent, ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject, ProtocolError,
-    PullComplete, PushComplete, RefEntry, RefUpdated, RepositoryTransferPlan,
-    admit_declared_received_len,
+    AdvertisedRef, GitLaneTransferIntent, ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject,
+    ProtocolError, PullComplete, PushComplete, RefEntry, RefKind, RefUpdated,
+    RepositoryTransferPlan, admit_declared_received_len,
 };
 
 use super::{
@@ -190,13 +190,13 @@ pub(crate) fn decode_pull_refs(
         .into_iter()
         .map(|(name, state_id, is_thread, revision_address)| {
             let state_id = decode_bootstrap_state_id(state_id, "ref state")?;
-            Ok(HostedRefEntry {
+            Ok(HostedRefEntry::from_advertised(
                 name,
                 state_id,
                 is_thread,
                 revision_address,
-                thread_id: None,
-            })
+                None,
+            ))
         })
         .collect::<Result<Vec<_>, ProtocolError>>()?;
     let _ = head_state;
@@ -382,9 +382,49 @@ pub struct PullObjectMix {
 pub struct HostedRefEntry {
     pub name: String,
     pub state_id: StateId,
-    pub is_thread: bool,
+    pub kind: RefKind,
     pub revision_address: String,
     pub thread_id: Option<String>,
+}
+
+impl HostedRefEntry {
+    pub fn from_advertised(
+        name: String,
+        state_id: StateId,
+        advertised_as_thread: bool,
+        revision_address: String,
+        thread_id: Option<String>,
+    ) -> Self {
+        let kind = RefKind::from_advertised_name(&name, advertised_as_thread);
+        let thread_id = if kind.is_user_thread() {
+            thread_id
+        } else {
+            None
+        };
+        Self {
+            name,
+            state_id,
+            kind,
+            revision_address,
+            thread_id,
+        }
+    }
+
+    pub fn is_user_thread(&self) -> bool {
+        self.kind.is_user_thread()
+    }
+
+    pub fn is_marker(&self) -> bool {
+        self.kind.is_marker()
+    }
+
+    pub fn to_wire_entry(&self) -> RefEntry {
+        RefEntry {
+            name: self.name.clone(),
+            state_id: self.state_id,
+            kind: self.kind,
+        }
+    }
 }
 
 impl PullObjectMix {
@@ -491,11 +531,7 @@ impl HostedClient {
             .list_refs_with_revision_addresses(repo_path)
             .await?
             .into_iter()
-            .map(|entry| RefEntry {
-                name: entry.name,
-                state_id: entry.state_id,
-                is_thread: entry.is_thread,
-            })
+            .map(|entry| entry.to_wire_entry())
             .collect())
     }
 
@@ -520,7 +556,8 @@ impl HostedClient {
             while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
                 match response.frame {
                     Some(list_refs_response::Frame::Item(entry)) => {
-                        let thread_id = if entry.is_thread {
+                        let kind = RefKind::from_advertised_name(&entry.name, entry.is_thread);
+                        let thread_id = if kind.is_user_thread() {
                             if entry.thread_id.is_empty() {
                                 return Err(ProtocolError::InvalidState(format!(
                                     "hosted thread ref '{}' is missing its stable identity",
@@ -539,7 +576,7 @@ impl HostedClient {
                                         "ref is missing its state ID".to_string(),
                                     )
                                 })?,
-                            is_thread: entry.is_thread,
+                            kind,
                             revision_address: entry.revision_address,
                             thread_id,
                         });
@@ -643,7 +680,7 @@ impl HostedClient {
                 .as_deref()
                 .unwrap_or_default()
                 .iter()
-                .find(|entry| entry.is_thread && entry.name == name)
+                .find(|entry| entry.is_user_thread() && entry.name == name)
                 .and_then(|entry| entry.thread_id.clone())
                 .unwrap_or_default()
         } else {
@@ -926,7 +963,7 @@ impl HostedClient {
         let remote_refs = self.list_refs_with_revision_addresses(repo_path).await?;
         let remote_target = remote_refs
             .iter()
-            .find(|entry| entry.is_thread && entry.name == target_thread);
+            .find(|entry| entry.is_user_thread() && entry.name == target_thread);
         let target_thread_id = remote_target
             .and_then(|entry| entry.thread_id.clone())
             .unwrap_or_default();
@@ -2242,7 +2279,7 @@ impl HostedClient {
             .list_refs(repo_path)
             .await?
             .into_iter()
-            .filter(|entry| !entry.is_thread)
+            .filter(|entry| entry.is_marker())
             .map(|entry| (entry.name, entry.state_id))
             .collect::<HashMap<_, _>>();
         for marker in local_markers {
@@ -2288,19 +2325,26 @@ impl HostedClient {
         repo_path: &str,
     ) -> Result<(), ProtocolError> {
         let remote_markers = self.list_refs(repo_path).await?;
-        for marker in remote_markers.into_iter().filter(|entry| !entry.is_thread) {
-            if !repo.store().has_state(&marker.state_id)? {
+        for entry in remote_markers {
+            if !repo.store().has_state(&entry.state_id)? {
                 continue;
             }
-            let marker_name = MarkerName::from(marker.name.as_str());
-            match repo.refs().get_marker(&marker_name)? {
-                Some(existing) if existing == marker.state_id => {}
-                Some(existing) => repo.set_marker_recorded_cas(
-                    &marker_name,
-                    refs::RefExpectation::Value(existing),
-                    &marker.state_id,
-                )?,
-                None => repo.create_marker_recorded(&marker_name, &marker.state_id)?,
+            match entry.advertised() {
+                Ok(AdvertisedRef::Marker(marker_name)) => {
+                    match repo.refs().get_marker(&marker_name)? {
+                        Some(existing) if existing == entry.state_id => {}
+                        Some(existing) => repo.set_marker_recorded_cas(
+                            &marker_name,
+                            refs::RefExpectation::Value(existing),
+                            &entry.state_id,
+                        )?,
+                        None => repo.create_marker_recorded(&marker_name, &entry.state_id)?,
+                    }
+                }
+                Ok(AdvertisedRef::SyntheticFrontier(name)) => {
+                    repo.refs().set_synthetic_frontier(&name, &entry.state_id)?;
+                }
+                Ok(AdvertisedRef::Thread(_)) | Err(_) => {}
             }
         }
         Ok(())
@@ -2340,7 +2384,7 @@ fn expected_remote_head_from_refs(
 ) -> ExpectedRemoteHead {
     remote_refs
         .iter()
-        .find(|entry| entry.is_thread && entry.name == target_thread)
+        .find(|entry| entry.kind.is_user_thread() && entry.name == target_thread)
         .map(|entry| entry.state_id)
         .map_or(ExpectedRemoteHead::Missing, ExpectedRemoteHead::State)
 }
@@ -2980,6 +3024,7 @@ mod pull_bootstrap_tests {
         DiscussionTurn, Principal, StateAttachment, SymbolAnchor, VisibilityTier,
     };
     use tempfile::TempDir;
+    use wire::{AdvertisedRef, RefKind};
 
     use super::*;
 
@@ -3072,11 +3117,45 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs.len(), 2);
         assert_eq!(decoded.refs[0].name, "main");
         assert_eq!(decoded.refs[0].state_id, main);
-        assert!(decoded.refs[0].is_thread);
+        assert_eq!(decoded.refs[0].kind, RefKind::Thread);
         assert_eq!(decoded.refs[0].revision_address, "git:0123456789abcdef");
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
-        assert!(!decoded.refs[1].is_thread);
+        assert_eq!(decoded.refs[1].kind, RefKind::Marker);
+    }
+
+    #[test]
+    fn folded_synthetic_frontier_is_not_a_thread_or_marker() {
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let frontier = objects::object::SyntheticFrontierName::new("main", change)
+            .unwrap()
+            .as_name();
+        let state = StateId::from_bytes([7; 32]);
+        let payload: PullRefsPayload = (
+            "main".to_string(),
+            Some(state.as_bytes().to_vec()),
+            vec![(
+                frontier.clone(),
+                state.as_bytes().to_vec(),
+                true,
+                String::new(),
+            )],
+        );
+        let checkpoint = format!(
+            "{PULL_REFS_LINE_PREFIX}{}\t{}\n",
+            hex::encode(rmp_serde::to_vec_named(&payload).expect("encode refs fixture")),
+            StateId::from_bytes([0; 32]).to_string_full(),
+        );
+        let decoded = decode_pull_refs(checkpoint.as_bytes())
+            .expect("decode")
+            .expect("refs");
+        assert_eq!(decoded.refs[0].kind, RefKind::SyntheticFrontierRoot);
+        assert!(!decoded.refs[0].is_user_thread());
+        assert!(!decoded.refs[0].is_marker());
+        match decoded.refs[0].to_wire_entry().advertised() {
+            Ok(AdvertisedRef::SyntheticFrontier(name)) => assert_eq!(name.as_name(), frontier),
+            other => panic!("synthetic must stay synthetic, got {other:?}"),
+        }
     }
 
     #[test]
@@ -3175,7 +3254,7 @@ fn hosted_thread_id(
 ) -> Result<String, ProtocolError> {
     remote_refs
         .iter()
-        .find(|entry| entry.is_thread && entry.name == thread_name)
+        .find(|entry| entry.is_user_thread() && entry.name == thread_name)
         .and_then(|entry| entry.thread_id.clone())
         .ok_or_else(|| ProtocolError::ObjectNotFound(format!("hosted thread '{thread_name}'")))
 }
@@ -3755,7 +3834,8 @@ mod transfer_id_tests {
     use repo::Repository;
     use tempfile::TempDir;
     use wire::{
-        GitLaneTransferIntent, ObjectId, ObjectInfo, ObjectType, RefEntry, RepositoryTransferPlan,
+        GitLaneTransferIntent, ObjectId, ObjectInfo, ObjectType, RefEntry, RefKind,
+        RepositoryTransferPlan,
     };
 
     use super::{
@@ -3995,7 +4075,7 @@ mod transfer_id_tests {
         let remote = [RefEntry {
             name: "main".to_string(),
             state_id: base.state_id,
-            is_thread: true,
+            kind: RefKind::Thread,
         }];
 
         assert_eq!(

--- a/crates/core/src/thread_plan.rs
+++ b/crates/core/src/thread_plan.rs
@@ -450,6 +450,16 @@ mod tests {
         assert!(validate_thread_name("feature/auth").is_ok());
         assert!(validate_thread_name("v1.2").is_ok());
         assert!(validate_thread_name("team@scope").is_ok());
+        assert!(validate_thread_name("heddle").is_ok());
+        assert!(validate_thread_name("main@hd-abc").is_ok());
+    }
+
+    #[test]
+    fn validate_thread_name_rejects_reserved_heddle_namespace() {
+        assert!(matches!(
+            validate_thread_name("heddle/frontier/main/hc-abc"),
+            Err(ThreadPlanError::InvalidName(_))
+        ));
     }
 
     #[test]

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -2969,7 +2969,10 @@ fn creatable_ref_names(
                     .iter()
                     .filter(|update| {
                         (matches!(update.namespace, RefNamespace::Branch) && update.name == branch)
-                            || matches!(update.namespace, RefNamespace::Note)
+                            || matches!(
+                                update.namespace,
+                                RefNamespace::Note | RefNamespace::Heddle
+                            )
                     })
                     .map(full_ref_name)
                     .collect(),
@@ -3091,7 +3094,7 @@ pub fn plan_destination_reconcile(
                         matches!(movement, RefMove::Rewind),
                     )
                 }
-                RefNamespace::Tag => {
+                RefNamespace::Tag | RefNamespace::Heddle => {
                     let verdict = classify_tag_move(old, update.target, recorded);
                     (
                         verdict,
@@ -3792,13 +3795,16 @@ pub fn push_authoritative_git_refs(
     let served_frontier = collect_ref_updates(source)?
         .into_iter()
         .filter(|update| {
-            matches!(update.namespace, RefNamespace::Branch | RefNamespace::Tag)
-                || (update.namespace == RefNamespace::Note && update.name == "heddle")
+            matches!(
+                update.namespace,
+                RefNamespace::Branch | RefNamespace::Tag | RefNamespace::Heddle
+            ) || (update.namespace == RefNamespace::Note && update.name == "heddle")
         })
         .filter(|update| match scope {
             GitPushScope::AllThreads => true,
             GitPushScope::CurrentThread => {
                 update.namespace == RefNamespace::Note
+                    || update.namespace == RefNamespace::Heddle
                     || (update.namespace == RefNamespace::Branch
                         && Some(update.name.as_str()) == current_branch)
             }

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -2077,7 +2077,7 @@ pub fn delete_reference_if_present(repo: &SleyRepository, name: &str) -> GitProj
     delete_reference(repo, name, None, true)
 }
 
-fn delete_reference_matching(
+pub(crate) fn delete_reference_matching(
     repo: &SleyRepository,
     name: &str,
     expected_old: ObjectId,
@@ -2969,10 +2969,7 @@ fn creatable_ref_names(
                     .iter()
                     .filter(|update| {
                         (matches!(update.namespace, RefNamespace::Branch) && update.name == branch)
-                            || matches!(
-                                update.namespace,
-                                RefNamespace::Note | RefNamespace::Heddle
-                            )
+                            || matches!(update.namespace, RefNamespace::Note | RefNamespace::Heddle)
                     })
                     .map(full_ref_name)
                     .collect(),
@@ -3763,11 +3760,49 @@ pub fn copy_reachable_objects_excluding(
     Ok(())
 }
 
+/// Overlay-authoritative Git refs that a push may serve.
+///
+/// Branches and tags come from the checkout because `.git` is authoritative
+/// there. Heddle synthetic roots are publishable only when they are in the
+/// managed ownership record and the on-disk target still matches that record.
+fn collect_authoritative_git_ref_updates(
+    source: &SleyRepository,
+    managed_record: &HashMap<String, ObjectId>,
+    scope: GitPushScope,
+    current_branch: Option<&str>,
+) -> GitProjectionResult<Vec<RefUpdate>> {
+    Ok(collect_ref_updates(source)?
+        .into_iter()
+        .filter(|update| {
+            let publishable = match update.namespace {
+                RefNamespace::Heddle => {
+                    managed_record.get(&full_ref_name(update)) == Some(&update.target)
+                }
+                RefNamespace::Branch | RefNamespace::Tag => true,
+                RefNamespace::Note => update.name == "heddle",
+            };
+            if !publishable {
+                return false;
+            }
+            match scope {
+                GitPushScope::AllThreads => true,
+                GitPushScope::CurrentThread => {
+                    update.namespace == RefNamespace::Note
+                        || update.namespace == RefNamespace::Heddle
+                        || (update.namespace == RefNamespace::Branch
+                            && Some(update.name.as_str()) == current_branch)
+                }
+            }
+        })
+        .collect())
+}
+
 /// Push the authoritative checkout's Git refs directly through Sley.
 ///
 /// Local branches and tags are intentional inputs because `.git` is authoritative
-/// in an overlay checkout. The per-remote manifest separately prevents Heddle
-/// from claiming, rewinding, or deleting destination refs it did not publish.
+/// in an overlay checkout. Synthetic Heddle refs are served only from the managed
+/// ownership record. The per-remote manifest separately prevents Heddle from
+/// claiming, rewinding, or deleting destination refs it did not publish.
 pub struct AuthoritativeGitPushOptions<'a> {
     pub heddle_dir: &'a Path,
     pub remote: &'a str,
@@ -3792,24 +3827,9 @@ pub fn push_authoritative_git_refs(
     let remote_url = source.remote(remote).map_err(git_err)?.push_url();
     let manifest_path = network_exported_refs_path(heddle_dir, &remote_url);
     let previously_exported = read_exported_refs_at(&manifest_path)?;
-    let served_frontier = collect_ref_updates(source)?
-        .into_iter()
-        .filter(|update| {
-            matches!(
-                update.namespace,
-                RefNamespace::Branch | RefNamespace::Tag | RefNamespace::Heddle
-            ) || (update.namespace == RefNamespace::Note && update.name == "heddle")
-        })
-        .filter(|update| match scope {
-            GitPushScope::AllThreads => true,
-            GitPushScope::CurrentThread => {
-                update.namespace == RefNamespace::Note
-                    || update.namespace == RefNamespace::Heddle
-                    || (update.namespace == RefNamespace::Branch
-                        && Some(update.name.as_str()) == current_branch)
-            }
-        })
-        .collect::<Vec<_>>();
+    let managed_record = read_projection_managed_refs(heddle_dir)?;
+    let served_frontier =
+        collect_authoritative_git_ref_updates(source, &managed_record, scope, current_branch)?;
 
     let records = source
         .ls_remote_with_http_client(
@@ -4188,6 +4208,114 @@ mod tests {
         assert!(
             main.is_none(),
             "must not serve the on-disk foreign tip under refs/heads/main, got {main:?}"
+        );
+    }
+
+    #[test]
+    fn collect_authoritative_git_ref_updates_publishes_only_managed_synthetic_roots() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
+        let owned = seed_commit(&repo, "owned");
+        let forged = seed_commit(&repo, "forged");
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let managed_name = objects::object::SyntheticFrontierName::new("main", change)
+            .expect("managed synthetic")
+            .git_ref();
+        let forged_change = objects::object::ChangeId::from_bytes([7; 16]);
+        let forged_name = objects::object::SyntheticFrontierName::new("main", forged_change)
+            .expect("forged synthetic")
+            .git_ref();
+        set_reference(
+            &repo,
+            &managed_name,
+            owned,
+            RefPrecondition::MustNotExist,
+            "test: managed synthetic",
+        )
+        .expect("write managed synthetic");
+        set_reference(
+            &repo,
+            &forged_name,
+            forged,
+            RefPrecondition::MustNotExist,
+            "test: unmanaged forged synthetic",
+        )
+        .expect("write forged synthetic");
+        set_reference(
+            &repo,
+            "refs/heddle/internal",
+            forged,
+            RefPrecondition::MustNotExist,
+            "test: internal heddle ref",
+        )
+        .expect("write internal heddle ref");
+        set_reference(
+            &repo,
+            "refs/heads/main",
+            owned,
+            RefPrecondition::MustNotExist,
+            "test: main",
+        )
+        .expect("write main");
+
+        let mut record = HashMap::new();
+        record.insert(managed_name.clone(), owned);
+
+        let updates = collect_authoritative_git_ref_updates(
+            &repo,
+            &record,
+            GitPushScope::AllThreads,
+            Some("main"),
+        )
+        .expect("collect authoritative updates");
+        let mut names: Vec<String> = updates.iter().map(full_ref_name).collect();
+        names.sort();
+
+        assert_eq!(
+            names,
+            vec![managed_name, "refs/heads/main".to_string()],
+            "only the managed synthetic root and overlay-authoritative heads may publish"
+        );
+        assert!(
+            updates
+                .iter()
+                .all(|update| update.namespace != RefNamespace::Heddle
+                    || full_ref_name(update) != forged_name),
+            "unmanaged frontier-shaped refs must not enter the served set"
+        );
+    }
+
+    #[test]
+    fn count_exported_commits_excludes_heddle_synthetic_tips() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
+        let head = seed_commit(&repo, "head");
+        let frontier = seed_commit(&repo, "frontier");
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let synthetic = objects::object::SyntheticFrontierName::new("main", change)
+            .expect("synthetic")
+            .git_ref();
+        set_reference(
+            &repo,
+            "refs/heads/main",
+            head,
+            RefPrecondition::MustNotExist,
+            "test: main",
+        )
+        .expect("write main");
+        set_reference(
+            &repo,
+            &synthetic,
+            frontier,
+            RefPrecondition::MustNotExist,
+            "test: synthetic",
+        )
+        .expect("write synthetic");
+
+        let counts = count_exported_commits(&repo, &HashSet::new()).expect("count");
+        assert_eq!(
+            counts.total, 1,
+            "synthetic Heddle tips must not inflate the exported commit walk"
         );
     }
 

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -4270,10 +4270,11 @@ mod tests {
         .expect("collect authoritative updates");
         let mut names: Vec<String> = updates.iter().map(full_ref_name).collect();
         names.sort();
+        let mut expected = vec![managed_name, "refs/heads/main".to_string()];
+        expected.sort();
 
         assert_eq!(
-            names,
-            vec![managed_name, "refs/heads/main".to_string()],
+            names, expected,
             "only the managed synthetic root and overlay-authoritative heads may publish"
         );
         assert!(

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -539,6 +539,9 @@ fn export_scoped(
             frontier_roots.push(state_id);
         }
     }
+    for (_name, state_id) in bridge.heddle_repo.refs().list_synthetic_frontiers()? {
+        frontier_roots.push(state_id);
+    }
     let frontier_reachable = reachable_states(bridge.heddle_repo, &frontier_roots)?;
 
     // Re-validate the served set against CURRENT visibility before anything treats
@@ -1051,6 +1054,13 @@ fn export_scoped(
         }
     }
 
+    crate::git_frontier::reconcile_synthetic_frontier_refs(
+        &repo,
+        bridge.heddle_repo,
+        &bridge.mapping,
+        &mut managed_record,
+    )?;
+
     // Persist the updated ownership record so the next reconcile — and the push
     // frontier (`collect_managed_ref_updates`) — read heddle's managed set by
     // name and recorded tip. A diverged on-disk tip is not a managed update.
@@ -1380,6 +1390,11 @@ fn project_desired_refs(
             let target = native_annotated_tag_oid(heddle_repo, marker_name, state_id, git_oid)?
                 .unwrap_or(git_oid);
             desired.insert(format!("refs/tags/{marker_name}"), target);
+        }
+    }
+    for (name, state_id) in heddle_repo.refs().list_synthetic_frontiers()? {
+        if let Some(git_oid) = mapping.get_git(&state_id) {
+            desired.insert(name.git_ref(), git_oid);
         }
     }
     Ok(desired)

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -1054,12 +1054,14 @@ fn export_scoped(
         }
     }
 
-    crate::git_frontier::reconcile_synthetic_frontier_refs(
-        &repo,
-        bridge.heddle_repo,
-        &bridge.mapping,
-        &mut managed_record,
-    )?;
+    stats
+        .failed_refs
+        .extend(crate::git_frontier::reconcile_synthetic_frontier_refs(
+            &repo,
+            bridge.heddle_repo,
+            &bridge.mapping,
+            &mut managed_record,
+        )?);
 
     // Persist the updated ownership record so the next reconcile — and the push
     // frontier (`collect_managed_ref_updates`) — read heddle's managed set by

--- a/crates/git-projection/src/git_frontier.rs
+++ b/crates/git-projection/src/git_frontier.rs
@@ -6,14 +6,24 @@
 //! The two namespaces are disjoint, so a user thread such as `main@hd-…`
 //! cannot overwrite a frontier root.
 
-use objects::object::SyntheticFrontierName;
-use sley::{ObjectId as SleyObjectId, RefPrecondition, Repository as SleyRepository};
+use std::collections::{HashMap, HashSet};
 
-use crate::git_core::{GitProjectionResult, git_err};
+use objects::object::SyntheticFrontierName;
+use repo::Repository as HeddleRepository;
+use sley::{
+    ObjectId as SleyObjectId, RefPrecondition, ReferenceTarget, Repository as SleyRepository,
+};
+
+use crate::git_core::{
+    delete_reference_if_present, git_err, GitProjectionError, GitProjectionResult, SyncMapping,
+};
 
 use super::git_sync::set_ref;
 
 /// Publish a synthetic frontier root into Heddle's reserved Git namespace.
+///
+/// Replacing an existing ref uses the observed raw target as a CAS
+/// precondition so a racing writer is reported instead of overwritten.
 pub fn sync_synthetic_frontier_to_git(
     repo: &SleyRepository,
     name: &SyntheticFrontierName,
@@ -21,15 +31,22 @@ pub fn sync_synthetic_frontier_to_git(
 ) -> GitProjectionResult<()> {
     let git_ref = name.git_ref();
     if let Some(existing) = repo.find_reference(&git_ref).map_err(git_err)? {
-        let current = existing.peeled_oid(repo).map_err(git_err)?;
-        if current == Some(git_oid) {
+        let current = match existing.target {
+            ReferenceTarget::Direct(oid) => oid,
+            ReferenceTarget::Symbolic(_) => {
+                return Err(GitProjectionError::Git(format!(
+                    "synthetic frontier {git_ref} is symbolic; refuse to overwrite"
+                )));
+            }
+        };
+        if current == git_oid {
             return Ok(());
         }
         return set_ref(
             repo,
             &git_ref,
             git_oid,
-            RefPrecondition::Any,
+            RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(current)),
             "heddle: sync synthetic frontier",
         );
     }
@@ -42,6 +59,36 @@ pub fn sync_synthetic_frontier_to_git(
     )
 }
 
+/// Materialize advertised synthetic frontier refs and drop stale managed ones.
+pub fn reconcile_synthetic_frontier_refs(
+    repo: &SleyRepository,
+    heddle_repo: &HeddleRepository,
+    mapping: &SyncMapping,
+    managed_record: &mut HashMap<String, SleyObjectId>,
+) -> GitProjectionResult<()> {
+    let advertised = heddle_repo.refs().list_synthetic_frontiers()?;
+    let mut desired: HashSet<String> = HashSet::new();
+    for (name, state) in advertised {
+        let git_ref = name.git_ref();
+        let Some(git_oid) = mapping.get_git(&state) else {
+            continue;
+        };
+        desired.insert(git_ref.clone());
+        sync_synthetic_frontier_to_git(repo, &name, git_oid)?;
+        managed_record.insert(git_ref, git_oid);
+    }
+    let stale: Vec<String> = managed_record
+        .keys()
+        .filter(|name| name.starts_with("refs/heddle/") && !desired.contains(*name))
+        .cloned()
+        .collect();
+    for git_ref in stale {
+        delete_reference_if_present(repo, &git_ref)?;
+        managed_record.remove(&git_ref);
+    }
+    Ok(())
+}
+
 /// True when a Git ref name is in the reserved `refs/heddle/` namespace.
 pub fn is_reserved_heddle_git_ref(name: &str) -> bool {
     let stripped = name.strip_prefix("refs/").unwrap_or(name);
@@ -52,13 +99,15 @@ pub fn is_reserved_heddle_git_ref(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use objects::object::ChangeId;
+    use repo::Repository as HeddleRepository;
     use sley::{
-        CommitObject, GitObjectType, GitTime, Signature, TreeEditor,
         plumbing::{sley_core::ByteString, sley_object::EncodedObject},
+        CommitObject, GitObjectType, GitTime, Signature, TreeEditor,
     };
     use tempfile::TempDir;
 
     use super::*;
+    use crate::GitProjection;
 
     fn test_signature() -> Signature {
         let time = GitTime::new(0, 0);
@@ -74,6 +123,11 @@ mod tests {
     fn bare_repo_with_commit() -> (TempDir, SleyRepository, SleyObjectId) {
         let temp = TempDir::new().unwrap();
         let repo = SleyRepository::init_bare(temp.path()).unwrap();
+        let oid = write_commit(&repo, "frontier");
+        (temp, repo, oid)
+    }
+
+    fn write_commit(repo: &SleyRepository, message: &str) -> SleyObjectId {
         let tree = repo.write_tree(TreeEditor::new()).unwrap();
         let sig = test_signature();
         let object = CommitObject {
@@ -82,22 +136,23 @@ mod tests {
             author: sig.to_ident_bytes(),
             committer: sig.to_ident_bytes(),
             encoding: None,
-            message: b"frontier".to_vec(),
+            message: format!("{message}\n").into_bytes(),
         };
-        let oid = repo
-            .write_object(EncodedObject::new(GitObjectType::Commit, object.write()))
-            .unwrap();
-        (temp, repo, oid)
+        repo.write_object(EncodedObject::new(GitObjectType::Commit, object.write()))
+            .unwrap()
+    }
+
+    fn frontier_name() -> SyntheticFrontierName {
+        let mut bytes = [0u8; 16];
+        bytes[15] = 9;
+        SyntheticFrontierName::new("main", ChangeId::from_bytes(bytes)).unwrap()
     }
 
     #[test]
     fn synthetic_git_ref_does_not_collide_with_user_branch_at_hd_suffix() {
         let (_temp, repo, oid) = bare_repo_with_commit();
-        let mut bytes = [0u8; 16];
-        bytes[15] = 9;
-        let change = ChangeId::from_bytes(bytes);
-        let synthetic = SyntheticFrontierName::new("main", change).unwrap();
-        let user_branch = format!("refs/heads/main@{}", change.to_string_full());
+        let synthetic = frontier_name();
+        let user_branch = format!("refs/heads/main@{}", synthetic.change_id().to_string_full());
 
         sync_synthetic_frontier_to_git(&repo, &synthetic, oid).unwrap();
         set_ref(
@@ -113,6 +168,74 @@ mod tests {
         assert!(synthetic.git_ref().starts_with("refs/heddle/frontier/"));
         assert!(repo.find_reference(&synthetic.git_ref()).unwrap().is_some());
         assert!(repo.find_reference(&user_branch).unwrap().is_some());
+    }
+
+    #[test]
+    fn replacing_synthetic_git_ref_uses_observed_raw_target() {
+        let (_temp, repo, first) = bare_repo_with_commit();
+        let second = write_commit(&repo, "retarget");
+        let synthetic = frontier_name();
+
+        sync_synthetic_frontier_to_git(&repo, &synthetic, first).unwrap();
+        sync_synthetic_frontier_to_git(&repo, &synthetic, second).unwrap();
+
+        let written = repo
+            .find_reference(&synthetic.git_ref())
+            .unwrap()
+            .expect("synthetic ref");
+        assert_eq!(written.target, ReferenceTarget::Direct(second));
+    }
+
+    #[test]
+    fn export_writes_synthetic_frontier_git_ref() {
+        let temp = TempDir::new().unwrap();
+        let repo = HeddleRepository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("README"), "frontier\n").unwrap();
+        let snapshot = repo
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                objects::object::Attribution::human(objects::object::Principal::new(
+                    "Test",
+                    "test@example.com",
+                )),
+            )
+            .expect("snapshot");
+        let synthetic = frontier_name();
+        repo.refs()
+            .set_synthetic_frontier(&synthetic, &snapshot.state_id)
+            .unwrap();
+
+        let mut bridge = GitProjection::new(&repo);
+        let dest = temp.path().join("export.git");
+        bridge.export_to_path(&dest).expect("export");
+
+        let exported = SleyRepository::open(&dest).expect("open export");
+        assert!(
+            exported
+                .find_reference(&synthetic.git_ref())
+                .unwrap()
+                .is_some(),
+            "export must publish {}",
+            synthetic.git_ref()
+        );
+    }
+
+    #[test]
+    fn reconcile_deletes_managed_synthetic_ref_when_desired_is_absent() {
+        let (_temp, repo, oid) = bare_repo_with_commit();
+        let synthetic = frontier_name();
+        sync_synthetic_frontier_to_git(&repo, &synthetic, oid).unwrap();
+        let mut managed = HashMap::new();
+        managed.insert(synthetic.git_ref(), oid);
+
+        let heddle_temp = TempDir::new().unwrap();
+        let heddle = HeddleRepository::init_default(heddle_temp.path()).unwrap();
+        reconcile_synthetic_frontier_refs(&repo, &heddle, &SyncMapping::new(), &mut managed)
+            .unwrap();
+
+        assert!(repo.find_reference(&synthetic.git_ref()).unwrap().is_none());
+        assert!(!managed.contains_key(&synthetic.git_ref()));
     }
 
     #[test]

--- a/crates/git-projection/src/git_frontier.rs
+++ b/crates/git-projection/src/git_frontier.rs
@@ -62,9 +62,10 @@ pub fn sync_synthetic_frontier_to_git(
 
 /// Materialize advertised synthetic frontier refs and drop stale managed ones.
 ///
-/// A formerly managed name is deleted only when the current Git target still
-/// matches the recorded managed OID. An out-of-band retarget is preserved and
-/// reported so CAS is an ownership check, not a tip-at-delete-time overwrite.
+/// A previously managed name — advertised or stale — is rewritten or deleted
+/// only when the current Git target still matches the recorded managed OID.
+/// An out-of-band retarget is preserved and reported so CAS is an ownership
+/// check, not a tip-at-sync-time overwrite.
 pub fn reconcile_synthetic_frontier_refs(
     repo: &SleyRepository,
     heddle_repo: &HeddleRepository,
@@ -73,12 +74,22 @@ pub fn reconcile_synthetic_frontier_refs(
 ) -> GitProjectionResult<Vec<(String, FailedRefExportReason)>> {
     let advertised = heddle_repo.refs().list_synthetic_frontiers()?;
     let mut desired: HashSet<String> = HashSet::new();
+    let mut diverged = Vec::new();
     for (name, state) in advertised {
         let git_ref = name.git_ref();
         let Some(git_oid) = mapping.get_git(&state) else {
             continue;
         };
         desired.insert(git_ref.clone());
+        if let Some(reason) = diverged_managed_synthetic_ref(
+            repo,
+            &git_ref,
+            managed_record.get(&git_ref).copied(),
+            git_oid,
+        )? {
+            diverged.push((git_ref, reason));
+            continue;
+        }
         sync_synthetic_frontier_to_git(repo, &name, git_oid)?;
         managed_record.insert(git_ref, git_oid);
     }
@@ -87,7 +98,6 @@ pub fn reconcile_synthetic_frontier_refs(
         .filter(|name| SyntheticFrontierName::parse(name).is_ok() && !desired.contains(*name))
         .cloned()
         .collect();
-    let mut diverged = Vec::new();
     for git_ref in stale {
         let Some(recorded) = managed_record.get(&git_ref).copied() else {
             continue;
@@ -122,6 +132,36 @@ pub fn reconcile_synthetic_frontier_refs(
         }
     }
     Ok(diverged)
+}
+
+/// Report a live advertised ref whose tip no longer matches the managed record.
+///
+/// First publication (no record) and a matching owned tip may sync. A
+/// retargeted Direct tip, or a symbolic ref, is left untouched.
+fn diverged_managed_synthetic_ref(
+    repo: &SleyRepository,
+    git_ref: &str,
+    recorded: Option<SleyObjectId>,
+    desired: SleyObjectId,
+) -> GitProjectionResult<Option<FailedRefExportReason>> {
+    let Some(recorded) = recorded else {
+        return Ok(None);
+    };
+    match repo.find_reference(git_ref).map_err(git_err)? {
+        None => Ok(None),
+        Some(reference) => match reference.target {
+            ReferenceTarget::Direct(current) if current == recorded => Ok(None),
+            ReferenceTarget::Direct(current) => {
+                Ok(Some(FailedRefExportReason::ModifiedConcurrentlyInGit {
+                    found: current,
+                    intended: desired,
+                }))
+            }
+            ReferenceTarget::Symbolic(_) => Ok(Some(FailedRefExportReason::FailedToDelete(
+                "synthetic frontier is symbolic; refuse to clobber".to_string(),
+            ))),
+        },
+    }
 }
 
 /// True when a Git ref name is in the reserved `refs/heddle/` namespace.
@@ -181,6 +221,32 @@ mod tests {
         let mut bytes = [0u8; 16];
         bytes[15] = 9;
         SyntheticFrontierName::new("main", ChangeId::from_bytes(bytes)).unwrap()
+    }
+
+    fn advertised_frontier(
+        desired_git: SleyObjectId,
+    ) -> (TempDir, HeddleRepository, SyncMapping, SyntheticFrontierName) {
+        let heddle_temp = TempDir::new().unwrap();
+        let heddle = HeddleRepository::init_default(heddle_temp.path()).unwrap();
+        std::fs::write(heddle_temp.path().join("README"), "frontier\n").unwrap();
+        let snapshot = heddle
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                objects::object::Attribution::human(objects::object::Principal::new(
+                    "Test",
+                    "test@example.com",
+                )),
+            )
+            .expect("snapshot");
+        let synthetic = frontier_name();
+        heddle
+            .refs()
+            .set_synthetic_frontier(&synthetic, &snapshot.state_id)
+            .unwrap();
+        let mut mapping = SyncMapping::new();
+        mapping.insert(snapshot.state_id, desired_git);
+        (heddle_temp, heddle, mapping, synthetic)
     }
 
     #[test]
@@ -314,6 +380,70 @@ mod tests {
                 }
             )]
         );
+    }
+
+    #[test]
+    fn reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_present() {
+        let (_temp, repo, recorded) = bare_repo_with_commit();
+        let out_of_band = write_commit(&repo, "out-of-band");
+        let desired = write_commit(&repo, "desired");
+        let synthetic = frontier_name();
+        sync_synthetic_frontier_to_git(&repo, &synthetic, recorded).unwrap();
+        set_ref(
+            &repo,
+            &synthetic.git_ref(),
+            out_of_band,
+            RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(recorded)),
+            "test: out-of-band retarget",
+        )
+        .unwrap();
+        let mut managed = HashMap::new();
+        managed.insert(synthetic.git_ref(), recorded);
+        let (_heddle_temp, heddle, mapping, advertised) = advertised_frontier(desired);
+        assert_eq!(advertised.git_ref(), synthetic.git_ref());
+
+        let diverged =
+            reconcile_synthetic_frontier_refs(&repo, &heddle, &mapping, &mut managed).unwrap();
+
+        let preserved = repo
+            .find_reference(&synthetic.git_ref())
+            .unwrap()
+            .expect("out-of-band synthetic must be preserved");
+        assert_eq!(preserved.target, ReferenceTarget::Direct(out_of_band));
+        assert_eq!(managed.get(&synthetic.git_ref()), Some(&recorded));
+        assert_eq!(
+            diverged,
+            vec![(
+                synthetic.git_ref(),
+                FailedRefExportReason::ModifiedConcurrentlyInGit {
+                    found: out_of_band,
+                    intended: desired,
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn reconcile_updates_owned_desired_synthetic_ref() {
+        let (_temp, repo, recorded) = bare_repo_with_commit();
+        let desired = write_commit(&repo, "desired");
+        let synthetic = frontier_name();
+        sync_synthetic_frontier_to_git(&repo, &synthetic, recorded).unwrap();
+        let mut managed = HashMap::new();
+        managed.insert(synthetic.git_ref(), recorded);
+        let (_heddle_temp, heddle, mapping, advertised) = advertised_frontier(desired);
+        assert_eq!(advertised.git_ref(), synthetic.git_ref());
+
+        let diverged =
+            reconcile_synthetic_frontier_refs(&repo, &heddle, &mapping, &mut managed).unwrap();
+
+        assert!(diverged.is_empty());
+        let written = repo
+            .find_reference(&synthetic.git_ref())
+            .unwrap()
+            .expect("owned synthetic must advance");
+        assert_eq!(written.target, ReferenceTarget::Direct(desired));
+        assert_eq!(managed.get(&synthetic.git_ref()), Some(&desired));
     }
 
     #[test]

--- a/crates/git-projection/src/git_frontier.rs
+++ b/crates/git-projection/src/git_frontier.rs
@@ -225,7 +225,12 @@ mod tests {
 
     fn advertised_frontier(
         desired_git: SleyObjectId,
-    ) -> (TempDir, HeddleRepository, SyncMapping, SyntheticFrontierName) {
+    ) -> (
+        TempDir,
+        HeddleRepository,
+        SyncMapping,
+        SyntheticFrontierName,
+    ) {
         let heddle_temp = TempDir::new().unwrap();
         let heddle = HeddleRepository::init_default(heddle_temp.path()).unwrap();
         std::fs::write(heddle_temp.path().join("README"), "frontier\n").unwrap();

--- a/crates/git-projection/src/git_frontier.rs
+++ b/crates/git-projection/src/git_frontier.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Git publish path for synthetic frontier roots.
+//!
+//! User threads publish to `refs/heads/{thread}`. Synthetic sibling-line
+//! roots publish only under `refs/heddle/frontier/<thread>/<full-changeid>`.
+//! The two namespaces are disjoint, so a user thread such as `main@hd-…`
+//! cannot overwrite a frontier root.
+
+use objects::object::SyntheticFrontierName;
+use sley::{ObjectId as SleyObjectId, RefPrecondition, Repository as SleyRepository};
+
+use crate::git_core::{GitProjectionResult, git_err};
+
+use super::git_sync::set_ref;
+
+/// Publish a synthetic frontier root into Heddle's reserved Git namespace.
+pub fn sync_synthetic_frontier_to_git(
+    repo: &SleyRepository,
+    name: &SyntheticFrontierName,
+    git_oid: SleyObjectId,
+) -> GitProjectionResult<()> {
+    let git_ref = name.git_ref();
+    if let Some(existing) = repo.find_reference(&git_ref).map_err(git_err)? {
+        let current = existing.peeled_oid(repo).map_err(git_err)?;
+        if current == Some(git_oid) {
+            return Ok(());
+        }
+        return set_ref(
+            repo,
+            &git_ref,
+            git_oid,
+            RefPrecondition::Any,
+            "heddle: sync synthetic frontier",
+        );
+    }
+    set_ref(
+        repo,
+        &git_ref,
+        git_oid,
+        RefPrecondition::MustNotExist,
+        "heddle: sync synthetic frontier",
+    )
+}
+
+/// True when a Git ref name is in the reserved `refs/heddle/` namespace.
+pub fn is_reserved_heddle_git_ref(name: &str) -> bool {
+    let stripped = name.strip_prefix("refs/").unwrap_or(name);
+    objects::object::is_reserved_heddle_namespace(stripped)
+        || objects::object::is_reserved_heddle_namespace(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::ChangeId;
+    use sley::{
+        CommitObject, GitObjectType, GitTime, Signature, TreeEditor,
+        plumbing::{sley_core::ByteString, sley_object::EncodedObject},
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_signature() -> Signature {
+        let time = GitTime::new(0, 0);
+        let raw = format!("Heddle Test <heddle@test> 0 {}", time.offset_token()).into_bytes();
+        Signature {
+            name: ByteString::new(b"Heddle Test".to_vec()),
+            email: ByteString::new(b"heddle@test".to_vec()),
+            time,
+            raw,
+        }
+    }
+
+    fn bare_repo_with_commit() -> (TempDir, SleyRepository, SleyObjectId) {
+        let temp = TempDir::new().unwrap();
+        let repo = SleyRepository::init_bare(temp.path()).unwrap();
+        let tree = repo.write_tree(TreeEditor::new()).unwrap();
+        let sig = test_signature();
+        let object = CommitObject {
+            tree,
+            parents: Vec::new(),
+            author: sig.to_ident_bytes(),
+            committer: sig.to_ident_bytes(),
+            encoding: None,
+            message: b"frontier".to_vec(),
+        };
+        let oid = repo
+            .write_object(EncodedObject::new(GitObjectType::Commit, object.write()))
+            .unwrap();
+        (temp, repo, oid)
+    }
+
+    #[test]
+    fn synthetic_git_ref_does_not_collide_with_user_branch_at_hd_suffix() {
+        let (_temp, repo, oid) = bare_repo_with_commit();
+        let mut bytes = [0u8; 16];
+        bytes[15] = 9;
+        let change = ChangeId::from_bytes(bytes);
+        let synthetic = SyntheticFrontierName::new("main", change).unwrap();
+        let user_branch = format!("refs/heads/main@{}", change.to_string_full());
+
+        sync_synthetic_frontier_to_git(&repo, &synthetic, oid).unwrap();
+        set_ref(
+            &repo,
+            &user_branch,
+            oid,
+            RefPrecondition::MustNotExist,
+            "test: user thread at hd suffix",
+        )
+        .unwrap();
+
+        assert_ne!(synthetic.git_ref(), user_branch);
+        assert!(synthetic.git_ref().starts_with("refs/heddle/frontier/"));
+        assert!(repo.find_reference(&synthetic.git_ref()).unwrap().is_some());
+        assert!(repo.find_reference(&user_branch).unwrap().is_some());
+    }
+
+    #[test]
+    fn reserved_git_ref_classifier_covers_heads_and_heddle_namespaces() {
+        assert!(is_reserved_heddle_git_ref(
+            "refs/heddle/frontier/main/hc-abc"
+        ));
+        assert!(is_reserved_heddle_git_ref("heddle/frontier/main/hc-abc"));
+        assert!(!is_reserved_heddle_git_ref("refs/heads/main@hd-abc"));
+        assert!(!is_reserved_heddle_git_ref("refs/heads/heddle"));
+    }
+}

--- a/crates/git-projection/src/git_frontier.rs
+++ b/crates/git-projection/src/git_frontier.rs
@@ -15,8 +15,9 @@ use sley::{
 };
 
 use crate::git_core::{
-    delete_reference_if_present, git_err, GitProjectionError, GitProjectionResult, SyncMapping,
+    GitProjectionError, GitProjectionResult, SyncMapping, delete_reference_matching, git_err,
 };
+use crate::git_util::FailedRefExportReason;
 
 use super::git_sync::set_ref;
 
@@ -60,12 +61,16 @@ pub fn sync_synthetic_frontier_to_git(
 }
 
 /// Materialize advertised synthetic frontier refs and drop stale managed ones.
+///
+/// A formerly managed name is deleted only when the current Git target still
+/// matches the recorded managed OID. An out-of-band retarget is preserved and
+/// reported so CAS is an ownership check, not a tip-at-delete-time overwrite.
 pub fn reconcile_synthetic_frontier_refs(
     repo: &SleyRepository,
     heddle_repo: &HeddleRepository,
     mapping: &SyncMapping,
     managed_record: &mut HashMap<String, SleyObjectId>,
-) -> GitProjectionResult<()> {
+) -> GitProjectionResult<Vec<(String, FailedRefExportReason)>> {
     let advertised = heddle_repo.refs().list_synthetic_frontiers()?;
     let mut desired: HashSet<String> = HashSet::new();
     for (name, state) in advertised {
@@ -79,14 +84,44 @@ pub fn reconcile_synthetic_frontier_refs(
     }
     let stale: Vec<String> = managed_record
         .keys()
-        .filter(|name| name.starts_with("refs/heddle/") && !desired.contains(*name))
+        .filter(|name| SyntheticFrontierName::parse(name).is_ok() && !desired.contains(*name))
         .cloned()
         .collect();
+    let mut diverged = Vec::new();
     for git_ref in stale {
-        delete_reference_if_present(repo, &git_ref)?;
-        managed_record.remove(&git_ref);
+        let Some(recorded) = managed_record.get(&git_ref).copied() else {
+            continue;
+        };
+        match repo.find_reference(&git_ref).map_err(git_err)? {
+            None => {
+                managed_record.remove(&git_ref);
+            }
+            Some(reference) => match reference.target {
+                ReferenceTarget::Direct(current) if current == recorded => {
+                    delete_reference_matching(repo, &git_ref, recorded)?;
+                    managed_record.remove(&git_ref);
+                }
+                ReferenceTarget::Direct(current) => {
+                    diverged.push((
+                        git_ref,
+                        FailedRefExportReason::ModifiedConcurrentlyInGit {
+                            found: current,
+                            intended: recorded,
+                        },
+                    ));
+                }
+                ReferenceTarget::Symbolic(_) => {
+                    diverged.push((
+                        git_ref,
+                        FailedRefExportReason::FailedToDelete(
+                            "synthetic frontier is symbolic; refuse to clobber".to_string(),
+                        ),
+                    ));
+                }
+            },
+        }
     }
-    Ok(())
+    Ok(diverged)
 }
 
 /// True when a Git ref name is in the reserved `refs/heddle/` namespace.
@@ -101,8 +136,8 @@ mod tests {
     use objects::object::ChangeId;
     use repo::Repository as HeddleRepository;
     use sley::{
-        plumbing::{sley_core::ByteString, sley_object::EncodedObject},
         CommitObject, GitObjectType, GitTime, Signature, TreeEditor,
+        plumbing::{sley_core::ByteString, sley_object::EncodedObject},
     };
     use tempfile::TempDir;
 
@@ -231,11 +266,54 @@ mod tests {
 
         let heddle_temp = TempDir::new().unwrap();
         let heddle = HeddleRepository::init_default(heddle_temp.path()).unwrap();
-        reconcile_synthetic_frontier_refs(&repo, &heddle, &SyncMapping::new(), &mut managed)
-            .unwrap();
+        let diverged =
+            reconcile_synthetic_frontier_refs(&repo, &heddle, &SyncMapping::new(), &mut managed)
+                .unwrap();
 
+        assert!(diverged.is_empty());
         assert!(repo.find_reference(&synthetic.git_ref()).unwrap().is_none());
         assert!(!managed.contains_key(&synthetic.git_ref()));
+    }
+
+    #[test]
+    fn reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_absent() {
+        let (_temp, repo, recorded) = bare_repo_with_commit();
+        let out_of_band = write_commit(&repo, "out-of-band");
+        let synthetic = frontier_name();
+        sync_synthetic_frontier_to_git(&repo, &synthetic, recorded).unwrap();
+        set_ref(
+            &repo,
+            &synthetic.git_ref(),
+            out_of_band,
+            RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(recorded)),
+            "test: out-of-band retarget",
+        )
+        .unwrap();
+        let mut managed = HashMap::new();
+        managed.insert(synthetic.git_ref(), recorded);
+
+        let heddle_temp = TempDir::new().unwrap();
+        let heddle = HeddleRepository::init_default(heddle_temp.path()).unwrap();
+        let diverged =
+            reconcile_synthetic_frontier_refs(&repo, &heddle, &SyncMapping::new(), &mut managed)
+                .unwrap();
+
+        let preserved = repo
+            .find_reference(&synthetic.git_ref())
+            .unwrap()
+            .expect("out-of-band synthetic must be preserved");
+        assert_eq!(preserved.target, ReferenceTarget::Direct(out_of_band));
+        assert_eq!(managed.get(&synthetic.git_ref()), Some(&recorded));
+        assert_eq!(
+            diverged,
+            vec![(
+                synthetic.git_ref(),
+                FailedRefExportReason::ModifiedConcurrentlyInGit {
+                    found: out_of_band,
+                    intended: recorded,
+                }
+            )]
+        );
     }
 
     #[test]

--- a/crates/git-projection/src/git_ingest.rs
+++ b/crates/git-projection/src/git_ingest.rs
@@ -8,8 +8,8 @@ use sley::ObjectId;
 
 use super::{
     git_core::{
-        GitProjection, GitProjectionError, GitProjectionResult, RefNamespace,
-        collect_import_source_ref_updates, open_repo,
+        collect_import_source_ref_updates, open_repo, GitProjection, GitProjectionError,
+        GitProjectionResult, RefNamespace,
     },
     git_export::commit_requires_residual,
     git_residual::ResidualStore,
@@ -79,7 +79,7 @@ fn capture_import_residuals(
         match update.namespace {
             // The ingest pack writes annotated tags directly into the native
             // object store. No bridge-only residual/sidecar path is needed.
-            RefNamespace::Tag => {}
+            RefNamespace::Tag | RefNamespace::Heddle => {}
             RefNamespace::Note => {
                 residuals.capture_object_closure_from_git_repo(&source_repo, &update.target)?;
                 residuals.record_note_ref(&update.name, update.target)?;

--- a/crates/git-projection/src/git_sync.rs
+++ b/crates/git-projection/src/git_sync.rs
@@ -64,7 +64,15 @@ pub fn sync_branches(bridge: &mut GitProjection) -> GitProjectionResult<usize> {
             continue;
         };
         if let Some(state_id) = bridge.mapping.get_heddle(target) {
-            let tn = ThreadName::new(name);
+            if crate::git_frontier::is_reserved_heddle_git_ref(&reference.name)
+                || objects::object::is_reserved_heddle_namespace(name)
+            {
+                return Err(GitProjectionError::InvalidMapping(format!(
+                    "refused to import reserved heddle/ Git branch '{name}'"
+                )));
+            }
+            let tn = ThreadName::try_new(name)
+                .map_err(|error| GitProjectionError::InvalidMapping(error.to_string()))?;
             if let Some(existing) = bridge.heddle_repo.refs().get_thread(&tn)?
                 && !thread_can_adopt_change(bridge, &existing, &state_id)?
             {
@@ -113,7 +121,15 @@ pub fn sync_tags(bridge: &mut GitProjection) -> GitProjectionResult<usize> {
         };
 
         if let Some(state_id) = bridge.mapping.get_heddle(oid) {
-            let mn = MarkerName::new(name);
+            if crate::git_frontier::is_reserved_heddle_git_ref(&reference.name)
+                || objects::object::is_reserved_heddle_namespace(name)
+            {
+                return Err(GitProjectionError::InvalidMapping(format!(
+                    "refused to import reserved heddle/ Git tag '{name}'"
+                )));
+            }
+            let mn = MarkerName::try_new(name)
+                .map_err(|error| GitProjectionError::InvalidMapping(error.to_string()))?;
             match bridge.heddle_repo.refs().get_marker(&mn) {
                 Ok(Some(existing)) if existing != state_id => bridge
                     .heddle_repo
@@ -241,7 +257,7 @@ pub fn sync_marker_to_tag(
     )
 }
 
-fn set_ref(
+pub(crate) fn set_ref(
     repo: &SleyRepository,
     name: &str,
     oid: SleyObjectId,

--- a/crates/git-projection/src/lib.rs
+++ b/crates/git-projection/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod credential;
 pub mod git_core;
 pub mod git_export;
+pub mod git_frontier;
 pub mod git_ingest;
 pub mod git_mapping;
 pub mod git_notes;

--- a/crates/git-projection/src/test_support.rs
+++ b/crates/git-projection/src/test_support.rs
@@ -17,6 +17,7 @@ pub enum RefNamespace {
     Branch,
     Tag,
     Note,
+    Heddle,
 }
 
 impl From<RefNamespace> for git_core::RefNamespace {
@@ -25,6 +26,7 @@ impl From<RefNamespace> for git_core::RefNamespace {
             RefNamespace::Branch => Self::Branch,
             RefNamespace::Tag => Self::Tag,
             RefNamespace::Note => Self::Note,
+            RefNamespace::Heddle => Self::Heddle,
         }
     }
 }
@@ -35,6 +37,7 @@ impl From<git_core::RefNamespace> for RefNamespace {
             git_core::RefNamespace::Branch => Self::Branch,
             git_core::RefNamespace::Tag => Self::Tag,
             git_core::RefNamespace::Note => Self::Note,
+            git_core::RefNamespace::Heddle => Self::Heddle,
         }
     }
 }

--- a/crates/object-model/src/object/frontier_ref.rs
+++ b/crates/object-model/src/object/frontier_ref.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Synthetic frontier-root names.
+//!
+//! Sibling-line roots advertised for a merge-frontier antichain live in the
+//! reserved `heddle/` namespace as `heddle/frontier/<thread>/<full-changeid>`.
+//! The Git projection of the same root is
+//! `refs/heddle/frontier/<thread>/<full-changeid>`.
+//!
+//! The ChangeId suffix is always [`ChangeId::to_string_full`] — never the
+//! truncatable [`ChangeId::short`] / `Display` form — so two siblings that
+//! share a prefix remain distinct refs.
+
+use super::{
+    ChangeId, ChangeIdParseError, RESERVED_REF_SEGMENT, ThreadName, is_reserved_heddle_namespace,
+};
+
+/// Wire and local-store prefix for synthetic frontier roots.
+pub const SYNTHETIC_FRONTIER_PREFIX: &str = "heddle/frontier/";
+
+/// Git-side prefix for the same roots. Disjoint from `refs/heads/`.
+pub const GIT_SYNTHETIC_FRONTIER_PREFIX: &str = "refs/heddle/frontier/";
+
+/// Type-distinct name of a synthetic frontier root.
+///
+/// This is not a [`ThreadName`] and not a [`MarkerName`]. Consume, store, and
+/// mirror sites must persist it through the synthetic-ref path.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SyntheticFrontierName {
+    thread: String,
+    change_id: ChangeId,
+}
+
+/// Why a synthetic frontier name could not be built or parsed.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SyntheticFrontierNameError {
+    #[error("synthetic frontier thread name is empty")]
+    EmptyThread,
+    #[error("synthetic frontier thread '{name}' occupies the reserved heddle/ namespace")]
+    ReservedThread { name: String },
+    #[error("synthetic frontier name '{name}' is not heddle/frontier/<thread>/<full-changeid>")]
+    InvalidForm { name: String },
+    #[error("synthetic frontier change id is not a full ChangeId: {0}")]
+    ChangeId(#[from] ChangeIdParseError),
+}
+
+impl SyntheticFrontierName {
+    /// Build a synthetic root for `thread` at `change_id`.
+    ///
+    /// `thread` is the user thread whose sibling line this root names. It must
+    /// itself be a user name (not `heddle/`-rooted).
+    pub fn new(
+        thread: impl AsRef<str>,
+        change_id: ChangeId,
+    ) -> Result<Self, SyntheticFrontierNameError> {
+        let thread = thread.as_ref();
+        if thread.is_empty() {
+            return Err(SyntheticFrontierNameError::EmptyThread);
+        }
+        if is_reserved_heddle_namespace(thread) {
+            return Err(SyntheticFrontierNameError::ReservedThread {
+                name: thread.to_string(),
+            });
+        }
+        Ok(Self {
+            thread: thread.to_string(),
+            change_id,
+        })
+    }
+
+    /// Parse a wire/store name of the form `heddle/frontier/<thread>/<full-changeid>`.
+    ///
+    /// The last `/`-segment is the ChangeId (`hc-` + full Crockford base32).
+    /// Everything between `heddle/frontier/` and that segment is the thread
+    /// name, which may itself contain `/`.
+    pub fn parse(name: &str) -> Result<Self, SyntheticFrontierNameError> {
+        let Some(rest) = strip_frontier_prefix(name) else {
+            return Err(SyntheticFrontierNameError::InvalidForm {
+                name: name.to_string(),
+            });
+        };
+        let Some((thread, change_id)) = rest.rsplit_once('/') else {
+            return Err(SyntheticFrontierNameError::InvalidForm {
+                name: name.to_string(),
+            });
+        };
+        let parsed = ChangeId::parse(change_id)?;
+        if change_id != parsed.to_string_full() {
+            return Err(SyntheticFrontierNameError::InvalidForm {
+                name: name.to_string(),
+            });
+        }
+        Self::new(thread, parsed)
+    }
+
+    /// True when `name` is a well-formed synthetic frontier root.
+    pub fn looks_like(name: &str) -> bool {
+        Self::parse(name).is_ok()
+    }
+
+    pub fn thread(&self) -> &str {
+        &self.thread
+    }
+
+    pub fn change_id(&self) -> ChangeId {
+        self.change_id
+    }
+
+    /// Wire / local-store name: `heddle/frontier/<thread>/<full-changeid>`.
+    pub fn as_name(&self) -> String {
+        format!(
+            "{SYNTHETIC_FRONTIER_PREFIX}{}/{}",
+            self.thread,
+            self.change_id.to_string_full()
+        )
+    }
+
+    /// Git-side name: `refs/heddle/frontier/<thread>/<full-changeid>`.
+    pub fn git_ref(&self) -> String {
+        format!(
+            "{GIT_SYNTHETIC_FRONTIER_PREFIX}{}/{}",
+            self.thread,
+            self.change_id.to_string_full()
+        )
+    }
+
+    /// The user thread this synthetic root belongs to, as a [`ThreadName`].
+    ///
+    /// Only the *owning* user thread is a ThreadName. The synthetic root
+    /// itself must never be coerced into one.
+    pub fn owning_thread(&self) -> ThreadName {
+        ThreadName::new(&self.thread)
+    }
+}
+
+impl std::fmt::Display for SyntheticFrontierName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.as_name())
+    }
+}
+
+fn strip_frontier_prefix(name: &str) -> Option<&str> {
+    if let Some(rest) = name.strip_prefix(SYNTHETIC_FRONTIER_PREFIX) {
+        return nonempty(rest);
+    }
+    if let Some(rest) = name.strip_prefix(GIT_SYNTHETIC_FRONTIER_PREFIX) {
+        return nonempty(rest);
+    }
+    let mut parts = name.splitn(3, '/');
+    let first = parts.next()?;
+    let second = parts.next()?;
+    let rest = parts.next()?;
+    if first.eq_ignore_ascii_case(RESERVED_REF_SEGMENT) && second.eq_ignore_ascii_case("frontier") {
+        nonempty(rest)
+    } else {
+        None
+    }
+}
+
+fn nonempty(rest: &str) -> Option<&str> {
+    if rest.is_empty() { None } else { Some(rest) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cid(last: u8) -> ChangeId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = last;
+        ChangeId::from_bytes(bytes)
+    }
+
+    #[test]
+    fn full_change_id_keeps_prefix_sharing_siblings_distinct() {
+        let a = cid(0);
+        let mut shared = [0u8; 16];
+        shared[0] = 0xaa;
+        shared[1] = 0xbb;
+        shared[15] = 1;
+        let b = ChangeId::from_bytes(shared);
+        let mut c_bytes = shared;
+        c_bytes[15] = 2;
+        let c = ChangeId::from_bytes(c_bytes);
+
+        let left = SyntheticFrontierName::new("main", b).unwrap();
+        let right = SyntheticFrontierName::new("main", c).unwrap();
+        assert_ne!(left.as_name(), right.as_name());
+        assert_ne!(left.git_ref(), right.git_ref());
+        assert!(left.as_name().contains(&b.to_string_full()));
+        assert!(right.as_name().contains(&c.to_string_full()));
+        assert!(!left.as_name().ends_with(&b.short()));
+        let _ = a;
+    }
+
+    #[test]
+    fn parse_round_trips_slashed_thread_and_full_change_id() {
+        let change = cid(9);
+        let name = SyntheticFrontierName::new("feature/auth", change).unwrap();
+        let parsed = SyntheticFrontierName::parse(&name.as_name()).unwrap();
+        assert_eq!(parsed.thread(), "feature/auth");
+        assert_eq!(parsed.change_id(), change);
+        assert_eq!(
+            parsed.git_ref(),
+            format!(
+                "refs/heddle/frontier/feature/auth/{}",
+                change.to_string_full()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_short_change_id_suffix() {
+        let change = cid(3);
+        let short = format!("heddle/frontier/main/{}", change.short());
+        assert!(SyntheticFrontierName::parse(&short).is_err());
+    }
+
+    #[test]
+    fn user_thread_at_change_id_is_not_a_synthetic_root() {
+        let change = cid(4);
+        let user = format!("main@{}", change.to_string_full());
+        assert!(!is_reserved_heddle_namespace(&user));
+        assert!(SyntheticFrontierName::parse(&user).is_err());
+        assert_ne!(
+            user,
+            SyntheticFrontierName::new("main", change)
+                .unwrap()
+                .as_name()
+        );
+    }
+
+    #[test]
+    fn refuses_a_reserved_thread_component() {
+        let change = cid(5);
+        assert!(SyntheticFrontierName::new("heddle/nested", change).is_err());
+    }
+}

--- a/crates/object-model/src/object/identifiers.rs
+++ b/crates/object-model/src/object/identifiers.rs
@@ -106,6 +106,59 @@ string_newtype!(
     MarkerName
 );
 
+/// First path segment reserved for Heddle-internal refs.
+///
+/// A user may still name a thread `heddle`, `heddlefoo`, or `my/heddle`.
+/// Only a `heddle/`-rooted name is reserved (Invariant C).
+pub const RESERVED_REF_SEGMENT: &str = "heddle";
+
+/// True when `name` occupies the reserved `heddle/` namespace.
+///
+/// The check is case-insensitive on the first segment so a raw-Git branch
+/// `Heddle/frontier/...` cannot slip past the reservation.
+pub fn is_reserved_heddle_namespace(name: &str) -> bool {
+    let mut parts = name.split('/');
+    match (parts.next(), parts.next()) {
+        (Some(first), Some(_)) => first.eq_ignore_ascii_case(RESERVED_REF_SEGMENT),
+        _ => false,
+    }
+}
+
+/// Rejection when a user thread or marker name occupies `heddle/`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "ref name '{name}' is reserved: the heddle/ namespace is internal and cannot be a user thread or marker"
+)]
+pub struct ReservedRefNameError {
+    pub name: String,
+}
+
+impl ThreadName {
+    /// Fallible constructor for user or imported names. Rejects the reserved
+    /// `heddle/` namespace. Trusted reconstruction of already-stored names
+    /// still uses [`ThreadName::new`].
+    pub fn try_new(s: impl Into<String>) -> Result<Self, ReservedRefNameError> {
+        let name = s.into();
+        if is_reserved_heddle_namespace(&name) {
+            return Err(ReservedRefNameError { name });
+        }
+        Ok(Self(name))
+    }
+}
+
+impl MarkerName {
+    /// Fallible constructor for user or imported names. Rejects the reserved
+    /// `heddle/` namespace. Trusted reconstruction of already-stored names
+    /// still uses [`MarkerName::new`].
+    pub fn try_new(s: impl Into<String>) -> Result<Self, ReservedRefNameError> {
+        let name = s.into();
+        if is_reserved_heddle_namespace(&name) {
+            return Err(ReservedRefNameError { name });
+        }
+        Ok(Self(name))
+    }
+}
+
 string_newtype!(
     /// Checkout/lane scope identifier for scoped operations.
     Scope
@@ -154,5 +207,26 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(ThreadName::new("main"), 1);
         assert_eq!(map.get("main"), Some(&1));
+    }
+
+    #[test]
+    fn reserved_namespace_is_heddle_rooted_only() {
+        assert!(!is_reserved_heddle_namespace("heddle"));
+        assert!(!is_reserved_heddle_namespace("heddlefoo"));
+        assert!(!is_reserved_heddle_namespace("my/heddle"));
+        assert!(!is_reserved_heddle_namespace("main@review"));
+        assert!(is_reserved_heddle_namespace("heddle/frontier/main/hc-abc"));
+        assert!(is_reserved_heddle_namespace("Heddle/x"));
+    }
+
+    #[test]
+    fn try_new_rejects_reserved_thread_and_marker_names() {
+        assert!(ThreadName::try_new("heddle/frontier/main/hc-1").is_err());
+        assert!(MarkerName::try_new("heddle/notes").is_err());
+        assert_eq!(ThreadName::try_new("heddle").unwrap().as_str(), "heddle");
+        assert_eq!(
+            ThreadName::try_new("main@hd-abc").unwrap().as_str(),
+            "main@hd-abc"
+        );
     }
 }

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -12,6 +12,7 @@ mod blob;
 pub mod collaboration;
 mod diff;
 mod discussion;
+mod frontier_ref;
 mod hash;
 mod identifiers;
 mod key_binding;
@@ -57,8 +58,15 @@ pub use discussion::{
     Discussion, DiscussionError, DiscussionId, DiscussionReference, DiscussionReferenceKind,
     DiscussionResolution, DiscussionTurn, DiscussionsBlob, generate_discussion_id,
 };
+pub use frontier_ref::{
+    GIT_SYNTHETIC_FRONTIER_PREFIX, SYNTHETIC_FRONTIER_PREFIX, SyntheticFrontierName,
+    SyntheticFrontierNameError,
+};
 pub use hash::{ChangeId, ChangeIdParseError, ContentHash, StateId, StateIdParseError};
-pub use identifiers::{MarkerName, Scope, ThreadName};
+pub use identifiers::{
+    MarkerName, RESERVED_REF_SEGMENT, ReservedRefNameError, Scope, ThreadName,
+    is_reserved_heddle_namespace,
+};
 pub use key_binding::{
     KEY_BINDING_REGISTRY_SIGNING_PAYLOAD_VERSION_TAG, KEY_BINDING_SIGNING_PAYLOAD_VERSION_TAG,
     KeyBinding, KeyBindingError, KeyBindingRegistry, KeyRole,

--- a/crates/refs/src/refs/backend.rs
+++ b/crates/refs/src/refs/backend.rs
@@ -114,7 +114,7 @@ mod tests {
     };
 
     use super::CoreRefBackend;
-    use crate::refs::{Head, RefBackend, RefExpectation, RefUpdate};
+    use crate::refs::{Head, RefBackend, RefExpectation, RefUpdate, require_user_ref_name};
 
     /// In-memory backend that does **not** override `resolve`, so the
     /// trait's default `resolve` (the only non-Pg, non-`RefManager`
@@ -136,6 +136,9 @@ mod tests {
                 .ok_or_else(|| HeddleError::Config("no head".to_string()))
         }
         fn write_head(&self, head: &Head) -> Result<(), HeddleError> {
+            if let Head::Attached { thread } = head {
+                require_user_ref_name(thread.as_str())?;
+            }
             *self.head.lock_or_poisoned() = Some(head.clone());
             Ok(())
         }
@@ -150,6 +153,7 @@ mod tests {
             Ok(self.threads.lock_or_poisoned().get(name.as_str()).copied())
         }
         fn set_thread(&self, name: &ThreadName, state: &StateId) -> Result<(), HeddleError> {
+            require_user_ref_name(name.as_str())?;
             self.threads
                 .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
@@ -189,6 +193,7 @@ mod tests {
             name: &MarkerName,
             state: &StateId,
         ) -> Result<(), HeddleError> {
+            require_user_ref_name(name.as_str())?;
             self.markers
                 .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
@@ -200,6 +205,7 @@ mod tests {
             _expected: RefExpectation<StateId>,
             state: &StateId,
         ) -> Result<(), HeddleError> {
+            require_user_ref_name(name.as_str())?;
             self.markers
                 .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
@@ -223,7 +229,24 @@ mod tests {
                 .map(|k| MarkerName::new(k.as_str()))
                 .collect())
         }
-        fn update_refs(&self, _updates: &[RefUpdate]) -> Result<(), HeddleError> {
+        fn update_refs(&self, updates: &[RefUpdate]) -> Result<(), HeddleError> {
+            for update in updates {
+                match update {
+                    RefUpdate::Thread { name, new: Some(_), .. } => {
+                        require_user_ref_name(name.as_str())?;
+                    }
+                    RefUpdate::Marker { name, new: Some(_), .. } => {
+                        require_user_ref_name(name.as_str())?;
+                    }
+                    RefUpdate::Head {
+                        new: Head::Attached { thread },
+                        ..
+                    } => {
+                        require_user_ref_name(thread.as_str())?;
+                    }
+                    _ => {}
+                }
+            }
             Ok(())
         }
         // `resolve` deliberately left unimplemented — exercises the default.
@@ -400,5 +423,22 @@ mod tests {
                 new: Some(thread_id),
             }])
             .unwrap();
+    }
+
+    #[test]
+    fn mem_backend_rejects_reserved_heddle_thread_name() {
+        let backend = MemRefBackend::default();
+        let state = crate::refs::fresh_state_id();
+        let reserved = ThreadName::new("heddle/frontier/main/hc-abc");
+        let error = backend.set_thread(&reserved, &state).unwrap_err();
+        assert!(matches!(
+            error,
+            HeddleError::InvalidRefName(name) if name == "heddle/frontier/main/hc-abc"
+        ));
+        assert!(
+            pollster::block_on(backend.get_thread(&reserved))
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -33,7 +33,7 @@ pub use backend::CoreRefBackend;
 pub use facet::SpoolFacet;
 pub use head::{Head, HeadParseError};
 pub use heddle_schema::refs::PackedRefsModel;
-pub use name::{RefNameError, validate_ref_name};
+pub use name::{RefNameError, require_user_ref_name, validate_ref_name};
 pub use operation_index::{IndexedOperation, OperationLogIndex, OperationLogQuery};
 #[cfg(feature = "postgres")]
 pub use pg_refs::PgRefBackend;

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -13,6 +13,7 @@ mod ref_summary_index;
 mod refs_head;
 mod refs_manager;
 mod refs_storage;
+mod refs_synthetic;
 mod refs_transactions;
 mod refs_types;
 mod resolve;

--- a/crates/refs/src/refs/name.rs
+++ b/crates/refs/src/refs/name.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Ref-name validation rules.
 
+use objects::object::is_reserved_heddle_namespace;
+
 /// Ref-name validation error.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("invalid ref name: {name}")]
@@ -31,6 +33,9 @@ pub fn validate_ref_name(name: &str) -> Result<(), RefNameError> {
         .split('/')
         .any(|component| component.ends_with(".lock"))
     {
+        return Err(invalid(name));
+    }
+    if is_reserved_heddle_namespace(name) {
         return Err(invalid(name));
     }
     Ok(())
@@ -70,5 +75,16 @@ mod tests {
     #[test]
     fn allows_plain_ref() {
         assert!(validate_ref_name("refs/heads/main").is_ok());
+    }
+
+    #[test]
+    fn reserves_heddle_rooted_names() {
+        assert!(validate_ref_name("heddle/frontier/main/hc-abc").is_err());
+        assert!(validate_ref_name("Heddle/x").is_err());
+        assert!(validate_ref_name("heddle").is_ok());
+        assert!(validate_ref_name("heddlefoo").is_ok());
+        assert!(validate_ref_name("my/heddle").is_ok());
+        assert!(validate_ref_name("main@review").is_ok());
+        assert!(validate_ref_name("main@hd-abc").is_ok());
     }
 }

--- a/crates/refs/src/refs/name.rs
+++ b/crates/refs/src/refs/name.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Ref-name validation rules.
 
-use objects::object::is_reserved_heddle_namespace;
+use objects::{error::HeddleError, object::is_reserved_heddle_namespace};
 
 /// Ref-name validation error.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -41,6 +41,18 @@ pub fn validate_ref_name(name: &str) -> Result<(), RefNameError> {
     Ok(())
 }
 
+/// Shared reservation chokepoint for every [`crate::refs::CoreRefBackend`].
+///
+/// Filesystem paths already call [`validate_ref_name`]. Hosted Postgres
+/// mutations (and the in-memory test backend) must go through this helper
+/// so a `ThreadName`/`MarkerName` minted via `new`/`From` cannot persist a
+/// user ref in the reserved `heddle/` namespace.
+///
+/// Serve-side `ListRefs`/`Pull` gating of synthetic roots remains weft#1728.
+pub fn require_user_ref_name(name: impl AsRef<str>) -> objects::error::Result<()> {
+    validate_ref_name(name.as_ref()).map_err(|error| HeddleError::InvalidRefName(error.name))
+}
+
 fn invalid(name: &str) -> RefNameError {
     RefNameError {
         name: name.to_string(),
@@ -49,7 +61,9 @@ fn invalid(name: &str) -> RefNameError {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_ref_name;
+    use objects::error::HeddleError;
+
+    use super::{require_user_ref_name, validate_ref_name};
 
     #[test]
     fn rejects_ref_ending_in_lock() {
@@ -86,5 +100,14 @@ mod tests {
         assert!(validate_ref_name("my/heddle").is_ok());
         assert!(validate_ref_name("main@review").is_ok());
         assert!(validate_ref_name("main@hd-abc").is_ok());
+    }
+
+    #[test]
+    fn require_user_ref_name_rejects_reserved_namespace() {
+        let error = require_user_ref_name("heddle/frontier/main/hc-abc").unwrap_err();
+        assert!(
+            matches!(error, HeddleError::InvalidRefName(name) if name == "heddle/frontier/main/hc-abc")
+        );
+        assert!(require_user_ref_name("main").is_ok());
     }
 }

--- a/crates/refs/src/refs/pg_refs.rs
+++ b/crates/refs/src/refs/pg_refs.rs
@@ -16,7 +16,31 @@ use runtime_bridge::RuntimeBridge;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
-use super::{CoreRefBackend, Head, RefBackend, RefExpectation, RefUpdate};
+use super::{
+    CoreRefBackend, Head, RefBackend, RefExpectation, RefUpdate, require_user_ref_name,
+};
+
+/// Reject reserved `heddle/` names before any SQL. Serve-side ListRefs/Pull
+/// gating of synthetic roots remains weft#1728; this chokepoint only stops a
+/// hosted caller persisting a *user* thread/marker in that namespace.
+fn require_user_ref_update(update: &RefUpdate) -> Result<()> {
+    match update {
+        RefUpdate::Thread { name, new: Some(_), .. } => require_user_ref_name(name.as_str()),
+        RefUpdate::Marker { name, new: Some(_), .. } => require_user_ref_name(name.as_str()),
+        RefUpdate::Head {
+            new: Head::Attached { thread },
+            ..
+        } => require_user_ref_name(thread.as_str()),
+        _ => Ok(()),
+    }
+}
+
+fn require_user_head(head: &Head) -> Result<()> {
+    match head {
+        Head::Attached { thread } => require_user_ref_name(thread.as_str()),
+        Head::Detached { .. } => Ok(()),
+    }
+}
 
 fn sqlx_err(e: sqlx::Error) -> HeddleError {
     HeddleError::Io(std::io::Error::other(e.to_string()))
@@ -175,6 +199,7 @@ impl CoreRefBackend for PgRefBackend {
     }
 
     fn write_head(&self, head: &Head) -> Result<()> {
+        require_user_head(head)?;
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let (thread, state_id): (Option<String>, Option<Vec<u8>>) = match head {
@@ -223,6 +248,7 @@ impl CoreRefBackend for PgRefBackend {
         Self::get_ref_async(self.pool.as_ref(), self.repo_id, name.as_str(), true).await
     }
     fn set_thread(&self, name: &ThreadName, state: &StateId) -> Result<()> {
+        require_user_ref_name(name.as_str())?;
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -235,6 +261,7 @@ impl CoreRefBackend for PgRefBackend {
         expected: RefExpectation<StateId>,
         state: &StateId,
     ) -> Result<()> {
+        require_user_ref_name(name.as_str())?;
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -275,6 +302,7 @@ impl CoreRefBackend for PgRefBackend {
         Self::get_ref_async(self.pool.as_ref(), self.repo_id, name.as_str(), false).await
     }
     async fn create_marker(&self, name: &MarkerName, state: &StateId) -> Result<()> {
+        require_user_ref_name(name.as_str())?;
         let bytes = Self::id_to_bytes(state);
         let n = sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, false, $3, NOW()) ON CONFLICT DO NOTHING")
             .bind(self.repo_id)
@@ -298,6 +326,7 @@ impl CoreRefBackend for PgRefBackend {
         expected: RefExpectation<StateId>,
         state: &StateId,
     ) -> Result<()> {
+        require_user_ref_name(name.as_str())?;
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -335,6 +364,9 @@ impl CoreRefBackend for PgRefBackend {
         })
     }
     fn update_refs(&self, updates: &[RefUpdate]) -> Result<()> {
+        for update in updates {
+            require_user_ref_update(update)?;
+        }
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let updates = updates.to_vec();

--- a/crates/refs/src/refs/pg_refs_tests.rs
+++ b/crates/refs/src/refs/pg_refs_tests.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
-use objects::object::{MarkerName, StateId, ThreadName};
+use objects::{error::HeddleError, object::{MarkerName, StateId, ThreadName}};
+use uuid::Uuid;
 use sqlx::{AssertSqlSafe, Executor, PgPool, postgres::PgPoolOptions};
 
 use super::*;
@@ -92,6 +93,23 @@ fn state_id_codec_requires_32_bytes() {
     let error = PgRefBackend::bytes_to_id(vec![0; 16]).unwrap_err();
     assert!(matches!(error, HeddleError::InvalidObject(_)));
     assert!(error.to_string().contains("expected 32 bytes, found 16"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn pg_set_thread_rejects_reserved_name_before_sql() {
+    let pool = PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(200))
+        .connect_lazy(&test_database_url())
+        .expect("connect_lazy accepts the URL");
+    let backend = PgRefBackend::new(Arc::new(pool), Uuid::new_v4());
+    let reserved = ThreadName::new("heddle/frontier/main/hc-abc");
+    let error = backend
+        .set_thread(&reserved, &full_width_state(1))
+        .expect_err("reserved names must fail before SQL");
+    assert!(matches!(
+        error,
+        HeddleError::InvalidRefName(name) if name == "heddle/frontier/main/hc-abc"
+    ));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -238,7 +238,10 @@ impl RefManager {
     /// check (`write_read_conformance` in the refs tests) fails CI if any other
     /// path calls a raw writer, so a path-by-path allowlist cannot silently
     /// re-open the class.
-    fn write_chokepoint<T>(&self, body: impl FnOnce(&RefsLock) -> Result<T>) -> Result<T> {
+    pub(super) fn write_chokepoint<T>(
+        &self,
+        body: impl FnOnce(&RefsLock) -> Result<T>,
+    ) -> Result<T> {
         let lock = self.lock_refs()?;
         self.materialize_committed_tail(&lock)?;
         body(&lock)

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -15,7 +15,7 @@ use objects::{
     object::ThreadName,
 };
 
-use super::{RefManager, name::validate_ref_name};
+use super::{name::require_user_ref_name, RefManager};
 use crate::fs_atomic::{create_dir_all_durable, write_file_atomic};
 
 const MAX_LOCK_WAIT_SECS: u64 = 10;
@@ -97,7 +97,7 @@ impl RefManager {
     /// fallback to a nested legacy layout is performed. Top-level (non-slashed)
     /// names never needed nesting and are stored plainly at `threads/<name>`.
     pub(super) fn thread_path(&self, name: &ThreadName) -> Result<PathBuf> {
-        validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
+        require_user_ref_name(name)?;
         if name.contains('/') {
             self.flat_thread_path(name)
         } else {
@@ -108,11 +108,11 @@ impl RefManager {
     /// name. Only valid for non-slashed names; slashed names use the flat
     /// layout via [`flat_thread_path`](Self::flat_thread_path).
     pub(super) fn plain_thread_path(&self, name: &str) -> Result<PathBuf> {
-        validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
+        require_user_ref_name(name)?;
         Ok(self.threads_dir().join(name))
     }
     pub(super) fn flat_thread_path(&self, name: &str) -> Result<PathBuf> {
-        validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
+        require_user_ref_name(name)?;
         Ok(self.flat_threads_dir().join(encode_flat_thread_name(name)))
     }
     pub(super) fn decode_flat_thread_entry(&self, entry: &str) -> Option<String> {
@@ -123,12 +123,12 @@ impl RefManager {
         decode_flat_thread_name(encoded)
     }
     pub(super) fn marker_path(&self, name: &str) -> Result<PathBuf> {
-        validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
+        require_user_ref_name(name)?;
         Ok(self.markers_dir().join(name))
     }
     pub(super) fn remote_thread_path(&self, remote: &str, thread: &str) -> Result<PathBuf> {
-        validate_ref_name(remote).map_err(|error| HeddleError::InvalidRefName(error.name))?;
-        validate_ref_name(thread).map_err(|error| HeddleError::InvalidRefName(error.name))?;
+        require_user_ref_name(remote)?;
+        require_user_ref_name(thread)?;
         Ok(self.remotes_dir().join(remote).join(thread))
     }
     pub(super) fn read_string(&self, path: &Path) -> Result<String> {
@@ -341,11 +341,9 @@ mod tests {
         });
 
         started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-        assert!(
-            acquired_rx
-                .recv_timeout(Duration::from_millis(100))
-                .is_err()
-        );
+        assert!(acquired_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
         assert!(lock_path.exists());
         assert_eq!(fs::read_to_string(&lock_path).unwrap(), old_lock_body);
 

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -275,7 +275,7 @@ fn is_lock_contended(err: &io::Error) -> bool {
     }
 }
 
-fn encode_flat_thread_name(name: &str) -> String {
+pub(super) fn encode_flat_thread_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len() * 2 + FLAT_THREAD_SUFFIX.len());
     for byte in name.as_bytes() {
         use std::fmt::Write as _;
@@ -285,7 +285,7 @@ fn encode_flat_thread_name(name: &str) -> String {
     out
 }
 
-fn decode_flat_thread_name(file_name: &str) -> Option<String> {
+pub(super) fn decode_flat_thread_name(file_name: &str) -> Option<String> {
     let encoded = file_name.strip_suffix(FLAT_THREAD_SUFFIX)?;
     if encoded.len() % 2 != 0 {
         return None;

--- a/crates/refs/src/refs/refs_synthetic.rs
+++ b/crates/refs/src/refs/refs_synthetic.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Dedicated store path for synthetic frontier roots.
+//!
+//! User threads and markers cannot occupy `heddle/` (the reservation in
+//! [`super::name::validate_ref_name`]). Synthetic roots therefore live in
+//! their own directory and are addressed by [`SyntheticFrontierName`], never
+//! by [`ThreadName`] or [`MarkerName`].
+
+use objects::{
+    error::{HeddleError, Result},
+    object::{StateId, SyntheticFrontierName},
+};
+
+use super::{
+    RefManager, format_state_id_text, parse_state_id_text,
+    refs_storage::{decode_flat_thread_name, encode_flat_thread_name},
+};
+use crate::fs_atomic::create_dir_all_durable;
+
+impl RefManager {
+    fn synthetic_dir(&self) -> std::path::PathBuf {
+        self.refs_dir().join("synthetic")
+    }
+
+    fn synthetic_frontier_path(&self, name: &SyntheticFrontierName) -> std::path::PathBuf {
+        self.synthetic_dir()
+            .join(encode_flat_thread_name(&name.as_name()))
+    }
+
+    /// Persist a synthetic frontier root. Does not construct a [`ThreadName`].
+    pub fn set_synthetic_frontier(
+        &self,
+        name: &SyntheticFrontierName,
+        state: &StateId,
+    ) -> Result<()> {
+        self.write_chokepoint(|_lock| {
+            let path = self.synthetic_frontier_path(name);
+            let parent = path.parent().ok_or_else(|| {
+                HeddleError::Config("invalid synthetic frontier path".to_string())
+            })?;
+            create_dir_all_durable(parent)?;
+            self.write_string(&path, &format_state_id_text(state))?;
+            Ok(())
+        })
+    }
+
+    /// Fetch a synthetic frontier root by its type-distinct name.
+    pub fn get_synthetic_frontier(&self, name: &SyntheticFrontierName) -> Result<Option<StateId>> {
+        let path = self.synthetic_frontier_path(name);
+        match self.read_optional_string(&path)? {
+            Some(contents) => parse_state_id_text(contents.trim())
+                .map(Some)
+                .map_err(|error| HeddleError::InvalidObject(error.to_string())),
+            None => Ok(None),
+        }
+    }
+
+    /// List every stored synthetic frontier root.
+    pub fn list_synthetic_frontiers(&self) -> Result<Vec<(SyntheticFrontierName, StateId)>> {
+        let dir = self.synthetic_dir();
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let file_name = match entry.file_name().to_str() {
+                Some(name) => name.to_string(),
+                None => continue,
+            };
+            let Some(decoded) = decode_flat_thread_name(&file_name) else {
+                continue;
+            };
+            let Ok(name) = SyntheticFrontierName::parse(&decoded) else {
+                continue;
+            };
+            let Some(state) = self.get_synthetic_frontier(&name)? else {
+                continue;
+            };
+            out.push((name, state));
+        }
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{ChangeId, ThreadName};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::refs::fresh_state_id;
+
+    fn cid(last: u8) -> ChangeId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = last;
+        ChangeId::from_bytes(bytes)
+    }
+
+    #[test]
+    fn prefix_sharing_siblings_are_distinct_and_individually_fetchable() {
+        let temp = TempDir::new().unwrap();
+        let refs = RefManager::new(temp.path());
+        let mut left_bytes = [0xaa; 16];
+        left_bytes[15] = 1;
+        let mut right_bytes = [0xaa; 16];
+        right_bytes[15] = 2;
+        let left = SyntheticFrontierName::new("main", ChangeId::from_bytes(left_bytes)).unwrap();
+        let right = SyntheticFrontierName::new("main", ChangeId::from_bytes(right_bytes)).unwrap();
+        let left_state = fresh_state_id();
+        let right_state = fresh_state_id();
+
+        refs.set_synthetic_frontier(&left, &left_state).unwrap();
+        refs.set_synthetic_frontier(&right, &right_state).unwrap();
+
+        assert_ne!(left.as_name(), right.as_name());
+        assert_eq!(
+            refs.get_synthetic_frontier(&left).unwrap(),
+            Some(left_state)
+        );
+        assert_eq!(
+            refs.get_synthetic_frontier(&right).unwrap(),
+            Some(right_state)
+        );
+        assert_eq!(refs.list_synthetic_frontiers().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn user_thread_at_change_id_does_not_overwrite_synthetic_root() {
+        let temp = TempDir::new().unwrap();
+        let refs = RefManager::new(temp.path());
+        let change = cid(7);
+        let synthetic = SyntheticFrontierName::new("main", change).unwrap();
+        let synthetic_state = fresh_state_id();
+        let user_state = fresh_state_id();
+        let user = ThreadName::try_new(format!("main@{}", change.to_string_full())).unwrap();
+
+        refs.set_synthetic_frontier(&synthetic, &synthetic_state)
+            .unwrap();
+        refs.set_thread(&user, &user_state).unwrap();
+
+        assert_eq!(
+            refs.get_synthetic_frontier(&synthetic).unwrap(),
+            Some(synthetic_state)
+        );
+        assert_eq!(refs.get_thread(&user).unwrap(), Some(user_state));
+        assert!(
+            refs.set_thread(&ThreadName::new(synthetic.as_name()), &user_state)
+                .is_err()
+        );
+    }
+}

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -328,6 +328,26 @@ fn test_invalid_marker_name_path_traversal() {
     let result = refs.create_marker(&MarkerName::new("../../../root"), &id);
     assert!(matches!(result, Err(HeddleError::InvalidRefName(_))));
 }
+
+#[test]
+fn reserved_heddle_namespace_is_rejected_at_the_store_chokepoint() {
+    let (_temp, refs) = create_ref_manager();
+    let id = crate::refs::fresh_state_id();
+    assert!(matches!(
+        refs.set_thread(&ThreadName::new("heddle/frontier/main/hc-abc"), &id),
+        Err(HeddleError::InvalidRefName(_))
+    ));
+    assert!(matches!(
+        refs.create_marker(&MarkerName::new("heddle/notes"), &id),
+        Err(HeddleError::InvalidRefName(_))
+    ));
+    assert!(refs.set_thread(&ThreadName::new("heddle"), &id).is_ok());
+    assert!(
+        refs.set_thread(&ThreadName::new("main@hd-abc"), &id)
+            .is_ok()
+    );
+}
+
 #[test]
 fn test_set_remote_thread_waits_for_refs_lock() {
     let (_temp, refs) = create_ref_manager();
@@ -1372,6 +1392,7 @@ mod write_read_conformance {
 
     const MANAGER_SRC: &str = include_str!("refs_manager.rs");
     const TXNS_SRC: &str = include_str!("refs_transactions.rs");
+    const SYNTHETIC_SRC: &str = include_str!("refs_synthetic.rs");
 
     /// Everything before the in-file `#[cfg(test)]` module — the invariant is
     /// enforced on production code only, never on the tests' own scaffolding.
@@ -1530,6 +1551,10 @@ mod write_read_conformance {
                 "write bypass: `{writer}` must route through `write_chokepoint`"
             );
         }
+        assert!(
+            first_body(&[SYNTHETIC_SRC], "set_synthetic_frontier").contains("write_chokepoint("),
+            "write bypass: `set_synthetic_frontier` must route through `write_chokepoint`"
+        );
     }
 
     /// Every public ref READER funnels through `reconciled_load` and never calls

--- a/crates/repo/src/git_ref_name.rs
+++ b/crates/repo/src/git_ref_name.rs
@@ -17,6 +17,8 @@ pub enum GitRefContentNamespace {
     Tag,
     /// `refs/notes/<name>`.
     Note,
+    /// `refs/heddle/<name>` — reserved synthetic frontier roots.
+    Heddle,
 }
 
 /// The wire-level kind used for hosted Git ref updates.
@@ -127,6 +129,9 @@ impl<'a> GitRefName<'a> {
     /// Return the named content namespace Heddle surfaces in local Git projection
     /// operations.
     pub fn content_namespace(&self) -> Option<GitRefContentNamespace> {
+        if self.heddle_name().is_some() {
+            return Some(GitRefContentNamespace::Heddle);
+        }
         match self.namespace() {
             GitRefNamespace::Branch => Some(GitRefContentNamespace::Branch),
             GitRefNamespace::Tag => Some(GitRefContentNamespace::Tag),
@@ -160,6 +165,7 @@ impl<'a> GitRefName<'a> {
             .or_else(|| self.remote_branch_parts().map(|(_, name)| name))
             .or_else(|| self.tag_name())
             .or_else(|| self.note_name())
+            .or_else(|| self.heddle_name())
     }
 
     /// Parse a Git-projection-visible ref. Notes are content refs in Heddle and are
@@ -232,6 +238,7 @@ impl<'a> GitRefName<'a> {
             GitRefContentNamespace::Branch => Self::branch_full_name(name),
             GitRefContentNamespace::Tag => Self::tag_full_name(name),
             GitRefContentNamespace::Note => Self::note_full_name(name),
+            GitRefContentNamespace::Heddle => format!("refs/heddle/{name}"),
         }
     }
 
@@ -245,6 +252,12 @@ impl<'a> GitRefName<'a> {
 
     fn note_name(&self) -> Option<&'a str> {
         self.full_name.strip_prefix("refs/notes/")
+    }
+
+    fn heddle_name(&self) -> Option<&'a str> {
+        self.full_name
+            .strip_prefix("refs/heddle/")
+            .filter(|name| !name.is_empty())
     }
 
     fn remote_branch_parts(&self) -> Option<(&'a str, &'a str)> {
@@ -331,9 +344,9 @@ mod tests {
                 false,
             ),
             (
-                "refs/heddle/internal",
+                "refs/heddle/frontier/main/hc-abc",
                 GitRefNamespace::Other,
-                None,
+                Some(GitRefContentNamespace::Heddle),
                 GitRefKind::Other,
                 false,
                 true,
@@ -423,5 +436,9 @@ mod tests {
         );
         assert_eq!(GitRefName::tag_full_name("v1.0"), "refs/tags/v1.0");
         assert_eq!(GitRefName::note_full_name("heddle"), "refs/notes/heddle");
+        assert_eq!(
+            GitRefName::content_full_name(GitRefContentNamespace::Heddle, "frontier/main/hc-abc"),
+            "refs/heddle/frontier/main/hc-abc"
+        );
     }
 }

--- a/crates/repo/src/git_ref_name.rs
+++ b/crates/repo/src/git_ref_name.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Typed classification for fully-qualified Git ref names.
 
+use objects::object::SyntheticFrontierName;
+
 /// Sentinel remote name for refs owned by the local repository.
 ///
 /// Local branches, tags, and notes use this owner when represented in the
@@ -17,7 +19,7 @@ pub enum GitRefContentNamespace {
     Tag,
     /// `refs/notes/<name>`.
     Note,
-    /// `refs/heddle/<name>` — reserved synthetic frontier roots.
+    /// A managed synthetic frontier root (`refs/heddle/frontier/<thread>/<full-changeid>`).
     Heddle,
 }
 
@@ -255,6 +257,7 @@ impl<'a> GitRefName<'a> {
     }
 
     fn heddle_name(&self) -> Option<&'a str> {
+        SyntheticFrontierName::parse(self.full_name).ok()?;
         self.full_name
             .strip_prefix("refs/heddle/")
             .filter(|name| !name.is_empty())
@@ -344,9 +347,17 @@ mod tests {
                 false,
             ),
             (
+                "refs/heddle/internal",
+                GitRefNamespace::Other,
+                None,
+                GitRefKind::Other,
+                false,
+                true,
+            ),
+            (
                 "refs/heddle/frontier/main/hc-abc",
                 GitRefNamespace::Other,
-                Some(GitRefContentNamespace::Heddle),
+                None,
                 GitRefKind::Other,
                 false,
                 true,
@@ -417,6 +428,39 @@ mod tests {
             GitRefName::new("refs/remotes/git/main").git_projection_ref(),
             None
         );
+    }
+
+    #[test]
+    fn classifies_only_parseable_synthetic_frontier_as_heddle_namespace() {
+        let change = objects::object::ChangeId::from_bytes([9; 16]);
+        let name = objects::object::SyntheticFrontierName::new("main", change)
+            .expect("fixture synthetic name")
+            .git_ref();
+        let ref_name = GitRefName::new(&name);
+        assert_eq!(
+            ref_name.content_namespace(),
+            Some(GitRefContentNamespace::Heddle)
+        );
+        assert_eq!(
+            ref_name.short_name().expect("heddle short name"),
+            name.strip_prefix("refs/heddle/").expect("heddle prefix")
+        );
+    }
+
+    #[test]
+    fn rejects_internal_and_forged_heddle_refs_as_publishable_namespace() {
+        for name in [
+            "refs/heddle/internal",
+            "refs/heddle/frontier/main/hc-abc",
+            "refs/heddle",
+            "refs/heddle/",
+        ] {
+            assert_eq!(
+                GitRefName::new(name).content_namespace(),
+                None,
+                "{name} must not be a publishable Heddle content ref"
+            );
+        }
     }
 
     #[test]

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -46,6 +46,16 @@ pub fn audience_tier_for_grant(
     role: Option<GrantRole>,
     audience_label: Option<&str>,
 ) -> AudienceTier {
+    // Role is authoritative. A stale or untrusted label must not promote a
+    // missing/unknown grant into Restricted (which can disclose Private).
+    match role {
+        None | Some(GrantRole::Unspecified) => return AudienceTier::Public,
+        Some(GrantRole::Reader)
+        | Some(GrantRole::Developer)
+        | Some(GrantRole::Maintainer)
+        | Some(GrantRole::Admin)
+        | Some(GrantRole::Owner) => {}
+    }
     if let Some(label) = audience_label
         .map(str::trim)
         .filter(|label| !label.is_empty())
@@ -106,6 +116,25 @@ mod tests {
         assert_eq!(
             audience_tier_for_grant(Some(GrantRole::Owner), Some("  ")),
             AudienceTier::Internal
+        );
+    }
+
+    #[test]
+    fn missing_or_unknown_role_with_label_is_public() {
+        assert_eq!(
+            audience_tier_for_grant(None, Some("sec-embargo")),
+            AudienceTier::Public
+        );
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Unspecified), Some("sec-embargo")),
+            AudienceTier::Public
+        );
+        assert_eq!(
+            audience_tier_for_grant(
+                Some(GrantRole::from_hosted_role_i32(99)),
+                Some("sec-embargo")
+            ),
+            AudienceTier::Public
         );
     }
 }

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Grant-role → [`AudienceTier`] mapping (O2).
+//!
+//! This is the heddle-side typed contract Weft gates `ListRefs`/`Pull` against.
+//! Unknown or missing roles fail closed to [`AudienceTier::Public`] so an
+//! unauthorized puller can never be treated as the internal trusted set.
+
+use super::visibility::AudienceTier;
+
+/// Hosted grant-role ordinal. Mirrors `HostedRole` without depending on
+/// generated proto, so the mapping stays auditable in this workspace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GrantRole {
+    Unspecified = 0,
+    Reader = 1,
+    Developer = 2,
+    Maintainer = 3,
+    Admin = 4,
+    Owner = 5,
+}
+
+impl GrantRole {
+    /// Parse a proto `HostedRole` i32. Unknown values fail closed to
+    /// [`GrantRole::Unspecified`].
+    pub fn from_hosted_role_i32(role: i32) -> Self {
+        match role {
+            1 => GrantRole::Reader,
+            2 => GrantRole::Developer,
+            3 => GrantRole::Maintainer,
+            4 => GrantRole::Admin,
+            5 => GrantRole::Owner,
+            _ => GrantRole::Unspecified,
+        }
+    }
+}
+
+/// Map a caller's grant to the audience the visibility gate must use.
+///
+/// * A non-empty `audience_label` is the authorized embargo scope and maps to
+///   [`AudienceTier::Restricted`]. Private content is visible only to that
+///   label, not to Internal.
+/// * Developer and above are the workspace-internal trusted set.
+/// * Reader, unspecified, and missing grants are [`AudienceTier::Public`].
+///   An unauthorized puller must never receive Internal.
+pub fn audience_tier_for_grant(
+    role: Option<GrantRole>,
+    audience_label: Option<&str>,
+) -> AudienceTier {
+    if let Some(label) = audience_label
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+    {
+        return AudienceTier::Restricted(label.to_string());
+    }
+    match role {
+        Some(GrantRole::Developer)
+        | Some(GrantRole::Maintainer)
+        | Some(GrantRole::Admin)
+        | Some(GrantRole::Owner) => AudienceTier::Internal,
+        Some(GrantRole::Reader) | Some(GrantRole::Unspecified) | None => AudienceTier::Public,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unauthorized_and_unknown_roles_are_public() {
+        assert_eq!(audience_tier_for_grant(None, None), AudienceTier::Public);
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Unspecified), None),
+            AudienceTier::Public
+        );
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::from_hosted_role_i32(99)), None),
+            AudienceTier::Public
+        );
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Reader), None),
+            AudienceTier::Public
+        );
+    }
+
+    #[test]
+    fn trusted_writers_are_internal() {
+        for role in [
+            GrantRole::Developer,
+            GrantRole::Maintainer,
+            GrantRole::Admin,
+            GrantRole::Owner,
+        ] {
+            assert_eq!(
+                audience_tier_for_grant(Some(role), None),
+                AudienceTier::Internal
+            );
+        }
+    }
+
+    #[test]
+    fn embargo_label_is_restricted_even_for_owners() {
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Owner), Some("sec-embargo")),
+            AudienceTier::Restricted("sec-embargo".into())
+        );
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Owner), Some("  ")),
+            AudienceTier::Internal
+        );
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -31,6 +31,7 @@ mod ephemeral_thread;
 mod fsmonitor;
 mod git_ref_name;
 pub mod git_worktree_status;
+mod grant_audience;
 mod hooks;
 pub mod identity;
 pub mod lazy_hydrator;
@@ -142,6 +143,7 @@ pub use git_ref_name::{
     GitRefContentNamespace, GitRefKind, GitRefName, GitRefNamespace, ParsedGitRef,
     REMOTE_NAME_FOR_LOCAL_GIT_REPO, is_reserved_git_remote_name,
 };
+pub use grant_audience::{GrantRole, audience_tier_for_grant};
 pub use hooks::{Hook, HookContext, HookManager, HookResponse};
 pub use merge_state::{MergeState, MergeStateManager};
 pub use objects::{

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -120,9 +120,11 @@ pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
 /// `-`, collapse runs, drop `..`, and trim. Always returns a non-empty,
 /// [`validate_thread_id`]-valid string.
 fn suggest_thread_id(value: &str) -> String {
-    let value = objects::object::is_reserved_heddle_namespace(value)
-        .then(|| value.split_once('/').map(|(_, rest)| rest).unwrap_or(value))
-        .unwrap_or(value);
+    let value = if objects::object::is_reserved_heddle_namespace(value) {
+        value.split_once('/').map(|(_, rest)| rest).unwrap_or(value)
+    } else {
+        value
+    };
     let mut slug = String::with_capacity(value.len());
     for ch in value.chars() {
         if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -104,7 +104,8 @@ pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
         // A leading '-' is in the safe set (for `my-thread`) but makes the id
         // look like a CLI flag: `heddle land --thread -foo` parses `-foo` as an
         // option, and argv-template construction panics. Reject it at the source.
-        && !value.starts_with('-');
+        && !value.starts_with('-')
+        && !objects::object::is_reserved_heddle_namespace(value);
     if ok {
         Ok(())
     } else {
@@ -119,6 +120,9 @@ pub fn validate_thread_id(value: &str) -> Result<(), ThreadIdError> {
 /// `-`, collapse runs, drop `..`, and trim. Always returns a non-empty,
 /// [`validate_thread_id`]-valid string.
 fn suggest_thread_id(value: &str) -> String {
+    let value = objects::object::is_reserved_heddle_namespace(value)
+        .then(|| value.split_once('/').map(|(_, rest)| rest).unwrap_or(value))
+        .unwrap_or(value);
     let mut slug = String::with_capacity(value.len());
     for ch in value.chars() {
         if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
@@ -511,6 +515,21 @@ mod thread_id_tests {
                 "expected '{ok}' to be a valid thread id"
             );
         }
+    }
+
+    #[test]
+    fn rejects_reserved_heddle_namespace() {
+        for bad in ["heddle/frontier/main/hc-abc", "Heddle/x", "heddle/notes"] {
+            assert!(
+                ThreadId::new(bad).is_err(),
+                "expected '{bad}' to be rejected as a reserved heddle/ name"
+            );
+        }
+        assert!(
+            ThreadId::new("heddle").is_ok(),
+            "a bare 'heddle' thread remains a user name"
+        );
+        assert!(ThreadId::new("main@hd-abc").is_ok());
     }
 
     #[test]

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -31,7 +31,9 @@ pub use message_hosted::{
 };
 pub use message_objects::{ObjectData, ObjectRequest};
 pub use message_pushpull::{PullComplete, PushComplete};
-pub use message_refs::{HeadInfo, RefEntry, RefFilter, RefUpdated, RefsList};
+pub use message_refs::{
+    AdvertisedRef, AdvertisedRefError, HeadInfo, RefEntry, RefFilter, RefKind, RefUpdated, RefsList,
+};
 pub use message_status::{
     Error, ErrorCode, RemoteCursorFailure, RemoteCursorReason, RemoteDuration, RemoteFailureCode,
     RemoteFailureDetail, RemoteTimestamp,

--- a/crates/wire/src/message_refs/kind.rs
+++ b/crates/wire/src/message_refs/kind.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Type-distinct advertised-ref discriminator and consume routing.
+
+use objects::object::{
+    MarkerName, ReservedRefNameError, StateId, SyntheticFrontierName, SyntheticFrontierNameError,
+    ThreadName, is_reserved_heddle_namespace,
+};
+use serde::{Deserialize, Serialize};
+
+use super::RefEntry;
+
+/// Type-distinct discriminator for an advertised ref.
+///
+/// Synthetic frontier roots must never be coerced into a [`ThreadName`] or
+/// [`MarkerName`]. Match on this enum at every consume/store/mirror site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefKind {
+    Thread,
+    Marker,
+    SyntheticFrontierRoot,
+}
+
+impl RefKind {
+    /// Classify an advertised name.
+    ///
+    /// A well-formed synthetic frontier name is always
+    /// [`RefKind::SyntheticFrontierRoot`], even if a boolean `is_thread` flag
+    /// still claims otherwise. A reserved `heddle/` name that is not a
+    /// well-formed frontier root is also classified as synthetic so it cannot
+    /// fall through to the thread or marker arms (fail closed).
+    pub fn from_advertised_name(name: &str, advertised_as_thread: bool) -> Self {
+        if SyntheticFrontierName::looks_like(name) || is_reserved_heddle_namespace(name) {
+            return RefKind::SyntheticFrontierRoot;
+        }
+        if advertised_as_thread {
+            RefKind::Thread
+        } else {
+            RefKind::Marker
+        }
+    }
+
+    pub fn is_user_thread(self) -> bool {
+        matches!(self, RefKind::Thread)
+    }
+
+    pub fn is_marker(self) -> bool {
+        matches!(self, RefKind::Marker)
+    }
+}
+
+/// Typed view of an advertised ref. The synthetic arm never holds a
+/// [`ThreadName`] or [`MarkerName`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdvertisedRef {
+    Thread(ThreadName),
+    Marker(MarkerName),
+    SyntheticFrontier(SyntheticFrontierName),
+}
+
+/// Why an advertised ref could not be consumed as its declared kind.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum AdvertisedRefError {
+    #[error("{0}")]
+    Reserved(#[from] ReservedRefNameError),
+    #[error("{0}")]
+    Synthetic(#[from] SyntheticFrontierNameError),
+    #[error("ref '{name}' is reserved and cannot be consumed as a {kind:?}")]
+    KindMismatch { name: String, kind: RefKind },
+}
+
+impl RefEntry {
+    pub fn thread(name: impl Into<String>, state_id: StateId) -> Self {
+        Self {
+            name: name.into(),
+            state_id,
+            kind: RefKind::Thread,
+        }
+    }
+
+    pub fn marker(name: impl Into<String>, state_id: StateId) -> Self {
+        Self {
+            name: name.into(),
+            state_id,
+            kind: RefKind::Marker,
+        }
+    }
+
+    pub fn synthetic_frontier(name: SyntheticFrontierName, state_id: StateId) -> Self {
+        Self {
+            name: name.as_name(),
+            state_id,
+            kind: RefKind::SyntheticFrontierRoot,
+        }
+    }
+
+    pub fn from_advertised(
+        name: impl Into<String>,
+        state_id: StateId,
+        advertised_as_thread: bool,
+    ) -> Self {
+        let name = name.into();
+        let kind = RefKind::from_advertised_name(&name, advertised_as_thread);
+        Self {
+            name,
+            state_id,
+            kind,
+        }
+    }
+
+    pub fn is_user_thread(&self) -> bool {
+        self.kind.is_user_thread()
+    }
+
+    pub fn is_marker(&self) -> bool {
+        self.kind.is_marker()
+    }
+
+    /// Route this entry to its type-distinct consume form.
+    ///
+    /// [`RefKind::SyntheticFrontierRoot`] yields only a
+    /// [`SyntheticFrontierName`]. It never constructs a [`ThreadName`] or
+    /// [`MarkerName`].
+    pub fn advertised(&self) -> Result<AdvertisedRef, AdvertisedRefError> {
+        match self.kind {
+            RefKind::Thread => {
+                if is_reserved_heddle_namespace(&self.name) {
+                    return Err(AdvertisedRefError::KindMismatch {
+                        name: self.name.clone(),
+                        kind: self.kind,
+                    });
+                }
+                Ok(AdvertisedRef::Thread(ThreadName::try_new(
+                    self.name.clone(),
+                )?))
+            }
+            RefKind::Marker => {
+                if is_reserved_heddle_namespace(&self.name) {
+                    return Err(AdvertisedRefError::KindMismatch {
+                        name: self.name.clone(),
+                        kind: self.kind,
+                    });
+                }
+                Ok(AdvertisedRef::Marker(MarkerName::try_new(
+                    self.name.clone(),
+                )?))
+            }
+            RefKind::SyntheticFrontierRoot => Ok(AdvertisedRef::SyntheticFrontier(
+                SyntheticFrontierName::parse(&self.name)?,
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{ChangeId, StateId, SyntheticFrontierName};
+
+    use super::*;
+
+    fn cid(last: u8) -> ChangeId {
+        let mut bytes = [0u8; 16];
+        bytes[15] = last;
+        ChangeId::from_bytes(bytes)
+    }
+
+    #[test]
+    fn advertised_synthetic_root_never_becomes_thread_or_marker_name() {
+        let change = cid(11);
+        let name = SyntheticFrontierName::new("main", change).unwrap();
+        let entry = RefEntry::from_advertised(name.as_name(), StateId::from_bytes([1; 32]), true);
+        assert_eq!(entry.kind, RefKind::SyntheticFrontierRoot);
+        match entry.advertised().expect("synthetic consume") {
+            AdvertisedRef::SyntheticFrontier(parsed) => assert_eq!(parsed, name),
+            AdvertisedRef::Thread(_) | AdvertisedRef::Marker(_) => {
+                panic!("synthetic root must not construct ThreadName or MarkerName")
+            }
+        }
+    }
+
+    #[test]
+    fn advertised_as_thread_flag_cannot_reclassify_a_frontier_root() {
+        let change = cid(12);
+        let name = SyntheticFrontierName::new("main", change).unwrap();
+        assert_eq!(
+            RefKind::from_advertised_name(&name.as_name(), true),
+            RefKind::SyntheticFrontierRoot
+        );
+        assert_eq!(
+            RefKind::from_advertised_name(&name.as_name(), false),
+            RefKind::SyntheticFrontierRoot
+        );
+        assert_eq!(
+            RefKind::from_advertised_name("heddle/not-a-frontier", true),
+            RefKind::SyntheticFrontierRoot
+        );
+    }
+
+    #[test]
+    fn user_thread_at_hd_suffix_stays_a_thread() {
+        let entry = RefEntry::from_advertised("main@hd-abcdef", StateId::from_bytes([2; 32]), true);
+        assert_eq!(entry.kind, RefKind::Thread);
+        match entry.advertised().expect("user thread") {
+            AdvertisedRef::Thread(name) => assert_eq!(name.as_str(), "main@hd-abcdef"),
+            other => panic!("expected thread, got {other:?}"),
+        }
+    }
+}

--- a/crates/wire/src/message_refs/mod.rs
+++ b/crates/wire/src/message_refs/mod.rs
@@ -2,6 +2,10 @@
 use objects::object::StateId;
 use serde::{Deserialize, Serialize};
 
+mod kind;
+
+pub use kind::{AdvertisedRef, AdvertisedRefError, RefKind};
+
 /// Filter applied when listing repository refs.
 ///
 /// Retained as part of the published `heddle-wire` 0.11 surface while Weft
@@ -16,6 +20,10 @@ pub struct RefFilter {
     pub include_threads: bool,
     #[serde(default = "default_true")]
     pub include_markers: bool,
+    /// Synthetic frontier roots are an internal embargo mechanism and stay
+    /// hidden unless a caller opts in.
+    #[serde(default)]
+    pub include_synthetic: bool,
     #[serde(default)]
     pub limit: Option<usize>,
 }
@@ -31,6 +39,7 @@ impl Default for RefFilter {
             patterns: Vec::new(),
             include_threads: true,
             include_markers: true,
+            include_synthetic: false,
             limit: None,
         }
     }
@@ -49,6 +58,14 @@ impl RefFilter {
         self.patterns
             .iter()
             .any(|pattern| Self::matches_pattern(name, pattern))
+    }
+
+    pub fn includes_kind(&self, kind: RefKind) -> bool {
+        match kind {
+            RefKind::Thread => self.include_threads,
+            RefKind::Marker => self.include_markers,
+            RefKind::SyntheticFrontierRoot => self.include_synthetic,
+        }
     }
 
     fn matches_pattern(name: &str, pattern: &str) -> bool {
@@ -83,11 +100,12 @@ pub struct RefsList {
     pub refs: Vec<RefEntry>,
 }
 
+/// One advertised repository ref.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RefEntry {
     pub name: String,
     pub state_id: StateId,
-    pub is_thread: bool,
+    pub kind: RefKind,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,7 +117,7 @@ pub struct RefUpdated {
 
 #[cfg(test)]
 mod tests {
-    use super::RefFilter;
+    use super::*;
 
     #[test]
     fn ref_filter_matches_union_of_names_and_patterns() {
@@ -122,6 +140,9 @@ mod tests {
         assert!(filter.matches("refs/heads/main"));
         assert!(filter.matches("refs/tags/v1.0.0"));
         assert!(filter.matches("threads/alice"));
+        assert!(!filter.includes_kind(RefKind::SyntheticFrontierRoot));
+        assert!(filter.includes_kind(RefKind::Thread));
+        assert!(filter.includes_kind(RefKind::Marker));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third bounce-fix for Codex review of HEAD `740fe5df` on heddle#1525. Does **not** merge. Does **not** close #318. Does **not** implement weft#1728. Does **not** ask Codex to implement.

The first-bounce work on `b745e04c` and second-bounce work on `740fe5df` remain: clone fetches advertised synthetic roots before persist, export writes `refs/heddle/frontier/…`, CAS on synthetic Git updates, reserved-name chokepoint on every RefBackend, fail-closed grant labels, synthetic sync after folded marker snapshots, publishable Heddle refs require `SyntheticFrontierName::parse` + managed record + OID match, pulls via `name.owning_thread()`, and stale cleanup deletes only when the current Git tip equals `managed_record`.

Live P1s fixed on this HEAD (`d5b47323`):

1. **Preserve retargeted desired synthetic refs.** When a previously managed `refs/heddle/frontier/*` ref is retargeted out of band but remains advertised, reconciliation now compares the current Git tip with the recorded managed OID and reports `ModifiedConcurrentlyInGit` instead of CAS-overwriting the foreign tip and claiming the desired OID. An owned tip (current == managed) may still advance.

2. **Upgrade partially present synthetic roots.** `fetch_synthetic_frontier_root` no longer returns on `has_state` alone. A later eager or deeper pull walks the pull planner's closure (`enumerate_state_closure_with_options` + depth) and, for lazy materialization, the state/tree graph. Missing blobs or ancestors keep the root incomplete so sibling roots hydrate with the requested closure.

Locks that still bind: publishable Heddle refs = parse + managed record + OID match; pulls via `name.owning_thread()`; stale cleanup deletes only when current Git tip == managed_record; `collect_managed_ref_updates` requires managed record + matching OID; #318 stays open.

## Closes

Closes HeddleCo/heddle#1511
Part of HeddleCo/heddle#318

Do not close #318. Do not implement weft#1728 here.

## Test evidence

```
$ cargo test -p heddle-git-projection --lib git_frontier
running 8 tests
test git_frontier::tests::reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_absent ... ok
test git_frontier::tests::reconcile_deletes_managed_synthetic_ref_when_desired_is_absent ... ok
test git_frontier::tests::replacing_synthetic_git_ref_uses_observed_raw_target ... ok
test git_frontier::tests::reserved_git_ref_classifier_covers_heads_and_heddle_namespaces ... ok
test git_frontier::tests::synthetic_git_ref_does_not_collide_with_user_branch_at_hd_suffix ... ok
test git_frontier::tests::reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_present ... ok
test git_frontier::tests::reconcile_updates_owned_desired_synthetic_ref ... ok
test git_frontier::tests::export_writes_synthetic_frontier_git_ref ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 68 filtered out; finished in 0.22s

$ cargo test -p heddle-git-projection --lib
running 76 tests
… including collect_authoritative_git_ref_updates_publishes_only_managed_synthetic_roots,
  collect_managed_ref_updates_drops_diverged_on_disk_tip,
  reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_absent,
  reconcile_preserves_out_of_band_synthetic_ref_when_desired_is_present,
  reconcile_updates_owned_desired_synthetic_ref …
test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.46s

$ cargo test -p heddle-cli --lib -- synthetic_frontier
running 6 tests
test hosted_runtime::hosted::sync::pull_bootstrap_tests::synthetic_frontier_pull_uses_owning_thread_and_keeps_synthetic_target ... ok
test hosted_runtime::hosted::sync::pull_bootstrap_tests::folded_synthetic_frontier_is_not_a_thread_or_marker ... ok
test hosted_runtime::hosted::sync::pull_bootstrap_tests::synthetic_frontier_root_skips_only_when_requested_closure_is_complete ... ok
test hosted_runtime::hosted::sync::pull_bootstrap_tests::synthetic_frontier_root_upgrades_when_ancestors_are_missing ... ok
test cli::commands::clone::tests::hosted_clone_persists_synthetic_frontier_and_does_not_treat_it_as_a_thread ... ok
test hosted_runtime::hosted::sync::pull_bootstrap_tests::folded_synthetic_frontier_survives_marker_snapshot ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 749 filtered out; finished in 0.03s

$ cargo clippy -p heddle-git-projection --lib -- -D warnings
Finished `dev` profile [unoptimized + debuginfo]

$ cargo clippy -p heddle-cli --lib -- -D warnings
Finished `dev` profile [unoptimized + debuginfo]
```

## Manual verification

N/A — each P1 has a unit test that fails the old behavior: an advertised out-of-band retarget is preserved instead of CAS-overwritten; a present State with missing blobs is incomplete for Full and complete for Lazy; a present tip with a missing parent is incomplete for an unbounded pull.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98c8ad84-b657-4962-b0b9-fe414ee7c4c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98c8ad84-b657-4962-b0b9-fe414ee7c4c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789832136&installation_model_id=21489&pr_number=1525&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1525&signature=45c5bd5325db8a264f8550b57a7378711d806d795e5e191a6f5609d3b52c78cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->