### PR TITLE
chore(deps): rebuild on heddle-api 0.12 + capability-verifier 0.4 (release 0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.14.0 - 2026-08-21
+
+- Rebuilt the workspace on `heddle-api` 0.12 and
+  `heddleco-capability-verifier` 0.4 so published Heddle crates share one
+  hosted API contract and BLAKE3 1.8.7 resolution.
+
 ## 0.13.0 - 2026-08-21
 
 - sley 0.7.0 (parallel-inflate) adoption + Rust 1.98.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,12 +215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,11 +468,10 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.6"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
@@ -2175,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e00b1fc8196016e77374bb244329fd52e40a801617190a807c7132d7bd98ace"
+checksum = "f01fcc75aebba90b53bb3c6ed62551d1f244bd123bd4cbaacb1424298f08bc8d"
 dependencies = [
  "blake3",
  "bytes",
@@ -2193,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2204,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2220,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2234,7 +2227,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "heddle-api 0.10.0",
+ "heddle-api 0.12.0",
  "heddle-ci-config",
  "heddle-ci-engine",
  "heddle-cli-args",
@@ -2302,11 +2295,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api 0.10.0",
+ "heddle-api 0.12.0",
  "heddle-cli-shared",
  "heddle-objects",
  "heddle-repo",
@@ -2315,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2336,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2357,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2378,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2405,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2424,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "heddle-crypto",
@@ -2443,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2457,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2466,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2477,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2497,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2519,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-iroh-transport-experiment"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bytes",
  "heddle-api 0.2.1",
@@ -2534,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2546,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2577,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2600,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2635,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2656,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2672,11 +2665,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2698,12 +2691,12 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "blake3",
  "chrono",
- "heddle-api 0.10.0",
+ "heddle-api 0.12.0",
  "heddle-crypto",
  "heddle-objects",
  "heddle-oplog",
@@ -2735,14 +2728,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2753,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2775,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2789,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2798,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2813,14 +2806,14 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf30254e60c9231fbffa087365bd6876a0e5b6b24bbda6ece5b43c9174f2a7b9"
+checksum = "4e10e14701015474d5b1615af01022ebed2793ea3e4480f2f2eb76651a4b29bc"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",
  "getrandom 0.2.17",
- "heddle-api 0.10.0",
+ "heddle-api 0.12.0",
  "hex",
  "prost 0.14.1",
  "serde",
@@ -8086,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.12.0",
+  "schemaVersion": "0.14.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.12.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.14.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/ci-config/Cargo.toml
+++ b/crates/ci-config/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-heddle-object-model = { path = "../object-model", version = "0.13" }
+heddle-object-model = { path = "../object-model", version = "0.14" }
 regex.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 blake3.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.13" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.14" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.10" }
+api = { package = "heddle-api", version = "0.12" }
 clap.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.13" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.14" }
 
 [features]
 default = []

--- a/crates/cli-contract/Cargo.toml
+++ b/crates/cli-contract/Cargo.toml
@@ -12,13 +12,13 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.13", default-features = false }
-heddle-core = { path = "../core", version = "0.13", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.14", default-features = false }
+heddle-core = { path = "../core", version = "0.14", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-render/Cargo.toml
+++ b/crates/cli-render/Cargo.toml
@@ -15,11 +15,11 @@ anstyle = "1"
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
-heddle-core = { path = "../core", version = "0.13", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
+heddle-core = { path = "../core", version = "0.14", default-features = false }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -13,12 +13,12 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,8 +25,8 @@ biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.13" }
-ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.13" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.14" }
+ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.14" }
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true
@@ -37,35 +37,35 @@ iroh-base = { workspace = true, optional = true }
 libc.workspace = true
 n0-watcher = { workspace = true, optional = true }
 noq-udp = { workspace = true, optional = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.14" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
-api = { package = "heddle-api", version = "0.10" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
-heddle-cli-args = { path = "../cli-args", version = "0.13", default-features = false }
-heddle-cli-contract = { path = "../cli-contract", version = "0.13", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.13", default-features = false }
-heddle-core = { path = "../core", version = "0.13", default-features = false }
-heddle-format = { path = "../format", version = "0.13" }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.13" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
+api = { package = "heddle-api", version = "0.12" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
+heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
+heddle-cli-contract = { path = "../cli-contract", version = "0.14", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.14", default-features = false }
+heddle-core = { path = "../core", version = "0.14", default-features = false }
+heddle-format = { path = "../format", version = "0.14" }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.14" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.13", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.14", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -78,7 +78,7 @@ rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
 sha2.workspace = true
 sley.workspace = true
 tempfile.workspace = true
@@ -107,13 +107,13 @@ webpki-roots = { workspace = true, optional = true }
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.13", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
 
 [features]
 # The default `heddle` build ships the full workflow: local
@@ -248,7 +248,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { path = "../cli-render", version = "0.13", features = ["test-utils"] }
+heddle-cli-render = { path = "../cli-render", version = "0.14", features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -93,6 +93,12 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
     ),
     ("LinkOAuthIdentity", AgentAuthOperationDisposition::Denied),
     ("StoreProviderToken", AgentAuthOperationDisposition::Denied),
+    // Registering a verified GitHub installation binds external account
+    // authority to the caller and must remain a parent-principal operation.
+    (
+        "RegisterGitHubInstallation",
+        AgentAuthOperationDisposition::Denied,
+    ),
     (
         "VerifySignupEmail",
         AgentAuthOperationDisposition::ReviewedSafe,
@@ -101,6 +107,9 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
         "BindSignupInviteEmail",
         AgentAuthOperationDisposition::Denied,
     ),
+    // Creating an invite spends the authenticated member's allowance, so a
+    // derived agent must not issue invitations on the parent's behalf.
+    ("CreateSignupInvite", AgentAuthOperationDisposition::Denied),
     // Invite claim registers a client-minted signup root; derived agents
     // must not consume invite codes on behalf of a parent principal.
     ("ClaimSignupInvite", AgentAuthOperationDisposition::Denied),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,21 +12,21 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.13" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
-merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
 ignore.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-heddle-git-projection = { path = "../git-projection", version = "0.13", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
 sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.13" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.14" }
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/fs-prims/Cargo.toml
+++ b/crates/fs-prims/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 fs2.workspace = true
-heddle-object-model = { path = "../object-model", version = "0.13" }
+heddle-object-model = { path = "../object-model", version = "0.14" }
 libc.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/lib.rs"
 name = "heddle_git_projection"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
 # `default-features = false` so this crate's `zstd` feature controls the
 # cascade end-to-end (same pattern as ingest/cli).
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay"] }
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.13", default-features = false }
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay"] }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.14", default-features = false }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay"] }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,11 +15,11 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+heddle-format = { path = "../format", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 similar.workspace = true
 sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.13" }
+heddle-format = { path = "../format", version = "0.14" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -16,7 +16,7 @@ blake3.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.13" }
+heddle-format = { path = "../format", version = "0.14" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,11 +17,11 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
-heddle-format = { path = "../format", version = "0.13" }
-heddle-object-model = { path = "../object-model", version = "0.13" }
-heddle-pack = { path = "../pack", version = "0.13" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
+heddle-format = { path = "../format", version = "0.14" }
+heddle-object-model = { path = "../object-model", version = "0.14" }
+heddle-pack = { path = "../pack", version = "0.14" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.13" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+heddle-schema = { path = "../schema", version = "0.14" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.13", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.14", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 bytes.workspace = true
-heddle-format = { path = "../format", version = "0.13" }
-heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
-heddle-object-model = { path = "../object-model", version = "0.13" }
+heddle-format = { path = "../format", version = "0.14" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
+heddle-object-model = { path = "../object-model", version = "0.14" }
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,16 +12,16 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.13" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+heddle-schema = { path = "../schema", version = "0.14" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.13", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.14", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -11,26 +11,26 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.10" }
+api = { package = "heddle-api", version = "0.12" }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.2"
+heddleco-capability-verifier = "0.4"
 ignore.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.13" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.13" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
 prost.workspace = true
-wire = { path = "../wire", package = "heddle-wire", version = "0.13", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.13" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13", optional = true }
-semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.13", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.13", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
+semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.14", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.14", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -91,7 +91,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic-recovery/Cargo.toml
+++ b/crates/semantic-recovery/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 fastembed.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.13" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
 rmp-serde.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -29,8 +29,8 @@ lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.13", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.13", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,7 +18,7 @@ chrono.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.13" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

- bump `heddle-api` from 0.10 to 0.12 in `crates/cli-args`, `crates/cli`, and `crates/repo`
- bump `heddleco-capability-verifier` from 0.2 to 0.4 in `crates/repo`; the lockfile pins 0.12.0/0.4.0 and BLAKE3 1.8.7
- keep the unpublished `experiments/iroh-transport` dependency on `heddle-api` 0.2.1
- release the workspace at 0.14.0, update every internal path requirement to 0.14, regenerate the checked-in npm schema version pins, and add the release changelog entry

## 0.10 → 0.12 / verifier migration

The migration was derived from recursive diffs of the published 0.10.0/0.12.0 and verifier 0.2.0/0.4.0 sources.

- Heddle's consumed framing functions, ALPN constants, request metadata/descriptor exports, generated message names, and verifier function signatures are unchanged.
- The 0.12 proto delta is additive. It adds collaboration severity, identity/signup/GitHub-installation messages and fields, remote-link/progress messages, and stacked-land messages; no Heddle-consumed symbol was removed.
- `IdentityService` gained `CreateSignupInvite` and `RegisterGitHubInstallation`. Heddle's exhaustive derived-agent policy now explicitly denies both: invite creation spends the parent member's allowance, and installation registration binds verified external-account authority.
- Verifier 0.4 keeps the same purge-verification surface and moves its exact shared contract requirement from API 0.10 to 0.12.
- No compatibility shim or dual-version path was added.

## Verification

```text
$ rustup run nightly rustfmt --edition 2024 --check crates/cli/src/hosted_runtime/device_flow.rs
# exit 0

$ cargo build --workspace --locked
Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.11s

$ cargo clippy --workspace --all-targets --locked -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.36s

$ cargo nextest run -p heddle-cli identity_service_agent_policy_exactly_matches_the_shared_descriptor
1 test run: 1 passed

$ cargo nextest run -p heddle-cli --test ts_types_in_sync
2 tests run: 2 passed

$ cargo nextest run --workspace --no-fail-fast --failure-output never --status-level none --final-status-level fail
Summary [297.094s] 5630 tests run: 5603 passed (3 slow), 27 failed, 66 skipped
```

The 27 remaining failures are the existing sandbox/worktree fixture families: 2 clone-intent, 19 `git_overlay_matrix` land-string, 1 `HEDDLE_HOME` isolation, 4 hidden-child-worktree/start-path, and 1 sandbox GC fixture. The API descriptor-policy test and both generated-client drift guards pass.

## Single-version proof

```text
$ cargo tree -i heddle-api 2>/dev/null
heddle-api v0.12.0
├── heddle-cli v0.14.0
├── heddle-cli-args v0.14.0
├── heddle-repo v0.14.0
└── heddleco-capability-verifier v0.4.0
```

The default/publishable graph contains only `heddle-api 0.12.0`. The unchanged, unpublished Iroh transport experiment remains separately on `heddle-api 0.2.1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789939991&installation_model_id=21489&pr_number=1530&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1530&signature=f4ddf2f52da236358a2d85aef4250febae5c368b90a6917959938daf992b0455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->