### PR TITLE
feat(discuss): --into-annotation resolve mode + --thread on open (#1536 slice)

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_discuss.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_discuss.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `heddle discuss` — durable repository collaboration.
 
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum DiscussCommands {
@@ -20,13 +20,59 @@ pub enum DiscussCommands {
 }
 
 #[derive(Clone, Debug, Args)]
+#[command(
+    group(
+        ArgGroup::new("positional_open")
+            .args(["file", "symbol", "body"])
+            .multiple(true)
+            .conflicts_with("named_open")
+    ),
+    group(
+        ArgGroup::new("named_open")
+            .args(["file_flag", "symbol_flag", "body_flag"])
+            .multiple(true)
+    )
+)]
 pub struct DiscussOpenArgs {
     /// Path of the file containing the symbol.
-    pub file: String,
+    #[arg(
+        value_name = "FILE",
+        required_unless_present_all = ["file_flag", "symbol_flag", "body_flag"]
+    )]
+    pub file: Option<String>,
     /// Symbol name (for example `Repository::open`).
-    pub symbol: String,
+    #[arg(
+        value_name = "SYMBOL",
+        required_unless_present_all = ["file_flag", "symbol_flag", "body_flag"]
+    )]
+    pub symbol: Option<String>,
     /// First turn of the discussion.
-    pub body: String,
+    #[arg(
+        value_name = "BODY",
+        required_unless_present_all = ["file_flag", "symbol_flag", "body_flag"]
+    )]
+    pub body: Option<String>,
+    /// Path of the file containing the symbol (named alternative to `<FILE>`).
+    #[arg(
+        long = "file",
+        value_name = "FILE",
+        required_unless_present_all = ["file", "symbol", "body"]
+    )]
+    pub file_flag: Option<String>,
+    /// Symbol name (named alternative to `<SYMBOL>`).
+    #[arg(
+        long = "symbol",
+        value_name = "SYMBOL",
+        required_unless_present_all = ["file", "symbol", "body"]
+    )]
+    pub symbol_flag: Option<String>,
+    /// First turn (named alternative to `<BODY>`).
+    #[arg(
+        long = "body",
+        value_name = "BODY",
+        required_unless_present_all = ["file", "symbol", "body"]
+    )]
+    pub body_flag: Option<String>,
     /// Human-readable summary. Defaults to the first line of the first turn.
     #[arg(long)]
     pub title: Option<String>,
@@ -36,6 +82,9 @@ pub struct DiscussOpenArgs {
     /// Visibility: `public` | `internal` | `team:NAME` | `restricted:LABEL` | `private:LABEL`.
     #[arg(long)]
     pub visibility: Option<String>,
+    /// Attach the discussion to a thread ref while keeping its symbol anchor.
+    #[arg(long, value_name = "REF")]
+    pub thread: Option<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -45,17 +94,38 @@ pub struct DiscussAppendArgs {
 }
 
 #[derive(Clone, Debug, Args)]
+#[command(group(
+    ArgGroup::new("resolution")
+        .required(true)
+        .args(["mode", "into_annotation"])
+))]
 pub struct DiscussResolveArgs {
     pub discussion_id: String,
     /// Resolution kind: `by-edit` or `dismiss`.
     #[arg(long, value_enum)]
-    pub mode: ResolveModeArg,
+    pub mode: Option<ResolveModeArg>,
+    /// Resolve by creating a context annotation from this discussion.
+    #[arg(long, requires = "body")]
+    pub into_annotation: bool,
     /// For `by-edit`: state containing the edit (defaults to HEAD).
-    #[arg(long)]
+    #[arg(long, requires = "mode")]
     pub state: Option<String>,
     /// For `dismiss`: non-empty reason.
-    #[arg(long)]
+    #[arg(long, requires = "mode")]
     pub reason: Option<String>,
+    /// For `--into-annotation`: annotation content.
+    #[arg(long, requires = "into_annotation")]
+    pub body: Option<String>,
+    /// For `--into-annotation`: constraint, invariant, or rationale (defaults to rationale).
+    #[arg(
+        long,
+        value_parser = ["constraint", "invariant", "rationale"],
+        requires = "into_annotation"
+    )]
+    pub kind: Option<String>,
+    /// For `--into-annotation`: annotation tag (can be repeated).
+    #[arg(long, requires = "into_annotation")]
+    pub tag: Vec<String>,
 }
 
 #[derive(Clone, Debug, clap::ValueEnum)]

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -1142,6 +1142,7 @@ pub struct DiscussionSchema {
     pub title: String,
     pub anchor: DiscussionAnchorSchema,
     pub visibility: String,
+    pub thread_ref: Option<String>,
     pub status: String,
     pub resolution: Option<DiscussionResolutionSchema>,
     pub conflict_operation_ids: Vec<String>,
@@ -1171,6 +1172,9 @@ pub struct DiscussionResolutionSchema {
     pub state_id: Option<String>,
     pub change_id: Option<String>,
     pub reason: Option<String>,
+    pub annotation_kind: Option<String>,
+    pub content: Option<String>,
+    pub tags: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -959,7 +959,13 @@ file, and symbol where the discussion began:\n\
 - `resolve <id> --mode by-edit`          with `--state` (defaults to HEAD).\n\
   Records that a subsequent edit addressed the discussion.\n\
 - `resolve <id> --mode dismiss`          requires non-empty `--reason`.\n\
+- `resolve <id> --into-annotation --body <text>` creates and links a context\n\
+  annotation; `--kind` defaults to rationale and `--tag` is repeatable.\n\
 - `reopen <id> --reason <text>`          compensates a prior resolution.\n\
+\n\
+`open` accepts either `<file> <symbol> <body>` or the equivalent named\n\
+`--file`, `--symbol`, and `--body` flags. `--thread <ref>` additionally attaches\n\
+the symbol-anchored discussion to a thread; it does not replace the anchor.\n\
 \n\
 Visibility: `--visibility public|internal|team:NAME|restricted:LABEL|private:LABEL`.\n\
 Empty visibility uses the configured discussion visibility policy.\n";

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -5,9 +5,9 @@ use std::time::SystemTime;
 
 use anyhow::{Context, Result, anyhow};
 use objects::object::{
-    CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey, CollaborationOperationBodyV1,
-    CollaborationOperationEnvelope, CollaborationResolution, DiscussionRecordId, DiscussionTurnV1,
-    MaterializedDiscussion, StateId, VisibilityTier,
+    AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
+    CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
+    DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, StateId, VisibilityTier,
 };
 use repo::{
     CollaborationStore, CollaborationWriteDisposition, CollaborationWriteOutcome,
@@ -80,6 +80,7 @@ struct DiscussionOutput {
     title: String,
     anchor: AnchorOutput,
     visibility: String,
+    thread_ref: Option<String>,
     status: &'static str,
     resolution: Option<ResolutionOutput>,
     conflict_operation_ids: Vec<String>,
@@ -112,10 +113,23 @@ enum AnchorOutput {
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 enum ResolutionOutput {
-    AddressedByState { state_id: String },
-    AddressedByChange { change_id: String },
-    Dismissed { reason: String },
-    Annotation { annotation_id: String },
+    AddressedByState {
+        state_id: String,
+    },
+    AddressedByChange {
+        change_id: String,
+    },
+    Dismissed {
+        reason: String,
+    },
+    IntoAnnotation {
+        annotation_kind: String,
+        content: String,
+        tags: Vec<String>,
+    },
+    Annotation {
+        annotation_id: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -174,19 +188,15 @@ fn run_open(
     store: &CollaborationStore,
     args: &DiscussOpenArgs,
 ) -> Result<()> {
+    let (file, symbol, body) = open_inputs(args)?;
     let state_id = resolve_open_state(repo, args.state.as_deref())?;
     let title = args
         .title
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .or_else(|| {
-            args.body
-                .lines()
-                .map(str::trim)
-                .find(|line| !line.is_empty())
-        })
-        .unwrap_or(&args.symbol)
+        .or_else(|| body.lines().map(str::trim).find(|line| !line.is_empty()))
+        .unwrap_or(symbol)
         .to_string();
     let discussion_id = DiscussionRecordId::generate();
     let operation = CollaborationOperationEnvelope::new(
@@ -199,19 +209,37 @@ fn run_open(
             title,
             anchor: CollaborationAnchor::Symbol {
                 state_id,
-                path: args.file.clone(),
-                symbol: args.symbol.clone(),
+                path: file.to_string(),
+                symbol: symbol.to_string(),
             },
             visibility: parse_visibility(
                 args.visibility.as_deref(),
                 repo.resolve_capture_default_visibility(),
             )?,
-            turn: DiscussionTurnV1::new(args.body.clone())?,
+            turn: DiscussionTurnV1::new(body)?,
+            thread_ref: args.thread.clone(),
         },
     )?;
     let outcome = store.write_operation(&operation)?;
     emit_locality_notice_once(repo, AnnotationSurface::Discuss);
     emit_write(cli, "discuss_open", store, discussion_id, outcome)
+}
+
+fn open_inputs(args: &DiscussOpenArgs) -> Result<(&str, &str, &str)> {
+    match (
+        args.file.as_deref(),
+        args.symbol.as_deref(),
+        args.body.as_deref(),
+        args.file_flag.as_deref(),
+        args.symbol_flag.as_deref(),
+        args.body_flag.as_deref(),
+    ) {
+        (Some(file), Some(symbol), Some(body), None, None, None)
+        | (None, None, None, Some(file), Some(symbol), Some(body)) => Ok((file, symbol, body)),
+        _ => Err(anyhow!(
+            "discuss open requires either <FILE> <SYMBOL> <BODY> or --file <FILE> --symbol <SYMBOL> --body <BODY>"
+        )),
+    }
 }
 
 fn run_append(
@@ -238,11 +266,11 @@ fn run_resolve(
     store: &CollaborationStore,
     args: &DiscussResolveArgs,
 ) -> Result<()> {
-    let resolution = match args.mode {
-        ResolveModeArg::ByEdit => CollaborationResolution::AddressedByState {
+    let resolution = match (args.mode.as_ref(), args.into_annotation) {
+        (Some(ResolveModeArg::ByEdit), false) => CollaborationResolution::AddressedByState {
             state_id: resolve_state(repo, args.state.as_deref())?,
         },
-        ResolveModeArg::Dismiss => CollaborationResolution::Dismissed {
+        (Some(ResolveModeArg::Dismiss), false) => CollaborationResolution::Dismissed {
             reason: args
                 .reason
                 .as_deref()
@@ -251,6 +279,27 @@ fn run_resolve(
                 .ok_or_else(|| anyhow!(RecoveryAdvice::discuss_resolve_missing_dismiss_reason()))?
                 .to_string(),
         },
+        (None, true) => CollaborationResolution::IntoAnnotation {
+            annotation_kind: args
+                .kind
+                .as_deref()
+                .unwrap_or("rationale")
+                .parse::<AnnotationKind>()
+                .map_err(|error| anyhow!(error))?,
+            content: args
+                .body
+                .as_deref()
+                .map(str::trim)
+                .filter(|body| !body.is_empty())
+                .ok_or_else(|| anyhow!("--body must not be empty for --into-annotation"))?
+                .to_string(),
+            tags: args.tag.clone(),
+        },
+        _ => {
+            return Err(anyhow!(
+                "discuss resolve requires exactly one of --mode or --into-annotation"
+            ));
+        }
     };
     write_descendant(
         cli,
@@ -413,6 +462,9 @@ fn emit_show(cli: &Cli, output: &DiscussionShowOutput) -> Result<()> {
     println!("  title: {}", discussion.title);
     println!("  anchor: {}", anchor_label(&discussion.anchor));
     println!("  visibility: {}", discussion.visibility);
+    if let Some(thread_ref) = &discussion.thread_ref {
+        println!("  thread: {thread_ref}");
+    }
     println!("  heads: {}", discussion.head_operation_ids.join(", "));
     for turn in &discussion.turns {
         let actor = turn.agent.as_deref().unwrap_or(&turn.author_name);
@@ -456,6 +508,7 @@ fn to_view(store: &CollaborationStore, value: &MaterializedDiscussion) -> Result
         title: value.title.clone(),
         anchor: anchor_output(&value.anchor),
         visibility: visibility_token(&value.visibility),
+        thread_ref: value.thread_ref.clone(),
         status,
         resolution: value.resolution.as_ref().map(resolution_output),
         conflict_operation_ids: value
@@ -625,6 +678,15 @@ fn resolution_output(value: &CollaborationResolution) -> ResolutionOutput {
         }
         CollaborationResolution::Dismissed { reason } => ResolutionOutput::Dismissed {
             reason: reason.clone(),
+        },
+        CollaborationResolution::IntoAnnotation {
+            annotation_kind,
+            content,
+            tags,
+        } => ResolutionOutput::IntoAnnotation {
+            annotation_kind: annotation_kind.to_string(),
+            content: content.clone(),
+            tags: tags.clone(),
         },
         CollaborationResolution::Annotation { annotation_id } => ResolutionOutput::Annotation {
             annotation_id: annotation_id.clone(),

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -32,6 +32,9 @@
 //! Push sends only turns that are self-authored AND unlinked; pull materializes
 //! only server ordinals not yet linked. Client operation ids are derived from
 //! the stable turn id, so a retry replays instead of conflicting.
+//! Resolve-into-annotation operations use the same durable mirror: their
+//! request identity is derived from the complete resolution payload and is
+//! recorded only after `ResolveDiscussion` succeeds.
 //!
 //! ## Reconciliation is author-aware, never body-alone
 //!
@@ -58,7 +61,7 @@
 //! leaves durable writes without their mapping.
 //!
 //! Scope: discussions only; `context`/`review` share the same seam (not built).
-//! `resolve`/`reopen` are not yet mirrored (turns only).
+//! By-edit, dismiss, and reopen state are not yet mirrored.
 
 #![cfg(feature = "client")]
 
@@ -114,6 +117,10 @@ struct MirrorEntry {
     /// Turns known to exist on BOTH sides, each carrying its identity on both.
     #[serde(default)]
     links: Vec<TurnLink>,
+    /// Client operation id of the resolve-into-annotation request known to
+    /// exist on both sides.
+    #[serde(default)]
+    resolved_into_annotation_operation_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,6 +182,18 @@ fn append_op_id(repo_path: &str, server_id: &str, turn_id: &str) -> String {
         format!("append:{repo_path}:{server_id}:{turn_id}").as_bytes(),
     )
     .to_string()
+}
+
+fn resolve_into_annotation_op_id(
+    repo_path: &str,
+    server_id: &str,
+    kind: objects::object::AnnotationKind,
+    content: &str,
+    tags: &[String],
+) -> Result<String> {
+    let identity = serde_json::to_vec(&(repo_path, server_id, kind.as_str(), content, tags))
+        .context("encode resolve-into-annotation operation identity")?;
+    Ok(uuid::Uuid::new_v5(&OP_NAMESPACE, &identity).to_string())
 }
 
 fn now_ms() -> i64 {
@@ -350,12 +369,11 @@ async fn push_one(
             crate::cli::style::warn_marker(),
         );
     }
-    if candidates.is_empty() {
-        return Ok(false);
-    }
-
-    match entry_index {
+    let (index, server_id, mut changed) = match entry_index {
         None => {
+            if candidates.is_empty() {
+                return Ok(false);
+            }
             let (open_turn_id, open_body) = candidates[0].clone();
             let hosted = client
                 .open_discussion(
@@ -365,6 +383,7 @@ async fn push_one(
                     symbol,
                     &open_body,
                     &visibility,
+                    discussion.thread_ref.as_deref(),
                     open_op_id(repo_path, local_id),
                 )
                 .await
@@ -378,6 +397,7 @@ async fn push_one(
                     local_turn_id: open_turn_id,
                     server_ordinal: 0,
                 }],
+                resolved_into_annotation_operation_id: None,
             });
             let index = repo_mirror.discussions.len() - 1;
             for (turn_id, body) in &candidates[1..] {
@@ -398,7 +418,7 @@ async fn push_one(
                     hosted.turns.len().saturating_sub(1),
                 );
             }
-            Ok(true)
+            (index, server_id, true)
         }
         Some(index) => {
             let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
@@ -420,9 +440,61 @@ async fn push_one(
                     hosted.turns.len().saturating_sub(1),
                 );
             }
-            Ok(true)
+            (index, server_id, !candidates.is_empty())
         }
+    };
+
+    if push_into_annotation_resolution(client, repo_path, mirror, index, &server_id, discussion)
+        .await?
+    {
+        changed = true;
     }
+    Ok(changed)
+}
+
+async fn push_into_annotation_resolution(
+    client: &mut HostedClient,
+    repo_path: &str,
+    mirror: &mut HostedMirror,
+    index: usize,
+    server_id: &str,
+    discussion: &MaterializedDiscussion,
+) -> Result<bool> {
+    let Some(objects::object::CollaborationResolution::IntoAnnotation {
+        annotation_kind,
+        content,
+        tags,
+    }) = &discussion.resolution
+    else {
+        return Ok(false);
+    };
+    let operation_id =
+        resolve_into_annotation_op_id(repo_path, server_id, *annotation_kind, content, tags)?;
+    if mirror.repos[repo_path].discussions[index]
+        .resolved_into_annotation_operation_id
+        .as_deref()
+        == Some(&operation_id)
+    {
+        return Ok(false);
+    }
+    client
+        .resolve_discussion_into_annotation(
+            repo_path,
+            server_id,
+            *annotation_kind,
+            content,
+            tags.clone(),
+            operation_id.clone(),
+        )
+        .await
+        .with_context(|| format!("resolve hosted discussion {server_id} into annotation"))?;
+    let entry = mirror
+        .repos
+        .get_mut(repo_path)
+        .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+        .ok_or_else(|| anyhow!("hosted discussion mirror entry disappeared during resolution"))?;
+    entry.resolved_into_annotation_operation_id = Some(operation_id);
+    Ok(true)
 }
 
 /// Fetch hosted discussions for the repository head and materialize any turns we
@@ -513,6 +585,7 @@ fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion 
         symbol: discussion.anchor.symbol,
         opened_against_state: Some(discussion.opened_against_state),
         visibility: discussion.visibility.as_str().to_string(),
+        thread_ref: discussion.thread_ref,
         turns: discussion
             .turns
             .into_iter()
@@ -568,6 +641,7 @@ fn pull_one(
                     anchor,
                     visibility,
                     turn: turn_body(first)?,
+                    thread_ref: discussion.thread_ref.clone(),
                 },
             )?;
             // Record the mapping immediately so a mid-materialization failure
@@ -580,6 +654,7 @@ fn pull_one(
                     local_turn_id: turn_identity(&open_op, 0),
                     server_ordinal: 0,
                 }],
+                resolved_into_annotation_operation_id: None,
             });
             let index = repo_mirror.discussions.len() - 1;
 
@@ -779,11 +854,11 @@ fn parse_visibility_token(token: &str) -> VisibilityTier {
 #[cfg(test)]
 mod tests {
     use objects::object::{
-        Attribution, CollaborationAnchor, CollaborationIdempotencyKey,
-        CollaborationOperationBodyV1, CollaborationOperationEnvelope, ContentHash, Discussion,
-        DiscussionRecordId, DiscussionResolution, DiscussionTurn, DiscussionTurnV1,
-        LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator, Principal,
-        StateAttachmentId, StateId, SymbolAnchor, VisibilityTier,
+        AnnotationKind, Attribution, CollaborationAnchor, CollaborationIdempotencyKey,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
+        ContentHash, Discussion, DiscussionRecordId, DiscussionResolution, DiscussionTurn,
+        DiscussionTurnV1, LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator,
+        Principal, StateAttachmentId, StateId, SymbolAnchor, VisibilityTier,
     };
     use tempfile::TempDir;
 
@@ -946,6 +1021,7 @@ mod tests {
                 },
                 visibility: VisibilityTier::Internal,
                 turn: DiscussionTurnV1::new("hi").unwrap(),
+                thread_ref: None,
             },
         )
         .unwrap();
@@ -1013,7 +1089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn push_discussion_opens_then_appends_only_unlinked_self_turns() {
+    async fn push_discussion_opens_appends_and_resolves_into_annotation() {
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
@@ -1043,6 +1119,7 @@ mod tests {
                 },
                 visibility: VisibilityTier::Internal,
                 turn: DiscussionTurnV1::new("first turn").unwrap(),
+                thread_ref: Some("refs/heads/feature/run".to_string()),
             },
         )
         .unwrap();
@@ -1054,11 +1131,11 @@ mod tests {
             1
         );
 
-        write_local_operation(
+        let append = write_local_operation(
             &store,
             discussion_id,
             vec![open],
-            author,
+            author.clone(),
             1_700_000_001_000,
             CollaborationOperationBodyV1::AppendTurn {
                 turn: DiscussionTurnV1::new("second turn").unwrap(),
@@ -1070,6 +1147,35 @@ mod tests {
                 .await
                 .unwrap(),
             1
+        );
+
+        write_local_operation(
+            &store,
+            discussion_id,
+            vec![append],
+            author,
+            1_700_000_002_000,
+            CollaborationOperationBodyV1::Resolve {
+                resolution: CollaborationResolution::IntoAnnotation {
+                    annotation_kind: AnnotationKind::Invariant,
+                    content: "the cache key includes visibility".to_string(),
+                    tags: vec!["cache".to_string()],
+                },
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            push_discussions(&repo, &mut client, "acme/widgets")
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            push_discussions(&repo, &mut client, "acme/widgets")
+                .await
+                .unwrap(),
+            0,
+            "a mirrored resolution must not be sent again"
         );
 
         client.close().await;

--- a/crates/cli/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/cli/src/hosted_runtime/hosted/collaboration.rs
@@ -17,11 +17,12 @@
 //! `Discussion.opened_against_state`.
 
 use api::heddle::api::v1alpha1::{
-    AppendTurnRequest, Discussion as ProtoDiscussion, DiscussionStatusFilter,
-    ListDiscussionsByStateRequest, OpenDiscussionRequest, PathSymbolRef, StateId as ProtoStateId,
-    list_discussions_response,
+    AppendTurnRequest, ContextAnnotationKind, Discussion as ProtoDiscussion,
+    DiscussionStatusFilter, ListDiscussionsByStateRequest, OpenDiscussionRequest, PathSymbolRef,
+    ResolveDiscussionRequest, StateId as ProtoStateId, list_discussions_response,
+    resolve_discussion_request,
 };
-use objects::object::{ChangeId, StateId};
+use objects::object::{AnnotationKind, ChangeId, StateId};
 use wire::ProtocolError;
 
 use super::{HostedClient, helpers::hosted_to_protocol_error};
@@ -46,6 +47,7 @@ pub struct HostedDiscussion {
     /// Genuine 32-byte anchor `StateId` echoed by the server, when present.
     pub opened_against_state: Option<StateId>,
     pub visibility: String,
+    pub thread_ref: Option<String>,
     pub turns: Vec<HostedDiscussionTurn>,
 }
 
@@ -59,6 +61,7 @@ fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
             .opened_against_state
             .and_then(|state| StateId::try_from_slice(&state.value).ok()),
         visibility: proto.visibility,
+        thread_ref: (!proto.thread_ref.is_empty()).then_some(proto.thread_ref),
         turns: proto
             .turns
             .into_iter()
@@ -106,24 +109,49 @@ impl HostedClient {
         symbol: &str,
         body: &str,
         visibility: &str,
+        thread_ref: Option<&str>,
         client_operation_id: String,
     ) -> Result<HostedDiscussion, ProtocolError> {
-        let request = OpenDiscussionRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-            state_id: change_id_state_field(change_id),
-            anchor: Some(PathSymbolRef {
-                file: file.to_string(),
-                symbol: symbol.to_string(),
-            }),
-            body: body.to_string(),
-            visibility: visibility.to_string(),
-            thread_ref: String::new(),
+        let request = open_discussion_request(
+            repo_path,
+            change_id,
+            file,
+            symbol,
+            body,
+            visibility,
+            thread_ref,
             client_operation_id,
-            thread_id: String::new(),
-        };
+        );
         let response = self
             .routes()
             .open_discussion(&request)
+            .await
+            .map_err(hosted_to_protocol_error)?;
+        Ok(decode_discussion(response))
+    }
+
+    /// Resolve a hosted discussion by creating and linking a context annotation.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn resolve_discussion_into_annotation(
+        &mut self,
+        repo_path: &str,
+        discussion_id: &str,
+        kind: AnnotationKind,
+        content: &str,
+        tags: Vec<String>,
+        client_operation_id: String,
+    ) -> Result<HostedDiscussion, ProtocolError> {
+        let request = resolve_into_annotation_request(
+            repo_path,
+            discussion_id,
+            kind,
+            content,
+            tags,
+            client_operation_id,
+        );
+        let response = self
+            .routes()
+            .resolve_discussion(&request)
             .await
             .map_err(hosted_to_protocol_error)?;
         Ok(decode_discussion(response))
@@ -211,6 +239,62 @@ impl HostedClient {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn open_discussion_request(
+    repo_path: &str,
+    change_id: ChangeId,
+    file: &str,
+    symbol: &str,
+    body: &str,
+    visibility: &str,
+    thread_ref: Option<&str>,
+    client_operation_id: String,
+) -> OpenDiscussionRequest {
+    OpenDiscussionRequest {
+        repo_path: super::helpers::repository_ref(repo_path),
+        state_id: change_id_state_field(change_id),
+        anchor: Some(PathSymbolRef {
+            file: file.to_string(),
+            symbol: symbol.to_string(),
+        }),
+        body: body.to_string(),
+        visibility: visibility.to_string(),
+        thread_ref: thread_ref.unwrap_or_default().to_string(),
+        client_operation_id,
+        thread_id: String::new(),
+    }
+}
+
+fn resolve_into_annotation_request(
+    repo_path: &str,
+    discussion_id: &str,
+    kind: AnnotationKind,
+    content: &str,
+    tags: Vec<String>,
+    client_operation_id: String,
+) -> ResolveDiscussionRequest {
+    ResolveDiscussionRequest {
+        repo_path: super::helpers::repository_ref(repo_path),
+        discussion_id: discussion_id.to_string(),
+        resolution: Some(resolve_discussion_request::Resolution::IntoAnnotation(
+            resolve_discussion_request::ResolveIntoAnnotation {
+                kind: annotation_kind_to_proto(kind) as i32,
+                content: content.to_string(),
+                tags,
+            },
+        )),
+        client_operation_id,
+    }
+}
+
+fn annotation_kind_to_proto(kind: AnnotationKind) -> ContextAnnotationKind {
+    match kind {
+        AnnotationKind::Constraint => ContextAnnotationKind::Constraint,
+        AnnotationKind::Invariant => ContextAnnotationKind::Invariant,
+        AnnotationKind::Rationale => ContextAnnotationKind::Rationale,
+    }
+}
+
 fn discussion_status_filter(status: &str) -> Result<DiscussionStatusFilter, ProtocolError> {
     match status {
         "all" => Ok(DiscussionStatusFilter::Unspecified),
@@ -227,8 +311,9 @@ fn discussion_status_filter(status: &str) -> Result<DiscussionStatusFilter, Prot
 mod tests {
     use api::heddle::api::v1alpha1::{
         DiscussionTurn as ProtoTurn, PathSymbolRef, StateId as ProtoStateId,
+        resolve_discussion_request::Resolution,
     };
-    use objects::object::ChangeId;
+    use objects::object::{AnnotationKind, ChangeId};
 
     use super::*;
 
@@ -258,6 +343,42 @@ mod tests {
         let change = ChangeId::from_bytes([0x11; 16]);
         let field = change_id_state_field(change).expect("proto state wrapper");
         assert_eq!(field.value, change.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn open_discussion_request_sets_thread_ref() {
+        let change = ChangeId::from_bytes([0x11; 16]);
+        let request = open_discussion_request(
+            "acme/widgets",
+            change,
+            "src/lib.rs",
+            "run",
+            "keep this stable",
+            "internal",
+            Some("refs/heads/feature/run"),
+            "open-op".to_string(),
+        );
+        assert_eq!(request.thread_ref, "refs/heads/feature/run");
+        assert_eq!(request.anchor.unwrap().file, "src/lib.rs");
+        assert_eq!(request.body, "keep this stable");
+    }
+
+    #[test]
+    fn resolve_into_annotation_request_uses_the_typed_resolution_variant() {
+        let request = resolve_into_annotation_request(
+            "acme/widgets",
+            "discussion-1",
+            AnnotationKind::Invariant,
+            "the cache key must include visibility",
+            vec!["cache".to_string(), "security".to_string()],
+            "resolve-op".to_string(),
+        );
+        let Some(Resolution::IntoAnnotation(annotation)) = request.resolution else {
+            panic!("expected ResolveIntoAnnotation request");
+        };
+        assert_eq!(annotation.kind, ContextAnnotationKind::Invariant as i32);
+        assert_eq!(annotation.content, "the cache key must include visibility");
+        assert_eq!(annotation.tags, ["cache", "security"]);
     }
 
     #[test]
@@ -291,6 +412,7 @@ mod tests {
         assert_eq!(decoded.symbol, "main");
         assert_eq!(decoded.opened_against_state, Some(state));
         assert_eq!(decoded.visibility, "team");
+        assert_eq!(decoded.thread_ref, None);
         assert_eq!(decoded.turns.len(), 1);
         assert_eq!(decoded.turns[0].author_name, "alice");
         assert_eq!(decoded.turns[0].body, "lgtm");

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -341,6 +341,13 @@ impl HostedRoutes<'_> {
         AppendTurnRequest,
         Discussion
     );
+    unary_method!(
+        resolve_discussion,
+        "CollaborationService",
+        "ResolveDiscussion",
+        ResolveDiscussionRequest,
+        Discussion
+    );
     server_stream_method!(
         list_discussions_by_state,
         "CollaborationService",

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8325,6 +8325,92 @@ fn discuss_resolve_by_edit_emits_resolved_state_json() {
 }
 
 #[test]
+fn discuss_open_named_flags_records_thread_ref() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::create_dir_all(temp.path().join("src")).unwrap();
+    std::fs::write(temp.path().join("src/lib.rs"), "fn foo() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+
+    let opened = json_value(
+        temp.path(),
+        &[
+            "discuss",
+            "open",
+            "--file",
+            "src/lib.rs",
+            "--symbol",
+            "foo",
+            "--body",
+            "Keep the thread context attached",
+            "--thread",
+            "refs/heads/feature/foo",
+        ],
+    );
+    assert_eq!(opened["output_kind"], "discuss_open");
+    assert_eq!(opened["discussion"]["thread_ref"], "refs/heads/feature/foo");
+    assert_eq!(opened["discussion"]["anchor"]["path"], "src/lib.rs");
+    assert_eq!(opened["discussion"]["anchor"]["symbol"], "foo");
+}
+
+#[test]
+fn discuss_resolve_into_annotation_records_complete_resolution() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::create_dir_all(temp.path().join("src")).unwrap();
+    std::fs::write(temp.path().join("src/lib.rs"), "fn foo() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json_value(
+        temp.path(),
+        &[
+            "discuss",
+            "open",
+            "src/lib.rs",
+            "foo",
+            "Please preserve this invariant",
+        ],
+    );
+    let discussion_id = opened["discussion"]["id"]
+        .as_str()
+        .expect("discuss open should return an id");
+
+    let resolved = json_value(
+        temp.path(),
+        &[
+            "discuss",
+            "resolve",
+            discussion_id,
+            "--into-annotation",
+            "--body",
+            "The cache key must include visibility",
+            "--kind",
+            "invariant",
+            "--tag",
+            "cache",
+            "--tag",
+            "security",
+        ],
+    );
+    assert_eq!(resolved["output_kind"], "discuss_resolve");
+    assert_eq!(
+        resolved["discussion"]["resolution"]["kind"],
+        "into_annotation"
+    );
+    assert_eq!(
+        resolved["discussion"]["resolution"]["annotation_kind"],
+        "invariant"
+    );
+    assert_eq!(
+        resolved["discussion"]["resolution"]["content"],
+        "The cache key must include visibility"
+    );
+    assert_eq!(
+        resolved["discussion"]["resolution"]["tags"],
+        serde_json::json!(["cache", "security"])
+    );
+}
+
+#[test]
 fn discuss_resolve_dismiss_requires_reason_with_typed_advice_json() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/object-model/src/object/collaboration/codec/mod.rs
+++ b/crates/object-model/src/object/collaboration/codec/mod.rs
@@ -60,7 +60,7 @@ mod tests {
 
     use super::*;
     use crate::object::{
-        Attribution, ChangeId, CollaborationAnchor, CollaborationIdempotencyKey,
+        AnnotationKind, Attribution, ChangeId, CollaborationAnchor, CollaborationIdempotencyKey,
         CollaborationOperationBodyV1, CollaborationResolution, ContentHash, DiscussionRecordId,
         DiscussionTurnV1, LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator,
         Principal, StateAttachmentId, StateId, VisibilityTier,
@@ -123,6 +123,7 @@ mod tests {
             anchor,
             visibility: VisibilityTier::default(),
             turn: turn(),
+            thread_ref: None,
         };
         let locator = LegacySourceLocator::new(
             state,
@@ -205,6 +206,16 @@ mod tests {
                 },
             ),
             golden_operation(
+                "resolve_into_annotation",
+                CollaborationOperationBodyV1::Resolve {
+                    resolution: CollaborationResolution::IntoAnnotation {
+                        annotation_kind: AnnotationKind::Rationale,
+                        content: "why".to_string(),
+                        tags: vec!["design".to_string()],
+                    },
+                },
+            ),
+            golden_operation(
                 "reopen",
                 CollaborationOperationBodyV1::Reopen {
                     reason: "r".to_string(),
@@ -282,6 +293,10 @@ mod tests {
             (
                 "resolve_annotation",
                 "9ca40f41cc72bbf6208a22f9dcbfeaa3773d1669366864b704e2251fd012bb39",
+            ),
+            (
+                "resolve_into_annotation",
+                "b3319a3a18c77c52dbf748dba14fdd06542555b7cd89b228b2938ef88888beb7",
             ),
             (
                 "reopen",

--- a/crates/object-model/src/object/collaboration/codec/v1.rs
+++ b/crates/object-model/src/object/collaboration/codec/v1.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::CollaborationCodecError;
 use crate::object::{
-    Attribution, ChangeId, ContentHash, StateId, VisibilityTier,
+    AnnotationKind, Attribution, ChangeId, ContentHash, StateId, VisibilityTier,
     collaboration::{
         COLLABORATION_OPERATION_SCHEMA_VERSION, CollabOpId, CollaborationAnchor,
         CollaborationIdempotencyKey, CollaborationOperationBodyV1, CollaborationOperationEnvelope,
@@ -54,10 +54,23 @@ struct WireTurnV1 {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 enum WireResolutionV1 {
-    AddressedByState { state_id: StateId },
-    AddressedByChange { change_id: ChangeId },
-    Dismissed { reason: String },
-    Annotation { annotation_id: String },
+    AddressedByState {
+        state_id: StateId,
+    },
+    AddressedByChange {
+        change_id: ChangeId,
+    },
+    Dismissed {
+        reason: String,
+    },
+    IntoAnnotation {
+        annotation_kind: AnnotationKind,
+        content: String,
+        tags: Vec<String>,
+    },
+    Annotation {
+        annotation_id: String,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -77,6 +90,8 @@ enum WireBodyV1 {
         anchor: WireAnchorV1,
         visibility: VisibilityTier,
         turn: WireTurnV1,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        thread_ref: Option<String>,
     },
     AppendTurn {
         turn: WireTurnV1,
@@ -202,6 +217,15 @@ impl From<CollaborationResolution> for WireResolutionV1 {
                 Self::AddressedByChange { change_id }
             }
             CollaborationResolution::Dismissed { reason } => Self::Dismissed { reason },
+            CollaborationResolution::IntoAnnotation {
+                annotation_kind,
+                content,
+                tags,
+            } => Self::IntoAnnotation {
+                annotation_kind,
+                content,
+                tags,
+            },
             CollaborationResolution::Annotation { annotation_id } => {
                 Self::Annotation { annotation_id }
             }
@@ -217,6 +241,15 @@ impl From<WireResolutionV1> for CollaborationResolution {
                 Self::AddressedByChange { change_id }
             }
             WireResolutionV1::Dismissed { reason } => Self::Dismissed { reason },
+            WireResolutionV1::IntoAnnotation {
+                annotation_kind,
+                content,
+                tags,
+            } => Self::IntoAnnotation {
+                annotation_kind,
+                content,
+                tags,
+            },
             WireResolutionV1::Annotation { annotation_id } => Self::Annotation { annotation_id },
         }
     }
@@ -260,11 +293,13 @@ impl From<CollaborationOperationBodyV1> for WireBodyV1 {
                 anchor,
                 visibility,
                 turn,
+                thread_ref,
             } => Self::Open {
                 title,
                 anchor: anchor.into(),
                 visibility,
                 turn: turn.into(),
+                thread_ref,
             },
             CollaborationOperationBodyV1::AppendTurn { turn } => {
                 Self::AppendTurn { turn: turn.into() }
@@ -311,11 +346,13 @@ impl From<WireBodyV1> for CollaborationOperationBodyV1 {
                 anchor,
                 visibility,
                 turn,
+                thread_ref,
             } => Self::Open {
                 title,
                 anchor: anchor.into(),
                 visibility,
                 turn: turn.into(),
+                thread_ref,
             },
             WireBodyV1::AppendTurn { turn } => Self::AppendTurn { turn: turn.into() },
             WireBodyV1::Resolve { resolution } => Self::Resolve {

--- a/crates/object-model/src/object/collaboration/materialize.rs
+++ b/crates/object-model/src/object/collaboration/materialize.rs
@@ -97,6 +97,7 @@ pub struct MaterializedDiscussion {
     pub title: String,
     pub anchor: CollaborationAnchor,
     pub visibility: VisibilityTier,
+    pub thread_ref: Option<String>,
     pub turns: Vec<(CollabOpId, DiscussionTurnV1)>,
     pub resolution: Option<CollaborationResolution>,
     pub conflict_operations: BTreeSet<CollabOpId>,
@@ -191,16 +192,18 @@ fn materialize_discussion(
     }
     let root_id = roots[0];
     let root = &all[&root_id].operation.body;
-    let (title, anchor, visibility, root_turns, base_resolution) = match root {
+    let (title, anchor, visibility, thread_ref, root_turns, base_resolution) = match root {
         CollaborationOperationBodyV1::Open {
             title,
             anchor,
             visibility,
             turn,
+            thread_ref,
         } => (
             title.clone(),
             anchor.clone(),
             visibility.clone(),
+            thread_ref.clone(),
             vec![turn.clone()],
             None,
         ),
@@ -215,6 +218,7 @@ fn materialize_discussion(
             title.clone(),
             anchor.clone(),
             visibility.clone(),
+            None,
             turns.clone(),
             legacy_resolution(resolution),
         ),
@@ -291,6 +295,7 @@ fn materialize_discussion(
         title,
         anchor,
         visibility,
+        thread_ref,
         turns,
         resolution,
         conflict_operations: conflicts,
@@ -415,6 +420,7 @@ mod tests {
                 anchor: CollaborationAnchor::Repository,
                 visibility: VisibilityTier::default(),
                 turn: DiscussionTurnV1::new("first").unwrap(),
+                thread_ref: None,
             },
         )
     }

--- a/crates/object-model/src/object/collaboration/operation.rs
+++ b/crates/object-model/src/object/collaboration/operation.rs
@@ -6,7 +6,7 @@ use super::{
     CollabOpId, CollaborationCodecError, CollaborationIdempotencyKey, DiscussionRecordId,
     LegacyDiscussionId, LegacySourceLocator,
 };
-use crate::object::{Attribution, ChangeId, ContentHash, StateId, VisibilityTier};
+use crate::object::{AnnotationKind, Attribution, ChangeId, ContentHash, StateId, VisibilityTier};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
@@ -59,10 +59,23 @@ impl DiscussionTurnV1 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum CollaborationResolution {
-    AddressedByState { state_id: StateId },
-    AddressedByChange { change_id: ChangeId },
-    Dismissed { reason: String },
-    Annotation { annotation_id: String },
+    AddressedByState {
+        state_id: StateId,
+    },
+    AddressedByChange {
+        change_id: ChangeId,
+    },
+    Dismissed {
+        reason: String,
+    },
+    IntoAnnotation {
+        annotation_kind: AnnotationKind,
+        content: String,
+        tags: Vec<String>,
+    },
+    Annotation {
+        annotation_id: String,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +95,7 @@ pub enum CollaborationOperationBodyV1 {
         anchor: CollaborationAnchor,
         visibility: VisibilityTier,
         turn: DiscussionTurnV1,
+        thread_ref: Option<String>,
     },
     AppendTurn {
         turn: DiscussionTurnV1,
@@ -126,10 +140,14 @@ impl CollaborationOperationBodyV1 {
                 title,
                 anchor,
                 turn,
+                thread_ref,
                 ..
             } => {
                 require_text(title, "discussion title")?;
                 validate_anchor(anchor)?;
+                if let Some(thread_ref) = thread_ref {
+                    require_text(thread_ref, "discussion thread ref")?;
+                }
                 turn.validate()
             }
             Self::AppendTurn { turn } => turn.validate(),
@@ -272,6 +290,9 @@ fn validate_anchor(anchor: &CollaborationAnchor) -> Result<(), CollaborationCode
 fn validate_resolution(value: &CollaborationResolution) -> Result<(), CollaborationCodecError> {
     match value {
         CollaborationResolution::Dismissed { reason } => require_text(reason, "dismiss reason"),
+        CollaborationResolution::IntoAnnotation { content, .. } => {
+            require_text(content, "annotation content")
+        }
         CollaborationResolution::Annotation { annotation_id } => {
             require_text(annotation_id, "annotation id")
         }

--- a/crates/repo/src/collaboration_store.rs
+++ b/crates/repo/src/collaboration_store.rs
@@ -448,6 +448,7 @@ mod tests {
                 anchor: CollaborationAnchor::Repository,
                 visibility: VisibilityTier::default(),
                 turn: DiscussionTurnV1::new("first").unwrap(),
+                thread_ref: None,
             },
         )
         .unwrap()


### PR DESCRIPTION
## Summary

- add `discuss resolve <id> --into-annotation --body <text>` with optional `--kind` and repeatable `--tag`, persist the resolution intent in the local collaboration log, and send the existing `ResolveIntoAnnotation` RPC variant through the post-push discussion bridge
- add `discuss open --thread <ref>` while retaining the required symbol anchor, carry the ref through local materialization/sync, and populate `OpenDiscussionRequest.thread_ref`
- keep positional `discuss open <file> <symbol> <body>` and add the complete named alternative `--file/--symbol/--body`
- update human help and the additive discussion JSON schema

This is the buildable-now slice of #1536 on heddle-api 0.12. Symbol-less `--ref` opens and resolve-link to an EXISTING annotation remain gated on weft#1788 and api#155/#157.

The CLI is offline-first: these values are recorded in the existing local collaboration operation and translated by the existing post-push discussion bridge. No daemon timing or network flow was added.

## Closes

Partial #1536.

## Test evidence

- API guard: resolved `heddle-api 0.12.0` contains `OpenDiscussionRequest.thread_ref` and `ResolveDiscussionRequest.ResolveIntoAnnotation { kind, content, tags }`
- `rustfmt +nightly --check --edition 2024 <touched files>` — passed
- `cargo build -p heddle-cli -p heddle-cli-args -p heddle-cli-contract` — passed
- `cargo clippy -p heddle-cli -p heddle-cli-args -p heddle-cli-contract -p heddle-object-model -p heddle-repo --all-targets -- -D warnings` — passed
- `cargo test -p heddle-object-model collaboration` — 10 passed
- `cargo test -p heddle-repo collaboration` — 6 passed
- `cargo test -p heddle-cli-contract` — 138 passed
- `cargo test -p heddle-cli --lib discussion` — 11 passed
- `cargo test -p heddle-cli --test cli_integration discuss_` — 10 passed
- focused request-construction tests passed for `OpenDiscussionRequest.thread_ref` and the typed `ResolveIntoAnnotation` oneof variant
- focused push-bridge test passed for open + append + idempotent resolve-into-annotation

Help evidence:

```text
Usage: heddle discuss open [OPTIONS] [FILE] [SYMBOL] [BODY]
      --file <FILE>
      --symbol <SYMBOL>
      --body <BODY>
      --thread <REF>

Usage: heddle discuss resolve [OPTIONS] <--mode <MODE>|--into-annotation> <DISCUSSION_ID>
      --into-annotation
      --body <BODY>
      --kind <KIND>
      --tag <TAG>
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790031617&installation_model_id=21489&pr_number=1539&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1539&signature=cde3b10aa81bdf3c6c929ab90f42df18ce5c2f57a13b437d18f3064fb1c97759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->