### PR TITLE
chore(release): heddle 0.13.0 (sley 0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.13.0 - 2026-08-21
+
+- sley 0.7.0 (parallel-inflate) adoption + Rust 1.98.
+
 ### Added
 
 - **`heddle completions` prints tab-completion scripts.** The field-study

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "heddle-crypto",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-iroh-transport-experiment"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytes",
  "heddle-api 0.2.1",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2672,11 +2672,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2735,14 +2735,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -8086,7 +8086,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/crates/ci-config/Cargo.toml
+++ b/crates/ci-config/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-heddle-object-model = { path = "../object-model", version = "0.12" }
+heddle-object-model = { path = "../object-model", version = "0.13" }
 regex.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 blake3.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.12" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.13" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -13,10 +13,10 @@ categories.workspace = true
 anyhow.workspace = true
 api = { package = "heddle-api", version = "0.10" }
 clap.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.12" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.13" }
 
 [features]
 default = []

--- a/crates/cli-contract/Cargo.toml
+++ b/crates/cli-contract/Cargo.toml
@@ -12,13 +12,13 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.12", default-features = false }
-heddle-core = { path = "../core", version = "0.12", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.13", default-features = false }
+heddle-core = { path = "../core", version = "0.13", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-render/Cargo.toml
+++ b/crates/cli-render/Cargo.toml
@@ -15,11 +15,11 @@ anstyle = "1"
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
-heddle-core = { path = "../core", version = "0.12", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
+heddle-core = { path = "../core", version = "0.13", default-features = false }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -13,12 +13,12 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,8 +25,8 @@ biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.12" }
-ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.12" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.13" }
+ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.13" }
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true
@@ -37,35 +37,35 @@ iroh-base = { workspace = true, optional = true }
 libc.workspace = true
 n0-watcher = { workspace = true, optional = true }
 noq-udp = { workspace = true, optional = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.13" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
 api = { package = "heddle-api", version = "0.10" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
-heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
-heddle-cli-contract = { path = "../cli-contract", version = "0.12", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.12", default-features = false }
-heddle-core = { path = "../core", version = "0.12", default-features = false }
-heddle-format = { path = "../format", version = "0.12" }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.12" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
+heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
+heddle-cli-contract = { path = "../cli-contract", version = "0.13", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.13", default-features = false }
+heddle-core = { path = "../core", version = "0.13", default-features = false }
+heddle-format = { path = "../format", version = "0.13" }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.13" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.12", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.13", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -78,7 +78,7 @@ rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
 sha2.workspace = true
 sley.workspace = true
 tempfile.workspace = true
@@ -107,13 +107,13 @@ webpki-roots = { workspace = true, optional = true }
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
 
 [features]
 # The default `heddle` build ships the full workflow: local
@@ -248,7 +248,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { path = "../cli-render", version = "0.12", features = ["test-utils"] }
+heddle-cli-render = { path = "../cli-render", version = "0.13", features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,21 +12,21 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
-merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
 ignore.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
 sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.12" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.13" }
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/fs-prims/Cargo.toml
+++ b/crates/fs-prims/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 fs2.workspace = true
-heddle-object-model = { path = "../object-model", version = "0.12" }
+heddle-object-model = { path = "../object-model", version = "0.13" }
 libc.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/lib.rs"
 name = "heddle_git_projection"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
 # `default-features = false` so this crate's `zstd` feature controls the
 # cascade end-to-end (same pattern as ingest/cli).
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay"] }
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.12", default-features = false }
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay"] }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.13", default-features = false }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay"] }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,11 +15,11 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.12" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+heddle-format = { path = "../format", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 similar.workspace = true
 sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.12" }
+heddle-format = { path = "../format", version = "0.13" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -16,7 +16,7 @@ blake3.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.12" }
+heddle-format = { path = "../format", version = "0.13" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,11 +17,11 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.12" }
-heddle-format = { path = "../format", version = "0.12" }
-heddle-object-model = { path = "../object-model", version = "0.12" }
-heddle-pack = { path = "../pack", version = "0.12" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
+heddle-format = { path = "../format", version = "0.13" }
+heddle-object-model = { path = "../object-model", version = "0.13" }
+heddle-pack = { path = "../pack", version = "0.13" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.12" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+heddle-schema = { path = "../schema", version = "0.13" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.12", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.13", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 bytes.workspace = true
-heddle-format = { path = "../format", version = "0.12" }
-heddle-fs-prims = { path = "../fs-prims", version = "0.12" }
-heddle-object-model = { path = "../object-model", version = "0.12" }
+heddle-format = { path = "../format", version = "0.13" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
+heddle-object-model = { path = "../object-model", version = "0.13" }
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,16 +12,16 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.12" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+heddle-schema = { path = "../schema", version = "0.13" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.12", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.13", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -17,20 +17,20 @@ chrono.workspace = true
 hex.workspace = true
 heddleco-capability-verifier = "0.2"
 ignore.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
 prost.workspace = true
-wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
-semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.12", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.12", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
+semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.13", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.13", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -91,7 +91,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic-recovery/Cargo.toml
+++ b/crates/semantic-recovery/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 fastembed.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.12" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
 rmp-serde.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -29,8 +29,8 @@ lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,7 +18,7 @@ chrono.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

- bump the workspace and publishable Heddle crates from 0.12.0 to 0.13.0
- update internal crate version constraints and Cargo.lock without changing external dependency versions
- add the 0.13.0 changelog entry for sley 0.7.0 (parallel-inflate) adoption and Rust 1.98

## Verification

- `cargo build --workspace`
- `grep -rn '0.12.0' Cargo.toml` (no matches)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789876975&installation_model_id=21489&pr_number=1529&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1529&signature=5ff0428a56b703c56b2ecf292dc6cfd47170fc058570155f1dd838acff49087a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->