### PR TITLE
Bounce five live identity-cursor P1s (signatures, SessionEnd, repack, parent, OpenCode)

### DIFF
--- a/.agents/agent-workflows.md
+++ b/.agents/agent-workflows.md
@@ -124,7 +124,7 @@ Notes:
 
 - `heddle init` can offer the same install step interactively, but it remains optional
 - repo-local install is preferred when the harness supports it
-- Codex uses user-scope `~/.codex/config.toml` `[hooks]` (`SessionStart`, `SubagentStart`, `PreToolUse`, `Stop`) that write a workspace `.heddle/identity` cursor
+- Codex uses user-scope `~/.codex/config.toml` `[hooks]` (`SessionStart`, `SubagentStart`, `PreToolUse`, `Stop`) that write a workspace `.heddle/identity` cursor. `Stop` (and uninstall) expire the cursor so a later human/Cursor capture cannot freeze the last Codex agent.
 - Claude Code uses hooks: `PreToolUse` and StatusLine stamp the cursor (StatusLine chains an existing command). Other events still relay
 - OpenCode uses a Heddle-managed plugin file plus a
   `heddle.timeline.json` capability manifest. The manifest advertises the

--- a/.agents/agent-workflows.md
+++ b/.agents/agent-workflows.md
@@ -124,8 +124,8 @@ Notes:
 
 - `heddle init` can offer the same install step interactively, but it remains optional
 - repo-local install is preferred when the harness supports it
-- Codex currently uses a user-scope `notify` install path
-- Claude Code uses hooks and an optional Heddle-owned status line command
+- Codex uses user-scope `~/.codex/config.toml` `[hooks]` (`SessionStart`, `SubagentStart`, `PreToolUse`, `Stop`) that write a workspace `.heddle/identity` cursor
+- Claude Code uses hooks: `PreToolUse` and StatusLine stamp the cursor (StatusLine chains an existing command). Other events still relay
 - OpenCode uses a Heddle-managed plugin file plus a
   `heddle.timeline.json` capability manifest. The manifest advertises the
   shipped timeline commands agents and desktop integrations can call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   `agent=null`. Codex `Stop` expires the cursor. OpenCode expire/merge go
   through locked `integration stamp`. A later parent-session event clears a
   stale subagent `parent`. Unpublished→published identity attaches to the
-  placeholder segment. User-scoped OpenCode discovers the workspace at
-  runtime (heddle#1518).
+  placeholder segment. User-scoped Claude, Codex, and OpenCode discover
+  the workspace at runtime (heddle#1518). Repository format 5 records the
+  cursor-hash / HCS2 boundary; format-4 agent states keep their stored
+  ids. Pointer-checkout cursor files are reserved from capture.
 
 - **`heddle completions` prints tab-completion scripts.** The field-study
   verb emits install lines, or a bash/zsh/fish script. Same scripts as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **Harness identity cursor on each capture.** `integration install` writes
+  per-harness hooks that stamp a workspace `.heddle/identity` sidecar
+  (`provider`, `model`, `thought_level`, `session`, `parent`). Each
+  `capture` freezes that cursor onto that state. Mid-thread `/model` or
+  `/effort` updates the cursor only; earlier states keep the old pair.
+  Session segments rotate when a published provider, model, or
+  thought_level changes (empty → set is attach). Claude PreToolUse and
+  StatusLine stay on the stamp hot path (~200-byte atomic rename);
+  StatusLine chains an existing command. Codex writes user-scope `[hooks]`
+  to a workspace sidecar. OpenCode reads `event.type` and object `model`.
+  Parent walk is last-resort kind only (exact basename). Cursor/Grok stay
+  `agent=null` (heddle#1518).
+
 - **`heddle completions` prints tab-completion scripts.** The field-study
   verb emits install lines, or a bash/zsh/fish script. Same scripts as
   `heddle shell completion`. First-screen help names it so it is findable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   StatusLine chains an existing command. Codex writes user-scope `[hooks]`
   to a workspace sidecar. OpenCode reads `event.type` and object `model`.
   Parent walk is last-resort kind only (exact basename). Cursor/Grok stay
-  `agent=null` (heddle#1518).
+  `agent=null`. Codex `Stop` expires the cursor. OpenCode expire/merge go
+  through locked `integration stamp`. A later parent-session event clears a
+  stale subagent `parent` (heddle#1518).
 
 - **`heddle completions` prints tab-completion scripts.** The field-study
   verb emits install lines, or a bash/zsh/fish script. Same scripts as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   Parent walk is last-resort kind only (exact basename). Cursor/Grok stay
   `agent=null`. Codex `Stop` expires the cursor. OpenCode expire/merge go
   through locked `integration stamp`. A later parent-session event clears a
-  stale subagent `parent` (heddle#1518).
+  stale subagent `parent`. Unpublished→published identity attaches to the
+  placeholder segment. User-scoped OpenCode discovers the workspace at
+  runtime (heddle#1518).
 
 - **`heddle completions` prints tab-completion scripts.** The field-study
   verb emits install lines, or a bash/zsh/fish script. Same scripts as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Format-4 agent states keep their signatures and pack ids.** Verification
+  and re-signing use the hash for the accepted stored id. Compact HCS2
+  repack accepts that pre-cursor id. Claude SessionEnd relays
+  `close_session` and then expires the cursor. A later main-agent Claude
+  event (`parent == session`) clears a stale subagent parent. OpenCode
+  relays await so timeline before/after stay ordered.
+
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now
   prints the same capture actor first and hosted authentication as a second

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,6 +160,10 @@ _Avoid_: done agent, generic blocked agent
 Operational metadata that defines an agent's delegated work and execution policy, such as whether offline continuation is allowed. Its identifier can be referenced by collaboration operations as optional provenance, but it is not repository collaboration history in v1.
 _Avoid_: discussion task, collaboration assignment
 
+**Identity Cursor**:
+The current harness identity published into the workspace sidecar `.heddle/identity` by installed hooks. Fields use ACP names (`provider`, `model`, `thought_level`, `session`, `parent`). Each capture freezes that cursor onto that state. Mid-thread `/model` or `/effort` updates the cursor only; earlier states keep the pair they froze. Session segments rotate when a published provider, model, or thought_level changes. Empty → set is attach, not a rotate. Unpublished fields are omitted. Heddle does not invent a model from hoped-for env or `/proc`.
+_Avoid_: model of the thread, hoped-for env, /proc hunt, Cursor-guesses-Sonnet
+
 **Agent Timeline**:
 A Heddle-native record stream for an agent run's tool-call activity, cursor movement, branches, and captures. Foundation objects and local storage are in place; richer cursor views, capture automation, and hosted projection are still planned. The public `AgentGatewayService` and `AgentService` contracts are also planned and are not registered as live services in the current v1alpha1 API contract. Agent timelines are adjacent repository metadata that explain agent execution without becoming source history states.
 _Avoid_: raw transcript, runner log, chat history

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fs2",
  "heddle-cli-shared",
  "heddle-crypto",
  "heddle-git-projection",

--- a/crates/cli-args/src/cli/cli_args/commands_integration.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_integration.rs
@@ -23,6 +23,10 @@ pub enum IntegrationCommands {
     /// Internal relay invoked by installed hooks/plugins.
     #[command(hide = true)]
     Relay(IntegrationRelayArgs),
+
+    /// Fast identity-cursor write. Prefer the argv fast path in `main`.
+    #[command(hide = true)]
+    Stamp(IntegrationStampArgs),
 }
 
 #[derive(Clone, Debug, clap::Args)]
@@ -63,4 +67,14 @@ pub struct IntegrationRelayArgs {
 
     /// Event name.
     pub event: String,
+}
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct IntegrationStampArgs {
+    /// Harness name (`claude-code`, `codex`, `opencode`, `pi`).
+    pub harness: String,
+
+    /// Existing StatusLine command to run after the cursor write.
+    #[arg(long)]
+    pub chain: Option<String>,
 }

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -65,7 +65,8 @@ pub use commands_discuss::{
 pub use commands_git_projection::{BridgeCommands, BridgeGitCommands, GitSource, SyncCommands};
 pub use commands_hook::{HookCommands, HookInstallSource};
 pub use commands_integration::{
-    IntegrationCommands, IntegrationInstallArgs, IntegrationRelayArgs, IntegrationTargetArgs,
+    IntegrationCommands, IntegrationInstallArgs, IntegrationRelayArgs, IntegrationStampArgs,
+    IntegrationTargetArgs,
 };
 pub use commands_main::{
     Commands, DaemonCommands, FsckArgs, FsckCommands, FsckRepairCommands, FsckRepairGitArgs,

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -4726,6 +4726,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             IntegrationCommands::Uninstall(_) => vec!["integration", "uninstall"],
             IntegrationCommands::Upgrade(_) => vec!["integration", "upgrade"],
             IntegrationCommands::Relay(_) => vec!["integration", "relay"],
+            IntegrationCommands::Stamp(_) => vec!["integration", "stamp"],
         },
         #[cfg(feature = "semantic")]
         Commands::Semantic { command } => match command {

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -2168,6 +2168,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
         )),
     ),
     entry(
+        &["integration", "stamp"],
+        hidden(surface(
+            opaque_schemas(METADATA_MUTATION_NO_OP_ID, &["integration stamp"]),
+            "admin",
+        )),
+    ),
+    entry(
         &["log"],
         front_door(
             json_discriminators(

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -276,6 +276,10 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
         &["integration", "relay"],
         &["integration", "relay", "codex", "agent_done"],
     ),
+    sample(
+        &["integration", "stamp"],
+        &["integration", "stamp", "claude-code"],
+    ),
     sample(&["log"], &["log"]),
     sample(&["maintenance", "inspect"], &["maintenance", "inspect"]),
     sample(&["maintenance", "refresh"], &["maintenance", "refresh"]),
@@ -1400,6 +1404,14 @@ fn materializer_effect_sets_include_refs_metadata_and_worktree() {
             ],
         );
     }
+}
+
+#[test]
+fn integration_stamp_writes_metadata_only() {
+    assert_command_effects(
+        &["integration", "stamp"],
+        &[CommandSideEffect::WritesMetadata],
+    );
 }
 
 #[test]

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -1242,6 +1242,10 @@ pub struct CommitAgentSchema {
     pub segment_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_level: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -720,7 +720,7 @@ fn install_codex(
     let heddle = HeddleInvocation::resolve(path_mode)?;
     // Workspace sidecar: discover `.heddle` from cwd. Do not bake the
     // install-repo path — a second workspace would stamp the wrong tree.
-    let command = format!("{heddle} integration stamp codex");
+    let stamp = format!("{heddle} integration stamp codex");
     let table = value
         .as_table_mut()
         .ok_or_else(|| anyhow!("codex config root must be a TOML table"))?;
@@ -738,6 +738,11 @@ fn install_codex(
         .as_table_mut()
         .ok_or_else(|| anyhow!("codex hooks must be a table"))?;
     for event in ["SessionStart", "SubagentStart", "PreToolUse", "Stop"] {
+        let command = if event == "Stop" {
+            format!("{stamp} --expire")
+        } else {
+            stamp.clone()
+        };
         upsert_codex_hook_event(hooks_table, event, &command);
     }
     if table.get("notify").is_some_and(|notify| {
@@ -916,59 +921,17 @@ fn install_opencode(
 
 fn opencode_plugin_script(exe: &str, repo: &str) -> String {
     format!(
-        r#"const fs = require("fs");
-const identityDest = () => {{
-  const marker = {repo:?} + "/.heddle";
-  try {{
-    if (fs.statSync(marker).isFile()) return {repo:?} + "/.heddle.identity";
-  }} catch {{}}
-  return marker + "/identity";
-}};
-const published = (value) => {{
-  if (value == null) return undefined;
-  const text = String(value).trim();
-  if (!text || text.toLowerCase() === "unknown") return undefined;
-  return text;
-}};
-const mergeCursor = (patch) => {{
-  const dest = identityDest();
-  let current = {{}};
-  try {{ current = JSON.parse(fs.readFileSync(dest, "utf8")); }} catch {{}}
-  const next = {{}};
-  for (const key of ["provider", "model", "thought_level", "session", "parent"]) {{
-    const value = published(patch[key]) || published(current[key]);
-    if (value) next[key] = value;
-  }}
-  fs.mkdirSync(require("path").dirname(dest), {{ recursive: true }});
-  const tmp = dest + ".tmp." + process.pid + "." + Date.now();
-  fs.writeFileSync(tmp, JSON.stringify(next));
-  fs.renameSync(tmp, dest);
-}};
-const modelPatch = (model) => {{
-  if (!model || typeof model !== "object") return {{ model: published(model) }};
-  return {{
-    provider: published(model.providerID),
-    model: published(model.id),
-    thought_level: published(model.variant),
-  }};
-}};
-export default async function() {{
+        r#"export default async function() {{
   return {{
     event: async (input) => {{
       const eventObj = input?.event || input;
-      const properties = eventObj?.properties || input?.properties || {{}};
       const event = eventObj?.type || eventObj?.name || input?.type || input?.name || "event";
-      if (["session.deleted","session.closed","session.end","session.idle","SessionEnd"].includes(event)) {{
-        try {{ fs.unlinkSync(identityDest()); }} catch {{}}
-        return;
-      }}
-      const model = properties.model || input?.model;
-      const patch = {{
-        ...modelPatch(model),
-        session: published(properties.sessionID || properties.session_id || input?.sessionID || input?.session_id || input?.session?.id),
-        parent: published(properties.parentID || properties.parent_id || input?.parentID || input?.parent_id),
-      }};
-      mergeCursor(patch);
+      const expire = ["session.deleted","session.closed","session.end","session.idle","SessionEnd"].includes(event);
+      const stamp = ["--repo", {repo:?}, "integration", "stamp", "opencode"];
+      if (expire) stamp.push("--expire");
+      Bun.spawnSync([{exe:?}, ...stamp], {{
+        stdin: JSON.stringify(input),
+      }});
       const allowed = new Set(["session.created","session.updated","session.diff","file.edited","tool.execute.before","tool.execute.after","permission.asked","permission.replied"]);
       if (allowed.has(event)) {{
         Bun.spawn([{exe:?}, "--repo", {repo:?}, "integration", "relay", "opencode", event], {{
@@ -1525,29 +1488,23 @@ mod tests {
             "opencode plugin must read event.type, got: {plugin_contents}"
         );
         assert!(
-            plugin_contents.contains("eventObj?.properties")
-                || plugin_contents.contains("event.properties"),
-            "opencode plugin must read nested event.properties, got: {plugin_contents}"
+            plugin_contents.contains("\"integration\", \"stamp\", \"opencode\"")
+                && plugin_contents.contains("Bun.spawnSync"),
+            "opencode writes must go through locked integration stamp, got: {plugin_contents}"
         );
         assert!(
-            plugin_contents.contains("model.providerID"),
-            "opencode plugin must read object model fields, got: {plugin_contents}"
+            plugin_contents.contains("session.deleted") && plugin_contents.contains("--expire"),
+            "plugin must expire the cursor on session end through stamp --expire"
         );
         assert!(
-            plugin_contents.contains(".heddle.identity"),
-            "opencode plugin must use .heddle.identity when .heddle is a file"
-        );
-        assert!(
-            plugin_contents.contains(".heddle") && plugin_contents.contains("/identity"),
-            "opencode plugin must write the workspace identity cursor"
+            !plugin_contents.contains("mergeCursor")
+                && !plugin_contents.contains("unlinkSync")
+                && !plugin_contents.contains("writeFileSync"),
+            "plugin must not unlocked-RMW the identity sidecar, got: {plugin_contents}"
         );
         assert!(
             !plugin_contents.contains("session.get"),
             "plugin must not hunt session.get, got: {plugin_contents}"
-        );
-        assert!(
-            plugin_contents.contains("session.deleted") && plugin_contents.contains("unlinkSync"),
-            "plugin must expire the cursor on session end"
         );
         let timeline_manifest_path = repo
             .root()
@@ -1638,8 +1595,42 @@ mod tests {
             contents.contains("heddle integration stamp codex"),
             "expected PATH-relative `heddle` in codex hook command, got: {contents}"
         );
+        let parsed: toml::Value = contents.parse().unwrap();
+        let hook_command = |event: &str| {
+            parsed["hooks"][event][0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap_or("")
+                .to_string()
+        };
+        assert_eq!(
+            hook_command("Stop"),
+            "heddle integration stamp codex --expire",
+            "Codex Stop must expire, same as Claude SessionEnd"
+        );
+        for event in ["SessionStart", "SubagentStart", "PreToolUse"] {
+            assert_eq!(
+                hook_command(event),
+                "heddle integration stamp codex",
+                "{event} must stamp without expiring"
+            );
+        }
         assert_eq!(manifest.integrations[0].harness, "codex");
         assert_eq!(manifest.integrations[0].path_mode, PathMode::Relative);
+
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("openai".into()),
+                model: Some("gpt-5.4".into()),
+                ..heddle_core::IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        uninstall_one(&repo, &mut manifest, "codex").unwrap();
+        assert!(
+            heddle_core::read_identity_cursor(repo.root()).is_empty(),
+            "codex uninstall must expire the identity cursor"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -810,6 +810,8 @@ fn install_claude(
     ] {
         let command = if event == "PreToolUse" {
             stamp.clone()
+        } else if event == "SessionEnd" {
+            format!("{stamp} --expire")
         } else {
             format!(
                 "{} --repo {} integration relay claude-code {}",
@@ -956,6 +958,10 @@ export default async function() {{
       const eventObj = input?.event || input;
       const properties = eventObj?.properties || input?.properties || {{}};
       const event = eventObj?.type || eventObj?.name || input?.type || input?.name || "event";
+      if (["session.deleted","session.closed","session.end","session.idle","SessionEnd"].includes(event)) {{
+        try {{ fs.unlinkSync(identityDest()); }} catch {{}}
+        return;
+      }}
       const model = properties.model || input?.model;
       const patch = {{
         ...modelPatch(model),
@@ -1153,7 +1159,7 @@ fn uninstall_one(
     manifest
         .integrations
         .retain(|entry| entry.harness != harness);
-    let _ = repo;
+    heddle_core::expire_identity_cursor(repo.root()).map_err(anyhow::Error::from)?;
     Ok(())
 }
 
@@ -1346,6 +1352,8 @@ mod tests {
         assert!(contents.contains("integration relay claude-code PostToolUse"));
         assert!(contents.contains("integration relay claude-code SubagentStop"));
         assert!(contents.contains("integration relay claude-code Stop"));
+        assert!(contents.contains("integration stamp claude-code --expire"));
+        assert!(!contents.contains("integration relay claude-code SessionEnd"));
         assert!(contents.contains("statusLine"));
 
         // Default install must use the PATH-relative literal `heddle` and must
@@ -1537,6 +1545,10 @@ mod tests {
             !plugin_contents.contains("session.get"),
             "plugin must not hunt session.get, got: {plugin_contents}"
         );
+        assert!(
+            plugin_contents.contains("session.deleted") && plugin_contents.contains("unlinkSync"),
+            "plugin must expire the cursor on session end"
+        );
         let timeline_manifest_path = repo
             .root()
             .join(".opencode")
@@ -1570,10 +1582,23 @@ mod tests {
             vec![timeline_manifest_path.display().to_string()]
         );
 
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("opencode".into()),
+                model: Some("sonnet".into()),
+                ..heddle_core::IdentityCursor::default()
+            },
+        )
+        .unwrap();
         uninstall_one(&repo, &mut manifest, "opencode").unwrap();
         assert!(!plugin_path.exists());
         assert!(!timeline_manifest_path.exists());
         assert!(manifest.integrations.is_empty());
+        assert!(
+            heddle_core::read_identity_cursor(repo.root()).is_empty(),
+            "uninstall must expire the identity cursor"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -689,7 +689,7 @@ fn validate_install_plan(harnesses: &[String], scope_value: &str) -> Result<()> 
 }
 
 fn install_codex(
-    repo: &Repository,
+    _repo: &Repository,
     manifest: &mut IntegrationManifest,
     scope: &IntegrationScope,
     force: bool,
@@ -718,11 +718,9 @@ fn install_codex(
         existing.parse::<toml::Value>()?
     };
     let heddle = HeddleInvocation::resolve(path_mode)?;
-    let command = format!(
-        "{} --repo {} integration stamp codex",
-        heddle,
-        shell_escape(repo.root())
-    );
+    // Workspace sidecar: discover `.heddle` from cwd. Do not bake the
+    // install-repo path — a second workspace would stamp the wrong tree.
+    let command = format!("{heddle} integration stamp codex");
     let table = value
         .as_table_mut()
         .ok_or_else(|| anyhow!("codex config root must be a TOML table"))?;
@@ -831,14 +829,10 @@ fn install_claude(
         .and_then(|obj| obj.get("command"))
         .and_then(Value::as_str)
         .map(str::to_string);
-    let heddle_owned = existing_status.as_deref().is_some_and(|command| {
-        command.contains("integration stamp claude-code")
-            || command.contains("integration relay claude-code StatusLine")
-    });
     let mut status_cmd = stamp;
-    if let Some(existing) = existing_status.filter(|_| !heddle_owned) {
+    if let Some(original) = status_line_user_command(existing_status.as_deref()) {
         status_cmd.push_str(" --chain ");
-        status_cmd.push_str(&shell_escape_arg(&existing));
+        status_cmd.push_str(&shell_escape_arg(&original));
     }
     root_obj.insert(
         "statusLine".to_string(),
@@ -921,9 +915,13 @@ fn install_opencode(
 fn opencode_plugin_script(exe: &str, repo: &str) -> String {
     format!(
         r#"const fs = require("fs");
-const destDir = {repo:?} + "/.heddle";
-const dest = destDir + "/identity";
-const tmp = destDir + "/.identity.tmp";
+const identityDest = () => {{
+  const marker = {repo:?} + "/.heddle";
+  try {{
+    if (fs.statSync(marker).isFile()) return {repo:?} + "/.heddle.identity";
+  }} catch {{}}
+  return marker + "/identity";
+}};
 const published = (value) => {{
   if (value == null) return undefined;
   const text = String(value).trim();
@@ -931,6 +929,7 @@ const published = (value) => {{
   return text;
 }};
 const mergeCursor = (patch) => {{
+  const dest = identityDest();
   let current = {{}};
   try {{ current = JSON.parse(fs.readFileSync(dest, "utf8")); }} catch {{}}
   const next = {{}};
@@ -938,7 +937,8 @@ const mergeCursor = (patch) => {{
     const value = published(patch[key]) || published(current[key]);
     if (value) next[key] = value;
   }}
-  fs.mkdirSync(destDir, {{ recursive: true }});
+  fs.mkdirSync(require("path").dirname(dest), {{ recursive: true }});
+  const tmp = dest + ".tmp." + process.pid + "." + Date.now();
   fs.writeFileSync(tmp, JSON.stringify(next));
   fs.renameSync(tmp, dest);
 }};
@@ -950,22 +950,19 @@ const modelPatch = (model) => {{
     thought_level: published(model.variant),
   }};
 }};
-export default async function(ctx) {{
+export default async function() {{
   return {{
     event: async (input) => {{
-      const event = input?.event?.type || input?.type || input?.event?.name || input?.name || "event";
-      const model = input?.properties?.model || input?.model;
+      const eventObj = input?.event || input;
+      const properties = eventObj?.properties || input?.properties || {{}};
+      const event = eventObj?.type || eventObj?.name || input?.type || input?.name || "event";
+      const model = properties.model || input?.model;
       const patch = {{
         ...modelPatch(model),
-        session: published(input?.sessionID || input?.session_id || input?.session?.id),
-        parent: published(input?.parentID || input?.parent_id),
+        session: published(properties.sessionID || properties.session_id || input?.sessionID || input?.session_id || input?.session?.id),
+        parent: published(properties.parentID || properties.parent_id || input?.parentID || input?.parent_id),
       }};
       mergeCursor(patch);
-      if (!patch.model && ctx?.client?.session?.get) {{
-        Promise.resolve(ctx.client.session.get({{ sessionID: patch.session }})).then((session) => {{
-          mergeCursor(modelPatch(session?.model || session));
-        }}).catch(() => {{}});
-      }}
       const allowed = new Set(["session.created","session.updated","session.diff","file.edited","tool.execute.before","tool.execute.after","permission.asked","permission.replied"]);
       if (allowed.has(event)) {{
         Bun.spawn([{exe:?}, "--repo", {repo:?}, "integration", "relay", "opencode", event], {{
@@ -976,8 +973,8 @@ export default async function(ctx) {{
   }};
 }}
 "#,
-        exe = exe,
         repo = repo,
+        exe = exe,
     )
 }
 
@@ -1231,6 +1228,42 @@ fn upsert_codex_hook_event(
     hooks_table.insert(event.to_string(), toml::Value::Array(groups));
 }
 
+fn status_line_user_command(existing: Option<&str>) -> Option<String> {
+    let command = existing?.trim();
+    if command.is_empty() {
+        return None;
+    }
+    if let Some(chained) = extract_status_line_chain(command) {
+        return Some(chained).filter(|value| !value.trim().is_empty());
+    }
+    if command.contains("integration stamp claude-code")
+        || command.contains("integration relay claude-code StatusLine")
+    {
+        return None;
+    }
+    Some(command.to_string())
+}
+
+fn extract_status_line_chain(command: &str) -> Option<String> {
+    if let Some(rest) = command.split_once(" --chain=").map(|(_, rest)| rest) {
+        return Some(unshell_escape_arg(rest.trim()));
+    }
+    command
+        .split_once(" --chain ")
+        .map(|(_, rest)| unshell_escape_arg(rest.trim()))
+}
+
+fn unshell_escape_arg(value: &str) -> String {
+    let value = value.trim();
+    if let Some(inner) = value.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        return inner.replace("'\"'\"'", "'");
+    }
+    if let Some(inner) = value.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+        return inner.replace("\\\"", "\"").replace("\\\\", "\\");
+    }
+    value.to_string()
+}
+
 fn shell_escape(path: &Path) -> String {
     shell_escape_arg(&path.display().to_string())
 }
@@ -1369,6 +1402,51 @@ mod tests {
     }
 
     #[test]
+    fn claude_status_line_reinstall_still_chains() {
+        let (_temp, repo) = init_repo();
+        let settings_path = repo.root().join(".claude").join("settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(
+            &settings_path,
+            r#"{"statusLine":{"type":"command","command":"echo custom-status"}}"#,
+        )
+        .unwrap();
+        let mut manifest = IntegrationManifest::default();
+        install_claude(
+            &repo,
+            &mut manifest,
+            &IntegrationScope::Repo,
+            false,
+            PathMode::Relative,
+        )
+        .unwrap();
+        install_claude(
+            &repo,
+            &mut manifest,
+            &IntegrationScope::Repo,
+            true,
+            PathMode::Relative,
+        )
+        .unwrap();
+        let parsed: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let status_line_cmd = parsed["statusLine"]["command"].as_str().unwrap();
+        assert!(status_line_cmd.contains("integration stamp claude-code"));
+        assert!(status_line_cmd.contains("--chain"));
+        assert!(
+            status_line_cmd.contains("echo custom-status"),
+            "reinstall/upgrade must keep the user's StatusLine, got: {status_line_cmd}"
+        );
+        assert_eq!(
+            status_line_cmd
+                .matches("integration stamp claude-code")
+                .count(),
+            1,
+            "must not nest stamp commands: {status_line_cmd}"
+        );
+    }
+
+    #[test]
     fn claude_repo_install_with_absolute_path_bakes_current_exe() {
         let (_temp, repo) = init_repo();
         let mut manifest = IntegrationManifest::default();
@@ -1435,16 +1513,29 @@ mod tests {
             "opencode plugin should reference PATH-relative `heddle`, got: {plugin_contents}"
         );
         assert!(
-            plugin_contents.contains("event?.type"),
+            plugin_contents.contains("event?.type") || plugin_contents.contains("eventObj?.type"),
             "opencode plugin must read event.type, got: {plugin_contents}"
+        );
+        assert!(
+            plugin_contents.contains("eventObj?.properties")
+                || plugin_contents.contains("event.properties"),
+            "opencode plugin must read nested event.properties, got: {plugin_contents}"
         );
         assert!(
             plugin_contents.contains("model.providerID"),
             "opencode plugin must read object model fields, got: {plugin_contents}"
         );
         assert!(
+            plugin_contents.contains(".heddle.identity"),
+            "opencode plugin must use .heddle.identity when .heddle is a file"
+        );
+        assert!(
             plugin_contents.contains(".heddle") && plugin_contents.contains("/identity"),
             "opencode plugin must write the workspace identity cursor"
+        );
+        assert!(
+            !plugin_contents.contains("session.get"),
+            "plugin must not hunt session.get, got: {plugin_contents}"
         );
         let timeline_manifest_path = repo
             .root()
@@ -1514,12 +1605,12 @@ mod tests {
         assert!(contents.contains("PreToolUse"));
         assert!(!contents.contains("notify ="));
         assert!(!contents.contains("/bin/sh"));
-        // Workspace sidecar: --repo is the install checkout, not ~/.codex.
-        assert!(contents.contains(&format!("heddle --repo {}", shell_escape(repo.root()))));
-        // The default codex install must invoke PATH-relative `heddle`, not the
-        // absolute path of the current binary.
         assert!(
-            contents.contains("heddle --repo "),
+            !contents.contains("--repo"),
+            "codex hook must discover the workspace from cwd, got: {contents}"
+        );
+        assert!(
+            contents.contains("heddle integration stamp codex"),
             "expected PATH-relative `heddle` in codex hook command, got: {contents}"
         );
         assert_eq!(manifest.integrations[0].harness, "codex");

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -715,7 +715,7 @@ fn install_codex(
     let mut value = if existing.trim().is_empty() {
         toml::Value::Table(toml::map::Map::new())
     } else {
-        existing.parse::<toml::Value>()?
+        toml::from_str(&existing)?
     };
     let heddle = HeddleInvocation::resolve(path_mode)?;
     // Workspace sidecar: discover `.heddle` from cwd. Do not bake the
@@ -1039,12 +1039,14 @@ fn uninstall_one(
     else {
         return Ok(());
     };
+    heddle_core::expire_identity_cursor(repo.root()).map_err(anyhow::Error::from)?;
     match harness {
         "codex" => {
             if let Some(path) = existing.paths.first() {
                 let config_path = PathBuf::from(path);
                 if config_path.exists() {
-                    let mut value = fs::read_to_string(&config_path)?.parse::<toml::Value>()?;
+                    let mut value: toml::Value =
+                        toml::from_str(&fs::read_to_string(&config_path)?)?;
                     if let Some(table) = value.as_table_mut() {
                         if let Some(hooks) = table.get_mut("hooks").and_then(|v| v.as_table_mut()) {
                             for event in ["SessionStart", "SubagentStart", "PreToolUse", "Stop"] {
@@ -1122,7 +1124,6 @@ fn uninstall_one(
     manifest
         .integrations
         .retain(|entry| entry.harness != harness);
-    heddle_core::expire_identity_cursor(repo.root()).map_err(anyhow::Error::from)?;
     Ok(())
 }
 
@@ -1595,25 +1596,25 @@ mod tests {
             contents.contains("heddle integration stamp codex"),
             "expected PATH-relative `heddle` in codex hook command, got: {contents}"
         );
-        let parsed: toml::Value = contents.parse().unwrap();
-        let hook_command = |event: &str| {
-            parsed["hooks"][event][0]["hooks"][0]["command"]
-                .as_str()
-                .unwrap_or("")
-                .to_string()
-        };
         assert_eq!(
-            hook_command("Stop"),
-            "heddle integration stamp codex --expire",
-            "Codex Stop must expire, same as Claude SessionEnd"
+            contents
+                .matches("heddle integration stamp codex --expire\"")
+                .count(),
+            1,
+            "Codex Stop must expire, same as Claude SessionEnd, got: {contents}"
         );
-        for event in ["SessionStart", "SubagentStart", "PreToolUse"] {
-            assert_eq!(
-                hook_command(event),
-                "heddle integration stamp codex",
-                "{event} must stamp without expiring"
-            );
-        }
+        assert_eq!(
+            contents
+                .matches("heddle integration stamp codex\"")
+                .count(),
+            3,
+            "SessionStart/SubagentStart/PreToolUse must stamp without expiring, got: {contents}"
+        );
+        assert!(
+            contents.contains("[[hooks.Stop]]")
+                && contents.contains("heddle integration stamp codex --expire"),
+            "Stop hook must be the expire command, got: {contents}"
+        );
         assert_eq!(manifest.integrations[0].harness, "codex");
         assert_eq!(manifest.integrations[0].path_mode, PathMode::Relative);
 
@@ -1630,6 +1631,11 @@ mod tests {
         assert!(
             heddle_core::read_identity_cursor(repo.root()).is_empty(),
             "codex uninstall must expire the identity cursor"
+        );
+        let after = fs::read_to_string(&config_path).unwrap();
+        assert!(
+            !after.contains("integration stamp"),
+            "codex uninstall must remove stamp hooks, got: {after}"
         );
     }
 

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -815,14 +815,19 @@ fn install_claude(
         "Stop",
         "SessionEnd",
     ] {
-        let command = if event == "PreToolUse" {
-            stamp.clone()
+        let commands = if event == "PreToolUse" {
+            vec![stamp.clone()]
         } else if event == "SessionEnd" {
-            format!("{stamp} --expire")
+            vec![
+                format!("{heddle}{repo_flag} integration relay claude-code {event}"),
+                format!("{stamp} --expire"),
+            ]
         } else {
-            format!("{heddle}{repo_flag} integration relay claude-code {event}")
+            vec![format!(
+                "{heddle}{repo_flag} integration relay claude-code {event}"
+            )]
         };
-        upsert_claude_hook_group(hooks_obj, event, command)?;
+        upsert_claude_hook_group(hooks_obj, event, commands)?;
     }
     let root_obj = root
         .as_object_mut()
@@ -939,7 +944,7 @@ fn opencode_plugin_script(exe: &str, repo: Option<&str>) -> String {
       }});
       const allowed = new Set(["session.created","session.updated","session.diff","file.edited","tool.execute.before","tool.execute.after","permission.asked","permission.replied"]);
       if (allowed.has(event)) {{
-        Bun.spawn([{exe:?}, {repo_args}"integration", "relay", "opencode", event], {{
+        Bun.spawnSync([{exe:?}, {repo_args}"integration", "relay", "opencode", event], {{
           stdin: JSON.stringify(input),
         }});
       }}
@@ -1145,14 +1150,20 @@ fn upsert_manifest(manifest: &mut IntegrationManifest, entry: InstalledIntegrati
 fn upsert_claude_hook_group(
     hooks_obj: &mut serde_json::Map<String, Value>,
     event: &str,
-    command: String,
+    commands: impl IntoIterator<Item = String>,
 ) -> Result<()> {
+    let hooks: Vec<Value> = commands
+        .into_iter()
+        .map(|command| {
+            serde_json::json!({
+                "type": "command",
+                "command": command
+            })
+        })
+        .collect();
     let group = serde_json::json!({
         "matcher": "*",
-        "hooks": [{
-            "type": "command",
-            "command": command
-        }]
+        "hooks": hooks
     });
     let entry = hooks_obj
         .entry(event.to_string())
@@ -1322,7 +1333,7 @@ mod tests {
         assert!(contents.contains("integration relay claude-code SubagentStop"));
         assert!(contents.contains("integration relay claude-code Stop"));
         assert!(contents.contains("integration stamp claude-code --expire"));
-        assert!(!contents.contains("integration relay claude-code SessionEnd"));
+        assert!(contents.contains("integration relay claude-code SessionEnd"));
         assert!(contents.contains("statusLine"));
 
         // Default install must use the PATH-relative literal `heddle` and must
@@ -1388,6 +1399,10 @@ mod tests {
         assert!(
             contents.contains("heddle integration stamp claude-code --expire"),
             "user-scoped SessionEnd must expire, got: {contents}"
+        );
+        assert!(
+            contents.contains("heddle integration relay claude-code SessionEnd"),
+            "user-scoped SessionEnd must still relay close_session, got: {contents}"
         );
         assert!(
             contents.contains("heddle integration relay claude-code SessionStart"),
@@ -1541,6 +1556,10 @@ mod tests {
             plugin_contents.contains("\"integration\", \"stamp\", \"opencode\"")
                 && plugin_contents.contains("Bun.spawnSync"),
             "opencode writes must go through locked integration stamp, got: {plugin_contents}"
+        );
+        assert!(
+            !plugin_contents.contains("Bun.spawn("),
+            "OpenCode relays must await via spawnSync so before/after stay ordered, got: {plugin_contents}"
         );
         assert!(
             plugin_contents.contains("session.deleted") && plugin_contents.contains("--expire"),

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -894,7 +894,11 @@ fn install_opencode(
     }
     let timeline_manifest_path = plugin_path.with_file_name("heddle.timeline.json");
     let heddle_raw = HeddleInvocation::raw(path_mode)?;
-    let script = opencode_plugin_script(&heddle_raw, &repo.root().display().to_string());
+    let baked_repo = match scope {
+        IntegrationScope::Repo => Some(repo.root().display().to_string()),
+        IntegrationScope::User => None,
+    };
+    let script = opencode_plugin_script(&heddle_raw, baked_repo.as_deref());
     write_file_atomic(&plugin_path, script.as_bytes())?;
     let capabilities = opencode_timeline_capabilities(repo, &heddle_raw);
     write_file_atomic(
@@ -919,7 +923,11 @@ fn install_opencode(
     Ok(())
 }
 
-fn opencode_plugin_script(exe: &str, repo: &str) -> String {
+fn opencode_plugin_script(exe: &str, repo: Option<&str>) -> String {
+    let repo_args = match repo {
+        Some(repo) => format!(r#""--repo", {repo:?}, "#),
+        None => String::new(),
+    };
     format!(
         r#"export default async function() {{
   return {{
@@ -927,14 +935,14 @@ fn opencode_plugin_script(exe: &str, repo: &str) -> String {
       const eventObj = input?.event || input;
       const event = eventObj?.type || eventObj?.name || input?.type || input?.name || "event";
       const expire = ["session.deleted","session.closed","session.end","session.idle","SessionEnd"].includes(event);
-      const stamp = ["--repo", {repo:?}, "integration", "stamp", "opencode"];
+      const stamp = [{repo_args}"integration", "stamp", "opencode"];
       if (expire) stamp.push("--expire");
       Bun.spawnSync([{exe:?}, ...stamp], {{
         stdin: JSON.stringify(input),
       }});
       const allowed = new Set(["session.created","session.updated","session.diff","file.edited","tool.execute.before","tool.execute.after","permission.asked","permission.replied"]);
       if (allowed.has(event)) {{
-        Bun.spawn([{exe:?}, "--repo", {repo:?}, "integration", "relay", "opencode", event], {{
+        Bun.spawn([{exe:?}, {repo_args}"integration", "relay", "opencode", event], {{
           stdin: JSON.stringify(input),
         }});
       }}
@@ -942,7 +950,7 @@ fn opencode_plugin_script(exe: &str, repo: &str) -> String {
   }};
 }}
 "#,
-        repo = repo,
+        repo_args = repo_args,
         exe = exe,
     )
 }
@@ -1556,6 +1564,48 @@ mod tests {
         assert!(
             heddle_core::read_identity_cursor(repo.root()).is_empty(),
             "uninstall must expire the identity cursor"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn opencode_user_install_discovers_workspace_at_runtime() {
+        static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_temp, repo) = init_repo();
+        let home = tempfile::TempDir::new().unwrap();
+        let _home_guard = HomeEnvGuard::set(home.path());
+        let mut manifest = IntegrationManifest::default();
+
+        install_opencode(
+            &repo,
+            &mut manifest,
+            &IntegrationScope::User,
+            false,
+            PathMode::Relative,
+        )
+        .unwrap();
+
+        let plugin_path = home
+            .path()
+            .join(".config")
+            .join("opencode")
+            .join("plugins")
+            .join("heddle.js");
+        let contents = fs::read_to_string(&plugin_path).unwrap();
+        let install_repo = repo.root().display().to_string();
+        assert!(
+            !contents.contains(&install_repo),
+            "user-scoped plugin must not bake the install-time repo, got: {contents}"
+        );
+        assert!(
+            !contents.contains("--repo"),
+            "user-scoped plugin must discover the workspace from cwd, got: {contents}"
+        );
+        assert!(
+            contents.contains("\"integration\", \"stamp\", \"opencode\"")
+                && contents.contains("Bun.spawnSync"),
+            "user-scoped plugin must still stamp through the locked path, got: {contents}"
         );
     }
 

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -179,6 +179,7 @@ pub fn cmd_integration(cli: &Cli, command: IntegrationCommands) -> Result<()> {
         IntegrationCommands::Uninstall(args) => uninstall_integrations(cli, &repo, args),
         IntegrationCommands::Upgrade(args) => upgrade_integrations(cli, &repo, args),
         IntegrationCommands::Relay(args) => relay_integration(&repo, args),
+        IntegrationCommands::Stamp(args) => stamp_integration(&repo, args),
     }
 }
 
@@ -447,8 +448,20 @@ fn detect_path_mode(harness: &str, entry: &InstalledIntegration) -> Option<PathM
             Some(path_mode_from_command(&cmd))
         }
         "codex" => {
-            // notify is `["/bin/sh", "-lc", "<cmd>"]` — read the third arg.
             let value: toml::Value = toml::from_str(&contents).ok()?;
+            if let Some(cmd) = value.get("hooks").and_then(|hooks| {
+                hooks.as_table()?.values().find_map(|event| {
+                    event.as_array()?.iter().find_map(|group| {
+                        group
+                            .get("hooks")?
+                            .as_array()?
+                            .iter()
+                            .find_map(|hook| hook.get("command")?.as_str().map(str::to_string))
+                    })
+                })
+            }) {
+                return Some(path_mode_from_command(&cmd));
+            }
             let arr = value.get("notify")?.as_array()?;
             let cmd = arr.get(2)?.as_str()?;
             Some(path_mode_from_command(cmd))
@@ -475,6 +488,13 @@ fn relay_integration(repo: &Repository, args: IntegrationRelayArgs) -> Result<()
     let mut payload = String::new();
     io::stdin().read_to_string(&mut payload)?;
     harness::relay_harness_event(repo, &args.harness, &args.event, &payload)
+}
+
+fn stamp_integration(repo: &Repository, args: crate::cli::IntegrationStampArgs) -> Result<()> {
+    let mut payload = String::new();
+    io::stdin().read_to_string(&mut payload)?;
+    crate::identity_stamp::stamp_bytes(repo.root(), &args.harness, &payload)?;
+    Ok(())
 }
 
 fn manifest_path(repo: &Repository) -> PathBuf {
@@ -684,7 +704,8 @@ fn install_codex(
         String::new()
     };
     if existing.contains("notify =")
-        && !existing.contains("integration relay codex notify")
+        && !existing.contains("integration relay codex")
+        && !existing.contains("integration stamp codex")
         && !force
     {
         return Err(anyhow!(
@@ -698,21 +719,35 @@ fn install_codex(
     };
     let heddle = HeddleInvocation::resolve(path_mode)?;
     let command = format!(
-        "{} --repo {} integration relay codex notify",
+        "{} --repo {} integration stamp codex",
         heddle,
         shell_escape(repo.root())
     );
     let table = value
         .as_table_mut()
         .ok_or_else(|| anyhow!("codex config root must be a TOML table"))?;
-    table.insert(
-        "notify".to_string(),
-        toml::Value::Array(vec![
-            toml::Value::String("/bin/sh".to_string()),
-            toml::Value::String("-lc".to_string()),
-            toml::Value::String(command),
-        ]),
-    );
+    let features = table
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    features
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("codex features must be a table"))?
+        .insert("hooks".to_string(), toml::Value::Boolean(true));
+    let hooks = table
+        .entry("hooks")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let hooks_table = hooks
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("codex hooks must be a table"))?;
+    for event in ["SessionStart", "SubagentStart", "PreToolUse", "Stop"] {
+        upsert_codex_hook_event(hooks_table, event, &command);
+    }
+    if table.get("notify").is_some_and(|notify| {
+        let text = notify.to_string();
+        text.contains("integration relay codex") || text.contains("integration stamp codex")
+    }) {
+        table.remove("notify");
+    }
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -722,7 +757,7 @@ fn install_codex(
         InstalledIntegration {
             harness: "codex".to_string(),
             scope: scope.clone(),
-            method: "notify".to_string(),
+            method: "hooks".to_string(),
             paths: vec![config_path.display().to_string()],
             status: "installed".to_string(),
             heddle_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -760,6 +795,11 @@ fn install_claude(
         .ok_or_else(|| anyhow!("claude settings hooks must be an object"))?;
 
     let heddle = HeddleInvocation::resolve(path_mode)?;
+    let stamp = format!(
+        "{} --repo {} integration stamp claude-code",
+        heddle,
+        shell_escape(repo.root())
+    );
     for event in [
         "SessionStart",
         "UserPromptSubmit",
@@ -770,56 +810,43 @@ fn install_claude(
         "Stop",
         "SessionEnd",
     ] {
-        let command = format!(
-            "{} --repo {} integration relay claude-code {}",
-            heddle,
-            shell_escape(repo.root()),
-            event
-        );
-        let group = serde_json::json!({
-            "matcher": "*",
-            "hooks": [{
-                "type": "command",
-                "command": command
-            }]
-        });
-        let entry = hooks_obj
-            .entry(event.to_string())
-            .or_insert_with(|| Value::Array(Vec::new()));
-        let groups = entry
-            .as_array_mut()
-            .ok_or_else(|| anyhow!("claude hook event entries must be arrays"))?;
-        let exists = groups
-            .iter()
-            .any(|group| group.to_string().contains("integration relay claude-code"));
-        if !exists {
-            groups.push(group);
-        }
+        let command = if event == "PreToolUse" {
+            stamp.clone()
+        } else {
+            format!(
+                "{} --repo {} integration relay claude-code {}",
+                heddle,
+                shell_escape(repo.root()),
+                event
+            )
+        };
+        upsert_claude_hook_group(hooks_obj, event, command)?;
     }
     let root_obj = root
         .as_object_mut()
         .ok_or_else(|| anyhow!("claude settings root must be a JSON object"))?;
-    let install_status_line = match root_obj.get("statusLine") {
-        None => true,
-        Some(value) => value
-            .as_object()
-            .and_then(|obj| obj.get("command"))
-            .and_then(Value::as_str)
-            .is_some_and(|command| command.contains("integration relay claude-code StatusLine")),
-    };
-    if install_status_line {
-        root_obj.insert(
-            "statusLine".to_string(),
-            serde_json::json!({
-                "type": "command",
-                "command": format!(
-                    "{} --repo {} integration relay claude-code StatusLine",
-                    heddle,
-                    shell_escape(repo.root())
-                )
-            }),
-        );
+    let existing_status = root_obj
+        .get("statusLine")
+        .and_then(Value::as_object)
+        .and_then(|obj| obj.get("command"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let heddle_owned = existing_status.as_deref().is_some_and(|command| {
+        command.contains("integration stamp claude-code")
+            || command.contains("integration relay claude-code StatusLine")
+    });
+    let mut status_cmd = stamp;
+    if let Some(existing) = existing_status.filter(|_| !heddle_owned) {
+        status_cmd.push_str(" --chain ");
+        status_cmd.push_str(&shell_escape_arg(&existing));
     }
+    root_obj.insert(
+        "statusLine".to_string(),
+        serde_json::json!({
+            "type": "command",
+            "command": status_cmd
+        }),
+    );
     if let Some(parent) = settings_path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -866,28 +893,7 @@ fn install_opencode(
     }
     let timeline_manifest_path = plugin_path.with_file_name("heddle.timeline.json");
     let heddle_raw = HeddleInvocation::raw(path_mode)?;
-    let script = format!(
-        "const relay = async (event, payload) => {{
-  const proc = Bun.spawnSync([{exe:?}, '--repo', {repo:?}, 'integration', 'relay', 'opencode', event], {{
-    stdin: JSON.stringify(payload),
-  }});
-  if (proc.exitCode !== 0) console.error(new TextDecoder().decode(proc.stderr));
-}};
-
-export default async function(ctx) {{
-  return {{
-    event: async (input) => {{
-      const event = input?.event?.name || input?.name || 'event';
-      const allowed = new Set(['session.created','session.updated','session.diff','file.edited','tool.execute.before','tool.execute.after','permission.asked','permission.replied']);
-      if (allowed.has(event)) {{
-        await relay(event, input);
-      }}
-    }},
-  }};
-}}",
-        exe = heddle_raw,
-        repo = repo.root().display().to_string(),
-    );
+    let script = opencode_plugin_script(&heddle_raw, &repo.root().display().to_string());
     write_file_atomic(&plugin_path, script.as_bytes())?;
     let capabilities = opencode_timeline_capabilities(repo, &heddle_raw);
     write_file_atomic(
@@ -910,6 +916,69 @@ export default async function(ctx) {{
         },
     );
     Ok(())
+}
+
+fn opencode_plugin_script(exe: &str, repo: &str) -> String {
+    format!(
+        r#"const fs = require("fs");
+const destDir = {repo:?} + "/.heddle";
+const dest = destDir + "/identity";
+const tmp = destDir + "/.identity.tmp";
+const published = (value) => {{
+  if (value == null) return undefined;
+  const text = String(value).trim();
+  if (!text || text.toLowerCase() === "unknown") return undefined;
+  return text;
+}};
+const mergeCursor = (patch) => {{
+  let current = {{}};
+  try {{ current = JSON.parse(fs.readFileSync(dest, "utf8")); }} catch {{}}
+  const next = {{}};
+  for (const key of ["provider", "model", "thought_level", "session", "parent"]) {{
+    const value = published(patch[key]) || published(current[key]);
+    if (value) next[key] = value;
+  }}
+  fs.mkdirSync(destDir, {{ recursive: true }});
+  fs.writeFileSync(tmp, JSON.stringify(next));
+  fs.renameSync(tmp, dest);
+}};
+const modelPatch = (model) => {{
+  if (!model || typeof model !== "object") return {{ model: published(model) }};
+  return {{
+    provider: published(model.providerID),
+    model: published(model.id),
+    thought_level: published(model.variant),
+  }};
+}};
+export default async function(ctx) {{
+  return {{
+    event: async (input) => {{
+      const event = input?.event?.type || input?.type || input?.event?.name || input?.name || "event";
+      const model = input?.properties?.model || input?.model;
+      const patch = {{
+        ...modelPatch(model),
+        session: published(input?.sessionID || input?.session_id || input?.session?.id),
+        parent: published(input?.parentID || input?.parent_id),
+      }};
+      mergeCursor(patch);
+      if (!patch.model && ctx?.client?.session?.get) {{
+        Promise.resolve(ctx.client.session.get({{ sessionID: patch.session }})).then((session) => {{
+          mergeCursor(modelPatch(session?.model || session));
+        }}).catch(() => {{}});
+      }}
+      const allowed = new Set(["session.created","session.updated","session.diff","file.edited","tool.execute.before","tool.execute.after","permission.asked","permission.replied"]);
+      if (allowed.has(event)) {{
+        Bun.spawn([{exe:?}, "--repo", {repo:?}, "integration", "relay", "opencode", event], {{
+          stdin: JSON.stringify(input),
+        }});
+      }}
+    }},
+  }};
+}}
+"#,
+        exe = exe,
+        repo = repo,
+    )
 }
 
 fn opencode_timeline_capabilities(repo: &Repository, heddle_raw: &str) -> Value {
@@ -1010,14 +1079,28 @@ fn uninstall_one(
                 let config_path = PathBuf::from(path);
                 if config_path.exists() {
                     let mut value = fs::read_to_string(&config_path)?.parse::<toml::Value>()?;
-                    if let Some(table) = value.as_table_mut()
-                        && table.get("notify").is_some_and(|notify| {
-                            notify
-                                .to_string()
-                                .contains("integration relay codex notify")
-                        })
-                    {
-                        table.remove("notify");
+                    if let Some(table) = value.as_table_mut() {
+                        if let Some(hooks) = table.get_mut("hooks").and_then(|v| v.as_table_mut()) {
+                            for event in ["SessionStart", "SubagentStart", "PreToolUse", "Stop"] {
+                                if let Some(groups) =
+                                    hooks.get_mut(event).and_then(|v| v.as_array_mut())
+                                {
+                                    groups.retain(|group| !is_heddle_hook_text(&group.to_string()));
+                                    if groups.is_empty() {
+                                        hooks.remove(event);
+                                    }
+                                }
+                            }
+                            if hooks.is_empty() {
+                                table.remove("hooks");
+                            }
+                        }
+                        if table
+                            .get("notify")
+                            .is_some_and(|notify| is_heddle_hook_text(&notify.to_string()))
+                        {
+                            table.remove("notify");
+                        }
                         write_file_atomic(
                             &config_path,
                             toml::to_string_pretty(&value)?.as_bytes(),
@@ -1036,7 +1119,9 @@ fn uninstall_one(
                         for groups in hooks.values_mut() {
                             if let Some(array) = groups.as_array_mut() {
                                 array.retain(|group| {
-                                    !group.to_string().contains("integration relay claude-code")
+                                    let text = group.to_string();
+                                    !text.contains("integration relay claude-code")
+                                        && !text.contains("integration stamp claude-code")
                                 });
                             }
                         }
@@ -1046,7 +1131,8 @@ fn uninstall_one(
                         .and_then(Value::as_object)
                         .and_then(|obj| obj.get("command"))
                         .and_then(Value::as_str)
-                        && command.contains("integration relay claude-code StatusLine")
+                        && (command.contains("integration relay claude-code StatusLine")
+                            || command.contains("integration stamp claude-code"))
                     {
                         root.as_object_mut().map(|obj| obj.remove("statusLine"));
                     }
@@ -1084,8 +1170,73 @@ fn upsert_manifest(manifest: &mut IntegrationManifest, entry: InstalledIntegrati
         .sort_by(|a, b| a.harness.cmp(&b.harness));
 }
 
+fn upsert_claude_hook_group(
+    hooks_obj: &mut serde_json::Map<String, Value>,
+    event: &str,
+    command: String,
+) -> Result<()> {
+    let group = serde_json::json!({
+        "matcher": "*",
+        "hooks": [{
+            "type": "command",
+            "command": command
+        }]
+    });
+    let entry = hooks_obj
+        .entry(event.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let groups = entry
+        .as_array_mut()
+        .ok_or_else(|| anyhow!("claude hook event entries must be arrays"))?;
+    groups.retain(|group| {
+        let text = group.to_string();
+        !text.contains("integration relay claude-code")
+            && !text.contains("integration stamp claude-code")
+    });
+    groups.push(group);
+    Ok(())
+}
+
+fn is_heddle_hook_text(text: &str) -> bool {
+    text.contains("integration stamp") || text.contains("integration relay")
+}
+
+fn upsert_codex_hook_event(
+    hooks_table: &mut toml::map::Map<String, toml::Value>,
+    event: &str,
+    command: &str,
+) {
+    let mut groups = hooks_table
+        .get(event)
+        .and_then(toml::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    groups.retain(|group| !is_heddle_hook_text(&group.to_string()));
+    let mut hook = toml::map::Map::new();
+    hook.insert(
+        "type".to_string(),
+        toml::Value::String("command".to_string()),
+    );
+    hook.insert(
+        "command".to_string(),
+        toml::Value::String(command.to_string()),
+    );
+    let mut group = toml::map::Map::new();
+    group.insert("matcher".to_string(), toml::Value::String("*".to_string()));
+    group.insert(
+        "hooks".to_string(),
+        toml::Value::Array(vec![toml::Value::Table(hook)]),
+    );
+    groups.push(toml::Value::Table(group));
+    hooks_table.insert(event.to_string(), toml::Value::Array(groups));
+}
+
 fn shell_escape(path: &Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\"'\"'"))
+    shell_escape_arg(&path.display().to_string())
+}
+
+fn shell_escape_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 #[cfg(test)]
@@ -1157,11 +1308,12 @@ mod tests {
         let contents = fs::read_to_string(&settings_path).unwrap();
         assert!(contents.contains("integration relay claude-code SessionStart"));
         assert!(contents.contains("integration relay claude-code UserPromptSubmit"));
-        assert!(contents.contains("integration relay claude-code PreToolUse"));
+        assert!(contents.contains("integration stamp claude-code"));
+        assert!(!contents.contains("integration relay claude-code PreToolUse"));
         assert!(contents.contains("integration relay claude-code PostToolUse"));
         assert!(contents.contains("integration relay claude-code SubagentStop"));
         assert!(contents.contains("integration relay claude-code Stop"));
-        assert!(contents.contains("integration relay claude-code StatusLine"));
+        assert!(contents.contains("statusLine"));
 
         // Default install must use the PATH-relative literal `heddle` and must
         // NOT bake in an absolute path. We assert the exact command shape so a
@@ -1187,6 +1339,33 @@ mod tests {
         assert_eq!(manifest.integrations.len(), 1);
         assert_eq!(manifest.integrations[0].harness, "claude-code");
         assert_eq!(manifest.integrations[0].path_mode, PathMode::Relative);
+    }
+
+    #[test]
+    fn claude_repo_install_chains_existing_status_line() {
+        let (_temp, repo) = init_repo();
+        let settings_path = repo.root().join(".claude").join("settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(
+            &settings_path,
+            r#"{"statusLine":{"type":"command","command":"echo custom-status"}}"#,
+        )
+        .unwrap();
+        let mut manifest = IntegrationManifest::default();
+        install_claude(
+            &repo,
+            &mut manifest,
+            &IntegrationScope::Repo,
+            false,
+            PathMode::Relative,
+        )
+        .unwrap();
+        let parsed: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).unwrap();
+        let status_line_cmd = parsed["statusLine"]["command"].as_str().unwrap();
+        assert!(status_line_cmd.contains("integration stamp claude-code"));
+        assert!(status_line_cmd.contains("--chain"));
+        assert!(status_line_cmd.contains("echo custom-status"));
     }
 
     #[test]
@@ -1255,6 +1434,18 @@ mod tests {
             plugin_contents.contains("\"heddle\""),
             "opencode plugin should reference PATH-relative `heddle`, got: {plugin_contents}"
         );
+        assert!(
+            plugin_contents.contains("event?.type"),
+            "opencode plugin must read event.type, got: {plugin_contents}"
+        );
+        assert!(
+            plugin_contents.contains("model.providerID"),
+            "opencode plugin must read object model fields, got: {plugin_contents}"
+        );
+        assert!(
+            plugin_contents.contains(".heddle") && plugin_contents.contains("/identity"),
+            "opencode plugin must write the workspace identity cursor"
+        );
         let timeline_manifest_path = repo
             .root()
             .join(".opencode")
@@ -1296,7 +1487,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn codex_user_install_writes_notify_command() {
+    fn codex_user_install_writes_workspace_stamp_hooks() {
         // Serialize env-var access across tests. The credential store
         // (in CLI-owned hosted runtime when the client feature is enabled) has its own mutex; this is
         // a local fallback for cli-only builds.
@@ -1318,12 +1509,18 @@ mod tests {
 
         let config_path = home.path().join(".codex").join("config.toml");
         let contents = fs::read_to_string(&config_path).unwrap();
-        assert!(contents.contains("integration relay codex notify"));
+        assert!(contents.contains("integration stamp codex"));
+        assert!(contents.contains("SessionStart"));
+        assert!(contents.contains("PreToolUse"));
+        assert!(!contents.contains("notify ="));
+        assert!(!contents.contains("/bin/sh"));
+        // Workspace sidecar: --repo is the install checkout, not ~/.codex.
+        assert!(contents.contains(&format!("heddle --repo {}", shell_escape(repo.root()))));
         // The default codex install must invoke PATH-relative `heddle`, not the
         // absolute path of the current binary.
         assert!(
-            contents.contains("\"heddle --repo "),
-            "expected PATH-relative `heddle` in codex notify command, got: {contents}"
+            contents.contains("heddle --repo "),
+            "expected PATH-relative `heddle` in codex hook command, got: {contents}"
         );
         assert_eq!(manifest.integrations[0].harness, "codex");
         assert_eq!(manifest.integrations[0].path_mode, PathMode::Relative);

--- a/crates/cli/src/cli/commands/integration.rs
+++ b/crates/cli/src/cli/commands/integration.rs
@@ -798,11 +798,13 @@ fn install_claude(
         .ok_or_else(|| anyhow!("claude settings hooks must be an object"))?;
 
     let heddle = HeddleInvocation::resolve(path_mode)?;
-    let stamp = format!(
-        "{} --repo {} integration stamp claude-code",
-        heddle,
-        shell_escape(repo.root())
-    );
+    // User-scoped hooks run in whichever workspace launched Claude. Do not
+    // bake the install-repo path — a second workspace would stamp the wrong tree.
+    let repo_flag = match scope {
+        IntegrationScope::Repo => format!(" --repo {}", shell_escape(repo.root())),
+        IntegrationScope::User => String::new(),
+    };
+    let stamp = format!("{heddle}{repo_flag} integration stamp claude-code");
     for event in [
         "SessionStart",
         "UserPromptSubmit",
@@ -818,12 +820,7 @@ fn install_claude(
         } else if event == "SessionEnd" {
             format!("{stamp} --expire")
         } else {
-            format!(
-                "{} --repo {} integration relay claude-code {}",
-                heddle,
-                shell_escape(repo.root()),
-                event
-            )
+            format!("{heddle}{repo_flag} integration relay claude-code {event}")
         };
         upsert_claude_hook_group(hooks_obj, event, command)?;
     }
@@ -1355,6 +1352,50 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn claude_user_install_discovers_workspace_at_runtime() {
+        static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_temp, repo) = init_repo();
+        let home = tempfile::TempDir::new().unwrap();
+        let _home_guard = HomeEnvGuard::set(home.path());
+        let mut manifest = IntegrationManifest::default();
+
+        install_claude(
+            &repo,
+            &mut manifest,
+            &IntegrationScope::User,
+            false,
+            PathMode::Relative,
+        )
+        .unwrap();
+
+        let settings_path = home.path().join(".claude").join("settings.json");
+        let contents = fs::read_to_string(&settings_path).unwrap();
+        let install_repo = repo.root().display().to_string();
+        assert!(
+            !contents.contains(&install_repo),
+            "user-scoped Claude hooks must not bake the install-time repo, got: {contents}"
+        );
+        assert!(
+            !contents.contains("--repo"),
+            "user-scoped Claude hooks must discover the workspace from cwd, got: {contents}"
+        );
+        assert!(
+            contents.contains("heddle integration stamp claude-code"),
+            "user-scoped Claude must still stamp, got: {contents}"
+        );
+        assert!(
+            contents.contains("heddle integration stamp claude-code --expire"),
+            "user-scoped SessionEnd must expire, got: {contents}"
+        );
+        assert!(
+            contents.contains("heddle integration relay claude-code SessionStart"),
+            "user-scoped Claude must still relay without a baked repo, got: {contents}"
+        );
+    }
+
+    #[test]
     fn claude_repo_install_chains_existing_status_line() {
         let (_temp, repo) = init_repo();
         let settings_path = repo.root().join(".claude").join("settings.json");
@@ -1654,9 +1695,7 @@ mod tests {
             "Codex Stop must expire, same as Claude SessionEnd, got: {contents}"
         );
         assert_eq!(
-            contents
-                .matches("heddle integration stamp codex\"")
-                .count(),
+            contents.matches("heddle integration stamp codex\"").count(),
             3,
             "SessionStart/SubagentStart/PreToolUse must stamp without expiring, got: {contents}"
         );

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -1493,6 +1493,34 @@ mod tests {
     }
 
     #[test]
+    fn session_end_expire_leaves_human_capture() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: Some("high".into()),
+                session: Some("dead-session".into()),
+                parent: Some("agent-1".into()),
+            },
+        )
+        .unwrap();
+        heddle_core::expire_identity_cursor(repo.root()).unwrap();
+        let attribution = build_attribution(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+        )
+        .unwrap();
+        assert!(
+            attribution.agent.is_none(),
+            "expired SessionEnd cursor must not invent an agent on the next capture"
+        );
+    }
+
+    #[test]
     fn build_attribution_omits_unpublished_cursor_fields() {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -188,15 +188,6 @@ pub struct SnapshotAgentOverrides {
     pub no_agent: bool,
 }
 
-#[derive(Clone, Debug, Default)]
-struct AgentEnv {
-    provider: Option<String>,
-    model: Option<String>,
-    policy: Option<String>,
-    session: Option<String>,
-    segment: Option<String>,
-}
-
 pub async fn cmd_snapshot(
     cli: &Cli,
     intent: Option<String>,
@@ -1127,31 +1118,6 @@ pub(crate) fn build_attribution(
     user_config: &UserConfig,
     agent: &SnapshotAgentOverrides,
 ) -> Result<Attribution> {
-    build_attribution_with_env(repo, user_config, agent, current_agent_env())
-}
-
-fn current_agent_env() -> AgentEnv {
-    AgentEnv {
-        provider: std::env::var("HEDDLE_AGENT_PROVIDER")
-            .ok()
-            .and_then(clean_attribution_value),
-        model: std::env::var("HEDDLE_AGENT_MODEL")
-            .ok()
-            .and_then(clean_attribution_value),
-        policy: std::env::var("HEDDLE_AGENT_POLICY")
-            .ok()
-            .and_then(clean_attribution_value),
-        session: std::env::var("HEDDLE_SESSION_ID").ok(),
-        segment: std::env::var("HEDDLE_SESSION_SEGMENT").ok(),
-    }
-}
-
-fn build_attribution_with_env(
-    repo: &Repository,
-    user_config: &UserConfig,
-    agent: &SnapshotAgentOverrides,
-    env: AgentEnv,
-) -> Result<Attribution> {
     let principal = resolve_principal(repo, user_config)?;
     if is_default_unknown_principal(&principal) {
         return Err(anyhow!(missing_capture_identity_advice()));
@@ -1161,140 +1127,34 @@ fn build_attribution_with_env(
         return Ok(Attribution::human(principal));
     }
 
+    // Put state in. Do not hunt `/proc`, hoped-for env, thread actor, or
+    // repo/user `agent.model` after a cursor miss. Cursor/Grok stay
+    // `agent=null`. Never invent a model.
     let frozen = crate::identity_freeze::freeze_identity_for_capture(repo).unwrap_or_default();
     let current_session = SessionManager::new(repo.root()).get_current_session()?;
-    let explicit_provider = agent.provider.clone().or(env.provider.clone());
-    let explicit_model = agent.model.clone().or(env.model.clone());
-    let explicit_agent_identity = explicit_provider.is_some() && explicit_model.is_some();
-    let cursor_agent_identity = frozen.provider.is_some() && frozen.model.is_some();
-
-    // Pull the thread's declared actor — set when the user ran
-    // `heddle start --agent-provider X --agent-model Y` to dedicate this
-    // thread to a specific agent. The `start` command writes an
-    // `ActorPresence` into the `ActorPresenceStore`; `heddle status` already
-    // surfaces it via `build_thread_view`. We look it up here so
-    // `heddle capture` propagates it onto the resulting state's
-    // `attribution.agent` — otherwise every captured state on an agent
-    // thread would show `Principal: Unknown`, which broke the
-    // provenance demo and the `heddle query --attribution --context` story.
-    //
-    // Precedence: explicit CLI overrides and `HEDDLE_AGENT_*` env are
-    // user-supplied attribution for this capture, so they must not be
-    // silently masked by a detected harness actor. The active thread
-    // actor remains the zero-config fallback for agent threads when no
-    // explicit attribution is present.
-    let thread_actor = (!explicit_agent_identity)
-        .then(|| {
-            current_thread(repo)
-                .ok()
-                .flatten()
-                .and_then(|t| find_active_thread_entry(repo, &t.id).ok().flatten())
-        })
-        .flatten();
-    // Harness probing writes the literal "unknown" placeholder into
-    // `ActorPresence.model` and `SessionSegment.model` when it can't
-    // identify the model from argv/env (see `harness::open_session`
-    // and `claude_hook::handle_user_prompt_segment_rotate`). If we
-    // let that placeholder participate in the precedence chain, an
-    // ambient `HEDDLE_AGENT_MODEL=claude-opus-4-7` set by the user
-    // never wins — captures keep surfacing as `anthropic/unknown`.
-    // Strip the placeholder at every non-env source so explicit env
-    // vars and config can fill in real data.
-    let thread_provider = thread_actor
-        .as_ref()
-        .and_then(|e| e.provider.clone())
+    let provider = agent
+        .provider
+        .clone()
+        .or(frozen.provider.clone())
         .and_then(clean_attribution_value);
-    let thread_model = thread_actor
-        .as_ref()
-        .and_then(|e| e.model.clone())
-        .and_then(clean_attribution_value);
-    let session_provider = current_session
-        .as_ref()
-        .and_then(|session| session.current_segment())
-        .map(|segment| segment.provider.clone())
-        .and_then(clean_attribution_value);
-    let session_model = current_session
-        .as_ref()
-        .and_then(|session| session.current_segment())
-        .map(|segment| segment.model.clone())
+    let model = agent
+        .model
+        .clone()
+        .or(frozen.model.clone())
         .and_then(clean_attribution_value);
     let session_policy = current_session
         .as_ref()
         .and_then(|session| session.current_segment())
         .and_then(|segment| segment.policy_id.clone())
         .and_then(clean_attribution_value);
-    let harness_probe = (!explicit_agent_identity && !cursor_agent_identity)
-        .then(|| {
-            crate::harness::probe_current_process_harness(
-                repo,
-                thread_provider.clone().or_else(|| session_provider.clone()),
-                thread_model.clone().or_else(|| session_model.clone()),
-                session_policy.clone(),
-            )
-            .ok()
-        })
-        .flatten();
-    let harness_provider = harness_probe
-        .as_ref()
-        .and_then(|probe| probe.provider.clone())
-        .and_then(clean_attribution_value);
-    let harness_model = harness_probe
-        .as_ref()
-        .and_then(|probe| probe.model.clone())
-        .and_then(clean_attribution_value);
-    let harness_policy = harness_probe
-        .as_ref()
-        .and_then(|probe| probe.policy.clone())
-        .and_then(clean_attribution_value);
-
-    let provider = explicit_provider
-        .or(frozen.provider.clone())
-        .or(thread_provider)
-        .or(harness_provider)
-        .or(session_provider)
-        .or_else(|| {
-            user_config
-                .agent
-                .provider
-                .clone()
-                .and_then(clean_attribution_value)
-        })
-        .or_else(|| {
-            repo.config()
-                .agent
-                .provider
-                .clone()
-                .and_then(clean_attribution_value)
-        });
-    let model = explicit_model
-        .or(frozen.model.clone())
-        .or(thread_model)
-        .or(harness_model)
-        .or(session_model)
-        .or_else(|| {
-            user_config
-                .agent
-                .model
-                .clone()
-                .and_then(clean_attribution_value)
-        })
-        .or_else(|| {
-            repo.config()
-                .agent
-                .model
-                .clone()
-                .and_then(clean_attribution_value)
-        });
+    // Heddle Session.id — never the sidecar harness session.
     let session_id = agent
         .session
         .clone()
-        .or(env.session)
-        .or(frozen.session.clone())
         .or_else(|| current_session.as_ref().map(|session| session.id.clone()));
     let segment_id = agent
         .segment
         .clone()
-        .or(env.segment)
         .or(frozen.segment_id.clone())
         .or_else(|| {
             current_session
@@ -1307,8 +1167,11 @@ fn build_attribution_with_env(
         agent
             .policy
             .clone()
-            .or(env.policy)
-            .or(harness_policy)
+            .or_else(|| {
+                std::env::var("HEDDLE_AGENT_POLICY")
+                    .ok()
+                    .and_then(clean_attribution_value)
+            })
             .or(session_policy)
             .or_else(|| user_config.agent.default_policy.clone())
             .or_else(|| repo.config().policies.default_policy.clone())
@@ -1453,6 +1316,28 @@ mod tests {
 
     use super::*;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     fn user_config_with_principal() -> UserConfig {
         UserConfig {
             principal: Some(crate::config::UserPrincipalConfig {
@@ -1520,53 +1405,44 @@ mod tests {
     }
 
     #[test]
-    fn build_attribution_explicit_env_wins_over_active_harness_actor() {
+    #[serial_test::serial]
+    fn cursor_grok_stays_agent_null_when_env_or_repo_model_set() {
+        let _model = EnvVarGuard::set("HEDDLE_AGENT_MODEL", "claude-opus-4-7");
+        let _provider = EnvVarGuard::set("HEDDLE_AGENT_PROVIDER", "anthropic");
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         save_active_harness_entry(&repo, "anthropic", "claude-opus-4-8[1m]");
+        let config_path = temp.path().join(".heddle/config.toml");
+        let mut config = repo::RepoConfig::load(&config_path).unwrap();
+        config.agent.provider = Some("anthropic".into());
+        config.agent.model = Some("claude-opus-4-7".into());
+        config.save(&config_path).unwrap();
+        let repo = Repository::open(temp.path()).unwrap();
 
-        let attribution = build_attribution_with_env(
-            &repo,
-            &user_config_with_principal(),
-            &empty_agent_overrides(),
-            AgentEnv {
-                provider: Some("openai".to_string()),
-                model: Some("gpt-5-codex".to_string()),
-                ..AgentEnv::default()
-            },
-        )
-        .unwrap();
+        let mut user_config = user_config_with_principal();
+        user_config.agent.provider = Some("openai".into());
+        user_config.agent.model = Some("gpt-5".into());
 
-        let agent = attribution.agent.expect("explicit env should set agent");
-        assert_eq!(agent.provider, "openai");
-        assert_eq!(agent.model, "gpt-5-codex");
+        let attribution = build_attribution(&repo, &user_config, &empty_agent_overrides()).unwrap();
+        assert!(
+            attribution.agent.is_none(),
+            "Cursor/Grok must stay agent=null; do not invent from env, repo, or thread actor"
+        );
     }
 
     #[test]
-    fn build_attribution_uses_detected_harness_actor_when_env_absent() {
+    fn model_change_mid_thread_rotates_segment_and_leaves_old_state() {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
-        save_active_harness_entry(&repo, "anthropic", "claude-opus-4-8[1m]");
-
-        let attribution = build_attribution_with_env(
-            &repo,
-            &user_config_with_principal(),
-            &empty_agent_overrides(),
-            AgentEnv::default(),
-        )
-        .unwrap();
-
-        let agent = attribution
-            .agent
-            .expect("detected harness actor should set agent");
-        assert_eq!(agent.provider, "anthropic");
-        assert_eq!(agent.model, "claude-opus-4-8[1m]");
-    }
-
-    #[test]
-    fn build_attribution_freezes_cursor_and_keeps_old_pair_after_model_change() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut manager = SessionManager::new(repo.root());
+        manager
+            .start_session(
+                objects::object::Principal::new("Ada Lovelace", "ada@example.com"),
+                "anthropic".into(),
+                "opus".into(),
+                None,
+            )
+            .unwrap();
         heddle_core::write_identity_cursor(
             repo.root(),
             &heddle_core::IdentityCursor {
@@ -1578,17 +1454,17 @@ mod tests {
             },
         )
         .unwrap();
-        let first = build_attribution_with_env(
+        let first = build_attribution(
             &repo,
             &user_config_with_principal(),
             &empty_agent_overrides(),
-            AgentEnv::default(),
         )
         .unwrap();
         let first_agent = first.agent.expect("cursor should freeze agent");
         assert_eq!(first_agent.model, "opus");
         assert_eq!(first_agent.thought_level.as_deref(), Some("high"));
         assert_eq!(first_agent.parent.as_deref(), Some("agent-1"));
+        let first_segment = first_agent.segment_id.clone();
 
         heddle_core::write_identity_cursor(
             repo.root(),
@@ -1601,18 +1477,19 @@ mod tests {
             },
         )
         .unwrap();
-        let second = build_attribution_with_env(
+        let second = build_attribution(
             &repo,
             &user_config_with_principal(),
             &empty_agent_overrides(),
-            AgentEnv::default(),
         )
         .unwrap();
         let second_agent = second.agent.expect("updated cursor should freeze");
         assert_eq!(second_agent.model, "sonnet");
         assert_eq!(second_agent.thought_level.as_deref(), Some("low"));
+        assert_ne!(second_agent.segment_id, first_segment);
         assert_eq!(first_agent.model, "opus");
         assert_eq!(first_agent.thought_level.as_deref(), Some("high"));
+        assert_eq!(first_agent.segment_id, first_segment);
     }
 
     #[test]
@@ -1628,16 +1505,23 @@ mod tests {
             },
         )
         .unwrap();
-        let attribution = build_attribution_with_env(
+        let attribution = build_attribution(
             &repo,
             &user_config_with_principal(),
             &empty_agent_overrides(),
-            AgentEnv::default(),
         )
         .unwrap();
         let agent = attribution.agent.expect("published model should freeze");
         assert!(agent.thought_level.is_none());
         assert!(agent.parent.is_none());
+        assert!(
+            agent.session_id.is_none()
+                || !agent
+                    .session_id
+                    .as_deref()
+                    .is_some_and(|s| s == "sess-live"),
+            "harness session must not be stuffed into Heddle Session.id"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -1521,6 +1521,40 @@ mod tests {
     }
 
     #[test]
+    fn codex_stop_expire_leaves_human_capture() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        crate::identity_stamp::stamp_bytes(
+            repo.root(),
+            "codex",
+            r#"{"model":"gpt-5.4","session_id":"c1"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            heddle_core::read_identity_cursor(repo.root())
+                .model
+                .as_deref(),
+            Some("gpt-5.4")
+        );
+        crate::identity_stamp::stamp_bytes(
+            repo.root(),
+            "codex",
+            r#"{"hook_event_name":"Stop","session_id":"c1"}"#,
+        )
+        .unwrap();
+        let attribution = build_attribution(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+        )
+        .unwrap();
+        assert!(
+            attribution.agent.is_none(),
+            "expired Codex Stop cursor must not invent an agent on the next capture"
+        );
+    }
+
+    #[test]
     fn build_attribution_omits_unpublished_cursor_fields() {
         let temp = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -119,6 +119,10 @@ pub(crate) struct SnapshotAgentOutput {
     segment_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     policy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thought_level: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<String>,
 }
 
 impl From<&Principal> for SnapshotPrincipalOutput {
@@ -138,6 +142,8 @@ impl From<&Agent> for SnapshotAgentOutput {
             session_id: agent.session_id.clone(),
             segment_id: agent.segment_id.clone(),
             policy_id: agent.policy_id.clone(),
+            thought_level: agent.thought_level.clone(),
+            parent: agent.parent.clone(),
         }
     }
 }
@@ -1155,10 +1161,12 @@ fn build_attribution_with_env(
         return Ok(Attribution::human(principal));
     }
 
+    let frozen = crate::identity_freeze::freeze_identity_for_capture(repo).unwrap_or_default();
     let current_session = SessionManager::new(repo.root()).get_current_session()?;
     let explicit_provider = agent.provider.clone().or(env.provider.clone());
     let explicit_model = agent.model.clone().or(env.model.clone());
     let explicit_agent_identity = explicit_provider.is_some() && explicit_model.is_some();
+    let cursor_agent_identity = frozen.provider.is_some() && frozen.model.is_some();
 
     // Pull the thread's declared actor — set when the user ran
     // `heddle start --agent-provider X --agent-model Y` to dedicate this
@@ -1215,7 +1223,7 @@ fn build_attribution_with_env(
         .and_then(|session| session.current_segment())
         .and_then(|segment| segment.policy_id.clone())
         .and_then(clean_attribution_value);
-    let harness_probe = (!explicit_agent_identity)
+    let harness_probe = (!explicit_agent_identity && !cursor_agent_identity)
         .then(|| {
             crate::harness::probe_current_process_harness(
                 repo,
@@ -1240,6 +1248,7 @@ fn build_attribution_with_env(
         .and_then(clean_attribution_value);
 
     let provider = explicit_provider
+        .or(frozen.provider.clone())
         .or(thread_provider)
         .or(harness_provider)
         .or(session_provider)
@@ -1258,6 +1267,7 @@ fn build_attribution_with_env(
                 .and_then(clean_attribution_value)
         });
     let model = explicit_model
+        .or(frozen.model.clone())
         .or(thread_model)
         .or(harness_model)
         .or(session_model)
@@ -1279,12 +1289,18 @@ fn build_attribution_with_env(
         .session
         .clone()
         .or(env.session)
+        .or(frozen.session.clone())
         .or_else(|| current_session.as_ref().map(|session| session.id.clone()));
-    let segment_id = agent.segment.clone().or(env.segment).or_else(|| {
-        current_session
-            .as_ref()
-            .and_then(|session| session.current_segment_id.clone())
-    });
+    let segment_id = agent
+        .segment
+        .clone()
+        .or(env.segment)
+        .or(frozen.segment_id.clone())
+        .or_else(|| {
+            current_session
+                .as_ref()
+                .and_then(|session| session.current_segment_id.clone())
+        });
     let policy = if agent.no_policy {
         None
     } else {
@@ -1306,6 +1322,12 @@ fn build_attribution_with_env(
             }
             if let Some(pol) = policy {
                 agent = agent.with_policy(pol);
+            }
+            if let Some(thought_level) = frozen.thought_level {
+                agent = agent.with_thought_level(thought_level);
+            }
+            if let Some(parent) = frozen.parent {
+                agent = agent.with_parent(parent);
             }
             Ok(Attribution::with_agent(principal, agent))
         }
@@ -1539,6 +1561,83 @@ mod tests {
             .expect("detected harness actor should set agent");
         assert_eq!(agent.provider, "anthropic");
         assert_eq!(agent.model, "claude-opus-4-8[1m]");
+    }
+
+    #[test]
+    fn build_attribution_freezes_cursor_and_keeps_old_pair_after_model_change() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: Some("high".into()),
+                session: Some("sess-live".into()),
+                parent: Some("agent-1".into()),
+            },
+        )
+        .unwrap();
+        let first = build_attribution_with_env(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+            AgentEnv::default(),
+        )
+        .unwrap();
+        let first_agent = first.agent.expect("cursor should freeze agent");
+        assert_eq!(first_agent.model, "opus");
+        assert_eq!(first_agent.thought_level.as_deref(), Some("high"));
+        assert_eq!(first_agent.parent.as_deref(), Some("agent-1"));
+
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("sonnet".into()),
+                thought_level: Some("low".into()),
+                session: Some("sess-live".into()),
+                parent: Some("agent-1".into()),
+            },
+        )
+        .unwrap();
+        let second = build_attribution_with_env(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+            AgentEnv::default(),
+        )
+        .unwrap();
+        let second_agent = second.agent.expect("updated cursor should freeze");
+        assert_eq!(second_agent.model, "sonnet");
+        assert_eq!(second_agent.thought_level.as_deref(), Some("low"));
+        assert_eq!(first_agent.model, "opus");
+        assert_eq!(first_agent.thought_level.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn build_attribution_omits_unpublished_cursor_fields() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        heddle_core::write_identity_cursor(
+            repo.root(),
+            &heddle_core::IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                ..heddle_core::IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        let attribution = build_attribution_with_env(
+            &repo,
+            &user_config_with_principal(),
+            &empty_agent_overrides(),
+            AgentEnv::default(),
+        )
+        .unwrap();
+        let agent = attribution.agent.expect("published model should freeze");
+        assert!(agent.thought_level.is_none());
+        assert!(agent.parent.is_none());
     }
 
     #[test]

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -127,11 +127,8 @@ fn detected_harness_argv_impl() -> Option<Vec<String>> {
             .filter(|part| !part.is_empty())
             .map(|part| String::from_utf8_lossy(part).to_string())
             .collect::<Vec<_>>();
-        let program = argv.first().map(|arg| arg.to_ascii_lowercase())?;
-        if ["codex", "claude", "opencode", "aider"]
-            .iter()
-            .any(|needle| program.contains(needle))
-        {
+        let program = argv.first()?;
+        if heddle_core::harness_kind_from_basename(program).is_some() {
             return Some(argv);
         }
     }

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -10,12 +10,12 @@ use anyhow::{Result, anyhow};
 use base64::Engine as _;
 use chrono::Utc;
 use heddle_core::{
-    ExplicitAgentBind, SessionAttachFacts, SessionLookupFact, SessionPolicy, TokenSidFact,
-    WorktreeSessionFact, decide_session_attach, first_value_string, map_from_pairs,
-    merge_string_vec, opencode_tool_name, opencode_tool_status,
-    parse_relay_payload as core_parse_relay_payload,
-    should_rotate_segment as pure_should_rotate_segment, value_array_join, value_cost_micros,
-    value_cost_micros_u64, value_string, value_string_array, value_u64, value_u64_string,
+    ExplicitAgentBind, SegmentRotation, SessionAttachFacts, SessionLookupFact, SessionPolicy,
+    TokenSidFact, WorktreeSessionFact, attach_published_segment_fields, cursor_segment_rotation,
+    decide_session_attach, first_value_string, map_from_pairs, merge_string_vec,
+    opencode_tool_name, opencode_tool_status, parse_relay_payload as core_parse_relay_payload,
+    value_array_join, value_cost_micros, value_cost_micros_u64, value_string, value_string_array,
+    value_u64, value_u64_string,
 };
 use objects::{
     fs_atomic::write_file_atomic,
@@ -1003,20 +1003,8 @@ impl HarnessBridgeRuntime {
         )?;
 
         let mut segment_id = session.current_segment_id.clone().unwrap_or_default();
-        if should_rotate_segment(&session, &identity) {
-            let segment = sessions.add_segment(
-                &session.id,
-                identity
-                    .provider
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
-                identity
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
-                identity.policy.clone(),
-            )?;
-            segment_id = segment.id;
+        if let Some(next_segment) = apply_identity_segment(&mut sessions, &session, &identity)? {
+            segment_id = next_segment;
         }
 
         let base_state = self
@@ -1521,22 +1509,13 @@ impl HarnessBridgeRuntime {
         let Some(session) = sessions.get_session(&report.heddle_session_id)? else {
             return Ok(());
         };
-        if !session.is_active() || !should_rotate_segment(&session, identity) {
+        if !session.is_active() {
             return Ok(());
         }
-        let segment = sessions.add_segment(
-            &report.heddle_session_id,
-            identity
-                .provider
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string()),
-            identity
-                .model
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string()),
-            identity.policy.clone(),
-        )?;
-        report.heddle_segment_id = Some(segment.id);
+        let Some(segment_id) = apply_identity_segment(&mut sessions, &session, identity)? else {
+            return Ok(());
+        };
+        report.heddle_segment_id = Some(segment_id);
         if identity.provider.is_some() {
             report.harness.provider = identity.provider.clone();
         }
@@ -2272,16 +2251,59 @@ struct TokenClaims {
     agent_model: Option<String>,
 }
 
-fn should_rotate_segment(session: &objects::object::Session, identity: &ResolvedIdentity) -> bool {
-    let Some(segment) = session.current_segment() else {
-        return false;
-    };
-    pure_should_rotate_segment(
-        Some(segment.provider.as_str()),
-        Some(segment.model.as_str()),
+fn apply_identity_segment(
+    sessions: &mut SessionManager,
+    session: &Session,
+    identity: &ResolvedIdentity,
+) -> Result<Option<String>> {
+    let current = session.current_segment();
+    match cursor_segment_rotation(
+        current.map(|segment| segment.provider.as_str()),
+        current.map(|segment| segment.model.as_str()),
+        current.and_then(|segment| segment.thought_level.as_deref()),
         identity.provider.as_deref(),
         identity.model.as_deref(),
-    )
+        identity.thinking_level.as_deref(),
+    ) {
+        SegmentRotation::Rotate => {
+            let segment = sessions.add_segment(
+                &session.id,
+                identity
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                identity
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                identity.policy.clone(),
+            )?;
+            if let Some(thought_level) = identity.thinking_level.clone()
+                && let Some(mut updated) = sessions.get_session(&session.id)?
+            {
+                if let Some(current) = updated.current_segment_mut() {
+                    current.thought_level = Some(thought_level);
+                }
+                sessions.save_session(&updated)?;
+            }
+            Ok(Some(segment.id))
+        }
+        SegmentRotation::Attach => {
+            if let Some(mut updated) = sessions.get_session(&session.id)? {
+                if let Some(segment) = updated.current_segment_mut() {
+                    attach_published_segment_fields(
+                        segment,
+                        identity.provider.as_deref(),
+                        identity.model.as_deref(),
+                        identity.thinking_level.as_deref(),
+                    );
+                }
+                sessions.save_session(&updated)?;
+            }
+            Ok(session.current_segment_id.clone())
+        }
+        SegmentRotation::Keep => Ok(session.current_segment_id.clone()),
+    }
 }
 
 fn thread_id_for_name(repo: &Repository, thread_name: Option<&str>) -> Result<Option<String>> {
@@ -3284,6 +3306,46 @@ mod tests {
             report.heddle_segment_id.as_deref(),
             Some(expected_segment.as_str())
         );
+    }
+
+    #[test]
+    fn unpublished_identity_attaches_to_placeholder_segment() {
+        let (_temp, repo) = init_repo();
+        let user_config = UserConfig::default();
+        let mut runtime = HarnessBridgeRuntime::new(repo, user_config);
+
+        let opened = runtime
+            .open_session(OpenSessionParams {
+                harness: Some("aider".to_string()),
+                ..OpenSessionParams::default()
+            })
+            .unwrap();
+        let first_segment = opened.heddle_segment_id.clone();
+        runtime
+            .update_progress(UpdateProgressParams {
+                heddle_session_id: opened.heddle_session_id.clone(),
+                provider: Some("anthropic".to_string()),
+                model: Some("opus".to_string()),
+                thinking_level: Some("high".to_string()),
+                ..UpdateProgressParams::default()
+            })
+            .unwrap();
+
+        let session = SessionManager::new(runtime.repo.root())
+            .get_session(&opened.heddle_session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.segments.len(), 1, "empty → set must attach, not rotate");
+        let segment = session.current_segment().unwrap();
+        assert_eq!(segment.provider, "anthropic");
+        assert_eq!(segment.model, "opus");
+        assert_eq!(segment.thought_level.as_deref(), Some("high"));
+        let report = runtime
+            .reports
+            .load(&opened.heddle_session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.heddle_segment_id, first_segment);
     }
 
     #[test]

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -111,6 +111,15 @@ fn detected_harness_argv() -> Option<Vec<String>> {
     detected_harness_argv_impl()
 }
 
+/// Parent walk is kind-only: basename of argv0, never `--model` or other args.
+fn harness_kind_argv_from_cmdline(raw: &[u8]) -> Option<Vec<String>> {
+    let program = raw
+        .split(|byte| *byte == 0)
+        .find(|part| !part.is_empty())
+        .map(|part| String::from_utf8_lossy(part).to_string())?;
+    heddle_core::harness_kind_from_basename(&program).map(|_| vec![program])
+}
+
 #[cfg(target_os = "linux")]
 fn detected_harness_argv_impl() -> Option<Vec<String>> {
     let mut pid = std::process::id();
@@ -122,13 +131,7 @@ fn detected_harness_argv_impl() -> Option<Vec<String>> {
         }
         pid = ppid;
         let raw = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
-        let argv = raw
-            .split(|byte| *byte == 0)
-            .filter(|part| !part.is_empty())
-            .map(|part| String::from_utf8_lossy(part).to_string())
-            .collect::<Vec<_>>();
-        let program = argv.first()?;
-        if heddle_core::harness_kind_from_basename(program).is_some() {
+        if let Some(argv) = harness_kind_argv_from_cmdline(&raw) {
             return Some(argv);
         }
     }
@@ -3117,6 +3120,23 @@ mod tests {
                 "harness default must match the canonical thread_dir for {id:?}"
             );
         }
+    }
+
+    #[test]
+    fn parent_walk_cmdline_is_kind_only_and_does_not_extract_model() {
+        let raw = b"/usr/bin/claude\0--model\0claude-opus-4-7\0--effort\0high\0";
+        let argv = super::harness_kind_argv_from_cmdline(raw).expect("claude basename is a kind");
+        assert_eq!(argv, vec!["/usr/bin/claude".to_string()]);
+        assert!(
+            !argv
+                .iter()
+                .any(|arg| arg.contains("opus") || arg == "--model"),
+            "parent walk must not extract a model from /proc cmdline"
+        );
+        let ignored = super::harness_kind_argv_from_cmdline(
+            b"/home/u/dev/claude/target/debug/heddle\0--model\0opus\0",
+        );
+        assert!(ignored.is_none());
     }
 
     #[test]

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -316,6 +316,7 @@ fn relay_claude(runtime: &mut HarnessBridgeRuntime, event: &str, payload: &Value
     })?;
     match event {
         "SessionEnd" => {
+            heddle_core::expire_identity_cursor(runtime.repo.root())?;
             runtime.close_session(CloseSessionParams {
                 heddle_session_id: opened.heddle_session_id,
                 summary: value_string(payload, &["reason"])
@@ -448,6 +449,9 @@ fn relay_claude(runtime: &mut HarnessBridgeRuntime, event: &str, payload: &Value
 }
 
 fn relay_opencode(runtime: &mut HarnessBridgeRuntime, event: &str, payload: &Value) -> Result<()> {
+    if heddle_core::cursor_event_expires(payload, Some(event)) {
+        heddle_core::expire_identity_cursor(runtime.repo.root())?;
+    }
     let metadata = map_from_pairs([
         (
             "session_id",

--- a/crates/cli/src/harness/probe/claude_code.rs
+++ b/crates/cli/src/harness/probe/claude_code.rs
@@ -58,8 +58,6 @@ impl HarnessActorProbe for ClaudeCodeProbe {
                 .or_else(|| metadata.get("model").cloned())
                 .or_else(|| argv_value(argv, "--model"))
                 .or_else(|| input.env_hints.get("CLAUDE_MODEL").cloned())
-                .or_else(|| input.env_hints.get("ANTHROPIC_MODEL").cloned())
-                .or_else(|| input.env_hints.get("MODEL").cloned())
                 .or_else(|| input.current_model.clone()),
             thinking_level: metadata
                 .get("effort")

--- a/crates/cli/src/harness/probe/claude_code.rs
+++ b/crates/cli/src/harness/probe/claude_code.rs
@@ -54,10 +54,7 @@ impl HarnessActorProbe for ClaudeCodeProbe {
             model: input
                 .explicit_model
                 .clone()
-                .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
                 .or_else(|| metadata.get("model").cloned())
-                .or_else(|| argv_value(argv, "--model"))
-                .or_else(|| input.env_hints.get("CLAUDE_MODEL").cloned())
                 .or_else(|| input.current_model.clone()),
             thinking_level: metadata
                 .get("effort")

--- a/crates/cli/src/harness/probe/codex.rs
+++ b/crates/cli/src/harness/probe/codex.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_matches_harness, argv_value, attribution_env_hint, csv_paths, parse_u64,
+    argv_matches_harness, attribution_env_hint, csv_paths, parse_u64,
 };
 
 pub(crate) struct CodexProbe;
@@ -130,7 +130,6 @@ impl HarnessActorProbe for CodexProbe {
 
     fn probe(&self, input: &HarnessProbeInput) -> Result<HarnessProbeResult> {
         let metadata = &input.probe_metadata;
-        let argv = input.argv.as_deref().unwrap_or(&[]);
         let thread_id = metadata
             .get("thread_id")
             .cloned()
@@ -148,11 +147,7 @@ impl HarnessActorProbe for CodexProbe {
         let model = input
             .explicit_model
             .clone()
-            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
             .or_else(|| metadata.get("model").cloned())
-            .or_else(|| argv_value(argv, "--model"))
-            .or_else(|| input.env_hints.get("CODEX_MODEL").cloned())
-            .or_else(|| input.env_hints.get("OPENAI_MODEL").cloned())
             .or_else(|| input.current_model.clone());
         let provider = input
             .explicit_provider

--- a/crates/cli/src/harness/probe/mod.rs
+++ b/crates/cli/src/harness/probe/mod.rs
@@ -211,7 +211,10 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("codex"));
         assert_eq!(result.provider.as_deref(), Some("openai"));
-        assert_eq!(result.model.as_deref(), Some("gpt-5.5"));
+        assert!(
+            result.model.is_none(),
+            "do not invent model from CODEX_MODEL"
+        );
         assert_eq!(result.thinking_level.as_deref(), Some("xhigh"));
         assert_eq!(
             result.native_actor_key.as_deref(),
@@ -235,7 +238,10 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("codex"));
         assert_eq!(result.provider.as_deref(), Some("openai-compatible"));
-        assert_eq!(result.model.as_deref(), Some("gpt-5.3-codex"));
+        assert!(
+            result.model.is_none(),
+            "do not invent model from OPENAI_MODEL"
+        );
     }
 
     #[test]
@@ -252,8 +258,11 @@ mod tests {
         .expect("probe should succeed");
 
         assert_eq!(result.harness, None);
-        assert_eq!(result.provider.as_deref(), Some("custom-ai"));
-        assert_eq!(result.model.as_deref(), Some("custom-model"));
+        assert!(result.provider.is_none());
+        assert!(
+            result.model.is_none(),
+            "do not invent model from HEDDLE_AGENT_MODEL"
+        );
     }
 
     #[test]
@@ -276,7 +285,11 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("claude-code"));
         assert_eq!(result.provider.as_deref(), Some("openai"));
-        assert_eq!(result.model.as_deref(), Some("gpt-5-codex"));
+        assert_eq!(
+            result.model.as_deref(),
+            Some("claude-opus-4-8[1m]"),
+            "hook payload model wins; env must not invent a different model"
+        );
     }
 
     #[test]
@@ -321,7 +334,10 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("claude-code"));
         assert_eq!(result.provider.as_deref(), Some("anthropic"));
-        assert_eq!(result.model.as_deref(), Some("claude-opus-4-7"));
+        assert!(
+            result.model.is_none(),
+            "parent-walk / argv --model must not invent a model"
+        );
     }
 
     #[test]
@@ -384,7 +400,10 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("claude-code"));
         assert_eq!(result.provider.as_deref(), Some("anthropic"));
-        assert_eq!(result.model.as_deref(), Some("claude-opus-4-7"));
+        assert!(
+            result.model.is_none(),
+            "do not invent model from HEDDLE_AGENT_MODEL"
+        );
         assert_eq!(result.thinking_level.as_deref(), Some("xhigh"));
     }
 
@@ -407,6 +426,9 @@ mod tests {
 
         assert_eq!(result.harness.as_deref(), Some("opencode"));
         assert_eq!(result.provider.as_deref(), Some("anthropic"));
-        assert_eq!(result.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert!(
+            result.model.is_none(),
+            "do not invent model from OPENCODE_MODEL"
+        );
     }
 }

--- a/crates/cli/src/harness/probe/opencode.rs
+++ b/crates/cli/src/harness/probe/opencode.rs
@@ -49,12 +49,8 @@ impl HarnessActorProbe for OpenCodeProbe {
         let model = input
             .explicit_model
             .clone()
-            .or_else(|| attribution_env_hint(&input.env_hints, "HEDDLE_AGENT_MODEL"))
             .or_else(|| metadata.get("model").cloned())
             .or_else(|| metadata.get("agent_model").cloned())
-            .or_else(|| argv_value(argv, "--model"))
-            .or_else(|| input.env_hints.get("OPENCODE_MODEL").cloned())
-            .or_else(|| input.env_hints.get("MODEL").cloned())
             .or_else(|| input.current_model.clone());
         let probe_source = if metadata.get("hook_event").is_some() {
             ProbeSource::HookPayload

--- a/crates/cli/src/identity_freeze.rs
+++ b/crates/cli/src/identity_freeze.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Freeze the current identity cursor onto a capture, rotating the session
+//! segment when a published provider / model / thought_level changes.
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use heddle_core::{
+    IdentityCursor, SegmentRotation, cursor_patch_from_child_env, cursor_segment_rotation,
+    published_field, read_identity_cursor, write_identity_cursor,
+};
+use objects::object::Session;
+use repo::{Repository, SessionManager};
+
+/// Cursor values frozen onto one capture (ACP names).
+#[derive(Clone, Debug, Default)]
+pub struct FrozenIdentity {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub thought_level: Option<String>,
+    pub session: Option<String>,
+    pub parent: Option<String>,
+    pub segment_id: Option<String>,
+}
+
+/// Read the workspace cursor, attach child-env fallbacks, persist so later
+/// captures are not env-shaped, and rotate the Heddle segment when needed.
+pub fn freeze_identity_for_capture(repo: &Repository) -> Result<FrozenIdentity> {
+    let mut cursor = read_identity_cursor(repo.root());
+    let child = cursor_patch_from_child_env(&child_env_hints());
+    if !child.is_empty() {
+        cursor = cursor.merge_event(&child);
+        let _ = write_identity_cursor(repo.root(), &cursor);
+    }
+    let mut manager = SessionManager::new(repo.root());
+    let session = manager.get_current_session()?;
+    let (heddle_session, segment_id) =
+        apply_segment_policy(&mut manager, session.as_ref(), &cursor)?;
+    Ok(FrozenIdentity {
+        provider: cursor.provider,
+        model: cursor.model,
+        thought_level: cursor.thought_level,
+        session: cursor.session.or(heddle_session),
+        parent: cursor.parent,
+        segment_id,
+    })
+}
+
+fn child_env_hints() -> BTreeMap<String, String> {
+    std::env::vars()
+        .filter(|(key, value)| {
+            !value.trim().is_empty()
+                && matches!(
+                    key.as_str(),
+                    "CLAUDE_CODE_SESSION_ID"
+                        | "CLAUDE_EFFORT"
+                        | "PI_MODEL"
+                        | "PI_REASONING_LEVEL"
+                        | "PI_SESSION_ID"
+                        | "PI_PROVIDER"
+                        | "PI_PARENT_ID"
+                )
+        })
+        .collect()
+}
+
+fn apply_segment_policy(
+    manager: &mut SessionManager,
+    session: Option<&Session>,
+    cursor: &IdentityCursor,
+) -> Result<(Option<String>, Option<String>)> {
+    let Some(session) = session else {
+        return Ok((None, None));
+    };
+    let current = session.current_segment();
+    let rotation = cursor_segment_rotation(
+        current.map(|s| s.provider.as_str()),
+        current.map(|s| s.model.as_str()),
+        current.and_then(|s| s.thought_level.as_deref()),
+        cursor.provider.as_deref(),
+        cursor.model.as_deref(),
+        cursor.thought_level.as_deref(),
+    );
+    if rotation == SegmentRotation::Rotate {
+        let provider = cursor
+            .provider
+            .clone()
+            .or_else(|| current.map(|s| s.provider.clone()))
+            .unwrap_or_default();
+        let model = cursor
+            .model
+            .clone()
+            .or_else(|| current.map(|s| s.model.clone()))
+            .unwrap_or_default();
+        if published_field(Some(&provider)).is_some() && published_field(Some(&model)).is_some() {
+            let segment = manager.add_segment(&session.id, provider, model, None)?;
+            if let Some(thought_level) = cursor.thought_level.clone()
+                && let Some(mut updated) = manager.get_session(&session.id)?
+            {
+                if let Some(current) = updated.current_segment_mut() {
+                    current.thought_level = Some(thought_level);
+                }
+                manager.save_session(&updated)?;
+            }
+            return Ok((Some(session.id.clone()), Some(segment.id)));
+        }
+    } else if let Some(thought_level) = cursor.thought_level.clone()
+        && current.and_then(|s| s.thought_level.as_deref()).is_none()
+        && let Some(mut updated) = manager.get_session(&session.id)?
+    {
+        updated.attach_thought_level(thought_level);
+        manager.save_session(&updated)?;
+    }
+    Ok((Some(session.id.clone()), session.current_segment_id.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use objects::object::Principal;
+    use repo::Repository;
+
+    fn principal() -> Principal {
+        Principal::new("Ada", "ada@example.com")
+    }
+
+    #[test]
+    fn freeze_rotates_on_model_change_and_attaches_thought_level() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut manager = SessionManager::new(repo.root());
+        manager
+            .start_session(principal(), "anthropic".into(), "opus".into(), None)
+            .unwrap();
+        write_identity_cursor(
+            repo.root(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: Some("high".into()),
+                session: Some("claude-sess".into()),
+                parent: None,
+            },
+        )
+        .unwrap();
+        let first = freeze_identity_for_capture(&repo).unwrap();
+        assert_eq!(first.model.as_deref(), Some("opus"));
+        assert_eq!(first.thought_level.as_deref(), Some("high"));
+        assert_eq!(first.session.as_deref(), Some("claude-sess"));
+        let first_seg = first.segment_id.clone();
+
+        write_identity_cursor(
+            repo.root(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("sonnet".into()),
+                thought_level: Some("high".into()),
+                session: Some("claude-sess".into()),
+                parent: None,
+            },
+        )
+        .unwrap();
+        let second = freeze_identity_for_capture(&repo).unwrap();
+        assert_eq!(second.model.as_deref(), Some("sonnet"));
+        assert_ne!(second.segment_id, first_seg);
+    }
+
+    #[test]
+    fn empty_thought_level_to_set_does_not_rotate() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut manager = SessionManager::new(repo.root());
+        manager
+            .start_session(principal(), "anthropic".into(), "opus".into(), None)
+            .unwrap();
+        write_identity_cursor(
+            repo.root(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: Some("max".into()),
+                ..IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        let frozen = freeze_identity_for_capture(&repo).unwrap();
+        let session = SessionManager::new(repo.root())
+            .get_current_session()
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.segments.len(), 1);
+        assert_eq!(
+            session.current_segment().unwrap().thought_level.as_deref(),
+            Some("max")
+        );
+        assert_eq!(frozen.thought_level.as_deref(), Some("max"));
+    }
+}

--- a/crates/cli/src/identity_freeze.rs
+++ b/crates/cli/src/identity_freeze.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use anyhow::Result;
 use heddle_core::{
-    IdentityCursor, SegmentRotation, cursor_patch_from_child_env, cursor_segment_rotation,
-    published_field, read_identity_cursor, stamp_identity_cursor,
+    IdentityCursor, SegmentRotation, attach_published_segment_fields, cursor_patch_from_child_env,
+    cursor_segment_rotation, published_field, read_identity_cursor, stamp_identity_cursor,
 };
 use objects::{lock::RepositoryLockExt, object::Session};
 use repo::{Repository, SessionManager};
@@ -107,32 +107,20 @@ fn apply_segment_policy(
             }
             return Ok(Some(segment.id));
         }
-    } else if let Some(mut updated) = manager.get_session(&session.id)? {
-        attach_unpublished_segment_fields(&mut updated, cursor);
+    } else if rotation == SegmentRotation::Attach
+        && let Some(mut updated) = manager.get_session(&session.id)?
+    {
+        if let Some(segment) = updated.current_segment_mut() {
+            attach_published_segment_fields(
+                segment,
+                cursor.provider.as_deref(),
+                cursor.model.as_deref(),
+                cursor.thought_level.as_deref(),
+            );
+        }
         manager.save_session(&updated)?;
     }
     Ok(session.current_segment_id.clone())
-}
-
-fn attach_unpublished_segment_fields(session: &mut Session, cursor: &IdentityCursor) {
-    let Some(segment) = session.current_segment_mut() else {
-        return;
-    };
-    if published_field(Some(&segment.provider)).is_none()
-        && let Some(provider) = cursor.provider.clone()
-    {
-        segment.provider = provider;
-    }
-    if published_field(Some(&segment.model)).is_none()
-        && let Some(model) = cursor.model.clone()
-    {
-        segment.model = model;
-    }
-    if segment.thought_level.is_none()
-        && let Some(thought_level) = cursor.thought_level.clone()
-    {
-        segment.thought_level = Some(thought_level);
-    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/identity_freeze.rs
+++ b/crates/cli/src/identity_freeze.rs
@@ -34,13 +34,12 @@ pub fn freeze_identity_for_capture(repo: &Repository) -> Result<FrozenIdentity> 
     }
     let mut manager = SessionManager::new(repo.root());
     let session = manager.get_current_session()?;
-    let (heddle_session, segment_id) =
-        apply_segment_policy(&mut manager, session.as_ref(), &cursor)?;
+    let segment_id = apply_segment_policy(&mut manager, session.as_ref(), &cursor)?;
     Ok(FrozenIdentity {
         provider: cursor.provider,
         model: cursor.model,
         thought_level: cursor.thought_level,
-        session: cursor.session.or(heddle_session),
+        session: cursor.session,
         parent: cursor.parent,
         segment_id,
     })
@@ -68,9 +67,9 @@ fn apply_segment_policy(
     manager: &mut SessionManager,
     session: Option<&Session>,
     cursor: &IdentityCursor,
-) -> Result<(Option<String>, Option<String>)> {
+) -> Result<Option<String>> {
     let Some(session) = session else {
-        return Ok((None, None));
+        return Ok(None);
     };
     let current = session.current_segment();
     let rotation = cursor_segment_rotation(
@@ -102,16 +101,34 @@ fn apply_segment_policy(
                 }
                 manager.save_session(&updated)?;
             }
-            return Ok((Some(session.id.clone()), Some(segment.id)));
+            return Ok(Some(segment.id));
         }
-    } else if let Some(thought_level) = cursor.thought_level.clone()
-        && current.and_then(|s| s.thought_level.as_deref()).is_none()
-        && let Some(mut updated) = manager.get_session(&session.id)?
-    {
-        updated.attach_thought_level(thought_level);
+    } else if let Some(mut updated) = manager.get_session(&session.id)? {
+        attach_unpublished_segment_fields(&mut updated, cursor);
         manager.save_session(&updated)?;
     }
-    Ok((Some(session.id.clone()), session.current_segment_id.clone()))
+    Ok(session.current_segment_id.clone())
+}
+
+fn attach_unpublished_segment_fields(session: &mut Session, cursor: &IdentityCursor) {
+    let Some(segment) = session.current_segment_mut() else {
+        return;
+    };
+    if published_field(Some(&segment.provider)).is_none()
+        && let Some(provider) = cursor.provider.clone()
+    {
+        segment.provider = provider;
+    }
+    if published_field(Some(&segment.model)).is_none()
+        && let Some(model) = cursor.model.clone()
+    {
+        segment.model = model;
+    }
+    if segment.thought_level.is_none()
+        && let Some(thought_level) = cursor.thought_level.clone()
+    {
+        segment.thought_level = Some(thought_level);
+    }
 }
 
 #[cfg(test)]
@@ -194,5 +211,41 @@ mod tests {
             Some("max")
         );
         assert_eq!(frozen.thought_level.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn empty_provider_model_to_set_attaches_without_rotate() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut manager = SessionManager::new(repo.root());
+        manager
+            .start_session(principal(), "unknown".into(), "unknown".into(), None)
+            .unwrap();
+        write_identity_cursor(
+            repo.root(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: Some("high".into()),
+                ..IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        let frozen = freeze_identity_for_capture(&repo).unwrap();
+        let session = SessionManager::new(repo.root())
+            .get_current_session()
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.segments.len(), 1);
+        assert_eq!(session.current_segment().unwrap().provider, "anthropic");
+        assert_eq!(session.current_segment().unwrap().model, "opus");
+        assert_eq!(
+            session.current_segment().unwrap().thought_level.as_deref(),
+            Some("high")
+        );
+        assert!(
+            frozen.session.is_none(),
+            "harness session stays unset; do not pair Heddle Session.id"
+        );
     }
 }

--- a/crates/cli/src/identity_freeze.rs
+++ b/crates/cli/src/identity_freeze.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use heddle_core::{
     IdentityCursor, SegmentRotation, cursor_patch_from_child_env, cursor_segment_rotation,
-    published_field, read_identity_cursor, write_identity_cursor,
+    published_field, read_identity_cursor, stamp_identity_cursor,
 };
-use objects::object::Session;
+use objects::{lock::RepositoryLockExt, object::Session};
 use repo::{Repository, SessionManager};
 
 /// Cursor values frozen onto one capture (ACP names).
@@ -26,11 +26,15 @@ pub struct FrozenIdentity {
 /// Read the workspace cursor, attach child-env fallbacks, persist so later
 /// captures are not env-shaped, and rotate the Heddle segment when needed.
 pub fn freeze_identity_for_capture(repo: &Repository) -> Result<FrozenIdentity> {
+    let _guard = repo.locker().write()?;
+    freeze_identity_for_capture_locked(repo)
+}
+
+fn freeze_identity_for_capture_locked(repo: &Repository) -> Result<FrozenIdentity> {
     let mut cursor = read_identity_cursor(repo.root());
     let child = cursor_patch_from_child_env(&child_env_hints());
     if !child.is_empty() {
-        cursor = cursor.merge_event(&child);
-        let _ = write_identity_cursor(repo.root(), &cursor);
+        cursor = stamp_identity_cursor(repo.root(), &child)?;
     }
     let mut manager = SessionManager::new(repo.root());
     let session = manager.get_current_session()?;
@@ -134,6 +138,7 @@ fn attach_unpublished_segment_fields(session: &mut Session, cursor: &IdentityCur
 #[cfg(test)]
 mod tests {
     use super::*;
+    use heddle_core::write_identity_cursor;
     use objects::object::Principal;
     use repo::Repository;
 
@@ -247,5 +252,40 @@ mod tests {
             frozen.session.is_none(),
             "harness session stays unset; do not pair Heddle Session.id"
         );
+    }
+
+    #[test]
+    fn freeze_waits_for_repo_write_lock() {
+        use std::{sync::mpsc, time::Duration};
+
+        use objects::lock::RepositoryLockExt;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        write_identity_cursor(
+            repo.root(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                ..IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        let hold = repo.locker().write().unwrap();
+        let root = repo.root().to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let repo = Repository::open(root).unwrap();
+            let frozen = freeze_identity_for_capture(&repo);
+            let _ = tx.send(frozen.is_ok());
+        });
+        assert!(
+            rx.recv_timeout(Duration::from_millis(150)).is_err(),
+            "freeze must not mutate sessions until it holds the repo write lock"
+        );
+        drop(hold);
+        let ok = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(ok, "freeze must succeed after the write lock is released");
+        worker.join().unwrap();
     }
 }

--- a/crates/cli/src/identity_stamp.rs
+++ b/crates/cli/src/identity_stamp.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use heddle_core::{
-    IdentityCursor, cursor_event_expires, cursor_patch_from_stdin, expire_identity_cursor,
+    IdentityCursor, cursor_patch_from_stdin, expire_identity_cursor, stamp_event_expires,
     stamp_harness_name, stamp_identity_cursor,
 };
 
@@ -97,7 +97,7 @@ fn apply_identity_stamp(
     let expires = expire
         || serde_json::from_str::<serde_json::Value>(stdin.trim())
             .ok()
-            .is_some_and(|payload| cursor_event_expires(&payload, None));
+            .is_some_and(|payload| stamp_event_expires(harness, &payload, None));
     if expires {
         expire_identity_cursor(repo_root)?;
         return Ok(IdentityCursor::default());
@@ -230,5 +230,88 @@ mod tests {
             "SessionEnd must expire the cursor so a later capture cannot freeze it"
         );
         assert!(!identity_cursor_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn parse_recognises_expire_flag() {
+        let parsed = parse_stamp_args(&[
+            "integration".into(),
+            "stamp".into(),
+            "codex".into(),
+            "--expire".into(),
+        ])
+        .expect("codex stamp --expire is a stamp invocation");
+        assert!(parsed.expire);
+        assert_eq!(parsed.harness, "codex");
+    }
+
+    #[test]
+    fn codex_stop_stamp_expires_cursor() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".heddle")).unwrap();
+        stamp_bytes(
+            dir.path(),
+            "codex",
+            r#"{"model":"gpt-5.4","session_id":"c1"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_identity_cursor(dir.path()).model.as_deref(),
+            Some("gpt-5.4")
+        );
+        stamp_bytes(
+            dir.path(),
+            "codex",
+            r#"{"hook_event_name":"Stop","session_id":"c1"}"#,
+        )
+        .unwrap();
+        assert!(
+            read_identity_cursor(dir.path()).is_empty(),
+            "Codex Stop must expire the cursor so a later capture cannot freeze it"
+        );
+        assert!(!identity_cursor_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn expire_flag_removes_cursor_without_payload() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".heddle")).unwrap();
+        stamp_bytes(
+            dir.path(),
+            "codex",
+            r#"{"model":"gpt-5.4","session_id":"c1"}"#,
+        )
+        .unwrap();
+        apply_identity_stamp(dir.path(), "codex", "", true).unwrap();
+        assert!(read_identity_cursor(dir.path()).is_empty());
+        assert!(!identity_cursor_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn parent_session_stamp_clears_stale_subagent_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".heddle")).unwrap();
+        stamp_bytes(
+            dir.path(),
+            "codex",
+            r#"{"session_id":"sub-1","parent_id":"parent-1","model":"gpt-5.4"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_identity_cursor(dir.path()).parent.as_deref(),
+            Some("parent-1")
+        );
+        stamp_bytes(
+            dir.path(),
+            "codex",
+            r#"{"session_id":"parent-1","model":"gpt-5.4"}"#,
+        )
+        .unwrap();
+        let cursor = read_identity_cursor(dir.path());
+        assert_eq!(cursor.session.as_deref(), Some("parent-1"));
+        assert!(
+            cursor.parent.is_none(),
+            "later parent-session stamp must not keep the subagent parent"
+        );
     }
 }

--- a/crates/cli/src/identity_stamp.rs
+++ b/crates/cli/src/identity_stamp.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fast-path `heddle integration stamp` — parse stdin, atomic-rename cursor.
+//!
+//! Dispatched before tokio / clap / repo open. Budget: the user cannot feel
+//! the hook. No relay, no JSONL, no session.get, no disk glob.
+
+use std::{
+    env, io,
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use heddle_core::{
+    IdentityCursor, cursor_patch_from_stdin, stamp_harness_name, stamp_identity_cursor,
+};
+
+/// Run the stamp fast path when argv is `integration stamp`. Returns exit code.
+pub fn maybe_run_fast_path() -> Option<i32> {
+    let args: Vec<String> = env::args().skip(1).collect();
+    parse_stamp_args(&args).map(|parsed| match run_stamp(&parsed) {
+        Ok(()) => 0,
+        Err(_) => 0, // hooks must not fail the tool; next capture retries
+    })
+}
+
+#[derive(Debug)]
+struct StampArgs {
+    repo: Option<PathBuf>,
+    harness: String,
+    chain: Option<String>,
+}
+
+fn parse_stamp_args(args: &[String]) -> Option<StampArgs> {
+    let mut repo = None;
+    let mut chain = None;
+    let mut positional = Vec::new();
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        if arg == "--repo" {
+            idx += 1;
+            repo = args.get(idx).map(PathBuf::from);
+        } else if let Some(value) = arg.strip_prefix("--repo=") {
+            repo = Some(PathBuf::from(value));
+        } else if arg == "--chain" {
+            idx += 1;
+            chain = args.get(idx).cloned();
+        } else if let Some(value) = arg.strip_prefix("--chain=") {
+            chain = Some(value.to_string());
+        } else if arg == "--" {
+            positional.extend(args[idx + 1..].iter().cloned());
+            break;
+        } else {
+            positional.push(arg.clone());
+        }
+        idx += 1;
+    }
+    if positional.first().map(String::as_str) != Some("integration") {
+        return None;
+    }
+    if positional.get(1).map(String::as_str) != Some("stamp") {
+        return None;
+    }
+    let harness = positional.get(2)?.clone();
+    stamp_harness_name(&harness)?;
+    Some(StampArgs {
+        repo,
+        harness,
+        chain,
+    })
+}
+
+fn run_stamp(args: &StampArgs) -> io::Result<()> {
+    let mut stdin = Vec::new();
+    io::stdin().read_to_end(&mut stdin)?;
+    let stdin_text = String::from_utf8_lossy(&stdin);
+    let Some(root) = resolve_repo_root(args.repo.as_deref()) else {
+        return chain_status_line(args.chain.as_deref(), &stdin);
+    };
+    let patch = cursor_patch_from_stdin(&args.harness, &stdin_text);
+    let _ = stamp_identity_cursor(&root, &patch);
+    chain_status_line(args.chain.as_deref(), &stdin)
+}
+
+fn resolve_repo_root(explicit: Option<&Path>) -> Option<PathBuf> {
+    let start = match explicit {
+        Some(path) => path.to_path_buf(),
+        None => env::current_dir().ok()?,
+    };
+    let mut dir = start.canonicalize().unwrap_or(start);
+    for _ in 0..12 {
+        let marker = dir.join(".heddle");
+        if marker.is_dir() || marker.is_file() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn chain_status_line(chain: Option<&str>, stdin: &[u8]) -> io::Result<()> {
+    let Some(command) = chain.filter(|c| !c.trim().is_empty()) else {
+        return Ok(());
+    };
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    if let Some(mut child_stdin) = child.stdin.take() {
+        use io::Write;
+        let _ = child_stdin.write_all(stdin);
+    }
+    let _ = child.wait();
+    Ok(())
+}
+
+/// Library entry for tests (no process stdin).
+pub fn stamp_bytes(
+    repo_root: &Path,
+    harness: &str,
+    stdin: &str,
+) -> Result<IdentityCursor, io::Error> {
+    let patch = cursor_patch_from_stdin(harness, stdin);
+    stamp_identity_cursor(repo_root, &patch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use heddle_core::{identity_cursor_path, read_identity_cursor};
+
+    #[test]
+    fn parse_recognises_stamp_and_rejects_relay() {
+        assert!(
+            parse_stamp_args(&[
+                "--repo".into(),
+                "/tmp/r".into(),
+                "integration".into(),
+                "stamp".into(),
+                "claude-code".into()
+            ])
+            .is_some()
+        );
+        assert!(
+            parse_stamp_args(&[
+                "integration".into(),
+                "relay".into(),
+                "claude-code".into(),
+                "PreToolUse".into()
+            ])
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn stamp_bytes_merges_claude_effort_object() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".heddle")).unwrap();
+        stamp_bytes(
+            dir.path(),
+            "claude-code",
+            r#"{"session_id":"s1","effort":{"level":"high"}}"#,
+        )
+        .unwrap();
+        stamp_bytes(
+            dir.path(),
+            "claude-code",
+            r#"{"model":{"id":"claude-opus-4-7"}}"#,
+        )
+        .unwrap();
+        let cursor = read_identity_cursor(dir.path());
+        assert_eq!(cursor.model.as_deref(), Some("claude-opus-4-7"));
+        assert_eq!(cursor.thought_level.as_deref(), Some("high"));
+        assert_eq!(cursor.session.as_deref(), Some("s1"));
+        let raw = fs::read_to_string(identity_cursor_path(dir.path())).unwrap();
+        assert!(raw.len() < 400);
+    }
+}

--- a/crates/cli/src/identity_stamp.rs
+++ b/crates/cli/src/identity_stamp.rs
@@ -12,7 +12,8 @@ use std::{
 };
 
 use heddle_core::{
-    IdentityCursor, cursor_patch_from_stdin, stamp_harness_name, stamp_identity_cursor,
+    IdentityCursor, cursor_event_expires, cursor_patch_from_stdin, expire_identity_cursor,
+    stamp_harness_name, stamp_identity_cursor,
 };
 
 /// Run the stamp fast path when argv is `integration stamp`. Returns exit code.
@@ -29,11 +30,13 @@ struct StampArgs {
     repo: Option<PathBuf>,
     harness: String,
     chain: Option<String>,
+    expire: bool,
 }
 
 fn parse_stamp_args(args: &[String]) -> Option<StampArgs> {
     let mut repo = None;
     let mut chain = None;
+    let mut expire = false;
     let mut positional = Vec::new();
     let mut idx = 0;
     while idx < args.len() {
@@ -48,6 +51,8 @@ fn parse_stamp_args(args: &[String]) -> Option<StampArgs> {
             chain = args.get(idx).cloned();
         } else if let Some(value) = arg.strip_prefix("--chain=") {
             chain = Some(value.to_string());
+        } else if arg == "--expire" {
+            expire = true;
         } else if arg == "--" {
             positional.extend(args[idx + 1..].iter().cloned());
             break;
@@ -68,6 +73,7 @@ fn parse_stamp_args(args: &[String]) -> Option<StampArgs> {
         repo,
         harness,
         chain,
+        expire,
     })
 }
 
@@ -78,9 +84,25 @@ fn run_stamp(args: &StampArgs) -> io::Result<()> {
     let Some(root) = resolve_repo_root(args.repo.as_deref()) else {
         return chain_status_line(args.chain.as_deref(), &stdin);
     };
-    let patch = cursor_patch_from_stdin(&args.harness, &stdin_text);
-    let _ = stamp_identity_cursor(&root, &patch);
+    let _ = apply_identity_stamp(&root, &args.harness, &stdin_text, args.expire);
     chain_status_line(args.chain.as_deref(), &stdin)
+}
+
+fn apply_identity_stamp(
+    repo_root: &Path,
+    harness: &str,
+    stdin: &str,
+    expire: bool,
+) -> io::Result<IdentityCursor> {
+    let expires = expire
+        || serde_json::from_str::<serde_json::Value>(stdin.trim())
+            .ok()
+            .is_some_and(|payload| cursor_event_expires(&payload, None));
+    if expires {
+        expire_identity_cursor(repo_root)?;
+        return Ok(IdentityCursor::default());
+    }
+    stamp_identity_cursor(repo_root, &cursor_patch_from_stdin(harness, stdin))
 }
 
 fn resolve_repo_root(explicit: Option<&Path>) -> Option<PathBuf> {
@@ -126,8 +148,7 @@ pub fn stamp_bytes(
     harness: &str,
     stdin: &str,
 ) -> Result<IdentityCursor, io::Error> {
-    let patch = cursor_patch_from_stdin(harness, stdin);
-    stamp_identity_cursor(repo_root, &patch)
+    apply_identity_stamp(repo_root, harness, stdin, false)
 }
 
 #[cfg(test)]
@@ -182,5 +203,32 @@ mod tests {
         assert_eq!(cursor.session.as_deref(), Some("s1"));
         let raw = fs::read_to_string(identity_cursor_path(dir.path())).unwrap();
         assert!(raw.len() < 400);
+    }
+
+    #[test]
+    fn session_end_stamp_expires_cursor() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".heddle")).unwrap();
+        stamp_bytes(
+            dir.path(),
+            "claude-code",
+            r#"{"session_id":"s1","model":{"id":"claude-opus-4-7"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_identity_cursor(dir.path()).model.as_deref(),
+            Some("claude-opus-4-7")
+        );
+        stamp_bytes(
+            dir.path(),
+            "claude-code",
+            r#"{"hook_event_name":"SessionEnd","session_id":"s1"}"#,
+        )
+        .unwrap();
+        assert!(
+            read_identity_cursor(dir.path()).is_empty(),
+            "SessionEnd must expire the cursor so a later capture cannot freeze it"
+        );
+        assert!(!identity_cursor_path(dir.path()).exists());
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -20,6 +20,8 @@ pub mod harness;
 mod hosted_failure;
 #[cfg(feature = "client")]
 mod hosted_runtime;
+pub mod identity_freeze;
+pub mod identity_stamp;
 pub mod operation_id;
 pub mod perf;
 #[cfg(feature = "semantic")]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -59,6 +59,9 @@ use tracing::debug;
 // multi-thread flavor pays for thread-pool creation + teardown.
 fn main() -> Result<()> {
     install_broken_pipe_panic_hook();
+    if let Some(code) = cli::identity_stamp::maybe_run_fast_path() {
+        std::process::exit(code);
+    }
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
@@ -906,7 +909,7 @@ fn is_harness_relay_invocation(command: &Commands) -> bool {
     matches!(
         command,
         Commands::Integration {
-            command: IntegrationCommands::Relay(_),
+            command: IntegrationCommands::Relay(_) | IntegrationCommands::Stamp(_),
         }
     )
 }

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1748,8 +1748,12 @@ fn git_overlay_matrix_init_excludes_only_heddle_metadata() {
     );
 
     let exclude = std::fs::read_to_string(temp.path().join(".git/info/exclude")).unwrap();
-    {
-        let pattern = ".heddle/";
+    for pattern in [
+        ".heddle/",
+        ".heddle.identity",
+        ".identity.lock",
+        ".identity.tmp.*",
+    ] {
         assert!(
             exclude.lines().any(|line| line.trim() == pattern),
             "local Git exclude should contain {pattern:?}: {exclude}"

--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -400,6 +400,66 @@ fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
 }
 
 #[test]
+fn native_capture_cannot_ingest_pointer_checkout_cursor_artifacts() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join("kept.txt"), "captured\n").unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join(".heddle.identity"),
+        "{\"provider\":\"anthropic\"}\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join(".identity.lock"), "").unwrap();
+    std::fs::write(temp.path().join(".identity.tmp.1.2"), "{}").unwrap();
+    std::fs::create_dir_all(temp.path().join("examples/foo")).unwrap();
+    std::fs::write(
+        temp.path().join("examples/foo/.heddle.identity"),
+        "fixture\n",
+    )
+    .unwrap();
+
+    let status = heddle(&["status", "--output", "json-compact"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&status).expect("status json");
+    let paths: Vec<&str> = parsed["changed_paths"]
+        .as_array()
+        .unwrap_or_else(|| panic!("status must carry changed_paths: {status}"))
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        paths.contains(&"kept.txt"),
+        "status must still list real worktree files: {paths:?}"
+    );
+    assert!(
+        paths.iter().all(|path| {
+            *path != ".heddle.identity"
+                && *path != ".identity.lock"
+                && !path.starts_with(".identity.tmp")
+        }),
+        "status must not list pointer-cursor artifacts: {paths:?}"
+    );
+    assert!(
+        paths.contains(&"examples/foo/.heddle.identity"),
+        "status must still list nested cursor-named fixtures: {paths:?}"
+    );
+
+    heddle(
+        &["capture", "-m", "must not capture pointer cursor files"],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    assert!(!captured_path_exists(temp.path(), ".heddle.identity"));
+    assert!(!captured_path_exists(temp.path(), ".identity.lock"));
+    assert!(!captured_path_exists(temp.path(), ".identity.tmp.1.2"));
+    assert!(captured_path_exists(temp.path(), "kept.txt"));
+    assert!(captured_path_exists(
+        temp.path(),
+        "examples/foo/.heddle.identity"
+    ));
+}
+
+#[test]
 fn init_text_points_at_ignore_help_when_heddleignore_not_installed() {
     let temp = TempDir::new().unwrap();
     let out = heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10360,8 +10360,12 @@ fn verify_after_git_overlay_clone_reports_clone_verified() {
         serde_json::json!([])
     );
     let exclude = std::fs::read_to_string(work.join(".git/info/exclude")).unwrap();
-    {
-        let pattern = ".heddle/";
+    for pattern in [
+        ".heddle/",
+        ".heddle.identity",
+        ".identity.lock",
+        ".identity.tmp.*",
+    ] {
         assert!(
             exclude.lines().any(|line| line.trim() == pattern),
             "clone should install the same local Git exclude policy as init; missing {pattern:?}: {exclude}"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
+fs2.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
 merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
 ignore.workspace = true

--- a/crates/core/src/harness_policy.rs
+++ b/crates/core/src/harness_policy.rs
@@ -4,7 +4,8 @@
 //! Owns:
 //! - harness kind fingerprinting from argv / env hint maps
 //! - session attach-vs-create decision given caller-gathered probe facts
-//! - segment rotation when provider or model changes
+//! - segment rotation when provider, model, or thought_level changes
+//!   (empty → set is attach, not a rotate)
 //!
 //! Process detection, registry lookups, session store I/O, and path
 //! canonicalization remain CLI-owned. Callers pass pure facts in and apply
@@ -151,7 +152,6 @@ pub fn fingerprint_harness_from_hints(
         .and_then(clean_attribution_value)
         .or_else(|| env_hints.get("CODEX_MODEL").cloned())
         .or_else(|| env_hints.get("CLAUDE_MODEL").cloned())
-        .or_else(|| env_hints.get("ANTHROPIC_MODEL").cloned())
         .or_else(|| env_hints.get("OPENAI_MODEL").cloned())
         .or_else(|| env_hints.get("OPENCODE_MODEL").cloned())
         .or_else(|| env_hints.get("AIDER_MODEL").cloned())
@@ -533,31 +533,57 @@ pub enum SegmentRotation {
     Rotate,
 }
 
-/// Pure segment rotation policy: rotate when provider or model changes.
+/// Pure segment rotation policy: rotate when a published provider, model,
+/// or thought_level **changes**. Empty → set is attach (`Keep`), not a rotate.
 ///
 /// - No current segment → keep (caller creates the first segment elsewhere).
-/// - `new_*` is `None` → does not force rotation (blank hints fall through).
-/// - Rotation only when a new value is present and differs from current.
+/// - Incoming `None` / empty / `unknown` does not force rotation.
+/// - Rotation only when both sides have a published value and they differ.
 pub fn segment_rotation_policy(
     current_provider: Option<&str>,
     current_model: Option<&str>,
     new_provider: Option<&str>,
     new_model: Option<&str>,
 ) -> SegmentRotation {
-    let Some(current_provider) = current_provider else {
+    cursor_segment_rotation(
+        current_provider,
+        current_model,
+        None,
+        new_provider,
+        new_model,
+        None,
+    )
+}
+
+/// Same as [`segment_rotation_policy`] plus `thought_level`.
+pub fn cursor_segment_rotation(
+    current_provider: Option<&str>,
+    current_model: Option<&str>,
+    current_thought_level: Option<&str>,
+    new_provider: Option<&str>,
+    new_model: Option<&str>,
+    new_thought_level: Option<&str>,
+) -> SegmentRotation {
+    let Some(current_provider) = crate::identity_cursor::published_field(current_provider) else {
         return SegmentRotation::Keep;
     };
-    // Model may be missing on a segment only if caller has no current segment;
-    // when a segment exists both provider and model are set. Treat missing
-    // current model as empty for comparison only when provider was present.
-    let current_model = current_model.unwrap_or("");
-
-    let provider_changed = new_provider.is_some_and(|p| p != current_provider);
-    let model_changed = new_model.is_some_and(|m| m != current_model);
-    if provider_changed || model_changed {
+    if field_rotates(Some(current_provider), new_provider)
+        || field_rotates(current_model, new_model)
+        || field_rotates(current_thought_level, new_thought_level)
+    {
         SegmentRotation::Rotate
     } else {
         SegmentRotation::Keep
+    }
+}
+
+fn field_rotates(current: Option<&str>, incoming: Option<&str>) -> bool {
+    match (
+        crate::identity_cursor::published_field(current),
+        crate::identity_cursor::published_field(incoming),
+    ) {
+        (Some(current), Some(incoming)) => current != incoming,
+        _ => false,
     }
 }
 
@@ -747,6 +773,43 @@ mod tests {
                 Some("sonnet"),
             ),
             SegmentRotation::Rotate
+        );
+    }
+
+    #[test]
+    fn segment_rotates_on_thought_level_change_empty_set_is_attach() {
+        assert_eq!(
+            cursor_segment_rotation(
+                Some("anthropic"),
+                Some("opus"),
+                None,
+                Some("anthropic"),
+                Some("opus"),
+                Some("high"),
+            ),
+            SegmentRotation::Keep
+        );
+        assert_eq!(
+            cursor_segment_rotation(
+                Some("anthropic"),
+                Some("opus"),
+                Some("high"),
+                Some("anthropic"),
+                Some("opus"),
+                Some("low"),
+            ),
+            SegmentRotation::Rotate
+        );
+        assert_eq!(
+            cursor_segment_rotation(
+                Some("anthropic"),
+                Some(""),
+                None,
+                Some("anthropic"),
+                Some("opus"),
+                None,
+            ),
+            SegmentRotation::Keep
         );
     }
 

--- a/crates/core/src/harness_policy.rs
+++ b/crates/core/src/harness_policy.rs
@@ -138,24 +138,6 @@ pub fn fingerprint_harness_from_hints(
         policy: None,
     };
 
-    // HEDDLE_AGENT_PROVIDER fills only when no harness default was set
-    // (historical `or_else` order in the CLI fingerprint).
-    fingerprint.provider = fingerprint.provider.or_else(|| {
-        env_hints
-            .get("HEDDLE_AGENT_PROVIDER")
-            .cloned()
-            .and_then(clean_attribution_value)
-    });
-    fingerprint.model = env_hints
-        .get("HEDDLE_AGENT_MODEL")
-        .cloned()
-        .and_then(clean_attribution_value)
-        .or_else(|| env_hints.get("CODEX_MODEL").cloned())
-        .or_else(|| env_hints.get("CLAUDE_MODEL").cloned())
-        .or_else(|| env_hints.get("OPENAI_MODEL").cloned())
-        .or_else(|| env_hints.get("OPENCODE_MODEL").cloned())
-        .or_else(|| env_hints.get("AIDER_MODEL").cloned())
-        .or_else(|| env_hints.get("MODEL").cloned());
     fingerprint.thinking_level = env_hints
         .get("THINKING_LEVEL")
         .cloned()
@@ -684,23 +666,28 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_reads_model_and_thinking_env() {
+    fn fingerprint_does_not_invent_model_from_hoped_for_env() {
         let fp = fingerprint_harness_from_hints(
             None,
             &env(&[
                 ("CODEX_THREAD_ID", "t1"),
                 ("CODEX_MODEL", "gpt-5.5"),
+                ("HEDDLE_AGENT_MODEL", "claude-opus-4-7"),
+                ("MODEL", "fallback-model"),
                 ("CODEX_REASONING_EFFORT", "xhigh"),
             ]),
         );
         assert_eq!(fp.kind, HarnessKind::Codex);
-        assert_eq!(fp.model.as_deref(), Some("gpt-5.5"));
+        assert!(
+            fp.model.is_none(),
+            "kind-only fingerprint must not hunt a model"
+        );
         assert_eq!(fp.thinking_level.as_deref(), Some("xhigh"));
         assert_eq!(fp.provider.as_deref(), Some("openai"));
     }
 
     #[test]
-    fn fingerprint_strips_blank_heddle_agent_env() {
+    fn fingerprint_strips_blank_heddle_agent_policy() {
         let fp = fingerprint_harness_from_hints(
             None,
             &env(&[
@@ -710,8 +697,8 @@ mod tests {
                 ("MODEL", "fallback-model"),
             ]),
         );
-        assert_eq!(fp.provider.as_deref(), Some("custom"));
-        assert_eq!(fp.model.as_deref(), Some("fallback-model"));
+        assert!(fp.provider.is_none());
+        assert!(fp.model.is_none());
         assert_eq!(fp.policy, None);
     }
 

--- a/crates/core/src/harness_policy.rs
+++ b/crates/core/src/harness_policy.rs
@@ -508,19 +508,23 @@ fn create_decision(
 // Segment rotation
 // ---------------------------------------------------------------------------
 
-/// Whether the current session segment should rotate for a new identity.
+/// Whether the current session segment should rotate or attach for a new identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SegmentRotation {
     Keep,
+    /// Unpublished → published: write onto the current placeholder segment.
+    Attach,
     Rotate,
 }
 
 /// Pure segment rotation policy: rotate when a published provider, model,
-/// or thought_level **changes**. Empty → set is attach (`Keep`), not a rotate.
+/// or thought_level **changes**. Empty → set is [`SegmentRotation::Attach`],
+/// not a rotate.
 ///
-/// - No current segment → keep (caller creates the first segment elsewhere).
 /// - Incoming `None` / empty / `unknown` does not force rotation.
 /// - Rotation only when both sides have a published value and they differ.
+/// - Each field is evaluated independently so an unpublished provider cannot
+///   mask a published model / thought_level change.
 pub fn segment_rotation_policy(
     current_provider: Option<&str>,
     current_model: Option<&str>,
@@ -546,14 +550,16 @@ pub fn cursor_segment_rotation(
     new_model: Option<&str>,
     new_thought_level: Option<&str>,
 ) -> SegmentRotation {
-    let Some(current_provider) = crate::identity_cursor::published_field(current_provider) else {
-        return SegmentRotation::Keep;
-    };
-    if field_rotates(Some(current_provider), new_provider)
+    if field_rotates(current_provider, new_provider)
         || field_rotates(current_model, new_model)
         || field_rotates(current_thought_level, new_thought_level)
     {
         SegmentRotation::Rotate
+    } else if field_attaches(current_provider, new_provider)
+        || field_attaches(current_model, new_model)
+        || field_attaches(current_thought_level, new_thought_level)
+    {
+        SegmentRotation::Attach
     } else {
         SegmentRotation::Keep
     }
@@ -566,6 +572,35 @@ fn field_rotates(current: Option<&str>, incoming: Option<&str>) -> bool {
     ) {
         (Some(current), Some(incoming)) => current != incoming,
         _ => false,
+    }
+}
+
+fn field_attaches(current: Option<&str>, incoming: Option<&str>) -> bool {
+    crate::identity_cursor::published_field(current).is_none()
+        && crate::identity_cursor::published_field(incoming).is_some()
+}
+
+/// Write newly published values onto a placeholder segment (empty → set).
+pub fn attach_published_segment_fields(
+    segment: &mut objects::object::SessionSegment,
+    provider: Option<&str>,
+    model: Option<&str>,
+    thought_level: Option<&str>,
+) {
+    if crate::identity_cursor::published_field(Some(segment.provider.as_str())).is_none()
+        && let Some(provider) = crate::identity_cursor::published_field(provider)
+    {
+        segment.provider = provider.to_string();
+    }
+    if crate::identity_cursor::published_field(Some(segment.model.as_str())).is_none()
+        && let Some(model) = crate::identity_cursor::published_field(model)
+    {
+        segment.model = model.to_string();
+    }
+    if crate::identity_cursor::published_field(segment.thought_level.as_deref()).is_none()
+        && let Some(thought_level) = crate::identity_cursor::published_field(thought_level)
+    {
+        segment.thought_level = Some(thought_level.to_string());
     }
 }
 
@@ -774,7 +809,7 @@ mod tests {
                 Some("opus"),
                 Some("high"),
             ),
-            SegmentRotation::Keep
+            SegmentRotation::Attach
         );
         assert_eq!(
             cursor_segment_rotation(
@@ -796,7 +831,56 @@ mod tests {
                 Some("opus"),
                 None,
             ),
-            SegmentRotation::Keep
+            SegmentRotation::Attach
+        );
+    }
+
+    #[test]
+    fn unpublished_to_published_attaches_placeholder_segment() {
+        assert_eq!(
+            cursor_segment_rotation(
+                Some("unknown"),
+                Some("unknown"),
+                None,
+                Some("anthropic"),
+                Some("opus"),
+                Some("high"),
+            ),
+            SegmentRotation::Attach
+        );
+        assert!(!should_rotate_segment(
+            Some("unknown"),
+            Some("unknown"),
+            Some("anthropic"),
+            Some("opus"),
+        ));
+        let mut segment = objects::object::SessionSegment {
+            id: "sess-1-seg-1".into(),
+            provider: "unknown".into(),
+            model: "unknown".into(),
+            started_at: chrono::Utc::now(),
+            policy_id: None,
+            thought_level: None,
+        };
+        attach_published_segment_fields(
+            &mut segment,
+            Some("anthropic"),
+            Some("opus"),
+            Some("high"),
+        );
+        assert_eq!(segment.provider, "anthropic");
+        assert_eq!(segment.model, "opus");
+        assert_eq!(segment.thought_level.as_deref(), Some("high"));
+        assert_eq!(
+            cursor_segment_rotation(
+                Some("anthropic"),
+                Some("opus"),
+                Some("high"),
+                Some("anthropic"),
+                Some("sonnet"),
+                Some("high"),
+            ),
+            SegmentRotation::Rotate
         );
     }
 

--- a/crates/core/src/identity_cursor.rs
+++ b/crates/core/src/identity_cursor.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Current harness identity cursor (`provider`, `model`, `thought_level`,
+//! `session`, `parent`) written by install hooks and frozen onto each capture.
+//!
+//! This is live cursor state, not “the model of the thread”. Mid-thread
+//! `/model` or `/effort` updates the cursor only; already-captured states
+//! keep the pair they froze.
+
+use std::{fs, io, path::Path};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::harness_json::{first_value_string, value_string};
+
+/// Sidecar file name under `.heddle/` (not `identity.toml`, the signing key).
+pub const IDENTITY_CURSOR_FILE: &str = "identity";
+
+/// ACP-named current identity. Omit unpublished fields.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityCursor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_level: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+}
+
+impl IdentityCursor {
+    /// Drop empty / `unknown` placeholders so unpublished fields stay omitted.
+    pub fn omit_unpublished(mut self) -> Self {
+        self.provider = published_owned(self.provider);
+        self.model = published_owned(self.model);
+        self.thought_level = published_owned(self.thought_level);
+        self.session = published_owned(self.session);
+        self.parent = published_owned(self.parent);
+        self
+    }
+
+    /// Merge an event patch: missing incoming fields keep the last cursor value.
+    pub fn merge_event(&self, patch: &IdentityCursor) -> Self {
+        Self {
+            provider: published_owned(patch.provider.clone()).or_else(|| self.provider.clone()),
+            model: published_owned(patch.model.clone()).or_else(|| self.model.clone()),
+            thought_level: published_owned(patch.thought_level.clone())
+                .or_else(|| self.thought_level.clone()),
+            session: published_owned(patch.session.clone()).or_else(|| self.session.clone()),
+            parent: published_owned(patch.parent.clone()).or_else(|| self.parent.clone()),
+        }
+        .omit_unpublished()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.provider.is_none()
+            && self.model.is_none()
+            && self.thought_level.is_none()
+            && self.session.is_none()
+            && self.parent.is_none()
+    }
+
+    /// Compact JSON (~200 bytes) for the sidecar hot path.
+    pub fn to_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}
+
+/// Treat empty / `unknown` as unpublished.
+pub fn published_field(value: Option<&str>) -> Option<&str> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("unknown"))
+}
+
+fn published_owned(value: Option<String>) -> Option<String> {
+    published_field(value.as_deref()).map(str::to_string)
+}
+
+/// Workspace sidecar path.
+///
+/// Directory checkout: `.heddle/identity`. Pointer checkout (`.heddle` is a
+/// file): `.heddle.identity` beside it so the cursor stays workspace-local.
+pub fn identity_cursor_path(repo_root: &Path) -> std::path::PathBuf {
+    let marker = repo_root.join(".heddle");
+    if marker.is_file() {
+        repo_root.join(".heddle.identity")
+    } else {
+        marker.join(IDENTITY_CURSOR_FILE)
+    }
+}
+
+/// Read the current cursor. Missing or unreadable → empty cursor.
+pub fn read_identity_cursor(repo_root: &Path) -> IdentityCursor {
+    let path = identity_cursor_path(repo_root);
+    let Ok(bytes) = fs::read(&path) else {
+        return IdentityCursor::default();
+    };
+    serde_json::from_slice::<IdentityCursor>(&bytes)
+        .unwrap_or_default()
+        .omit_unpublished()
+}
+
+/// Atomic rename of a reconstructible sidecar. No fsync — next hook rewrites.
+pub fn write_identity_cursor(repo_root: &Path, cursor: &IdentityCursor) -> io::Result<()> {
+    let dest = identity_cursor_path(repo_root);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = dest.with_file_name(".identity.tmp");
+    let body = cursor
+        .clone()
+        .omit_unpublished()
+        .to_vec()
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    fs::write(&tmp, body)?;
+    fs::rename(&tmp, dest)?;
+    Ok(())
+}
+
+/// Merge `patch` onto the on-disk cursor and publish it.
+pub fn stamp_identity_cursor(
+    repo_root: &Path,
+    patch: &IdentityCursor,
+) -> io::Result<IdentityCursor> {
+    let current = read_identity_cursor(repo_root);
+    let next = current.merge_event(patch);
+    write_identity_cursor(repo_root, &next)?;
+    Ok(next)
+}
+
+/// Walk `path` for a string, or an object's `id` / `level` field.
+pub fn value_string_or_named(value: &Value, path: &[&str], object_keys: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    match current {
+        Value::String(s) => published_owned(Some(s.clone())),
+        Value::Bool(v) => Some(v.to_string()),
+        Value::Number(v) => Some(v.to_string()),
+        Value::Object(obj) => object_keys
+            .iter()
+            .find_map(|key| obj.get(*key).and_then(Value::as_str))
+            .and_then(|s| published_owned(Some(s.to_string()))),
+        _ => None,
+    }
+}
+
+/// Claude / Codex / OpenCode thought_level mapping (ACP name, not wire).
+pub fn thought_level_from_payload(payload: &Value) -> Option<String> {
+    value_string_or_named(payload, &["effort"], &["level"])
+        .or_else(|| first_value_string(payload, &[&["thought_level"], &["reasoning_effort"]]))
+        .or_else(|| value_string(payload, &["model", "variant"]))
+        .or_else(|| value_string(payload, &["turn_context", "effort"]))
+        .or_else(|| value_string(payload, &["turn_context", "reasoning_effort"]))
+        .and_then(|s| published_owned(Some(s)))
+}
+
+/// Exact ancestor basename → harness kind token. Never a model.
+pub fn harness_kind_from_basename(argv0: &str) -> Option<&'static str> {
+    crate::harness_policy::detect_harness_kind(Some(argv0), &Default::default()).as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn merge_keeps_last_cursor_when_event_omits_field() {
+        let current = IdentityCursor {
+            provider: Some("anthropic".into()),
+            model: Some("opus".into()),
+            thought_level: Some("high".into()),
+            session: Some("sess-1".into()),
+            parent: Some("agent-1".into()),
+        };
+        let next = current.merge_event(&IdentityCursor {
+            thought_level: Some("low".into()),
+            ..IdentityCursor::default()
+        });
+        assert_eq!(next.model.as_deref(), Some("opus"));
+        assert_eq!(next.thought_level.as_deref(), Some("low"));
+        assert_eq!(next.session.as_deref(), Some("sess-1"));
+    }
+
+    #[test]
+    fn omit_unpublished_drops_unknown_and_empty() {
+        let cursor = IdentityCursor {
+            provider: Some("anthropic".into()),
+            model: Some("unknown".into()),
+            thought_level: Some("".into()),
+            session: Some("  ".into()),
+            parent: None,
+        }
+        .omit_unpublished();
+        assert_eq!(cursor.provider.as_deref(), Some("anthropic"));
+        assert!(cursor.model.is_none());
+        assert!(cursor.thought_level.is_none());
+        assert!(cursor.session.is_none());
+    }
+
+    #[test]
+    fn effort_level_object_maps_to_thought_level() {
+        let payload = json!({"effort": {"level": "high"}, "session_id": "s1"});
+        assert_eq!(
+            thought_level_from_payload(&payload).as_deref(),
+            Some("high")
+        );
+        assert_eq!(
+            value_string_or_named(&payload, &["effort"], &["level"]).as_deref(),
+            Some("high")
+        );
+        assert!(value_string(&payload, &["effort"]).is_none());
+    }
+
+    #[test]
+    fn basename_kind_is_exact_not_path_contains() {
+        assert_eq!(
+            harness_kind_from_basename("/home/u/dev/codex/target/debug/heddle"),
+            None
+        );
+        assert_eq!(harness_kind_from_basename("/usr/bin/codex"), Some("codex"));
+        assert_eq!(
+            harness_kind_from_basename("/usr/local/bin/claude"),
+            Some("claude-code")
+        );
+    }
+
+    #[test]
+    fn write_and_read_roundtrip_omits_unpublished() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let written = stamp_identity_cursor(
+            dir.path(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                thought_level: None,
+                session: Some("s1".into()),
+                parent: None,
+            },
+        )
+        .unwrap();
+        assert!(written.thought_level.is_none());
+        let raw = fs::read_to_string(identity_cursor_path(dir.path())).unwrap();
+        assert!(!raw.contains("thought_level"));
+        assert!(!raw.contains("parent"));
+        assert_eq!(read_identity_cursor(dir.path()), written);
+    }
+}

--- a/crates/core/src/identity_cursor.rs
+++ b/crates/core/src/identity_cursor.rs
@@ -7,11 +7,13 @@
 //! keep the pair they froze.
 
 use std::{
-    fs, io,
+    fs::{self, OpenOptions},
+    io,
     path::Path,
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -99,6 +101,10 @@ pub fn identity_cursor_path(repo_root: &Path) -> std::path::PathBuf {
 
 /// Read the current cursor. Missing or unreadable → empty cursor.
 pub fn read_identity_cursor(repo_root: &Path) -> IdentityCursor {
+    read_identity_cursor_unlocked(repo_root)
+}
+
+fn read_identity_cursor_unlocked(repo_root: &Path) -> IdentityCursor {
     let path = identity_cursor_path(repo_root);
     let Ok(bytes) = fs::read(&path) else {
         return IdentityCursor::default();
@@ -110,6 +116,12 @@ pub fn read_identity_cursor(repo_root: &Path) -> IdentityCursor {
 
 /// Atomic rename of a reconstructible sidecar. No fsync — next hook rewrites.
 pub fn write_identity_cursor(repo_root: &Path, cursor: &IdentityCursor) -> io::Result<()> {
+    let dest = identity_cursor_path(repo_root);
+    let _guard = acquire_identity_lock(&dest)?;
+    write_identity_cursor_unlocked(repo_root, cursor)
+}
+
+fn write_identity_cursor_unlocked(repo_root: &Path, cursor: &IdentityCursor) -> io::Result<()> {
     let dest = identity_cursor_path(repo_root);
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
@@ -134,14 +146,54 @@ pub fn write_identity_cursor(repo_root: &Path, cursor: &IdentityCursor) -> io::R
 }
 
 /// Merge `patch` onto the on-disk cursor and publish it.
+///
+/// Holds an exclusive sidecar lock for the read-merge-write so StatusLine
+/// (model) and PreToolUse (effort) cannot clobber each other.
 pub fn stamp_identity_cursor(
     repo_root: &Path,
     patch: &IdentityCursor,
 ) -> io::Result<IdentityCursor> {
-    let current = read_identity_cursor(repo_root);
+    let dest = identity_cursor_path(repo_root);
+    let _guard = acquire_identity_lock(&dest)?;
+    let current = read_identity_cursor_unlocked(repo_root);
     let next = current.merge_event(patch);
-    write_identity_cursor(repo_root, &next)?;
+    write_identity_cursor_unlocked(repo_root, &next)?;
     Ok(next)
+}
+
+/// Drop the live cursor so a later human/Cursor capture cannot freeze a dead session.
+pub fn expire_identity_cursor(repo_root: &Path) -> io::Result<()> {
+    let dest = identity_cursor_path(repo_root);
+    let _guard = acquire_identity_lock(&dest)?;
+    match fs::remove_file(&dest) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+struct IdentityWriteGuard {
+    file: fs::File,
+}
+
+fn acquire_identity_lock(dest: &Path) -> io::Result<IdentityWriteGuard> {
+    let lock_path = dest.with_file_name(".identity.lock");
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&lock_path)?;
+    file.lock_exclusive()?;
+    Ok(IdentityWriteGuard { file })
+}
+
+impl Drop for IdentityWriteGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
 }
 
 /// Walk `path` for a string, or an object's `id` / `level` field.
@@ -303,5 +355,76 @@ mod tests {
             leftovers.is_empty(),
             "unique tmp files must be renamed away"
         );
+    }
+
+    #[test]
+    fn two_writer_merge_keeps_model_and_thought_level() {
+        let dir = tempfile::TempDir::new().unwrap();
+        stamp_identity_cursor(
+            dir.path(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                ..IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        let ready = std::sync::Barrier::new(2);
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                ready.wait();
+                for _ in 0..40 {
+                    stamp_identity_cursor(
+                        dir.path(),
+                        &IdentityCursor {
+                            model: Some("opus".into()),
+                            ..IdentityCursor::default()
+                        },
+                    )
+                    .unwrap();
+                }
+            });
+            scope.spawn(|| {
+                ready.wait();
+                for _ in 0..40 {
+                    stamp_identity_cursor(
+                        dir.path(),
+                        &IdentityCursor {
+                            thought_level: Some("high".into()),
+                            ..IdentityCursor::default()
+                        },
+                    )
+                    .unwrap();
+                }
+            });
+        });
+        let cursor = read_identity_cursor(dir.path());
+        assert_eq!(cursor.provider.as_deref(), Some("anthropic"));
+        assert_eq!(
+            cursor.model.as_deref(),
+            Some("opus"),
+            "StatusLine model must survive a concurrent PreToolUse effort stamp"
+        );
+        assert_eq!(
+            cursor.thought_level.as_deref(),
+            Some("high"),
+            "PreToolUse effort must survive a concurrent StatusLine model stamp"
+        );
+    }
+
+    #[test]
+    fn expire_removes_cursor_so_later_read_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        stamp_identity_cursor(
+            dir.path(),
+            &IdentityCursor {
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                ..IdentityCursor::default()
+            },
+        )
+        .unwrap();
+        expire_identity_cursor(dir.path()).unwrap();
+        assert!(read_identity_cursor(dir.path()).is_empty());
+        assert!(!identity_cursor_path(dir.path()).exists());
     }
 }

--- a/crates/core/src/identity_cursor.rs
+++ b/crates/core/src/identity_cursor.rs
@@ -49,6 +49,10 @@ impl IdentityCursor {
     }
 
     /// Merge an event patch: missing incoming fields keep the last cursor value.
+    ///
+    /// `parent` is the exception: a later parent-session event (incoming
+    /// `session` equals the stored parent, and the patch omits `parent`)
+    /// clears the stale subagent parent instead of keeping it.
     pub fn merge_event(&self, patch: &IdentityCursor) -> Self {
         Self {
             provider: published_owned(patch.provider.clone()).or_else(|| self.provider.clone()),
@@ -56,7 +60,7 @@ impl IdentityCursor {
             thought_level: published_owned(patch.thought_level.clone())
                 .or_else(|| self.thought_level.clone()),
             session: published_owned(patch.session.clone()).or_else(|| self.session.clone()),
-            parent: published_owned(patch.parent.clone()).or_else(|| self.parent.clone()),
+            parent: merge_parent(self, patch),
         }
         .omit_unpublished()
     }
@@ -84,6 +88,21 @@ pub fn published_field(value: Option<&str>) -> Option<&str> {
 
 fn published_owned(value: Option<String>) -> Option<String> {
     published_field(value.as_deref()).map(str::to_string)
+}
+
+fn merge_parent(current: &IdentityCursor, patch: &IdentityCursor) -> Option<String> {
+    if let Some(incoming) = published_owned(patch.parent.clone()) {
+        return Some(incoming);
+    }
+    let incoming_session = published_owned(patch.session.clone());
+    if incoming_session
+        .as_ref()
+        .zip(current.parent.as_ref())
+        .is_some_and(|(session, parent)| session == parent)
+    {
+        return None;
+    }
+    current.parent.clone()
 }
 
 /// Workspace sidecar path.
@@ -250,6 +269,35 @@ mod tests {
         assert_eq!(next.model.as_deref(), Some("opus"));
         assert_eq!(next.thought_level.as_deref(), Some("low"));
         assert_eq!(next.session.as_deref(), Some("sess-1"));
+        assert_eq!(next.parent.as_deref(), Some("agent-1"));
+    }
+
+    #[test]
+    fn parent_session_event_clears_stale_subagent_parent() {
+        let current = IdentityCursor {
+            provider: Some("openai".into()),
+            model: Some("gpt-5.4".into()),
+            thought_level: None,
+            session: Some("sub-1".into()),
+            parent: Some("parent-1".into()),
+        };
+        let back_on_parent = current.merge_event(&IdentityCursor {
+            session: Some("parent-1".into()),
+            ..IdentityCursor::default()
+        });
+        assert_eq!(back_on_parent.session.as_deref(), Some("parent-1"));
+        assert!(
+            back_on_parent.parent.is_none(),
+            "parent-session event must not keep the subagent parent"
+        );
+
+        let still_subagent = current.merge_event(&IdentityCursor {
+            session: Some("sub-1".into()),
+            thought_level: Some("low".into()),
+            ..IdentityCursor::default()
+        });
+        assert_eq!(still_subagent.parent.as_deref(), Some("parent-1"));
+        assert_eq!(still_subagent.thought_level.as_deref(), Some("low"));
     }
 
     #[test]

--- a/crates/core/src/identity_cursor.rs
+++ b/crates/core/src/identity_cursor.rs
@@ -6,7 +6,11 @@
 //! `/model` or `/effort` updates the cursor only; already-captured states
 //! keep the pair they froze.
 
-use std::{fs, io, path::Path};
+use std::{
+    fs, io,
+    path::Path,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -110,15 +114,23 @@ pub fn write_identity_cursor(repo_root: &Path, cursor: &IdentityCursor) -> io::R
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp = dest.with_file_name(".identity.tmp");
+    static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+    let tmp = dest.with_file_name(format!(
+        ".identity.tmp.{}.{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
     let body = cursor
         .clone()
         .omit_unpublished()
         .to_vec()
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-    fs::write(&tmp, body)?;
-    fs::rename(&tmp, dest)?;
-    Ok(())
+    fs::write(&tmp, &body)?;
+    let renamed = fs::rename(&tmp, dest);
+    if renamed.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    renamed
 }
 
 /// Merge `patch` onto the on-disk cursor and publish it.
@@ -250,5 +262,46 @@ mod tests {
         assert!(!raw.contains("thought_level"));
         assert!(!raw.contains("parent"));
         assert_eq!(read_identity_cursor(dir.path()), written);
+    }
+
+    #[test]
+    fn concurrent_stamps_use_unique_tmp_and_leave_valid_cursor() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::thread::scope(|scope| {
+            for i in 0..8 {
+                let root = dir.path();
+                scope.spawn(move || {
+                    stamp_identity_cursor(
+                        root,
+                        &IdentityCursor {
+                            provider: Some("anthropic".into()),
+                            model: Some(format!("m{i}")),
+                            ..IdentityCursor::default()
+                        },
+                    )
+                    .unwrap();
+                });
+            }
+        });
+        let cursor = read_identity_cursor(dir.path());
+        assert_eq!(cursor.provider.as_deref(), Some("anthropic"));
+        assert!(
+            cursor
+                .model
+                .as_deref()
+                .is_some_and(|model| model.starts_with('m')),
+            "last writer must leave a published model, got {:?}",
+            cursor.model
+        );
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .filter(|name| name.to_string_lossy().starts_with(".identity.tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "unique tmp files must be renamed away"
+        );
     }
 }

--- a/crates/core/src/identity_cursor.rs
+++ b/crates/core/src/identity_cursor.rs
@@ -50,9 +50,11 @@ impl IdentityCursor {
 
     /// Merge an event patch: missing incoming fields keep the last cursor value.
     ///
-    /// `parent` is the exception: a later parent-session event (incoming
-    /// `session` equals the stored parent, and the patch omits `parent`)
-    /// clears the stale subagent parent instead of keeping it.
+    /// `parent` is the exception:
+    /// - incoming `parent` equal to incoming `session` is the main agent
+    ///   (Claude omits `agent_id`) and clears a stale subagent parent
+    /// - incoming `session` equal to the stored parent (Codex parent-session)
+    ///   also clears it
     pub fn merge_event(&self, patch: &IdentityCursor) -> Self {
         Self {
             provider: published_owned(patch.provider.clone()).or_else(|| self.provider.clone()),
@@ -91,10 +93,18 @@ fn published_owned(value: Option<String>) -> Option<String> {
 }
 
 fn merge_parent(current: &IdentityCursor, patch: &IdentityCursor) -> Option<String> {
-    if let Some(incoming) = published_owned(patch.parent.clone()) {
+    let incoming_parent = published_owned(patch.parent.clone());
+    let incoming_session = published_owned(patch.session.clone());
+    if incoming_parent
+        .as_ref()
+        .zip(incoming_session.as_ref())
+        .is_some_and(|(parent, session)| parent == session)
+    {
+        return None;
+    }
+    if let Some(incoming) = incoming_parent {
         return Some(incoming);
     }
-    let incoming_session = published_owned(patch.session.clone());
     if incoming_session
         .as_ref()
         .zip(current.parent.as_ref())
@@ -298,6 +308,27 @@ mod tests {
         });
         assert_eq!(still_subagent.parent.as_deref(), Some("parent-1"));
         assert_eq!(still_subagent.thought_level.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn claude_main_agent_event_clears_subagent_parent() {
+        let current = IdentityCursor {
+            provider: Some("anthropic".into()),
+            model: Some("opus".into()),
+            thought_level: None,
+            session: Some("sess-1".into()),
+            parent: Some("agent-sub".into()),
+        };
+        let back_on_main = current.merge_event(&IdentityCursor {
+            session: Some("sess-1".into()),
+            parent: Some("sess-1".into()),
+            ..IdentityCursor::default()
+        });
+        assert_eq!(back_on_main.session.as_deref(), Some("sess-1"));
+        assert!(
+            back_on_main.parent.is_none(),
+            "main-agent event (parent == session) must clear the subagent parent"
+        );
     }
 
     #[test]

--- a/crates/core/src/identity_payload.rs
+++ b/crates/core/src/identity_payload.rs
@@ -193,6 +193,28 @@ mod tests {
     }
 
     #[test]
+    fn opencode_nested_event_properties() {
+        let payload = json!({
+            "event": {
+                "type": "session.updated",
+                "properties": {
+                    "model": {
+                        "id": "claude-sonnet-4-6",
+                        "providerID": "anthropic",
+                        "variant": "max"
+                    },
+                    "sessionID": "ses-nested"
+                }
+            }
+        });
+        let patch = opencode_cursor_patch(&payload);
+        assert_eq!(patch.provider.as_deref(), Some("anthropic"));
+        assert_eq!(patch.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(patch.thought_level.as_deref(), Some("max"));
+        assert_eq!(patch.session.as_deref(), Some("ses-nested"));
+    }
+
+    #[test]
     fn opencode_object_model_and_event_type() {
         let payload = json!({
             "event": {"type": "session.updated"},

--- a/crates/core/src/identity_payload.rs
+++ b/crates/core/src/identity_payload.rs
@@ -44,15 +44,18 @@ pub fn cursor_patch_from_stdin(harness: &str, stdin: &str) -> IdentityCursor {
 ///
 /// Live model is StatusLine `model.id`. Hooks otherwise carry optional model
 /// on SessionStart only. Effort is `{level}` (not a string). Parent is
-/// `agent_id`. Do not invent a model.
+/// `agent_id`. A main-agent event omits `agent_id`, so parent is set to
+/// `session` and merge treats `parent == session` as a clear. Do not invent
+/// a model.
 pub fn claude_cursor_patch(payload: &Value) -> IdentityCursor {
+    let session = first_value_string(payload, &[&["session_id"], &["sessionId"]]);
     IdentityCursor {
         provider: Some("anthropic".to_string()),
         model: value_string_or_named(payload, &["model"], &["id"])
             .or_else(|| value_string(payload, &["model", "display_name"])),
         thought_level: thought_level_from_payload(payload),
-        session: first_value_string(payload, &[&["session_id"], &["sessionId"]]),
-        parent: value_string(payload, &["agent_id"]),
+        session: session.clone(),
+        parent: value_string(payload, &["agent_id"]).or_else(|| session.clone()),
     }
     .omit_unpublished()
 }
@@ -258,6 +261,32 @@ mod tests {
         assert_eq!(patch.thought_level.as_deref(), Some("max"));
         assert_eq!(patch.session.as_deref(), Some("sess-claude"));
         assert_eq!(patch.parent.as_deref(), Some("agent-9"));
+    }
+
+    #[test]
+    fn claude_main_agent_omits_agent_id_and_clears_parent() {
+        let subagent = claude_cursor_patch(&json!({
+            "session_id": "sess-claude",
+            "agent_id": "agent-9"
+        }));
+        let current = IdentityCursor::default().merge_event(&subagent);
+        assert_eq!(current.parent.as_deref(), Some("agent-9"));
+
+        let main = claude_cursor_patch(&json!({
+            "session_id": "sess-claude"
+        }));
+        assert_eq!(main.session.as_deref(), Some("sess-claude"));
+        assert_eq!(
+            main.parent.as_deref(),
+            Some("sess-claude"),
+            "main-agent Claude events signal clear by setting parent to session"
+        );
+        let next = current.merge_event(&main);
+        assert!(
+            next.parent.is_none(),
+            "later main-agent events must not keep the stale subagent parent"
+        );
+        assert_eq!(next.session.as_deref(), Some("sess-claude"));
     }
 
     #[test]

--- a/crates/core/src/identity_payload.rs
+++ b/crates/core/src/identity_payload.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Parse harness hook stdin into an identity-cursor patch.
+//!
+//! Hot path: stdin JSON only. No JSONL, no `session.get`, no disk glob.
+//! Stamp what this event said. Missing fields stay unset so merge keeps
+//! the last cursor value.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::harness_json::{first_value_string, value_string};
+use crate::identity_cursor::{
+    IdentityCursor, published_field, thought_level_from_payload, value_string_or_named,
+};
+
+/// Supported stamp harness names (install + stdin parsers).
+pub fn stamp_harness_name(name: &str) -> Option<&'static str> {
+    match name {
+        "claude" | "claude-code" => Some("claude-code"),
+        "codex" => Some("codex"),
+        "opencode" => Some("opencode"),
+        "pi" => Some("pi"),
+        _ => None,
+    }
+}
+
+/// Parse a hook stdin body for `harness`. Empty / invalid JSON → empty patch.
+pub fn cursor_patch_from_stdin(harness: &str, stdin: &str) -> IdentityCursor {
+    let payload = match serde_json::from_str::<Value>(stdin.trim()) {
+        Ok(value) if !value.is_null() => value,
+        _ => return IdentityCursor::default(),
+    };
+    match stamp_harness_name(harness).unwrap_or(harness) {
+        "claude-code" => claude_cursor_patch(&payload),
+        "codex" => codex_cursor_patch(&payload),
+        "opencode" => opencode_cursor_patch(&payload),
+        "pi" => pi_cursor_patch(&payload),
+        _ => IdentityCursor::default(),
+    }
+}
+
+/// Claude PreToolUse / StatusLine / SessionStart stdin.
+///
+/// Live model is StatusLine `model.id`. Hooks otherwise carry optional model
+/// on SessionStart only. Effort is `{level}` (not a string). Parent is
+/// `agent_id`. Do not invent a model.
+pub fn claude_cursor_patch(payload: &Value) -> IdentityCursor {
+    IdentityCursor {
+        provider: Some("anthropic".to_string()),
+        model: value_string_or_named(payload, &["model"], &["id"])
+            .or_else(|| value_string(payload, &["model", "display_name"])),
+        thought_level: thought_level_from_payload(payload),
+        session: first_value_string(payload, &[&["session_id"], &["sessionId"]]),
+        parent: value_string(payload, &["agent_id"]),
+    }
+    .omit_unpublished()
+}
+
+/// Codex hook stdin: `model` + session. Effort only if present on stdin
+/// (`reasoning_effort` or `turn_context`). Do not read `transcript_path`.
+pub fn codex_cursor_patch(payload: &Value) -> IdentityCursor {
+    IdentityCursor {
+        provider: Some("openai".to_string()),
+        model: value_string_or_named(payload, &["model"], &["id", "slug"]),
+        thought_level: thought_level_from_payload(payload),
+        session: first_value_string(
+            payload,
+            &[&["session_id"], &["sessionId"], &["conversation_id"]],
+        ),
+        parent: first_value_string(payload, &[&["parent_id"], &["parentId"], &["agent_id"]]),
+    }
+    .omit_unpublished()
+}
+
+/// OpenCode event payload. Use `event.type` (not `event.name`). Object
+/// `model` exposes `id` / `providerID` / `variant`.
+pub fn opencode_cursor_patch(payload: &Value) -> IdentityCursor {
+    let nested = payload.get("event").unwrap_or(payload);
+    let properties = nested
+        .get("properties")
+        .or_else(|| payload.get("properties"))
+        .unwrap_or(payload);
+    IdentityCursor {
+        provider: value_string(properties, &["model", "providerID"])
+            .or_else(|| value_string(properties, &["provider"]))
+            .or_else(|| value_string(payload, &["model", "providerID"])),
+        model: value_string_or_named(properties, &["model"], &["id"])
+            .or_else(|| value_string_or_named(payload, &["model"], &["id"])),
+        thought_level: value_string(properties, &["model", "variant"])
+            .or_else(|| thought_level_from_payload(properties))
+            .or_else(|| thought_level_from_payload(payload)),
+        session: first_value_string(
+            payload,
+            &[&["sessionID"], &["session_id"], &["session", "id"]],
+        )
+        .or_else(|| first_value_string(properties, &[&["sessionID"], &["session_id"]])),
+        parent: first_value_string(payload, &[&["parentID"], &["parent_id"]])
+            .or_else(|| first_value_string(properties, &[&["parentID"], &["parent_id"]])),
+    }
+    .omit_unpublished()
+}
+
+/// Pi payload or already-shaped cursor JSON (`PI_*` maps at the caller).
+pub fn pi_cursor_patch(payload: &Value) -> IdentityCursor {
+    IdentityCursor {
+        provider: first_value_string(payload, &[&["provider"], &["PI_PROVIDER"]]),
+        model: first_value_string(payload, &[&["model"], &["PI_MODEL"]]),
+        thought_level: first_value_string(
+            payload,
+            &[&["thought_level"], &["PI_REASONING_LEVEL"], &["variant"]],
+        ),
+        session: first_value_string(
+            payload,
+            &[&["session"], &["PI_SESSION_ID"], &["session_id"]],
+        ),
+        parent: first_value_string(payload, &[&["parent"], &["PI_PARENT_ID"]]),
+    }
+    .omit_unpublished()
+}
+
+/// Child-process fallback env. Claude: session + effort only — never
+/// `$ANTHROPIC_MODEL`. Pi: model + reasoning + session.
+pub fn cursor_patch_from_child_env(env: &BTreeMap<String, String>) -> IdentityCursor {
+    let claude_session = env.get("CLAUDE_CODE_SESSION_ID").cloned();
+    let claude_effort = env.get("CLAUDE_EFFORT").cloned();
+    let pi_model = env.get("PI_MODEL").cloned();
+    let pi_effort = env.get("PI_REASONING_LEVEL").cloned();
+    let pi_session = env.get("PI_SESSION_ID").cloned();
+    let provider = if pi_model.is_some() {
+        env.get("PI_PROVIDER").cloned()
+    } else if claude_session.is_some() || claude_effort.is_some() {
+        Some("anthropic".to_string())
+    } else {
+        None
+    };
+    IdentityCursor {
+        provider,
+        model: pi_model,
+        thought_level: claude_effort.or(pi_effort),
+        session: claude_session.or(pi_session),
+        parent: env.get("PI_PARENT_ID").cloned(),
+    }
+    .omit_unpublished()
+}
+
+/// OpenCode plugin should key on `event.type`, not `event.name`.
+pub fn opencode_event_type(payload: &Value) -> Option<String> {
+    first_value_string(
+        payload,
+        &[&["event", "type"], &["type"], &["event", "name"], &["name"]],
+    )
+    .and_then(|s| published_field(Some(&s)).map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn claude_effort_level_object_and_no_anthropic_model_invent() {
+        let patch = claude_cursor_patch(&json!({
+            "session_id": "sess-claude",
+            "agent_id": "agent-9",
+            "effort": {"level": "max"}
+        }));
+        assert_eq!(patch.provider.as_deref(), Some("anthropic"));
+        assert!(patch.model.is_none());
+        assert_eq!(patch.thought_level.as_deref(), Some("max"));
+        assert_eq!(patch.session.as_deref(), Some("sess-claude"));
+        assert_eq!(patch.parent.as_deref(), Some("agent-9"));
+    }
+
+    #[test]
+    fn claude_status_line_model_id() {
+        let patch = claude_cursor_patch(&json!({
+            "model": {"id": "claude-opus-4-7"}
+        }));
+        assert_eq!(patch.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn child_env_uses_claude_effort_not_anthropic_model() {
+        let mut env = BTreeMap::new();
+        env.insert("ANTHROPIC_MODEL".into(), "claude-sonnet-4-6".into());
+        env.insert("CLAUDE_CODE_SESSION_ID".into(), "sess-env".into());
+        env.insert("CLAUDE_EFFORT".into(), "high".into());
+        let patch = cursor_patch_from_child_env(&env);
+        assert!(patch.model.is_none());
+        assert_eq!(patch.session.as_deref(), Some("sess-env"));
+        assert_eq!(patch.thought_level.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn opencode_object_model_and_event_type() {
+        let payload = json!({
+            "event": {"type": "session.updated"},
+            "model": {
+                "id": "claude-sonnet-4-6",
+                "providerID": "anthropic",
+                "variant": "max"
+            },
+            "sessionID": "ses-1"
+        });
+        assert_eq!(
+            opencode_event_type(&payload).as_deref(),
+            Some("session.updated")
+        );
+        let patch = opencode_cursor_patch(&payload);
+        assert_eq!(patch.provider.as_deref(), Some("anthropic"));
+        assert_eq!(patch.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(patch.thought_level.as_deref(), Some("max"));
+        assert_eq!(patch.session.as_deref(), Some("ses-1"));
+    }
+
+    #[test]
+    fn codex_model_from_stdin_skips_missing_effort() {
+        let patch = cursor_patch_from_stdin(
+            "codex",
+            r#"{"model":"gpt-5.4","session_id":"c1","transcript_path":"/tmp/t.jsonl"}"#,
+        );
+        assert_eq!(patch.model.as_deref(), Some("gpt-5.4"));
+        assert!(patch.thought_level.is_none());
+        assert_eq!(patch.session.as_deref(), Some("c1"));
+    }
+}

--- a/crates/core/src/identity_payload.rs
+++ b/crates/core/src/identity_payload.rs
@@ -144,6 +144,33 @@ pub fn cursor_patch_from_child_env(env: &BTreeMap<String, String>) -> IdentityCu
     .omit_unpublished()
 }
 
+/// SessionEnd / session.deleted / session.closed expire the live cursor.
+pub fn cursor_event_expires(payload: &Value, event_hint: Option<&str>) -> bool {
+    expire_event_name(event_hint)
+        || first_value_string(
+            payload,
+            &[
+                &["hook_event_name"],
+                &["hook_event"],
+                &["event", "type"],
+                &["type"],
+                &["event", "name"],
+                &["name"],
+            ],
+        )
+        .is_some_and(|name| expire_event_name(Some(&name)))
+}
+
+fn expire_event_name(name: Option<&str>) -> bool {
+    let Some(name) = published_field(name) else {
+        return false;
+    };
+    matches!(
+        name,
+        "SessionEnd" | "session.end" | "session.deleted" | "session.closed" | "session.idle"
+    ) || name.eq_ignore_ascii_case("sessionend")
+}
+
 /// OpenCode plugin should key on `event.type`, not `event.name`.
 pub fn opencode_event_type(payload: &Value) -> Option<String> {
     first_value_string(
@@ -157,6 +184,27 @@ pub fn opencode_event_type(payload: &Value) -> Option<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn session_end_payload_expires_cursor() {
+        assert!(cursor_event_expires(
+            &json!({"hook_event_name": "SessionEnd", "session_id": "s1"}),
+            None
+        ));
+        assert!(cursor_event_expires(
+            &json!({"event": {"type": "session.deleted"}}),
+            None
+        ));
+        assert!(cursor_event_expires(&json!({}), Some("SessionEnd")));
+        assert!(!cursor_event_expires(
+            &json!({"hook_event_name": "PreToolUse"}),
+            None
+        ));
+        assert!(!cursor_event_expires(
+            &json!({"event": {"type": "session.updated"}}),
+            None
+        ));
+    }
 
     #[test]
     fn claude_effort_level_object_and_no_anthropic_model_invent() {

--- a/crates/core/src/identity_payload.rs
+++ b/crates/core/src/identity_payload.rs
@@ -147,18 +147,35 @@ pub fn cursor_patch_from_child_env(env: &BTreeMap<String, String>) -> IdentityCu
 /// SessionEnd / session.deleted / session.closed expire the live cursor.
 pub fn cursor_event_expires(payload: &Value, event_hint: Option<&str>) -> bool {
     expire_event_name(event_hint)
-        || first_value_string(
-            payload,
-            &[
-                &["hook_event_name"],
-                &["hook_event"],
-                &["event", "type"],
-                &["type"],
-                &["event", "name"],
-                &["name"],
-            ],
-        )
-        .is_some_and(|name| expire_event_name(Some(&name)))
+        || event_name_from_payload(payload).is_some_and(|name| expire_event_name(Some(&name)))
+}
+
+/// Stamp-path expire: SessionEnd-class events, plus Codex `Stop`.
+///
+/// Codex has no SessionEnd. Claude `Stop` is turn-end and stays on relay.
+pub fn stamp_event_expires(harness: &str, payload: &Value, event_hint: Option<&str>) -> bool {
+    if cursor_event_expires(payload, event_hint) {
+        return true;
+    }
+    if stamp_harness_name(harness) != Some("codex") {
+        return false;
+    }
+    expire_codex_stop(event_hint)
+        || event_name_from_payload(payload).is_some_and(|name| expire_codex_stop(Some(&name)))
+}
+
+fn event_name_from_payload(payload: &Value) -> Option<String> {
+    first_value_string(
+        payload,
+        &[
+            &["hook_event_name"],
+            &["hook_event"],
+            &["event", "type"],
+            &["type"],
+            &["event", "name"],
+            &["name"],
+        ],
+    )
 }
 
 fn expire_event_name(name: Option<&str>) -> bool {
@@ -169,6 +186,10 @@ fn expire_event_name(name: Option<&str>) -> bool {
         name,
         "SessionEnd" | "session.end" | "session.deleted" | "session.closed" | "session.idle"
     ) || name.eq_ignore_ascii_case("sessionend")
+}
+
+fn expire_codex_stop(name: Option<&str>) -> bool {
+    published_field(name).is_some_and(|name| name == "Stop")
 }
 
 /// OpenCode plugin should key on `event.type`, not `event.name`.
@@ -202,6 +223,25 @@ mod tests {
         ));
         assert!(!cursor_event_expires(
             &json!({"event": {"type": "session.updated"}}),
+            None
+        ));
+        assert!(stamp_event_expires(
+            "codex",
+            &json!({"hook_event_name": "Stop", "session_id": "c1"}),
+            None
+        ));
+        assert!(stamp_event_expires("codex", &json!({}), Some("Stop")));
+        assert!(
+            !stamp_event_expires(
+                "claude-code",
+                &json!({"hook_event_name": "Stop", "session_id": "s1"}),
+                None
+            ),
+            "Claude Stop is turn-end; only SessionEnd expires the cursor"
+        );
+        assert!(!stamp_event_expires(
+            "codex",
+            &json!({"hook_event_name": "PreToolUse"}),
             None
         ));
     }

--- a/crates/core/src/integration_plan.rs
+++ b/crates/core/src/integration_plan.rs
@@ -91,13 +91,19 @@ pub fn classify_command_path_mode(cmd: &str) -> PathModeKind {
     }
 }
 
-/// Probe OpenCode plugin script text for relative vs absolute `Bun.spawnSync`.
+/// Probe OpenCode plugin script text for relative vs absolute Bun spawn.
 pub fn classify_opencode_plugin_path_mode(contents: &str) -> Option<PathModeKind> {
-    if contents.contains("Bun.spawnSync([\"heddle\"")
+    let relative = contents.contains("Bun.spawnSync([\"heddle\"")
         || contents.contains("Bun.spawnSync(['heddle'")
-    {
+        || contents.contains("Bun.spawn([\"heddle\"")
+        || contents.contains("Bun.spawn(['heddle'");
+    let absolute = contents.contains("Bun.spawnSync([\"/")
+        || contents.contains("Bun.spawnSync(['/")
+        || contents.contains("Bun.spawn([\"/")
+        || contents.contains("Bun.spawn(['/");
+    if relative {
         Some(PathModeKind::Relative)
-    } else if contents.contains("Bun.spawnSync([\"/") || contents.contains("Bun.spawnSync(['/") {
+    } else if absolute {
         Some(PathModeKind::Absolute)
     } else {
         None
@@ -212,14 +218,15 @@ pub fn plan_harness_selection(
     }
 }
 
-/// Whether a claude settings body still contains the Heddle relay marker.
+/// Whether a claude settings body still contains a Heddle hook marker.
 pub fn claude_settings_has_relay(contents: &str) -> bool {
     contents.contains("heddle integration relay claude-code")
+        || contents.contains("integration stamp claude-code")
 }
 
-/// Whether a codex config body still contains the Heddle notify marker.
+/// Whether a codex config body still contains a Heddle hook marker.
 pub fn codex_config_has_relay(contents: &str) -> bool {
-    contents.contains("integration relay codex notify")
+    contents.contains("integration stamp codex") || contents.contains("integration relay codex")
 }
 
 /// Timeline capability path filter for opencode installs.
@@ -410,8 +417,10 @@ mod tests {
         assert!(claude_settings_has_relay(
             "heddle integration relay claude-code SessionStart"
         ));
+        assert!(claude_settings_has_relay("integration stamp claude-code"));
         assert!(!claude_settings_has_relay("{}"));
         assert!(codex_config_has_relay("integration relay codex notify"));
+        assert!(codex_config_has_relay("integration stamp codex"));
         assert!(is_timeline_capability_path(
             "/repo/.opencode/plugins/heddle.timeline.json"
         ));

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -151,9 +151,9 @@ pub use harness_json::{
 pub use harness_policy::{
     ExplicitAgentBind, HarnessFingerprint, HarnessKind, HarnessProbeDecision, SegmentRotation,
     SessionAttachDecision, SessionAttachFacts, SessionAttachRule, SessionLookupFact, SessionPolicy,
-    TokenSidFact, WorktreeSessionFact, cursor_segment_rotation, decide_harness_probe,
-    decide_session_attach, detect_harness_kind, fingerprint_harness_from_hints,
-    segment_rotation_policy, should_rotate_segment,
+    TokenSidFact, WorktreeSessionFact, attach_published_segment_fields, cursor_segment_rotation,
+    decide_harness_probe, decide_session_attach, detect_harness_kind,
+    fingerprint_harness_from_hints, segment_rotation_policy, should_rotate_segment,
 };
 pub use hook_plan::{
     HookInstallSourceKind, HookInstallSourcePlan, hook_install_empty_stdin_kind,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -160,13 +160,14 @@ pub use hook_plan::{
     hook_install_source_required_kind, hook_unknown_kind, plan_hook_install_source,
 };
 pub use identity_cursor::{
-    IDENTITY_CURSOR_FILE, IdentityCursor, harness_kind_from_basename, identity_cursor_path,
-    published_field, read_identity_cursor, stamp_identity_cursor, thought_level_from_payload,
-    value_string_or_named, write_identity_cursor,
+    IDENTITY_CURSOR_FILE, IdentityCursor, expire_identity_cursor, harness_kind_from_basename,
+    identity_cursor_path, published_field, read_identity_cursor, stamp_identity_cursor,
+    thought_level_from_payload, value_string_or_named, write_identity_cursor,
 };
 pub use identity_payload::{
-    claude_cursor_patch, codex_cursor_patch, cursor_patch_from_child_env, cursor_patch_from_stdin,
-    opencode_cursor_patch, opencode_event_type, pi_cursor_patch, stamp_harness_name,
+    claude_cursor_patch, codex_cursor_patch, cursor_event_expires, cursor_patch_from_child_env,
+    cursor_patch_from_stdin, opencode_cursor_patch, opencode_event_type, pi_cursor_patch,
+    stamp_harness_name,
 };
 pub use init_plan::{
     InitPrincipalPlan, SET_PRINCIPAL_COMMAND, init_recommended_action, init_side_effects,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod git_projection_io_plan;
 pub mod harness_json;
 pub mod harness_policy;
 pub mod hook_plan;
+pub mod identity_cursor;
+pub mod identity_payload;
 pub mod index_plan;
 pub mod init_plan;
 pub mod integration_plan;
@@ -149,13 +151,22 @@ pub use harness_json::{
 pub use harness_policy::{
     ExplicitAgentBind, HarnessFingerprint, HarnessKind, HarnessProbeDecision, SegmentRotation,
     SessionAttachDecision, SessionAttachFacts, SessionAttachRule, SessionLookupFact, SessionPolicy,
-    TokenSidFact, WorktreeSessionFact, decide_harness_probe, decide_session_attach,
-    detect_harness_kind, fingerprint_harness_from_hints, segment_rotation_policy,
-    should_rotate_segment,
+    TokenSidFact, WorktreeSessionFact, cursor_segment_rotation, decide_harness_probe,
+    decide_session_attach, detect_harness_kind, fingerprint_harness_from_hints,
+    segment_rotation_policy, should_rotate_segment,
 };
 pub use hook_plan::{
     HookInstallSourceKind, HookInstallSourcePlan, hook_install_empty_stdin_kind,
     hook_install_source_required_kind, hook_unknown_kind, plan_hook_install_source,
+};
+pub use identity_cursor::{
+    IDENTITY_CURSOR_FILE, IdentityCursor, harness_kind_from_basename, identity_cursor_path,
+    published_field, read_identity_cursor, stamp_identity_cursor, thought_level_from_payload,
+    value_string_or_named, write_identity_cursor,
+};
+pub use identity_payload::{
+    claude_cursor_patch, codex_cursor_patch, cursor_patch_from_child_env, cursor_patch_from_stdin,
+    opencode_cursor_patch, opencode_event_type, pi_cursor_patch, stamp_harness_name,
 };
 pub use init_plan::{
     InitPrincipalPlan, SET_PRINCIPAL_COMMAND, init_recommended_action, init_side_effects,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -167,7 +167,7 @@ pub use identity_cursor::{
 pub use identity_payload::{
     claude_cursor_patch, codex_cursor_patch, cursor_event_expires, cursor_patch_from_child_env,
     cursor_patch_from_stdin, opencode_cursor_patch, opencode_event_type, pi_cursor_patch,
-    stamp_harness_name,
+    stamp_event_expires, stamp_harness_name,
 };
 pub use init_plan::{
     InitPrincipalPlan, SET_PRINCIPAL_COMMAND, init_recommended_action, init_side_effects,

--- a/crates/object-model/src/compact/dictionary.rs
+++ b/crates/object-model/src/compact/dictionary.rs
@@ -14,6 +14,8 @@ pub(super) struct AgentKey {
     pub(super) session_id: Option<Vec<u8>>,
     pub(super) segment_id: Option<Vec<u8>>,
     pub(super) policy_id: Option<Vec<u8>>,
+    pub(super) thought_level: Option<Vec<u8>>,
+    pub(super) parent: Option<Vec<u8>>,
 }
 
 pub(super) struct StateDictionaries {
@@ -90,5 +92,10 @@ fn agent_key(value: &Agent) -> AgentKey {
             .policy_id
             .as_ref()
             .map(|value| value.as_bytes().to_vec()),
+        thought_level: value
+            .thought_level
+            .as_ref()
+            .map(|value| value.as_bytes().to_vec()),
+        parent: value.parent.as_ref().map(|value| value.as_bytes().to_vec()),
     }
 }

--- a/crates/object-model/src/compact/extract.rs
+++ b/crates/object-model/src/compact/extract.rs
@@ -11,7 +11,11 @@ use crate::object::{State, StateId};
 pub fn extract_state(bytes: &[u8], expected: StateId) -> Result<State> {
     decode_state_frame(bytes)?
         .into_iter()
-        .find(|state| state.id() == expected)
+        .find(|state| state.accepts_stored_id(&expected))
+        .map(|mut state| {
+            state.state_id = expected;
+            state
+        })
         .ok_or(CompactError::Missing)
 }
 

--- a/crates/object-model/src/compact/limits.rs
+++ b/crates/object-model/src/compact/limits.rs
@@ -34,7 +34,7 @@ pub(super) const MIN_EXTRA_HEADER_BYTES: usize = 2;
 pub(super) const MIN_LINEAGE_BYTES: usize = 1 + 16 + 32;
 pub(super) const MIN_VERIFICATION_CUSTOM_BYTES: usize = 2;
 pub(super) const MIN_PRINCIPAL_BYTES: usize = 2;
-pub(super) const MIN_AGENT_BYTES: usize = 5;
+pub(super) const MIN_AGENT_BYTES: usize = 7;
 
 /// Reject a declared count before any `Vec::with_capacity` or `blank_state`.
 pub(super) fn admit_count(

--- a/crates/object-model/src/compact/state.rs
+++ b/crates/object-model/src/compact/state.rs
@@ -189,6 +189,8 @@ fn encode_dictionaries(output: &mut Writer, dictionaries: &StateDictionaries) {
         output.put_optional_bytes(agent.session_id.as_deref());
         output.put_optional_bytes(agent.segment_id.as_deref());
         output.put_optional_bytes(agent.policy_id.as_deref());
+        output.put_optional_bytes(agent.thought_level.as_deref());
+        output.put_optional_bytes(agent.parent.as_deref());
     }
 }
 

--- a/crates/object-model/src/compact/state.rs
+++ b/crates/object-model/src/compact/state.rs
@@ -9,15 +9,25 @@ use super::{
 };
 use crate::object::{ChangeLineageKind, State};
 
-pub(super) const STATE_MAGIC: &[u8; 4] = b"HCS1";
+pub(super) const STATE_MAGIC_V1: &[u8; 4] = b"HCS1";
+pub(super) const STATE_MAGIC: &[u8; 4] = b"HCS2";
 
-/// Whether `bytes` begin with the compact-state frame discriminator.
+/// Whether `bytes` begin with a compact-state frame discriminator.
 pub fn is_state_frame(bytes: &[u8]) -> bool {
-    bytes.starts_with(STATE_MAGIC)
+    bytes.starts_with(STATE_MAGIC) || bytes.starts_with(STATE_MAGIC_V1)
 }
 
 /// Encode states as lossless columns, omitting only the derivable state id.
 pub fn encode_state_frame(states: &[State]) -> Result<Vec<u8>> {
+    encode_state_frame_versioned(states, STATE_MAGIC)
+}
+
+#[cfg(test)]
+pub(super) fn encode_state_frame_hcs1(states: &[State]) -> Result<Vec<u8>> {
+    encode_state_frame_versioned(states, STATE_MAGIC_V1)
+}
+
+fn encode_state_frame_versioned(states: &[State], magic: &[u8; 4]) -> Result<Vec<u8>> {
     if states.len() > MAX_COMPACT_STATE_COUNT {
         return Err(invalid(format!(
             "state frame count {} exceeds maximum {MAX_COMPACT_STATE_COUNT}",
@@ -25,9 +35,9 @@ pub fn encode_state_frame(states: &[State]) -> Result<Vec<u8>> {
         )));
     }
     let dictionaries = StateDictionaries::from_states(states);
-    let mut output = Writer::new(STATE_MAGIC);
+    let mut output = Writer::new(magic);
     output.put_u64(states.len() as u64);
-    encode_dictionaries(&mut output, &dictionaries);
+    encode_dictionaries(&mut output, &dictionaries, magic == STATE_MAGIC);
     encode_structure(&mut output, states);
     encode_attribution(&mut output, states, &dictionaries);
     encode_intent_and_verification(&mut output, states)?;
@@ -176,7 +186,11 @@ fn encode_verification(output: &mut Writer, state: &State) -> Result<()> {
     Ok(())
 }
 
-fn encode_dictionaries(output: &mut Writer, dictionaries: &StateDictionaries) {
+fn encode_dictionaries(
+    output: &mut Writer,
+    dictionaries: &StateDictionaries,
+    include_cursor_fields: bool,
+) {
     output.put_u64(dictionaries.principals.len() as u64);
     for PrincipalKey(name, email) in &dictionaries.principals {
         output.put_bytes(name);
@@ -189,8 +203,10 @@ fn encode_dictionaries(output: &mut Writer, dictionaries: &StateDictionaries) {
         output.put_optional_bytes(agent.session_id.as_deref());
         output.put_optional_bytes(agent.segment_id.as_deref());
         output.put_optional_bytes(agent.policy_id.as_deref());
-        output.put_optional_bytes(agent.thought_level.as_deref());
-        output.put_optional_bytes(agent.parent.as_deref());
+        if include_cursor_fields {
+            output.put_optional_bytes(agent.thought_level.as_deref());
+            output.put_optional_bytes(agent.parent.as_deref());
+        }
     }
 }
 

--- a/crates/object-model/src/compact/state.rs
+++ b/crates/object-model/src/compact/state.rs
@@ -18,6 +18,10 @@ pub fn is_state_frame(bytes: &[u8]) -> bool {
 }
 
 /// Encode states as lossless columns, omitting only the derivable state id.
+///
+/// Format-4 agent states keep their accepted stored id through
+/// [`crate::object::State::accepts_stored_id`] after decode; the frame
+/// stays HCS2.
 pub fn encode_state_frame(states: &[State]) -> Result<Vec<u8>> {
     encode_state_frame_versioned(states, STATE_MAGIC)
 }

--- a/crates/object-model/src/compact/state_decode.rs
+++ b/crates/object-model/src/compact/state_decode.rs
@@ -14,7 +14,7 @@ use super::{
         MIN_PRINCIPAL_BYTES, MIN_STATE_COLUMN_BYTES, MIN_STATE_PARENT_BYTES,
         MIN_VERIFICATION_CUSTOM_BYTES, admit_count,
     },
-    state::STATE_MAGIC,
+    state::{STATE_MAGIC, STATE_MAGIC_V1},
 };
 use crate::object::{
     Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal, State,
@@ -23,9 +23,10 @@ use crate::object::{
 
 /// Decode and whole-frame-verify every state, recomputing each state id.
 pub fn decode_state_frame(bytes: &[u8]) -> Result<Vec<State>> {
-    let mut input = Reader::verified(bytes, STATE_MAGIC)?;
+    let magic = state_frame_magic(bytes)?;
+    let mut input = Reader::verified(bytes, magic)?;
     let count = input.get_count_at_most("state frame", 1, MAX_COMPACT_STATE_COUNT)?;
-    let (principals, agents) = decode_dictionaries(&mut input)?;
+    let (principals, agents) = decode_dictionaries(&mut input, magic == STATE_MAGIC)?;
     admit_count(
         "state frame",
         count,
@@ -212,11 +213,29 @@ fn decode_verification(input: &mut Reader<'_>) -> Result<Option<Verification>> {
     }
 }
 
-fn decode_dictionaries(input: &mut Reader<'_>) -> Result<(Vec<Principal>, Vec<Agent>)> {
+fn state_frame_magic(bytes: &[u8]) -> Result<&'static [u8; 4]> {
+    if bytes.starts_with(STATE_MAGIC) {
+        Ok(STATE_MAGIC)
+    } else if bytes.starts_with(STATE_MAGIC_V1) {
+        Ok(STATE_MAGIC_V1)
+    } else {
+        Err(invalid("frame magic does not match its object kind"))
+    }
+}
+
+fn decode_dictionaries(
+    input: &mut Reader<'_>,
+    include_cursor_fields: bool,
+) -> Result<(Vec<Principal>, Vec<Agent>)> {
     let principals = (0..input.get_count("principal dictionary", MIN_PRINCIPAL_BYTES)?)
         .map(|_| principal_from_key(PrincipalKey(input.get_bytes()?, input.get_bytes()?)))
         .collect::<Result<Vec<_>>>()?;
-    let agents = (0..input.get_count("agent dictionary", MIN_AGENT_BYTES)?)
+    let min_agent_bytes = if include_cursor_fields {
+        MIN_AGENT_BYTES
+    } else {
+        MIN_AGENT_BYTES.saturating_sub(2)
+    };
+    let agents = (0..input.get_count("agent dictionary", min_agent_bytes)?)
         .map(|_| {
             agent_from_key(AgentKey {
                 provider: input.get_bytes()?,
@@ -224,8 +243,16 @@ fn decode_dictionaries(input: &mut Reader<'_>) -> Result<(Vec<Principal>, Vec<Ag
                 session_id: input.get_optional_bytes()?,
                 segment_id: input.get_optional_bytes()?,
                 policy_id: input.get_optional_bytes()?,
-                thought_level: input.get_optional_bytes()?,
-                parent: input.get_optional_bytes()?,
+                thought_level: if include_cursor_fields {
+                    input.get_optional_bytes()?
+                } else {
+                    None
+                },
+                parent: if include_cursor_fields {
+                    input.get_optional_bytes()?
+                } else {
+                    None
+                },
             })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/object-model/src/compact/state_decode.rs
+++ b/crates/object-model/src/compact/state_decode.rs
@@ -245,6 +245,8 @@ fn agent_from_key(value: AgentKey) -> Result<Agent> {
         session_id: optional_string(value.session_id, "agent session id")?,
         segment_id: optional_string(value.segment_id, "agent segment id")?,
         policy_id: optional_string(value.policy_id, "agent policy id")?,
+        thought_level: None,
+        parent: None,
     })
 }
 

--- a/crates/object-model/src/compact/state_decode.rs
+++ b/crates/object-model/src/compact/state_decode.rs
@@ -224,6 +224,8 @@ fn decode_dictionaries(input: &mut Reader<'_>) -> Result<(Vec<Principal>, Vec<Ag
                 session_id: input.get_optional_bytes()?,
                 segment_id: input.get_optional_bytes()?,
                 policy_id: input.get_optional_bytes()?,
+                thought_level: input.get_optional_bytes()?,
+                parent: input.get_optional_bytes()?,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -245,8 +247,8 @@ fn agent_from_key(value: AgentKey) -> Result<Agent> {
         session_id: optional_string(value.session_id, "agent session id")?,
         segment_id: optional_string(value.segment_id, "agent segment id")?,
         policy_id: optional_string(value.policy_id, "agent policy id")?,
-        thought_level: None,
-        parent: None,
+        thought_level: optional_string(value.thought_level, "agent thought_level")?,
+        parent: optional_string(value.parent, "agent parent")?,
     })
 }
 

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -7,7 +7,8 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
     CompactError, decode_blob_frame, decode_state_frame, decode_tree_frame, encode_blob_frame,
-    encode_state_frame, encode_tree_frame, extract_state, extract_tree,
+    encode_state_frame, encode_tree_frame, extract_state, extract_tree, is_state_frame,
+    state::{STATE_MAGIC, STATE_MAGIC_V1, encode_state_frame_hcs1},
 };
 use crate::object::{
     Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal,
@@ -213,11 +214,49 @@ fn compact_and_hash_include_thought_level_and_parent() {
         "thought_level and parent must not be interchangeable in the hash"
     );
     let encoded = encode_state_frame(&[with.clone()]).unwrap();
+    assert!(
+        encoded.starts_with(STATE_MAGIC),
+        "current encode must use the HCS2 cursor dictionary"
+    );
     let decoded = decode_state_frame(&encoded).unwrap();
     let agent = decoded[0].attribution.agent.as_ref().unwrap();
     assert_eq!(agent.thought_level.as_deref(), Some("high"));
     assert_eq!(agent.parent.as_deref(), Some("agent-1"));
     assert_eq!(decoded[0].id(), with.id());
+}
+
+#[test]
+fn hcs1_agent_frames_keep_the_five_field_dictionary() {
+    let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let mut state = State::new(
+        ContentHash::from_bytes([70; 32]),
+        Vec::new(),
+        Attribution::with_agent(
+            Principal::new("Author", "author@example.com"),
+            Agent::new("anthropic", "opus"),
+        ),
+    );
+    state.created_at = created_at;
+    state.state_id = state.pre_cursor_id();
+    let encoded = encode_state_frame_hcs1(&[state.clone()]).unwrap();
+    assert!(
+        encoded.starts_with(STATE_MAGIC_V1),
+        "format-4 packs keep HCS1 magic, got {:x?}",
+        &encoded[..4.min(encoded.len())]
+    );
+    assert!(is_state_frame(&encoded));
+    let decoded = decode_state_frame(&encoded).unwrap();
+    let agent = decoded[0].attribution.agent.as_ref().unwrap();
+    assert_eq!(agent.provider, "anthropic");
+    assert_eq!(agent.model, "opus");
+    assert!(agent.thought_level.is_none());
+    assert!(agent.parent.is_none());
+    assert!(
+        decoded[0].accepts_stored_id(&state.pre_cursor_id()),
+        "HCS1 decode must not desync into the seven-field dictionary"
+    );
+    let extracted = extract_state(&encoded, state.pre_cursor_id()).unwrap();
+    assert_eq!(extracted.state_id, state.pre_cursor_id());
 }
 
 #[test]

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -177,6 +177,41 @@ fn compact_and_hash_include_thought_level_and_parent() {
         with.id(),
         "thought_level and parent must participate in the state hash"
     );
+    let mut thought_only = State::new(
+        tree,
+        Vec::new(),
+        Attribution::with_agent(
+            Principal::new("Author", "author@example.com"),
+            Agent::new("anthropic", "opus").with_thought_level("high"),
+        ),
+    );
+    thought_only.created_at = created_at;
+    thought_only.state_id = thought_only.id();
+    let mut parent_only = State::new(
+        tree,
+        Vec::new(),
+        Attribution::with_agent(
+            Principal::new("Author", "author@example.com"),
+            Agent::new("anthropic", "opus").with_parent("agent-1"),
+        ),
+    );
+    parent_only.created_at = created_at;
+    parent_only.state_id = parent_only.id();
+    assert_ne!(
+        without.id(),
+        thought_only.id(),
+        "changing thought_level must change the state id"
+    );
+    assert_ne!(
+        without.id(),
+        parent_only.id(),
+        "changing parent must change the state id"
+    );
+    assert_ne!(
+        thought_only.id(),
+        parent_only.id(),
+        "thought_level and parent must not be interchangeable in the hash"
+    );
     let encoded = encode_state_frame(&[with.clone()]).unwrap();
     let decoded = decode_state_frame(&encoded).unwrap();
     let agent = decoded[0].attribution.agent.as_ref().unwrap();

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -53,7 +53,9 @@ fn state_frame_round_trips_every_fidelity_field_and_recomputes_id() {
     let committer = Principal::new("Committer", "committer@example.com");
     let agent = Agent::new("openai", "gpt-test")
         .with_session("session", "segment")
-        .with_policy("policy");
+        .with_policy("policy")
+        .with_thought_level("high")
+        .with_parent("agent-1");
     let mut custom = BTreeMap::new();
     custom.insert(
         "nested".to_string(),
@@ -113,6 +115,26 @@ fn state_frame_round_trips_every_fidelity_field_and_recomputes_id() {
             rmp_serde::to_vec_named(expected).unwrap()
         );
     }
+    assert_eq!(
+        decoded[0]
+            .attribution
+            .agent
+            .as_ref()
+            .unwrap()
+            .thought_level
+            .as_deref(),
+        Some("high")
+    );
+    assert_eq!(
+        decoded[0]
+            .attribution
+            .agent
+            .as_ref()
+            .unwrap()
+            .parent
+            .as_deref(),
+        Some("agent-1")
+    );
     assert_eq!(decoded[0].confidence.unwrap().to_bits(), 0x7fc0_0123);
     assert_eq!(
         decoded[0]
@@ -124,6 +146,43 @@ fn state_frame_round_trips_every_fidelity_field_and_recomputes_id() {
             .to_bits(),
         0xffc0_0456
     );
+}
+
+#[test]
+fn compact_and_hash_include_thought_level_and_parent() {
+    let principal = Principal::new("Author", "author@example.com");
+    let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let tree = ContentHash::from_bytes([70; 32]);
+    let mut without = State::new(
+        tree,
+        Vec::new(),
+        Attribution::with_agent(principal.clone(), Agent::new("anthropic", "opus")),
+    );
+    without.created_at = created_at;
+    without.state_id = without.id();
+    let mut with = State::new(
+        tree,
+        Vec::new(),
+        Attribution::with_agent(
+            principal,
+            Agent::new("anthropic", "opus")
+                .with_thought_level("high")
+                .with_parent("agent-1"),
+        ),
+    );
+    with.created_at = created_at;
+    with.state_id = with.id();
+    assert_ne!(
+        without.id(),
+        with.id(),
+        "thought_level and parent must participate in the state hash"
+    );
+    let encoded = encode_state_frame(&[with.clone()]).unwrap();
+    let decoded = decode_state_frame(&encoded).unwrap();
+    let agent = decoded[0].attribution.agent.as_ref().unwrap();
+    assert_eq!(agent.thought_level.as_deref(), Some("high"));
+    assert_eq!(agent.parent.as_deref(), Some("agent-1"));
+    assert_eq!(decoded[0].id(), with.id());
 }
 
 #[test]

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -260,6 +260,35 @@ fn hcs1_agent_frames_keep_the_five_field_dictionary() {
 }
 
 #[test]
+fn hcs2_repack_accepts_format4_agent_stored_id() {
+    let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let mut state = State::new(
+        ContentHash::from_bytes([71; 32]),
+        Vec::new(),
+        Attribution::with_agent(
+            Principal::new("Author", "author@example.com"),
+            Agent::new("anthropic", "opus"),
+        ),
+    );
+    state.created_at = created_at;
+    let stored_id = state.pre_cursor_id();
+    state.state_id = stored_id;
+    let encoded = encode_state_frame(&[state.clone()]).unwrap();
+    assert!(
+        encoded.starts_with(STATE_MAGIC),
+        "current encode must stay HCS2, got {:x?}",
+        &encoded[..4.min(encoded.len())]
+    );
+    let decoded = decode_state_frame(&encoded).unwrap();
+    assert!(
+        decoded[0].accepts_stored_id(&stored_id),
+        "HCS2 decode must keep the accepted format-4 stored id"
+    );
+    let extracted = extract_state(&encoded, stored_id).unwrap();
+    assert_eq!(extracted.state_id, stored_id);
+}
+
+#[test]
 fn corrupt_frame_byte_rejects_every_contained_object() {
     let hash = ContentHash::from_bytes([21; 32]);
     let trees = vec![

--- a/crates/object-model/src/object/session.rs
+++ b/crates/object-model/src/object/session.rs
@@ -43,6 +43,7 @@ impl Session {
             model,
             started_at: Utc::now(),
             policy_id,
+            thought_level: None,
         };
         Self {
             id,
@@ -78,10 +79,28 @@ impl Session {
             model,
             started_at: Utc::now(),
             policy_id,
+            thought_level: None,
         };
         self.segments.push(segment);
         self.current_segment_id = Some(segment_id);
         self.segments.last().expect("segment was just pushed")
+    }
+
+    /// Attach unpublished thought_level onto the current segment (empty → set).
+    pub fn attach_thought_level(&mut self, thought_level: impl Into<String>) {
+        let Some(id) = self.current_segment_id.clone() else {
+            return;
+        };
+        if let Some(segment) = self.segments.iter_mut().find(|segment| segment.id == id)
+            && segment.thought_level.is_none()
+        {
+            segment.thought_level = Some(thought_level.into());
+        }
+    }
+
+    pub fn current_segment_mut(&mut self) -> Option<&mut SessionSegment> {
+        let id = self.current_segment_id.as_ref()?;
+        self.segments.iter_mut().find(|segment| &segment.id == id)
     }
 
     pub fn end(&mut self) {
@@ -97,6 +116,9 @@ pub struct SessionSegment {
     pub model: String,
     pub started_at: DateTime<Utc>,
     pub policy_id: Option<String>,
+    /// Published thought_level for this segment. Empty → set attaches in place.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_level: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/object-model/src/object/state_attribution.rs
+++ b/crates/object-model/src/object/state_attribution.rs
@@ -66,6 +66,12 @@ pub struct Agent {
     pub segment_id: Option<String>,
     /// Policy or prompt template identifier.
     pub policy_id: Option<String>,
+    /// Frozen harness thought_level (ACP name: Claude effort, Codex reasoning, OpenCode variant).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_level: Option<String>,
+    /// Frozen harness parent actor / agent_id (ACP name).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
 }
 
 impl Agent {
@@ -77,6 +83,8 @@ impl Agent {
             session_id: None,
             segment_id: None,
             policy_id: None,
+            thought_level: None,
+            parent: None,
         }
     }
 
@@ -110,7 +118,21 @@ impl Agent {
             session_id,
             segment_id,
             policy_id,
+            thought_level: None,
+            parent: None,
         })
+    }
+
+    /// Freeze a published thought_level onto this agent.
+    pub fn with_thought_level(mut self, thought_level: impl Into<String>) -> Self {
+        self.thought_level = Some(thought_level.into());
+        self
+    }
+
+    /// Freeze a published parent actor onto this agent.
+    pub fn with_parent(mut self, parent: impl Into<String>) -> Self {
+        self.parent = Some(parent.into());
+        self
     }
 }
 

--- a/crates/object-model/src/object/state_core.rs
+++ b/crates/object-model/src/object/state_core.rs
@@ -580,6 +580,16 @@ impl State {
             if let Some(policy_id) = &agent.policy_id {
                 len += policy_id.len() as u64 + 1;
             }
+
+            len += 1;
+            if let Some(thought_level) = &agent.thought_level {
+                len += thought_level.len() as u64 + 1;
+            }
+
+            len += 1;
+            if let Some(parent) = &agent.parent {
+                len += parent.len() as u64 + 1;
+            }
         }
 
         len += 1;
@@ -683,6 +693,8 @@ impl State {
             write_optional_string(hasher, &agent.session_id);
             write_optional_string(hasher, &agent.segment_id);
             write_optional_string(hasher, &agent.policy_id);
+            write_optional_string(hasher, &agent.thought_level);
+            write_optional_string(hasher, &agent.parent);
         } else {
             hasher.update(&[0]);
         }

--- a/crates/object-model/src/object/state_core.rs
+++ b/crates/object-model/src/object/state_core.rs
@@ -547,6 +547,20 @@ impl State {
         unpublished_cursor && self.pre_cursor_id() == *stored
     }
 
+    /// Content hash that produced `stored` when this state accepts that id.
+    ///
+    /// Format-4 agent states keep a pre-cursor id. Verification and re-signing
+    /// must use that hash, not the current format-5 [`Self::compute_hash`].
+    pub fn hash_for_stored_id(&self, stored: &StateId) -> ContentHash {
+        if self.id() == *stored {
+            self.compute_hash()
+        } else if self.accepts_stored_id(stored) {
+            self.compute_pre_cursor_hash()
+        } else {
+            self.compute_hash()
+        }
+    }
+
     pub fn is_root(&self) -> bool {
         self.parents.is_empty()
     }
@@ -1021,6 +1035,15 @@ mod tests {
             human.id(),
             human.pre_cursor_id(),
             "human states never hashed the agent cursor tags"
+        );
+        assert_eq!(
+            agent_state.hash_for_stored_id(&agent_state.pre_cursor_id()),
+            agent_state.compute_pre_cursor_hash(),
+            "accepted format-4 ids must verify against the preserved hash"
+        );
+        assert_eq!(
+            agent_state.hash_for_stored_id(&agent_state.id()),
+            agent_state.compute_hash()
         );
     }
 

--- a/crates/object-model/src/object/state_core.rs
+++ b/crates/object-model/src/object/state_core.rs
@@ -527,6 +527,26 @@ impl State {
         StateId::from_content_hash(self.compute_hash())
     }
 
+    /// Format-4 identity for agent states hashed before `thought_level` and
+    /// `parent` entered the transcript. Graph edges keep this id.
+    pub fn pre_cursor_id(&self) -> StateId {
+        StateId::from_content_hash(self.compute_pre_cursor_hash())
+    }
+
+    /// Accept the current id, or a format-4 agent id that omitted unpublished
+    /// cursor fields. Published cursor fields require the current hash.
+    pub fn accepts_stored_id(&self, stored: &StateId) -> bool {
+        if self.id() == *stored {
+            return true;
+        }
+        let unpublished_cursor = self
+            .attribution
+            .agent
+            .as_ref()
+            .is_none_or(|agent| agent.thought_level.is_none() && agent.parent.is_none());
+        unpublished_cursor && self.pre_cursor_id() == *stored
+    }
+
     pub fn is_root(&self) -> bool {
         self.parents.is_empty()
     }
@@ -547,8 +567,20 @@ impl State {
         self.hash_len_core() + self.hash_len_fidelity()
     }
 
+    fn hash_len_pre_cursor(&self) -> u64 {
+        self.hash_len_core_pre_cursor() + self.hash_len_fidelity()
+    }
+
     /// Hashed length of the core state fields. Mirrors [`Self::update_hash_core`].
     fn hash_len_core(&self) -> u64 {
+        self.hash_len_core_versioned(true)
+    }
+
+    fn hash_len_core_pre_cursor(&self) -> u64 {
+        self.hash_len_core_versioned(false)
+    }
+
+    fn hash_len_core_versioned(&self, include_cursor_fields: bool) -> u64 {
         let principal = &self.attribution.principal;
         let mut len = 0u64;
 
@@ -581,14 +613,16 @@ impl State {
                 len += policy_id.len() as u64 + 1;
             }
 
-            len += 1;
-            if let Some(thought_level) = &agent.thought_level {
-                len += thought_level.len() as u64 + 1;
-            }
+            if include_cursor_fields {
+                len += 1;
+                if let Some(thought_level) = &agent.thought_level {
+                    len += thought_level.len() as u64 + 1;
+                }
 
-            len += 1;
-            if let Some(parent) = &agent.parent {
-                len += parent.len() as u64 + 1;
+                len += 1;
+                if let Some(parent) = &agent.parent {
+                    len += parent.len() as u64 + 1;
+                }
             }
         }
 
@@ -665,10 +699,30 @@ impl State {
         self.update_hash_fidelity(hasher);
     }
 
+    fn compute_pre_cursor_hash(&self) -> ContentHash {
+        let content_len = self.hash_len_pre_cursor();
+        ContentHash::compute_typed_with_len("state", content_len, |hasher| {
+            self.update_hash_pre_cursor(hasher);
+        })
+    }
+
+    fn update_hash_pre_cursor(&self, hasher: &mut blake3::Hasher) {
+        self.update_hash_core_pre_cursor(hasher);
+        self.update_hash_fidelity(hasher);
+    }
+
     /// Hash the pre-#565 fields (everything through the status byte). Mirrors
     /// [`Self::hash_len_core`]. The migration-only pre-bump hash is exactly
     /// this with no fidelity block appended.
     fn update_hash_core(&self, hasher: &mut blake3::Hasher) {
+        self.update_hash_core_versioned(hasher, true);
+    }
+
+    fn update_hash_core_pre_cursor(&self, hasher: &mut blake3::Hasher) {
+        self.update_hash_core_versioned(hasher, false);
+    }
+
+    fn update_hash_core_versioned(&self, hasher: &mut blake3::Hasher, include_cursor_fields: bool) {
         let principal = &self.attribution.principal;
 
         hasher.update(self.change_id.as_bytes());
@@ -693,8 +747,10 @@ impl State {
             write_optional_string(hasher, &agent.session_id);
             write_optional_string(hasher, &agent.segment_id);
             write_optional_string(hasher, &agent.policy_id);
-            write_optional_string(hasher, &agent.thought_level);
-            write_optional_string(hasher, &agent.parent);
+            if include_cursor_fields {
+                write_optional_string(hasher, &agent.thought_level);
+                write_optional_string(hasher, &agent.parent);
+            }
         } else {
             hasher.update(&[0]);
         }
@@ -913,6 +969,59 @@ mod tests {
 
     fn sample_attribution() -> Attribution {
         Attribution::human(Principal::new("Alice", "alice@example.com"))
+    }
+
+    #[test]
+    fn format4_agent_states_keep_pre_cursor_id_when_cursor_fields_are_unpublished() {
+        use crate::object::Agent;
+
+        let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let tree = ContentHash::from_bytes([11; 32]);
+        let mut agent_state = State::new(
+            tree,
+            Vec::new(),
+            Attribution::with_agent(
+                Principal::new("Author", "author@example.com"),
+                Agent::new("anthropic", "opus"),
+            ),
+        );
+        agent_state.created_at = created_at;
+        agent_state.state_id = agent_state.id();
+        assert_ne!(
+            agent_state.id(),
+            agent_state.pre_cursor_id(),
+            "None cursor tags must change the current id of every agent state"
+        );
+        assert!(
+            agent_state.accepts_stored_id(&agent_state.pre_cursor_id()),
+            "format-4 agent ids must still validate after the cursor hash bump"
+        );
+        assert!(agent_state.accepts_stored_id(&agent_state.id()));
+
+        let mut published = agent_state.clone();
+        published.attribution.agent = Some(
+            Agent::new("anthropic", "opus")
+                .with_thought_level("high")
+                .with_parent("agent-1"),
+        );
+        published.state_id = published.id();
+        assert!(
+            !published.accepts_stored_id(&agent_state.pre_cursor_id()),
+            "published cursor fields must not validate against a format-4 id"
+        );
+        assert_ne!(published.id(), agent_state.id());
+
+        let mut human = State::new(
+            tree,
+            Vec::new(),
+            Attribution::human(Principal::new("Author", "author@example.com")),
+        );
+        human.created_at = created_at;
+        assert_eq!(
+            human.id(),
+            human.pre_cursor_id(),
+            "human states never hashed the agent cursor tags"
+        );
     }
 
     #[test]

--- a/crates/object-model/src/object/state_core.rs
+++ b/crates/object-model/src/object/state_core.rs
@@ -975,7 +975,7 @@ mod tests {
     fn format4_agent_states_keep_pre_cursor_id_when_cursor_fields_are_unpublished() {
         use crate::object::Agent;
 
-        let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let created_at = DateTime::from_timestamp(1_700_000_000, 0).expect("fixed test timestamp");
         let tree = ContentHash::from_bytes([11; 32]);
         let mut agent_state = State::new(
             tree,

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -87,13 +87,13 @@ fn validate_annotated_tag(data: &[u8], hash: ContentHash) -> Result<AnnotatedTag
 }
 
 fn validate_loaded_state(requested_id: &StateId, mut state: State) -> Result<State> {
-    let computed = state.id();
-    if computed != *requested_id {
+    if !state.accepts_stored_id(requested_id) {
         return Err(HeddleError::InvalidObject(format!(
-            "state id mismatch: requested {requested_id}, computed {computed}"
+            "state id mismatch: requested {requested_id}, computed {}",
+            state.id()
         )));
     }
-    state.state_id = computed;
+    state.state_id = *requested_id;
     Ok(state)
 }
 

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -719,7 +719,7 @@ impl FsStore {
             };
             let loose_state = codec::decode_state(loose_data.as_slice())?;
             let packed_state = validate_state_serialized(&packed_data, *id)?;
-            if loose_state.id() != *id {
+            if !loose_state.accepts_stored_id(id) {
                 return Err(HeddleError::InvalidObject(format!(
                     "loose state id mismatch while pruning: expected {id}, computed {}",
                     loose_state.id()

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -16,7 +16,7 @@ use super::{
 use crate::{
     fs_atomic::temp_path,
     object::{
-        Action, Attribution, Blob, ContentHash, Operation, Principal, State, StateId, Tree,
+        Action, Agent, Attribution, Blob, ContentHash, Operation, Principal, State, StateId, Tree,
         TreeEntry,
     },
     store::{
@@ -1253,6 +1253,44 @@ fn test_get_state_rejects_wrong_object_swap() {
         .expect_err("swapped state should be rejected");
     assert!(
         matches!(error, HeddleError::InvalidObject(message) if message.contains("state id mismatch"))
+    );
+}
+
+#[test]
+fn test_get_state_accepts_format4_agent_id_after_cursor_hash_bump() {
+    let (_temp, store) = create_test_store();
+    let created_at = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let mut state = State::new(
+        ContentHash::from_bytes([9; 32]),
+        vec![],
+        Attribution::with_agent(
+            Principal::new("Author", "author@example.com"),
+            Agent::new("anthropic", "opus"),
+        ),
+    );
+    state.created_at = created_at;
+    let stored_id = state.pre_cursor_id();
+    assert_ne!(
+        state.id(),
+        stored_id,
+        "sanity: unpublished cursor tags must change the current id"
+    );
+    let path = store
+        .root
+        .join("objects/states")
+        .join(format!("{}.state", stored_id.to_string_full()));
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, rmp_serde::to_vec(&state).unwrap()).unwrap();
+    store.clear_recent_object_caches();
+
+    let loaded = store
+        .get_state(&stored_id)
+        .expect("format-4 agent id must still load")
+        .expect("state exists");
+    assert_eq!(loaded.state_id, stored_id);
+    assert_eq!(
+        loaded.attribution.agent.as_ref().unwrap().provider,
+        "anthropic"
     );
 }
 

--- a/crates/objects/src/store/fs/repack/compact_state_writer.rs
+++ b/crates/objects/src/store/fs/repack/compact_state_writer.rs
@@ -68,7 +68,7 @@ fn verify_state_frame(records: &[(StateId, State)], frame: &[u8]) -> Result<(), 
         );
     }
     for ((id, expected), actual) in records.iter().zip(decoded) {
-        if actual.id() != *id {
+        if !actual.accepts_stored_id(id) {
             return Err(HeddleError::InvalidObject(
                 "compact state frame changed its typed id".into(),
             )
@@ -84,4 +84,27 @@ fn verify_state_frame(records: &[(StateId, State)], frame: &[u8]) -> Result<(), 
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::{Agent, Attribution, Principal};
+
+    #[test]
+    fn hcs2_repack_keeps_format4_agent_stored_id() {
+        let mut state = State::new(
+            crate::object::ContentHash::from_bytes([9; 32]),
+            Vec::new(),
+            Attribution::with_agent(
+                Principal::new("Author", "author@example.com"),
+                Agent::new("anthropic", "opus"),
+            ),
+        );
+        let stored_id = state.pre_cursor_id();
+        state.state_id = stored_id;
+        let frame = encode_state_frame(std::slice::from_ref(&state)).expect("encode HCS2");
+        verify_state_frame(&[(stored_id, state)], &frame)
+            .expect("repack must accept the preserved pre-cursor id");
+    }
 }

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -145,7 +145,7 @@ impl ObjectStore for InMemoryStore {
         match self.states.read_or_poisoned().get(id) {
             Some(bytes) => {
                 let mut state: State = rmp_serde::from_slice(bytes)?;
-                if state.id() != *id {
+                if !state.accepts_stored_id(id) {
                     return Err(crate::error::HeddleError::InvalidObject(format!(
                         "state id mismatch: requested {id}, computed {}",
                         state.id()

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -564,10 +564,10 @@ pub trait ObjectStore: Send + Sync {
 
     fn put_state_serialized(&self, data: &[u8], id: StateId) -> Result<()> {
         let state: State = rmp_serde::from_slice(data)?;
-        let found = state.id();
-        if found != id {
+        if !state.accepts_stored_id(&id) {
             return Err(HeddleError::InvalidObject(format!(
-                "state id mismatch: expected {id}, computed {found}"
+                "state id mismatch: expected {id}, computed {}",
+                state.id()
             )));
         }
         self.put_state(&state)

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -17,9 +17,11 @@
 //! the gitignore-spec "match anywhere" behavior for those names can
 //! write `**/<name>` explicitly.
 //!
-//! Root `.heddle/` is also a reserved-path hard-deny evaluated after
-//! user rules. A later `!.heddle/` (or similar) cannot un-ignore
-//! identity material. Nested fixture `.heddle/` trees are not reserved.
+//! Root `.heddle/` and pointer-checkout cursor files (`.heddle.identity`,
+//! `.identity.lock`, `.identity.tmp.*`) are reserved-path hard-denies
+//! evaluated after user rules. A later `!.heddle/` (or similar) cannot
+//! un-ignore identity material. Nested fixture `.heddle/` trees are not
+//! reserved.
 
 use std::path::Path;
 
@@ -360,6 +362,18 @@ mod tests {
             assert!(
                 should_ignore(&PathBuf::from(".heddle"), patterns),
                 "reserved root .heddle must stay ignored under {patterns:?}"
+            );
+            assert!(
+                should_ignore(&PathBuf::from(".heddle.identity"), patterns),
+                "reserved pointer cursor must stay ignored under {patterns:?}"
+            );
+            assert!(
+                should_ignore(&PathBuf::from(".identity.lock"), patterns),
+                "reserved pointer lock must stay ignored under {patterns:?}"
+            );
+            assert!(
+                should_ignore(&PathBuf::from(".identity.tmp.1.2"), patterns),
+                "reserved pointer tmp must stay ignored under {patterns:?}"
             );
         }
         // Nested fixtures are not reserved. User rules still apply, so

--- a/crates/objects/src/worktree/worktree_reserved.rs
+++ b/crates/objects/src/worktree/worktree_reserved.rs
@@ -2,31 +2,44 @@
 //! Reserved worktree paths that user ignore rules cannot un-ignore.
 //!
 //! Root `.heddle/` holds identity material (`identity.toml`), credentials,
-//! and repository-engine state. Gitignore last-match-wins would otherwise
-//! let `!.heddle/` pull that tree into capture. Nested `.heddle/`
-//! directories (fixtures) stay ordinary content.
+//! and repository-engine state. Pointer checkout also writes cursor files
+//! beside the `.heddle` file (`.heddle.identity`, `.identity.lock`,
+//! `.identity.tmp.*`). Gitignore last-match-wins would otherwise let
+//! `!.heddle/` pull that tree into capture. Nested `.heddle/` directories
+//! (fixtures) stay ordinary content.
 
 use std::path::{Component, Path};
 
-/// Whether `path` is the worktree-root `.heddle` entry or a path under it.
+/// Whether `path` is a reserved worktree-root Heddle artifact.
 ///
 /// Root-anchored only: `examples/calculator/.heddle/` is not reserved.
 /// Leading `./` is skipped so `./.heddle/identity.toml` matches.
 #[must_use]
 pub fn is_reserved_worktree_path(path: &Path) -> bool {
-    first_normal_component(path).is_some_and(|name| name == ".heddle")
+    first_normal_component(path).is_some_and(is_reserved_root_name)
 }
 
 /// Whether a directory child is reserved without allocating a joined path.
 ///
-/// Used by the walker prune so root `.heddle` and anything already under
-/// that tree are skipped even if a matcher is later refactored.
+/// Used by the walker prune so root `.heddle` and pointer-cursor artifacts
+/// are skipped even if a matcher is later refactored.
 #[must_use]
 pub fn is_reserved_directory_child(parent: &Path, name: &str) -> bool {
     if is_reserved_worktree_path(parent) {
         return true;
     }
-    name == ".heddle" && is_worktree_root(parent)
+    is_worktree_root(parent) && is_reserved_root_name(std::ffi::OsStr::new(name))
+}
+
+fn is_reserved_root_name(name: &std::ffi::OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    name == ".heddle"
+        || name == ".heddle.identity"
+        || name == ".identity.lock"
+        || name == ".identity.tmp"
+        || name.starts_with(".identity.tmp.")
 }
 
 fn is_worktree_root(path: &Path) -> bool {
@@ -67,6 +80,22 @@ mod tests {
     }
 
     #[test]
+    fn reserves_pointer_checkout_cursor_artifacts() {
+        for path in [
+            ".heddle.identity",
+            "./.heddle.identity",
+            ".identity.lock",
+            ".identity.tmp.123.0",
+            ".identity.tmp",
+        ] {
+            assert!(
+                is_reserved_worktree_path(Path::new(path)),
+                "expected reserved: {path}"
+            );
+        }
+    }
+
+    #[test]
     fn does_not_reserve_nested_or_unrelated_paths() {
         for path in [
             "",
@@ -76,6 +105,9 @@ mod tests {
             ".heddleignore",
             "examples/calculator/.heddle/identity.toml",
             "examples/calculator/.heddle",
+            "examples/foo/.heddle.identity",
+            "examples/foo/.identity.lock",
+            "src/.identity.tmp.1.2",
             "../.heddle/identity.toml",
         ] {
             assert!(
@@ -93,10 +125,26 @@ mod tests {
             Path::new(".heddle"),
             "identity.toml"
         ));
+        assert!(is_reserved_directory_child(
+            Path::new(""),
+            ".heddle.identity"
+        ));
+        assert!(is_reserved_directory_child(
+            Path::new("."),
+            ".identity.lock"
+        ));
+        assert!(is_reserved_directory_child(
+            Path::new(""),
+            ".identity.tmp.9.1"
+        ));
         assert!(!is_reserved_directory_child(Path::new(""), "src"));
         assert!(!is_reserved_directory_child(
             Path::new("examples/calculator"),
             ".heddle"
+        ));
+        assert!(!is_reserved_directory_child(
+            Path::new("examples/foo"),
+            ".heddle.identity"
         ));
     }
 }

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -207,6 +207,12 @@ pub static MIGRATIONS: &[Migration] = &[
         applies_to: SchemaTarget::AnnotatedTags,
         run: run_first_class_annotated_tags,
     },
+    Migration {
+        id: "0005_identity_cursor_attribution",
+        description: "Record the identity-cursor state-hash and HCS2 compact-frame boundary",
+        applies_to: SchemaTarget::Mixed,
+        run: run_identity_cursor_attribution,
+    },
 ];
 
 /// Returns true when every registered migration id is already recorded in
@@ -346,6 +352,13 @@ fn run_first_class_annotated_tags(ctx: &mut MigrationCtx<'_>) -> Result<()> {
     // Format v3 repositories never stored annotated tags in the native object
     // graph. Existing Git-authority repositories are re-adopted at the v4
     // boundary, while native repositories have no tag bytes to transform.
+    bump_repo_format_to_supported(ctx.repo)
+}
+
+fn run_identity_cursor_attribution(ctx: &mut MigrationCtx<'_>) -> Result<()> {
+    // Format-4 agent states keep their pre-cursor ids via dual-hash. This
+    // migration records the HCS2 / thought_level+parent hash boundary so a
+    // format-4 binary refuses the repo as too new instead of mismatching ids.
     bump_repo_format_to_supported(ctx.repo)
 }
 
@@ -568,6 +581,7 @@ mod tests {
                 "0002_canonicalize_thread_records",
                 "0003_canonicalize_tree_entries",
                 "0004_first_class_annotated_tags",
+                "0005_identity_cursor_attribution",
             ],
             "the deletion-wave migration ids must stay ordered and reviewable",
         );
@@ -628,6 +642,26 @@ mod tests {
             config.repository.version,
             repo_config::SUPPORTED_REPO_FORMAT
         );
+    }
+
+    #[test]
+    fn migration_0005_bumps_format_4_to_supported() {
+        let (_temp, repo) = fresh_repo();
+        remove_ledger(&repo);
+        let config_path = repo.heddle_dir().join("config.toml");
+        let mut config = repo_config::RepoConfig::load(&config_path).unwrap();
+        config.repository.version = 4;
+        config.save(&config_path).unwrap();
+
+        apply_pending(&repo).unwrap();
+
+        let config = repo_config::RepoConfig::load(&config_path).unwrap();
+        assert_eq!(
+            config.repository.version,
+            repo_config::SUPPORTED_REPO_FORMAT
+        );
+        let ledger = std::fs::read_to_string(ledger_path(&repo)).unwrap();
+        assert!(ledger.contains("0005_identity_cursor_attribution"));
     }
 
     #[test]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -12,7 +12,11 @@ use serde::{Deserialize, Serialize};
 use super::Result;
 use crate::FsMonitorConfig;
 
-pub(crate) const SUPPORTED_REPO_FORMAT: u32 = 4;
+pub(crate) const SUPPORTED_REPO_FORMAT: u32 = 5;
+/// Oldest format this binary can open and migrate forward. Format 4
+/// repositories keep pre-cursor agent ids; `0005_identity_cursor_attribution`
+/// records the HCS2 / cursor-hash boundary and bumps the version.
+pub(crate) const MIN_MIGRATABLE_REPO_FORMAT: u32 = 4;
 
 /// Repository configuration stored in `.heddle/config.toml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -570,20 +574,7 @@ impl RepoConfig {
             });
         }
         let version = repository_format_version(&contents, &resolved)?;
-        if version > SUPPORTED_REPO_FORMAT {
-            return Err(HeddleError::RepositoryFormatTooNew {
-                path: resolved,
-                found: version,
-                supported: SUPPORTED_REPO_FORMAT,
-            });
-        }
-        if version < SUPPORTED_REPO_FORMAT {
-            return Err(HeddleError::RepositoryFormatMigrationRequired {
-                path: resolved,
-                found: version,
-                required: SUPPORTED_REPO_FORMAT,
-            });
-        }
+        reject_unsupported_repo_format(&resolved, version)?;
         Self::load(path)
     }
 
@@ -611,6 +602,24 @@ struct RepositoryFormatProbe {
 #[derive(Deserialize)]
 struct RepositoryVersionProbe {
     version: u32,
+}
+
+pub(crate) fn reject_unsupported_repo_format(path: &Path, version: u32) -> Result<()> {
+    if version > SUPPORTED_REPO_FORMAT {
+        return Err(HeddleError::RepositoryFormatTooNew {
+            path: path.to_path_buf(),
+            found: version,
+            supported: SUPPORTED_REPO_FORMAT,
+        });
+    }
+    if version < MIN_MIGRATABLE_REPO_FORMAT {
+        return Err(HeddleError::RepositoryFormatMigrationRequired {
+            path: path.to_path_buf(),
+            found: version,
+            required: SUPPORTED_REPO_FORMAT,
+        });
+    }
+    Ok(())
 }
 
 fn repository_format_version(contents: &str, path: &Path) -> Result<u32> {
@@ -803,6 +812,18 @@ format = "auto"
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn format_4_is_migratable_without_rewriting_the_file() {
+        let root = TempDir::new().unwrap();
+        let path = root.path().join("config.toml");
+        let fixture = "[repository]\nversion = 4\nsource_authority = \"native\"\n";
+        std::fs::write(&path, fixture).unwrap();
+
+        let loaded = RepoConfig::load_for_repository(&path).expect("format 4 must still load");
+        assert_eq!(loaded.repository.version, 4);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), fixture);
     }
 
     #[test]

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -139,7 +139,12 @@ mod status_untracked_scan;
 
 const GIT_CHECKPOINTS_FILE: &str = "git-checkpoints.json";
 const GIT_CHECKPOINT_INTENT_FILE: &str = "git-checkpoint-intent.json";
-const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[".heddle/"];
+const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[
+    ".heddle/",
+    ".heddle.identity",
+    ".identity.lock",
+    ".identity.tmp.*",
+];
 const HEDDLE_REPOSITORY_MEMBERS: &[&str] = &["HEAD", "objects", "objectstore", "oplog", "refs"];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -598,23 +603,7 @@ pub(crate) fn compute_op_scope(root: &Path) -> String {
 }
 
 fn ensure_supported_repo_format(config_path: &Path, config: &RepoConfig) -> Result<()> {
-    let found = config.repository.version;
-    let supported = repo_config::SUPPORTED_REPO_FORMAT;
-    if found > supported {
-        return Err(HeddleError::RepositoryFormatTooNew {
-            path: config_path.to_path_buf(),
-            found,
-            supported,
-        });
-    }
-    if found < supported {
-        return Err(HeddleError::RepositoryFormatMigrationRequired {
-            path: config_path.to_path_buf(),
-            found,
-            required: supported,
-        });
-    }
-    Ok(())
+    repo_config::reject_unsupported_repo_format(config_path, config.repository.version)
 }
 
 fn validate_snapshot_artifact_records(

--- a/crates/repo/src/repository_key_binding.rs
+++ b/crates/repo/src/repository_key_binding.rs
@@ -99,8 +99,14 @@ impl Repository {
         registry: &KeyBindingRegistry,
         trusted_authority: &TrustedKey,
     ) -> Result<AuthorshipVerification> {
+        let stored_id = if state.accepts_stored_id(&state.state_id) {
+            state.state_id
+        } else {
+            state.id()
+        };
+        let hash = state.hash_for_stored_id(&stored_id);
         let signatures: Vec<_> = self
-            .list_state_attachments(&state.id())?
+            .list_state_attachments(&stored_id)?
             .into_iter()
             .filter_map(|attachment| match attachment.body {
                 StateAttachmentBody::Signature(signature) => Some(signature),
@@ -117,7 +123,7 @@ impl Repository {
         let mut unauthorized_role = None;
         let mut saw_invalid = false;
         for signature in &signatures {
-            if verify_state_signature_bytes(signature, &state.compute_hash()).is_err() {
+            if verify_state_signature_bytes(signature, &hash).is_err() {
                 saw_invalid = true;
                 continue;
             }

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -29,9 +29,10 @@ where
     /// this device or repository. The legacy attachment remains as immutable
     /// evidence; migration appends a domain-tagged signature.
     pub(crate) fn resign_if_owned(&self, state: &State) -> Result<bool> {
-        let hash = state.compute_hash();
+        let stored_id = accepted_state_id(state);
+        let hash = state.hash_for_stored_id(&stored_id);
         let signatures: Vec<_> = self
-            .list_state_attachments(&state.id())?
+            .list_state_attachments(&stored_id)?
             .into_iter()
             .filter_map(|attachment| match attachment.body {
                 StateAttachmentBody::Signature(signature) => Some(signature),
@@ -57,13 +58,13 @@ where
                     HeddleError::Conflict(format!("failed to re-sign state: {error}"))
                 })?;
             self.put_state_attachment(&StateAttachment {
-                state_id: state.id(),
+                state_id: stored_id,
                 body: StateAttachmentBody::Signature(replacement),
                 attribution: state.attribution.clone(),
                 created_at: chrono::Utc::now(),
                 supersedes: None,
             })?;
-            debug!(state_id = %state.id().short(), "Re-signed owned legacy state signature");
+            debug!(state_id = %stored_id.short(), "Re-signed owned legacy state signature");
             return Ok(true);
         }
         Ok(false)
@@ -175,7 +176,10 @@ impl Repository {
             debug!("no signing identity available; state captured unsigned");
             return None;
         };
-        match state_signature_from_signer(&state.compute_hash(), &*signer) {
+        match state_signature_from_signer(
+            &state.hash_for_stored_id(&accepted_state_id(state)),
+            &*signer,
+        ) {
             Ok(signature) => Some(signature),
             Err(error) => {
                 tracing::warn!(%error, "auto-signing failed; state captured unsigned");
@@ -234,7 +238,7 @@ impl Repository {
             .store
             .get_state(state_id)?
             .ok_or(HeddleError::StateNotFound(*state_id))?;
-        let signature = state_signature_from_signer(&state.compute_hash(), signer)
+        let signature = state_signature_from_signer(&state.hash_for_stored_id(state_id), signer)
             .map_err(|error| HeddleError::Conflict(format!("failed to sign state: {error}")))?;
         self.put_state_attachment(&StateAttachment {
             state_id: *state_id,
@@ -301,7 +305,7 @@ impl Repository {
             debug!("State has no signature");
             return Ok(SignatureStatus::Unsigned);
         }
-        let status = classify_state_signatures(&signatures, &state.compute_hash());
+        let status = classify_state_signatures(&signatures, &state.hash_for_stored_id(state_id));
         debug!(?status, "Classified state signatures");
         Ok(status)
     }
@@ -317,7 +321,7 @@ impl Repository {
             .store
             .get_state(state_id)?
             .ok_or(HeddleError::StateNotFound(*state_id))?;
-        let hash = state.compute_hash();
+        let hash = state.hash_for_stored_id(state_id);
         Ok(self
             .list_state_attachments(state_id)?
             .into_iter()
@@ -326,6 +330,14 @@ impl Repository {
                 _ => None,
             })
             .find(|signature| verify_state_signature_bytes(signature, &hash).is_ok()))
+    }
+}
+
+fn accepted_state_id(state: &State) -> StateId {
+    if state.accepts_stored_id(&state.state_id) {
+        state.state_id
+    } else {
+        state.id()
     }
 }
 
@@ -377,7 +389,8 @@ fn classify_state_signatures(
 #[cfg(test)]
 mod tests {
     use crypto::Ed25519Signer;
-    use objects::object::{Attribution, Blob, Principal, Tree, TreeEntry};
+    use objects::object::{Agent, Attribution, Blob, Principal, Tree, TreeEntry};
+    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use super::*;
@@ -398,6 +411,44 @@ mod tests {
         let state = objects::object::State::new(tree_hash, vec![], attribution);
         repo.store().put_state(&state).expect("put state");
         state.id()
+    }
+
+    #[test]
+    fn format4_agent_signature_verifies_against_preserved_hash() {
+        let (_temp, repo) = setup_repo();
+        let tree = Tree::new();
+        let tree_hash = repo.store().put_tree(&tree).expect("put tree");
+        let mut state = objects::object::State::new(
+            tree_hash,
+            vec![],
+            Attribution::with_agent(
+                Principal::new("Author", "author@example.com"),
+                Agent::new("anthropic", "opus"),
+            ),
+        );
+        let stored_id = state.pre_cursor_id();
+        assert_ne!(
+            state.id(),
+            stored_id,
+            "unpublished cursor tags must change the current id"
+        );
+        let data = rmp_serde::to_vec(&state).expect("serialize format-4 agent state");
+        repo.store()
+            .put_state_serialized(&data, stored_id)
+            .expect("store under the preserved pre-cursor id");
+
+        let signer = Ed25519Signer::generate().expect("generate key");
+        repo.sign_state(&stored_id, &signer)
+            .expect("sign against the accepted stored hash");
+        assert_eq!(
+            repo.verify_state_signature(&stored_id).expect("verify"),
+            SignatureStatus::Valid
+        );
+        assert!(
+            repo.get_state_signature(&stored_id)
+                .expect("get signature")
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -418,7 +418,7 @@ mod tests {
         let (_temp, repo) = setup_repo();
         let tree = Tree::new();
         let tree_hash = repo.store().put_tree(&tree).expect("put tree");
-        let mut state = objects::object::State::new(
+        let state = objects::object::State::new(
             tree_hash,
             vec![],
             Attribution::with_agent(

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -948,6 +948,16 @@ fn snapshot_transaction_id(
         hasher.update(agent.segment_id.as_deref().unwrap_or_default().as_bytes());
         hasher.update(b"\0");
         hasher.update(agent.policy_id.as_deref().unwrap_or_default().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(
+            agent
+                .thought_level
+                .as_deref()
+                .unwrap_or_default()
+                .as_bytes(),
+        );
+        hasher.update(b"\0");
+        hasher.update(agent.parent.as_deref().unwrap_or_default().as_bytes());
     }
     hasher.update(b"\0lineage\0");
     hasher.update(

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -267,6 +267,36 @@ fn open_accepts_supported_repository_format() {
 }
 
 #[test]
+fn open_migrates_format_4_identity_cursor_boundary_to_supported() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let config_path = repo.heddle_dir().join("config.toml");
+    let ledger_path = repo.heddle_dir().join("state/schema_versions.toml");
+    let ledger = fs::read_to_string(&ledger_path).unwrap();
+    let stripped = ledger
+        .lines()
+        .filter(|line| !line.contains("0005_identity_cursor_attribution"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&ledger_path, stripped).unwrap();
+    fs::write(
+        &config_path,
+        "[repository]\nversion = 4\nsource_authority = \"native\"\n",
+    )
+    .unwrap();
+    drop(repo);
+
+    let reopened = Repository::open(temp_dir.path())
+        .expect("format 4 must open and migrate instead of state-id mismatch");
+    assert_eq!(reopened.config().repository.version, SUPPORTED_REPO_FORMAT);
+    let ledger = fs::read_to_string(&ledger_path).unwrap();
+    assert!(
+        ledger.contains("0005_identity_cursor_attribution"),
+        "open must record the identity-cursor format boundary: {ledger}"
+    );
+}
+
+#[test]
 fn open_refuses_v2_as_migration_required_without_rewriting_fixture() {
     let temp_dir = TempDir::new().unwrap();
     Repository::init_default(temp_dir.path()).unwrap();

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -272,13 +272,15 @@ fn open_migrates_format_4_identity_cursor_boundary_to_supported() {
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     let config_path = repo.heddle_dir().join("config.toml");
     let ledger_path = repo.heddle_dir().join("state/schema_versions.toml");
-    let ledger = fs::read_to_string(&ledger_path).unwrap();
-    let stripped = ledger
-        .lines()
-        .filter(|line| !line.contains("0005_identity_cursor_attribution"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(&ledger_path, stripped).unwrap();
+    fs::write(
+        &ledger_path,
+        "applied = [\n\
+         \"0002_canonicalize_thread_records\",\n\
+         \"0003_canonicalize_tree_entries\",\n\
+         \"0004_first_class_annotated_tags\",\n\
+         ]\n",
+    )
+    .unwrap();
     fs::write(
         &config_path,
         "[repository]\nversion = 4\nsource_authority = \"native\"\n",
@@ -286,14 +288,21 @@ fn open_migrates_format_4_identity_cursor_boundary_to_supported() {
     .unwrap();
     drop(repo);
 
-    let reopened = Repository::open(temp_dir.path())
+    let first = Repository::open(temp_dir.path())
         .expect("format 4 must open and migrate instead of state-id mismatch");
-    assert_eq!(reopened.config().repository.version, SUPPORTED_REPO_FORMAT);
+    drop(first);
+    let on_disk = fs::read_to_string(&config_path).unwrap();
+    assert!(
+        on_disk.contains(&format!("version = {SUPPORTED_REPO_FORMAT}")),
+        "0005 must bump the on-disk repository format, got: {on_disk}"
+    );
     let ledger = fs::read_to_string(&ledger_path).unwrap();
     assert!(
         ledger.contains("0005_identity_cursor_attribution"),
         "open must record the identity-cursor format boundary: {ledger}"
     );
+    let reopened = Repository::open(temp_dir.path()).expect("migrated format 5 must reopen");
+    assert_eq!(reopened.config().repository.version, SUPPORTED_REPO_FORMAT);
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bounce-fix for the five live Codex P1s on #1519 HEAD `16d0a608`. Ready to land. Same commits as #1519. No extra scope; remapped P1s on older SHAs were left alone.

## Summary

- Verify and re-sign format-4 agent states against the preserved pre-cursor hash.
- Claude SessionEnd relays `close_session` and then expires the cursor.
- HCS2 repack accepts the stored pre-cursor id via `accepts_stored_id`.
- A later main-agent Claude event (`parent == session`) clears a stale subagent parent.
- OpenCode relays await so timeline before/after stay ordered.

## Closes

Refs HeddleCo/heddle#1518
Refs HeddleCo/heddle#1519

## Red commit
`16d0a608` — live Codex P1s on this HEAD (signature verify, SessionEnd relay, HCS2 repack id, Claude parent clear, OpenCode await).

## P1s

1. **Verify legacy signatures against the preserved hash.** `State::hash_for_stored_id` uses the pre-cursor hash when a format-4 agent state is accepted under that id.

2. **Relay Claude SessionEnd before expiring the cursor.** SessionEnd installs relay then `stamp --expire`.

3. **Preserve legacy IDs when repacking HCS2 frames.** `verify_state_frame` uses `accepts_stored_id`.

4. **Clear Claude parents when returning to the main agent.** Main-agent events set `parent = session`; merge treats that as a clear.

5. **Await OpenCode relays.** Plugin uses `Bun.spawnSync` for relay.

Locks that still bind: `SUPPORTED_REPO_FORMAT = 5`, migration `0005_identity_cursor_attribution`, pre-cursor dual-hash, user-scoped Claude `repo_flag` empty, reserved pointer cursor files.

## Test evidence

```
$ cargo test -p heddle-object-model --lib -- --nocapture format4_agent_states_keep_pre_cursor_id hcs2_repack_accepts_format4_agent_stored_id compact_and_hash_include_thought_level hcs1_agent_frames_keep_the_five_field
    Finished `test` profile [unoptimized + debuginfo] target(s) in 25.85s
     Running unittests src/lib.rs (target/debug/deps/heddle_object_model-dbffae9332fc3a8e)

running 4 tests
test compact::tests::compact_and_hash_include_thought_level_and_parent ... ok
test compact::tests::hcs2_repack_accepts_format4_agent_stored_id ... ok
test compact::tests::hcs1_agent_frames_keep_the_five_field_dictionary ... ok
test object::state_core::tests::format4_agent_states_keep_pre_cursor_id_when_cursor_fields_are_unpublished ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 214 filtered out; finished in 0.00s

$ cargo test -p heddle-objects --lib -- --nocapture hcs2_repack_keeps_format4_agent_stored_id test_get_state_accepts_format4_agent_id_after_cursor_hash_bump test_get_state_rejects_wrong_object_swap reserves_pointer_checkout_cursor_artifacts
    Finished `test` profile [unoptimized + debuginfo] target(s) in 19.43s
     Running unittests src/lib.rs (target/debug/deps/objects-677c5fa928e206d8)

running 4 tests
test worktree::worktree_reserved::tests::reserves_pointer_checkout_cursor_artifacts ... ok
test store::fs::repack::compact::state_writer::tests::hcs2_repack_keeps_format4_agent_stored_id ... ok
test store::fs::fs_tests::test_get_state_accepts_format4_agent_id_after_cursor_hash_bump ... ok
test store::fs::fs_tests::test_get_state_rejects_wrong_object_swap ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 198 filtered out; finished in 0.01s

$ cargo test -p heddle-core --lib -- --nocapture claude_main_agent parent_session_event_clears merge_keeps_last_cursor claude_effort_level
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 11s
     Running unittests src/lib.rs (target/debug/deps/heddle_core-ab3a81b8d616e809)

running 5 tests
test identity_cursor::tests::claude_main_agent_event_clears_subagent_parent ... ok
test identity_cursor::tests::parent_session_event_clears_stale_subagent_parent ... ok
test identity_cursor::tests::merge_keeps_last_cursor_when_event_omits_field ... ok
test identity_payload::tests::claude_main_agent_omits_agent_id_and_clears_parent ... ok
test identity_payload::tests::claude_effort_level_object_and_no_anthropic_model_invent ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 465 filtered out; finished in 0.00s

$ cargo test -p heddle-repo --lib -- --nocapture format4_agent_signature_verifies_against_preserved_hash open_migrates_format_4_identity_cursor_boundary format_4_is_migratable migration_0005_bumps_format_4 open_accepts_supported open_refuses_v2 open_refuses_v1 open_refuses_newer migrations_are_registered_in_order
    Finished `test` profile [unoptimized + debuginfo] target(s) in 29.64s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 9 tests
test migration::tests::migrations_are_registered_in_order ... ok
test repository::repo_config::tests::format_4_is_migratable_without_rewriting_the_file ... ok
test repository::repository_tests::open_accepts_supported_repository_format ... ok
test repository::repository_tests::open_migrates_format_4_identity_cursor_boundary_to_supported ... ok
test migration::tests::migration_0005_bumps_format_4_to_supported ... ok
test repository::repository_tests::open_refuses_newer_repository_format_with_recovery_advice ... ok
test repository::repository_tests::open_refuses_v1_before_reading_legacy_objects ... ok
test repository::repository_tests::open_refuses_v2_as_migration_required_without_rewriting_fixture ... ok
test repository::repository_signing::tests::format4_agent_signature_verifies_against_preserved_hash ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 672 filtered out; finished in 0.05s

$ cargo test -p heddle-cli --lib -- --nocapture claude_user_install_discovers_workspace_at_runtime claude_repo_install_writes_project_hooks opencode_repo_install_and_uninstall_manage_plugin_file
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 07s
     Running unittests src/lib.rs (target/debug/deps/cli-79c84bfd31cb39a2)

running 3 tests
test cli::commands::integration::tests::claude_repo_install_writes_project_hooks_and_manifest ... ok
test cli::commands::integration::tests::claude_user_install_discovers_workspace_at_runtime ... ok
test cli::commands::integration::tests::opencode_repo_install_and_uninstall_manage_plugin_file ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 766 filtered out; finished in 0.03s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7258688a-b6fb-441a-aebe-0ed464a5f209?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7258688a-b6fb-441a-aebe-0ed464a5f209&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789839653&installation_model_id=21489&pr_number=1526&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1526&signature=107d820f2206e0597f33e2d2ccdd9f9bb6cb8e07e3a6a0d871c54f3ce7528f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->