### PR TITLE
chore(deps): upgrade sley to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1609,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3506,7 +3506,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5141,7 +5141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5174,7 +5174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5711,7 +5711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5803,7 +5803,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5997,7 +5997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6287,9 +6287,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69637e24518830470718dd9a0844ed3fb82d17ccf6ef343ad213b31f98d8320"
+checksum = "764956e8ef230a33374b443a6a74845b453eacca2e2f928d6e5178348b116db5"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6312,18 +6312,18 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb29fa07808aff17da26ca9317238c692e3705203ba1358abb793ff7dbfe4cf"
+checksum = "6fe09bd81f7754dc710dcf1a63d2d3952751e167633a9b7bf3798844c2b47c3e"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b7a23573be9596f611c1eed2333ff95a37cfa776f4c05e0ecaa23eea3f99b1"
+checksum = "67e4e3891cdd7c4bab0abcaac4b3216ce488dbd2b9abfef72d32d77b2f009b22"
 dependencies = [
  "sha1 0.11.0",
  "unicode-normalization",
@@ -6331,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "sley-diff-merge"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d8fe3d9acb7664fc9493b5ada09a41fa1e614572212f27c8550888f686887c"
+checksum = "2754a3964f914807319445c1a2cb54c6b088fc875bec3ca9965ab0a1f71442a7"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6348,26 +6348,23 @@ dependencies = [
 
 [[package]]
 name = "sley-formats"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c93fd8fb9695284aa40e84287e54da0f828a64ca09d17616acccd8224dfd0a6d"
+checksum = "6eecbdb3fbaca583cbd01c3c8b0f347e6f4b5da33ce1092ca9e4c281e7fa8305"
 dependencies = [
  "flate2",
  "sley-config",
  "sley-core",
- "sley-index",
- "sley-object",
 ]
 
 [[package]]
 name = "sley-fsck"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653b141e1e4c8b977a743fcb4d76985072b654107366503e51123bc943f5ba24"
+checksum = "02deb4aaf522225ee4c5b0ebbb3fca05578856e16c0e34f0d9cbdc650551c790"
 dependencies = [
  "sley-config",
  "sley-core",
- "sley-formats",
  "sley-object",
  "sley-odb",
  "sley-submodule",
@@ -6375,18 +6372,18 @@ dependencies = [
 
 [[package]]
 name = "sley-grep"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24f265f9c102f5f7062918ba19f2a36a48d5104ad85f66f2eef3d5b595cadf3"
+checksum = "084199d7eb68591644d883c787717bde5648080444b0405c94dc1b3553490ec1"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-index"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7861178f068b77a24d5c697590ec471c566e026dd31e10aeef480fdf603b9a"
+checksum = "33d54c82c66051e0e73186f25e1793d6ac643085d173a4752c26cf872270891e"
 dependencies = [
  "sley-core",
  "sley-mmap",
@@ -6394,18 +6391,18 @@ dependencies = [
 
 [[package]]
 name = "sley-mmap"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5856eebea7335eeb41547fb92e39850d11612537eebd4deb06247d7b799bbe"
+checksum = "cc8df49d0a53c9bc56adcd8594570fed33fb39d55ecd02fc373e5c17f887ce25"
 dependencies = [
  "memmap2",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495fd144f53ea61331589cd453e5aa44c8d28ffb0b06bae69d3739b32420a3ed"
+checksum = "66dc5b255ada4420808e35c67992ce55758adadc00adfa92ba6eca7605159b3c"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6418,18 +6415,18 @@ dependencies = [
 
 [[package]]
 name = "sley-object"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034ee0151c34099163a4295b53fba4cd90573b30c383714fb9df5f5d36cba205"
+checksum = "b25f57337cfa510d6bc3f9071af7f0f09e8cbe30c223303462e5fc2b9ed42d95"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccd3ad79c186016717b989f0765d100f1400b3066946a29b3969f7cba272088"
+checksum = "8b7dddcaef1f0f97efa9c17c0f0824e6006f6835a1c44e5b7e3d32b77336d054"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -6439,22 +6436,23 @@ dependencies = [
  "sley-mmap",
  "sley-object",
  "sley-pack",
+ "smallvec",
 ]
 
 [[package]]
 name = "sley-options"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf233c49401f7431608e849f29114229095a5f1cd066c77b2a153767fed1cf"
+checksum = "66cd2a937f84b300cb3fb94fce59e30f61c56f775be39acb441d9e8d0b94a840"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pack"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff8bbcfc07d92867352b66004763f6c5b3690e81c7d2a3ba552ceeee0c10209"
+checksum = "f2a76d534c00f36ca36a54a33d6851294b77eebf5be4b520d004b40fe1d060be"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -6465,18 +6463,18 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0730b3a44c5a5f5e3c3f994d22102ed8770f4fa7e5cd92c187bdd42543c95afc"
+checksum = "f809ed64126830cd32689c990c31f7c5f233823fb4229e162e7fa25bfa8c7bcc"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pretty"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7528cd4de1930aea9cfae958d6de79472134bffa9b346a7db30330df9296146d"
+checksum = "b95db30a7777e4d0faf599789da3125a58e3b7afb0b9c9a2388aaea5562d0223"
 dependencies = [
  "encoding_rs",
  "sley-config",
@@ -6491,18 +6489,18 @@ dependencies = [
 
 [[package]]
 name = "sley-protocol"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5e98d5156398816da013e6e8ceafa8bd6c679a4be190ff86f8c7b0bf877415"
+checksum = "26514c7852fb0e28b0995387de9da7eb760894fb9e0dc628236461a82a6e6427"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-ref-filter"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47d290c04c7b4c5bfd79fe2da594365657595be48be38c16856dbf465f88d30"
+checksum = "168bec8faa2d00a9b194eccdafccd8275490d47f81373de3471c1819efd5b015"
 dependencies = [
  "sley-core",
  "sley-strbuf-expand",
@@ -6510,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "sley-refs"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97991bc6730b44d5b87a7e8d429040d5f4015aa8e0abe0758686497c718841c3"
+checksum = "013d289dafd513134ad252bb4962c42addec1030902b9df240a5d325c22f1516"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6521,9 +6519,9 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18e1c70c4b90a106a7917493277befb4c948a74a8828acf06339842abaa35b3"
+checksum = "774ebb7cd2d56ef099a58ae2eaffb81fa153c4314c5a507fe2759ee84dbc676c"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6538,13 +6536,14 @@ dependencies = [
  "sley-rev",
  "sley-transport",
  "sley-worktree",
+ "tempfile",
 ]
 
 [[package]]
 name = "sley-rev"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0a6f8d110761a7161d484e6de277e5d9aa052629507d79a64aa046712b1d3d"
+checksum = "821f00de5d4900483ea607d813c814665a4fe4220452a5e0d34cb31e54c86b35"
 dependencies = [
  "regex",
  "sley-config",
@@ -6562,12 +6561,11 @@ dependencies = [
 
 [[package]]
 name = "sley-sequencer"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff5ec70f3912f440cb13013b73b4752b3fc1949a39a7b463da4a40b6b3d71ab"
+checksum = "7a297b6e763d28a17b52d6aea963bc5d39653f2bf0586576539db1020e8b009a"
 dependencies = [
  "sley-core",
- "sley-formats",
  "sley-object",
  "sley-odb",
  "sley-refs",
@@ -6576,18 +6574,18 @@ dependencies = [
 
 [[package]]
 name = "sley-strbuf-expand"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4006c8c689268f3af56cc3c1b5db9fe415e521a624f75ba2ce1222f14bc691f"
+checksum = "f10efd42e176b454d675bebee23d7c7377e483efe07a7e0f91bda434316d51d5"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-submodule"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513c2ab94208e05ab9fdc9f6e111578f0be8f1a4b70a0ab6752ff9fc30a84a28"
+checksum = "7d2e003e6e93b39edc5eca900deec3b93de72bf8d6a379f24887c04f7f440793"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6595,22 +6593,23 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429c8c4668dfb5ffcdc626db1f34c840b7ad108b57443fa9a314a463fbe918ee"
+checksum = "b29806b2294e887ec1fb02fe360804a5603dda82520db425b431b0db6082a838"
 dependencies = [
  "sley-config",
  "sley-core",
  "sley-protocol",
+ "tempfile",
  "ureq",
  "webpki-root-certs",
 ]
 
 [[package]]
 name = "sley-unpack-trees"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54f0fe1695727fdf820477cfa9683299927ace2a2cf700e549df20214607da8"
+checksum = "272ac7587eba2676e94ec4da8c3047b6a4462953c7eea73f1b1ace2bf1beea90"
 dependencies = [
  "sley-core",
  "sley-index",
@@ -6618,16 +6617,15 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb822dc55a3028d5890ce5b28d832d7c68c2b29e07b66bd56303dd5284f864e"
+checksum = "17e6fd692a3561c9c34ec95531cb8775727bb89ff100fa25fb5c7aae4846976d"
 dependencies = [
  "encoding_rs",
  "same-file",
  "sley-config",
  "sley-core",
  "sley-diff-merge",
- "sley-formats",
  "sley-index",
  "sley-mmap",
  "sley-object",
@@ -7117,7 +7115,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8129,7 +8127,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1609,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3506,7 +3506,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4261,7 +4261,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5711,7 +5711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5803,7 +5803,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5997,7 +5997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6287,9 +6287,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764956e8ef230a33374b443a6a74845b453eacca2e2f928d6e5178348b116db5"
+checksum = "45d1b59688289ef20fd3d9a5833d392185a2163fd5b052450ee7dfb90c7e11c6"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6312,18 +6312,18 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe09bd81f7754dc710dcf1a63d2d3952751e167633a9b7bf3798844c2b47c3e"
+checksum = "0ec2c9b1143b0b97e548718d4127ccd04365833757e9a58e8afb347cb7f4e975"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4e3891cdd7c4bab0abcaac4b3216ce488dbd2b9abfef72d32d77b2f009b22"
+checksum = "1f4dc75eaf0f3e0494587f2c6a00107bf718c3353582b2b1c8949ee4cc996a7d"
 dependencies = [
  "sha1 0.11.0",
  "unicode-normalization",
@@ -6331,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "sley-diff-merge"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2754a3964f914807319445c1a2cb54c6b088fc875bec3ca9965ab0a1f71442a7"
+checksum = "14e1db6a9c197448dd5b0eedab8f54cc813c87ac0453cf6d7d1d7c2492cc0e58"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6348,9 +6348,9 @@ dependencies = [
 
 [[package]]
 name = "sley-formats"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eecbdb3fbaca583cbd01c3c8b0f347e6f4b5da33ce1092ca9e4c281e7fa8305"
+checksum = "bf63ecda2d5c4939c268475987a4c983183198b90fdfd792d0f348bcf4675881"
 dependencies = [
  "flate2",
  "sley-config",
@@ -6359,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "sley-fsck"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02deb4aaf522225ee4c5b0ebbb3fca05578856e16c0e34f0d9cbdc650551c790"
+checksum = "22b760ed967b225958a96a58e3a1b326dbc344ac2b354fdfe609ace95b836144"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6372,18 +6372,18 @@ dependencies = [
 
 [[package]]
 name = "sley-grep"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084199d7eb68591644d883c787717bde5648080444b0405c94dc1b3553490ec1"
+checksum = "099e783526774a434df7850767343a97b035c826658501b15ffec57a21b6eeb7"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-index"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d54c82c66051e0e73186f25e1793d6ac643085d173a4752c26cf872270891e"
+checksum = "39e931f67a674546f93c4466c8ad88c93cf79b8af84f2101c937715d2d30b11f"
 dependencies = [
  "sley-core",
  "sley-mmap",
@@ -6391,18 +6391,18 @@ dependencies = [
 
 [[package]]
 name = "sley-mmap"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8df49d0a53c9bc56adcd8594570fed33fb39d55ecd02fc373e5c17f887ce25"
+checksum = "33641e53228302c50594b18046194cc362a5ed41007f4b762418d64331882253"
 dependencies = [
  "memmap2",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66dc5b255ada4420808e35c67992ce55758adadc00adfa92ba6eca7605159b3c"
+checksum = "fe92d7eaf3eb59c2a3490a739c030a069d50faa14b8094490022a4d3f123b73e"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6415,18 +6415,18 @@ dependencies = [
 
 [[package]]
 name = "sley-object"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25f57337cfa510d6bc3f9071af7f0f09e8cbe30c223303462e5fc2b9ed42d95"
+checksum = "2d1eeb12b9205b9d7f3353a6eb0a87833f96440b7fe84ed49ad3670bd8caad5b"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7dddcaef1f0f97efa9c17c0f0824e6006f6835a1c44e5b7e3d32b77336d054"
+checksum = "a2ec532b8cf66360df0eb930bfafcfcac95da75718cf8b75a3e628a01333c7c2"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -6441,18 +6441,18 @@ dependencies = [
 
 [[package]]
 name = "sley-options"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66cd2a937f84b300cb3fb94fce59e30f61c56f775be39acb441d9e8d0b94a840"
+checksum = "56b81b30949c1807a512cfebd51a27e60430242cf0b6da469e625120150b096b"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pack"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a76d534c00f36ca36a54a33d6851294b77eebf5be4b520d004b40fe1d060be"
+checksum = "7b342df40b3b2c6212f075f17c1c8ea7c884e8c3466e4299464502ee7a7a62c9"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -6463,18 +6463,18 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f809ed64126830cd32689c990c31f7c5f233823fb4229e162e7fa25bfa8c7bcc"
+checksum = "252e6a16c5f6d78f6f4acbfb1997c36f3849c9eddc7837380291b77767eab7e5"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pretty"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95db30a7777e4d0faf599789da3125a58e3b7afb0b9c9a2388aaea5562d0223"
+checksum = "1b232a92a63221975221083c4f18d210970b1351e1d9e8e26f2040bfc54186b3"
 dependencies = [
  "encoding_rs",
  "sley-config",
@@ -6489,18 +6489,18 @@ dependencies = [
 
 [[package]]
 name = "sley-protocol"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26514c7852fb0e28b0995387de9da7eb760894fb9e0dc628236461a82a6e6427"
+checksum = "16796c5e0b58c34e620e1dcf21a5d5bb8449c43f003c646ae6493070c68409b7"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-ref-filter"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168bec8faa2d00a9b194eccdafccd8275490d47f81373de3471c1819efd5b015"
+checksum = "0feaddd6c49b072ba5965b1f40b11f44dcf3b24e0453db08cf533705ff3ef7d4"
 dependencies = [
  "sley-core",
  "sley-strbuf-expand",
@@ -6508,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "sley-refs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013d289dafd513134ad252bb4962c42addec1030902b9df240a5d325c22f1516"
+checksum = "b580a9e1781cb2018161f6a0552d0e873610a6d654da79a3672d3576bcd5a5b5"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6519,9 +6519,9 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ebb7cd2d56ef099a58ae2eaffb81fa153c4314c5a507fe2759ee84dbc676c"
+checksum = "f2e0f1aaee417d327cfa6d947384904b8c62556a39f63278efefce046cafdbbf"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6541,9 +6541,9 @@ dependencies = [
 
 [[package]]
 name = "sley-rev"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821f00de5d4900483ea607d813c814665a4fe4220452a5e0d34cb31e54c86b35"
+checksum = "e677a9e100e5c141fc41e999cd416aa026cc2390736faa8116cbd40a664a193a"
 dependencies = [
  "regex",
  "sley-config",
@@ -6561,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "sley-sequencer"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a297b6e763d28a17b52d6aea963bc5d39653f2bf0586576539db1020e8b009a"
+checksum = "3546eb2d0338aa6406ef202d14002b94260fbecb2c86fe41a7cd70c1dd3212f2"
 dependencies = [
  "sley-core",
  "sley-object",
@@ -6574,18 +6574,18 @@ dependencies = [
 
 [[package]]
 name = "sley-strbuf-expand"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10efd42e176b454d675bebee23d7c7377e483efe07a7e0f91bda434316d51d5"
+checksum = "f5c4e3b2ff43245ae06527ddd968ca9c5ba72f42151955207bd31ed6104ec76c"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-submodule"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2e003e6e93b39edc5eca900deec3b93de72bf8d6a379f24887c04f7f440793"
+checksum = "318be5fa7f09eec24e1235c8e5f43237fb1646c2d610d0837e118ae3aed1d0bf"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6593,9 +6593,9 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29806b2294e887ec1fb02fe360804a5603dda82520db425b431b0db6082a838"
+checksum = "fadfb04e06ed285f936780c5d1053e6a334bc5ba48de55807ef952a0d4f44d53"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -6607,9 +6607,9 @@ dependencies = [
 
 [[package]]
 name = "sley-unpack-trees"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272ac7587eba2676e94ec4da8c3047b6a4462953c7eea73f1b1ace2bf1beea90"
+checksum = "b8ffa4f15f904e14833e8aa307fda9923c77b9e88dde8f8778140e3b7c82174c"
 dependencies = [
  "sley-core",
  "sley-index",
@@ -6617,9 +6617,9 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e6fd692a3561c9c34ec95531cb8775727bb89ff100fa25fb5c7aae4846976d"
+checksum = "1bd92af1957f174a739b36d676fb4856a9c4f368562f41314d4880d875b446b9"
 dependencies = [
  "encoding_rs",
  "same-file",
@@ -6653,7 +6653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7112,10 +7112,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8127,7 +8127,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ fs2 = "0.4.3"
 fastembed = { version = "=5.17.4", default-features = false, features = ["ort-download-binaries-rustls-tls"] }
 futures = "0.3"
 getrandom = { version = "0.4", features = ["sys_rng"] }
-sley = { version = "0.5.2", features = ["mmap", "fast-sha1"] }
-sley-transport = "0.5.2"
+sley = { version = "0.6.0", features = ["mmap", "fast-sha1"] }
+sley-transport = "0.6.0"
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ fs2 = "0.4.3"
 fastembed = { version = "=5.17.4", default-features = false, features = ["ort-download-binaries-rustls-tls"] }
 futures = "0.3"
 getrandom = { version = "0.4", features = ["sys_rng"] }
-sley = { version = "0.6.0", features = ["mmap", "fast-sha1"] }
-sley-transport = "0.6.0"
+sley = { version = "0.7.0", features = ["mmap", "fast-sha1"] }
+sley-transport = "0.7.0"
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/crates/cli/src/hosted_runtime/hosted/context.rs
+++ b/crates/cli/src/hosted_runtime/hosted/context.rs
@@ -413,7 +413,6 @@ fn deadline(timeout: Duration) -> Result<Timestamp> {
 #[cfg(test)]
 mod tests {
     use api::UNARY_SIGNING_V1_FIXTURE_JSON;
-    use crypto::Signer as _;
     #[cfg(feature = "telemetry")]
     use opentelemetry::trace::{TraceContextExt as _, TracerProvider as _};
     #[cfg(feature = "telemetry")]

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -367,29 +367,28 @@ mod tests {
     fn actor_filter_returns_backfilled_capture() {
         let temp = tempfile::tempdir().unwrap();
         let repo = repo::Repository::init_default(temp.path()).unwrap();
-        std::fs::write(temp.path().join("note.txt"), "probe\n").unwrap();
-        repo.snapshot_with_attribution(
-            Some("probe history".into()),
-            None,
+        let tree = repo
+            .store()
+            .put_tree(&objects::object::Tree::new())
+            .unwrap();
+        let state = objects::object::State::new_snapshot(
+            tree,
+            Vec::new(),
             objects::object::Attribution::human(objects::object::Principal::new(
                 "Heddle Test",
                 "heddle@example.com",
             )),
-        )
-        .unwrap();
+        );
+        repo.store().put_state(&state).unwrap();
 
-        let stored = indexed_from_oplog_entry(
-            &oplog::OpLog::new_unattributed(repo.heddle_dir())
-                .recent(100)
-                .unwrap()
-                .into_iter()
-                .find(|entry| entry.operation.verb() == "snapshot")
-                .expect("snapshot oplog entry"),
-        );
-        assert!(
-            stored.actor_email.is_empty(),
-            "fixture must store an empty oplog actor so the filter exercises backfill"
-        );
+        let stored_seq = oplog::OpLog::new_unattributed(repo.heddle_dir())
+            .record_batch(vec![oplog::OpRecord::Snapshot {
+                new_state: state.id(),
+                prev_head: None,
+                head: Some(state.id()),
+                thread: None,
+            }])
+            .unwrap()[0];
 
         let ctx = ExecutionContext::builder().repo(repo).build();
         let report = query(
@@ -402,10 +401,9 @@ mod tests {
         )
         .unwrap();
         assert!(
-            report
-                .hits
-                .iter()
-                .any(|hit| hit.verb == "snapshot" && hit.actor_email == "heddle@example.com"),
+            report.hits.iter().any(|hit| hit.seq == stored_seq
+                && hit.verb == "snapshot"
+                && hit.actor_email == "heddle@example.com"),
             "actor filter must match the backfilled capture: {report:?}"
         );
     }

--- a/crates/git-projection/src/credential.rs
+++ b/crates/git-projection/src/credential.rs
@@ -550,6 +550,8 @@ mod tests {
             Ok(HttpResponse {
                 status,
                 content_type: None,
+                content_length: None,
+                content_range: None,
                 body: Box::new(std::io::Cursor::new(Vec::new())),
             })
         })

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -1519,7 +1519,7 @@ mod tests {
     }
 
     fn append_git_oid(tree: &mut Vec<u8>, sha: &str) {
-        for pair in sha.as_bytes().chunks_exact(2) {
+        for pair in sha.as_bytes().as_chunks::<2>().0 {
             let hex = std::str::from_utf8(pair).expect("Git object id is ASCII");
             tree.push(u8::from_str_radix(hex, 16).expect("Git object id is hexadecimal"));
         }

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -110,7 +110,9 @@ fn decode_hex_fixture(source: &str) -> Vec<u8> {
         .collect::<Vec<_>>();
     assert_eq!(compact.len() % 2, 0, "hex fixture must contain byte pairs");
     compact
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let digits = std::str::from_utf8(pair).unwrap();
             u8::from_str_radix(digits, 16).unwrap()

--- a/crates/repo/src/timeline_store.rs
+++ b/crates/repo/src/timeline_store.rs
@@ -607,7 +607,9 @@ fn read_operation_index_journal_records_unlocked(
         ));
     }
     bytes
-        .chunks_exact(OPERATION_INDEX_JOURNAL_RECORD_SIZE as usize)
+        .as_chunks::<{ OPERATION_INDEX_JOURNAL_RECORD_SIZE as usize }>()
+        .0
+        .iter()
         .map(|record| {
             let id = TimelineOperationId::try_from_slice(&record[1..])
                 .map_err(|err| HeddleError::InvalidObject(err.to_string()))?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,5 +4,5 @@
 # clippy lints and reddened `-D warnings` on unrelated PRs. Bump this
 # channel deliberately (and fix any new lints) rather than drifting.
 [toolchain]
-channel = "1.97.0"
+channel = "1.98.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

Upgrade `sley` and `sley-transport` from 0.6.0 to 0.7.0 and resolve all 27 `sley-*` crates to the 0.7 line. Keep the Rust 1.98 toolchain from the prior 0.6 migration.

Also repair the pre-existing `actor_filter_returns_backfilled_capture` fixture broken after #1510, in its own commit.

## 0.6 to 0.7 migration

The published 0.6.0 and 0.7.0 sources were diffed for `sley`, `sley-pack`, `sley-odb`, `sley-worktree`, `sley-remote`, and `sley-transport`.

- The low-level streaming index surface was removed: `PackReadStream`, `PackStreamIndexBuild`, `PackStreamProgress`, `index_pack_from_reader*`, and `PackIndex::write_v2_for_pack_reader*` / path variants.
- The replacement surface operates on immutable pack bytes through `PackIndex::write_v2_for_pack_with_options`, `PackIndexOptions`, `PackIndexBuild`, and `PackIndexProgress`.
- ODB progress is now `PackInstallProgress { received_bytes, indexed_objects, total_objects }`. Reader installs use bounded buffered receipt, then mmap the staged pack and run parallel inflate, hashing, and dependency-level delta resolution.
- Heddle already calls the retained high-level `Repository::fetch_with_http_client` and chunked `RawPackStreamingInstall` facades. Their signatures remain source-compatible in 0.7; their implementations now route through the new bounded-spool and mmap/parallel index path. No shim or legacy low-level call site remains in heddle.
- `sley-worktree` has no source API delta for the calls heddle uses; `sley-remote` adapts transfer progress to `PackInstallProgress`, and `sley-transport` changes only HTTP receive timeout handling.

## actor filter fixture

Production repositories correctly stamp snapshot oplog entries with the configured repository principal. Backfill remains intentional only for historical or explicitly unattributed oplog entries, so the old test precondition depended on ambient repository identity and was obsolete.

The fixture now stores an attributed state, appends an explicitly unattributed snapshot oplog record, and asserts that the exact appended sequence survives the actor filter with the state email backfilled. A directly attributed record cannot satisfy the assertion accidentally.

## Verification

- `cargo build --workspace`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- Nightly rustfmt on the touched Rust file: passed.
- `cargo test -p heddle-core --lib`: 450 passed, 1 ignored; `actor_filter_returns_backfilled_capture` passed.
- `cargo test -p heddle-git-projection`: 66 passed.
- `cargo test -p heddle-cli --lib git_lane_pack_plan_tests`: 5 passed.
- `cargo test --workspace`: local shared sandbox reached 926 passed, 23 failed, 20 ignored before Cargo stopped at `heddle-cli`. Twenty-two are the known environmental failures: 19 land-action string cases, 2 clone-intent isolation cases, and 1 `HEDDLE_HOME` isolation case. The additional pre-existing `cli_help_consistency` failure is a shared-target stale spawned-binary mismatch. No sley-facing, pack-plan, git-projection, or actor-filter test failed.

Commits:
- `5b0edbac` `fix(query): repair actor_filter test precondition broken by #1510`
- `7314c468` `chore(deps): upgrade sley to 0.7.0`
