### PR TITLE
fix(state_review): wire invariant_annotations into SemanticContext (#881)

### DIFF
--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -11,8 +11,9 @@ use std::{
 use objects::{
     error::HeddleError,
     object::{
-        Blob, ContentHash, DiffKind, LeafPolicy, ObjectSource, SemanticEntryKind,
-        SemanticIndexRoot, SemanticTreeNode, State, StateId, Tree, diff_trees, resolve_tree_path,
+        AnnotationKind, AnnotationScope, AnnotationStatus, Blob, ContentHash, ContextTarget,
+        DiffKind, LeafPolicy, ObjectSource, SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode,
+        State, StateId, Tree, diff_trees, resolve_tree_path,
     },
     store::ObjectStore,
 };
@@ -20,7 +21,7 @@ use semantic::{
     SemanticParseCache,
     parser::{FunctionDef, Language},
 };
-use state_review::SemanticContext;
+use state_review::{SemanticContext, modules::invariant_adjacency::InvariantAnnotation};
 use tracing::warn;
 
 use crate::{Repository, Result};
@@ -167,12 +168,25 @@ pub(crate) fn build_semantic_context(
         &new_functions,
     );
 
+    let invariant_annotations = prior
+        .map(|p| {
+            collect_invariant_annotations(repo, p).unwrap_or_else(|err| {
+                warn!(
+                    error = %err,
+                    "semantic context: failed to load invariant annotations; invariant_adjacency module will stay quiet"
+                );
+                Vec::new()
+            })
+        })
+        .unwrap_or_default();
+
     Ok(SemanticContext {
         prior_functions,
         new_functions,
         changed_paths,
         changed_symbols,
         corpus_complete,
+        invariant_annotations,
     })
 }
 
@@ -294,6 +308,75 @@ fn blob_bytes_at_path(
         return Ok(None);
     };
     Ok(source.get_blob(&hash)?.map(|blob| blob.content().to_vec()))
+}
+
+/// Collect invariant-kind annotations from the new state's context attachment.
+///
+/// Reads the context tree attached to `new` (via the latest `Context`
+/// attachment), walks every file-target blob, and returns an
+/// `InvariantAnnotation` for each active revision whose `kind` is
+/// `Invariant` or whose `tags` contain `"enforces"`. The `anchor`
+/// is derived from the annotation's scope: File → `SignalAnchor::file`,
+/// Symbol → `SignalAnchor::symbol`, Lines → `SignalAnchor::file` (lines
+/// are advisory and not carried into the signal anchor to keep the shape
+/// stable).
+///
+/// Returns an empty `Vec` (not an error) when the state has no context
+/// attachment — that is the common case for the first capture.
+fn collect_invariant_annotations(
+    repo: &Repository,
+    new: &State,
+) -> Result<Vec<InvariantAnnotation>> {
+    use objects::object::SignalAnchor;
+
+    let context_root = match repo.inherit_parent_context(new)? {
+        Some(root) => root,
+        None => return Ok(Vec::new()),
+    };
+
+    let entries = repo.list_context_entries(&context_root, None)?;
+    let mut out = Vec::new();
+
+    for entry in entries {
+        // Only file targets carry per-symbol annotations that make sense
+        // as risk-signal anchors; state targets are advisory and skipped.
+        let path = match &entry.target {
+            ContextTarget::File { path } => path.clone(),
+            ContextTarget::State { .. } => continue,
+        };
+
+        for annotation in &entry.blob.annotations {
+            if annotation.status != AnnotationStatus::Active {
+                continue;
+            }
+            let Some(rev) = annotation.current_revision() else {
+                continue;
+            };
+            let is_invariant = matches!(rev.kind, AnnotationKind::Invariant)
+                || rev.tags.iter().any(|t| t == "enforces");
+            if !is_invariant {
+                continue;
+            }
+
+            let anchor = match &annotation.scope {
+                AnnotationScope::Symbol { name, .. } => {
+                    SignalAnchor::symbol(path.clone(), name.clone())
+                }
+                AnnotationScope::File | AnnotationScope::Lines(..) => {
+                    SignalAnchor::file(path.clone())
+                }
+            };
+
+            out.push(InvariantAnnotation {
+                anchor,
+                kind: rev.kind,
+                content: rev.content.clone(),
+                tags: rev.tags.clone(),
+            });
+        }
+    }
+
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -280,4 +280,67 @@ mod tests {
         cfg.novelty.enabled = true;
         assert!(tree_sitter_producers_enabled(&cfg));
     }
+
+    /// When a state has an invariant annotation attached to its context,
+    /// `compute_and_persist_signals` must fire an `invariant_adjacency` signal.
+    /// This was previously a permanent no-op: `ctx_annotations` returned the
+    /// hard-wired `EMPTY` static regardless of what `SemanticContext` carried.
+    #[test]
+    fn snapshot_with_invariant_annotation_persists_invariant_adjacency_signal() {
+        use chrono::Utc;
+        use objects::object::{
+            Annotation, AnnotationKind, AnnotationScope, ContextBlob,
+            ContextTarget, StateAttachment, StateAttachmentBody,
+        };
+
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("src.rs"), b"fn guarded() {}").unwrap();
+        let attribution = Attribution::human(Principal::new("Ann", "ann@example.com"));
+
+        // Take a seed snapshot so there is a prior state.
+        let seed = repo
+            .snapshot_with_attribution(Some("seed".to_string()), None, attribution.clone())
+            .unwrap();
+
+        // Attach an invariant annotation to the seed state, simulating what
+        // `heddle context` writes when an agent marks a symbol as invariant.
+        let target = ContextTarget::file("src.rs").unwrap();
+        let annotation = Annotation::new(
+            AnnotationScope::Symbol {
+                name: "guarded".to_string(),
+                resolved_lines: None,
+            },
+            AnnotationKind::Invariant,
+            "must hold across all operations".to_string(),
+            vec![],
+            "ann@example.com".to_string(),
+            0,
+            None,
+            None,
+        );
+        let blob = ContextBlob::new(vec![annotation]);
+        let context_root = repo.set_context_blob(None, &target, &blob).unwrap();
+        repo.put_state_attachment(&StateAttachment {
+            state_id: seed.id(),
+            body: StateAttachmentBody::Context(context_root),
+            attribution: attribution.clone(),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .unwrap();
+
+        // Take a second snapshot — this is the capture that should read the
+        // invariant annotation from the seed's context and fire the signal.
+        std::fs::write(temp.path().join("src.rs"), b"fn guarded() { changed() }").unwrap();
+        let state = repo
+            .snapshot_with_attribution(Some("change".to_string()), None, attribution)
+            .unwrap();
+
+        let modules = attached_risk_modules(&repo, &state);
+        assert!(
+            modules.iter().any(|m| m == "invariant_adjacency"),
+            "invariant_adjacency must fire when state has an invariant annotation; got {modules:?}"
+        );
+    }
 }

--- a/crates/state_review/src/modules/invariant_adjacency.rs
+++ b/crates/state_review/src/modules/invariant_adjacency.rs
@@ -21,21 +21,12 @@ pub fn run(
     _prior: &State,
     new: &State,
     cfg: &ReviewSignalsConfig,
-    _ctx: &SemanticContext,
+    ctx: &SemanticContext,
 ) -> Vec<RiskSignal> {
     if !cfg.invariant_adjacency.enabled {
         return Vec::new();
     }
-    // Annotations live in the state's context attachment. The caller materialises
-    // them into the SemanticContext when available; we don't want this
-    // module to do I/O. For the first ship, return empty when the
-    // SemanticContext doesn't carry decoded annotations — the wrapper
-    // above (R5/R7) will populate `ctx.invariant_annotations` once that
-    // surface stabilises.
-    //
-    // The code path below is exercised by test fixtures that synthesise
-    // a SemanticContext with pre-loaded annotations.
-    let annotations = ctx_annotations(_ctx);
+    let annotations = ctx_annotations(ctx);
     let computed_at = new
         .authored_at
         .map(|dt| dt.timestamp())
@@ -63,13 +54,7 @@ pub fn run(
 }
 
 fn ctx_annotations(ctx: &SemanticContext) -> &[InvariantAnnotation] {
-    // The SemanticContext is intentionally narrow; per-module side
-    // channels go on it as fields. For now the invariant module doesn't
-    // see annotations because there's no field — callers that have the
-    // data populate a synthetic context in tests via `set_invariants`.
-    static EMPTY: Vec<InvariantAnnotation> = Vec::new();
-    let _ = ctx;
-    &EMPTY
+    &ctx.invariant_annotations
 }
 
 /// Compact representation the module operates on. Lifted from the W1
@@ -88,6 +73,8 @@ use crate::truncate_reason;
 mod tests {
     use objects::object::{Attribution, ContentHash, Principal};
 
+    use crate::{registry::SemanticContext, ReviewSignalsConfig};
+
     use super::*;
 
     fn empty_state() -> State {
@@ -98,12 +85,74 @@ mod tests {
         )
     }
 
+    fn enabled_cfg() -> ReviewSignalsConfig {
+        ReviewSignalsConfig::default()
+    }
+
+    fn ctx_with(annotations: Vec<InvariantAnnotation>) -> SemanticContext {
+        SemanticContext {
+            invariant_annotations: annotations,
+            ..SemanticContext::default()
+        }
+    }
+
+    #[test]
+    fn run_fires_when_invariant_annotation_present() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Invariant,
+            content: "must hold across operations".to_string(),
+            tags: vec![],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].kind, RiskSignalKind::InvariantAdjacency);
+        assert!(signals[0].reason.contains("must hold across operations"));
+    }
+
+    #[test]
+    fn run_fires_when_enforces_tag_present() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Constraint,
+            content: "tagged as enforced".to_string(),
+            tags: vec!["enforces".to_string()],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert_eq!(signals.len(), 1);
+    }
+
+    #[test]
+    fn run_quiet_when_no_invariant_or_enforces() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Rationale,
+            content: "design decision".to_string(),
+            tags: vec!["history".to_string()],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert!(signals.is_empty());
+    }
+
+    #[test]
+    fn run_quiet_when_context_has_no_annotations() {
+        // The prior no-op: empty SemanticContext must produce no signals,
+        // and the module must stay quiet when the context carries nothing.
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = SemanticContext::default();
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert!(signals.is_empty());
+    }
+
     #[test]
     fn fires_when_invariant_annotation_present() {
-        // Direct invocation since the public `run` walks an empty fallback
-        // until R5 wires real annotations into SemanticContext. We exercise
-        // the in-module logic via a small helper that mirrors `run`'s body
-        // with a synthetic input — proves the *fires* shape.
         let new = empty_state();
         let annotations = vec![InvariantAnnotation {
             anchor: SignalAnchor::symbol("src/lib.rs", "foo"),

--- a/crates/state_review/src/modules/invariant_adjacency.rs
+++ b/crates/state_review/src/modules/invariant_adjacency.rs
@@ -21,21 +21,12 @@ pub fn run(
     _prior: &State,
     new: &State,
     cfg: &ReviewSignalsConfig,
-    _ctx: &SemanticContext,
+    ctx: &SemanticContext,
 ) -> Vec<RiskSignal> {
     if !cfg.invariant_adjacency.enabled {
         return Vec::new();
     }
-    // Annotations live in the state's context attachment. The caller materialises
-    // them into the SemanticContext when available; we don't want this
-    // module to do I/O. For the first ship, return empty when the
-    // SemanticContext doesn't carry decoded annotations — the wrapper
-    // above (R5/R7) will populate `ctx.invariant_annotations` once that
-    // surface stabilises.
-    //
-    // The code path below is exercised by test fixtures that synthesise
-    // a SemanticContext with pre-loaded annotations.
-    let annotations = ctx_annotations(_ctx);
+    let annotations = ctx_annotations(ctx);
     let computed_at = new
         .authored_at
         .map(|dt| dt.timestamp())
@@ -63,13 +54,7 @@ pub fn run(
 }
 
 fn ctx_annotations(ctx: &SemanticContext) -> &[InvariantAnnotation] {
-    // The SemanticContext is intentionally narrow; per-module side
-    // channels go on it as fields. For now the invariant module doesn't
-    // see annotations because there's no field — callers that have the
-    // data populate a synthetic context in tests via `set_invariants`.
-    static EMPTY: Vec<InvariantAnnotation> = Vec::new();
-    let _ = ctx;
-    &EMPTY
+    &ctx.invariant_annotations
 }
 
 /// Compact representation the module operates on. Lifted from the W1
@@ -88,6 +73,12 @@ use crate::truncate_reason;
 mod tests {
     use objects::object::{Attribution, ContentHash, Principal};
 
+    use crate::{
+        ReviewSignalsConfig,
+        config::InvariantAdjacencyConfig,
+        registry::SemanticContext,
+    };
+
     use super::*;
 
     fn empty_state() -> State {
@@ -98,12 +89,76 @@ mod tests {
         )
     }
 
+    fn enabled_cfg() -> ReviewSignalsConfig {
+        let mut cfg = ReviewSignalsConfig::default();
+        cfg.invariant_adjacency = InvariantAdjacencyConfig { enabled: true };
+        cfg
+    }
+
+    fn ctx_with(annotations: Vec<InvariantAnnotation>) -> SemanticContext {
+        SemanticContext {
+            invariant_annotations: annotations,
+            ..SemanticContext::default()
+        }
+    }
+
+    #[test]
+    fn run_fires_when_invariant_annotation_present() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Invariant,
+            content: "must hold across operations".to_string(),
+            tags: vec![],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].kind, RiskSignalKind::InvariantAdjacency);
+        assert!(signals[0].reason.contains("must hold across operations"));
+    }
+
+    #[test]
+    fn run_fires_when_enforces_tag_present() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Constraint,
+            content: "tagged as enforced".to_string(),
+            tags: vec!["enforces".to_string()],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert_eq!(signals.len(), 1);
+    }
+
+    #[test]
+    fn run_quiet_when_no_invariant_or_enforces() {
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = ctx_with(vec![InvariantAnnotation {
+            anchor: SignalAnchor::symbol("src/lib.rs", "foo"),
+            kind: AnnotationKind::Rationale,
+            content: "design decision".to_string(),
+            tags: vec!["history".to_string()],
+        }]);
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert!(signals.is_empty());
+    }
+
+    #[test]
+    fn run_quiet_when_context_has_no_annotations() {
+        // The prior no-op: empty SemanticContext must produce no signals,
+        // and the module must stay quiet when the context carries nothing.
+        let prior = empty_state();
+        let new = empty_state();
+        let ctx = SemanticContext::default();
+        let signals = run(&prior, &new, &enabled_cfg(), &ctx);
+        assert!(signals.is_empty());
+    }
+
     #[test]
     fn fires_when_invariant_annotation_present() {
-        // Direct invocation since the public `run` walks an empty fallback
-        // until R5 wires real annotations into SemanticContext. We exercise
-        // the in-module logic via a small helper that mirrors `run`'s body
-        // with a synthetic input — proves the *fires* shape.
         let new = empty_state();
         let annotations = vec![InvariantAnnotation {
             anchor: SignalAnchor::symbol("src/lib.rs", "foo"),

--- a/crates/state_review/src/registry.rs
+++ b/crates/state_review/src/registry.rs
@@ -9,7 +9,7 @@ use std::{
 use objects::object::{RiskSignal, State};
 use semantic::parser::FunctionDef;
 
-use crate::config::ReviewSignalsConfig;
+use crate::{config::ReviewSignalsConfig, modules::invariant_adjacency::InvariantAnnotation};
 
 /// Bundle of pre-extracted function lists per file, keyed by repo-relative
 /// path. The caller parses + extracts once per review pass and shares this
@@ -39,6 +39,12 @@ pub struct SemanticContext {
     /// stay quiet when this is false rather than scoring a partial repo.
     /// `Default` is `true` so hand-built unit-test contexts keep firing.
     pub corpus_complete: bool,
+    /// Invariant-kind annotations from the new state's attached context.
+    /// Populated by the capture path from the context tree; the
+    /// `invariant_adjacency` module reads this field instead of doing
+    /// its own I/O. Empty on the first capture (no prior context) or
+    /// when context loading is unavailable — the module stays quiet.
+    pub invariant_annotations: Vec<InvariantAnnotation>,
 }
 
 impl Default for SemanticContext {
@@ -49,6 +55,7 @@ impl Default for SemanticContext {
             changed_paths: BTreeSet::new(),
             changed_symbols: BTreeSet::new(),
             corpus_complete: true,
+            invariant_annotations: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `invariant_adjacency::run` was a permanent no-op: `ctx_annotations` returned a hard-wired empty `Vec` because `SemanticContext` had no field for invariant annotations
- Adds `invariant_annotations: Vec<InvariantAnnotation>` to `SemanticContext` in `registry.rs`
- Fixes `ctx_annotations()` to return `&ctx.invariant_annotations`
- Adds `collect_invariant_annotations()` in `repository_semantic_context.rs` that walks the prior state's context tree and collects active `Invariant`-kind (or `"enforces"`-tagged) annotations for each file target
- Adds four direct-`run()` unit tests in `invariant_adjacency` that exercise the module through `SemanticContext` (prior tests bypassed the module via a `synthetic_run` helper)
- Adds end-to-end integration test in `repository_signals.rs` confirming `compute_and_persist_signals` fires `invariant_adjacency` when a state has an invariant annotation in its prior's context

## Closes
Closes HeddleCo/heddle#881

## Test evidence
```
cargo test -p heddle-state-review modules::invariant_adjacency

running 7 tests
test modules::invariant_adjacency::tests::fires_when_enforces_tag_present ... ok
test modules::invariant_adjacency::tests::fires_when_invariant_annotation_present ... ok
test modules::invariant_adjacency::tests::quiet_when_no_invariant_or_enforces ... ok
test modules::invariant_adjacency::tests::run_fires_when_enforces_tag_present ... ok
test modules::invariant_adjacency::tests::run_quiet_when_no_invariant_or_enforces ... ok
test modules::invariant_adjacency::tests::run_fires_when_invariant_annotation_present ... ok
test modules::invariant_adjacency::tests::run_quiet_when_context_has_no_annotations ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.00s

cargo test -p heddle-repo --features tree-sitter-symbols snapshot_with_invariant

running 1 test
test repository_signals::tests::snapshot_with_invariant_annotation_persists_invariant_adjacency_signal ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 762 filtered out; finished in 4.38s

cargo test -p heddle-state-review -p heddle-repo --features tree-sitter-symbols

test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (state_review)
test result: ok. 760 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out (repo)
```

## Red commit (sabotage verification)
Temporarily reverted `ctx_annotations` to the old no-op and confirmed:
- `run_fires_when_invariant_annotation_present` FAILS (assert 0 == 1)
- `run_fires_when_enforces_tag_present` FAILS (assert 0 == 1)
- The legacy `synthetic_run` tests still pass (they bypass the module path)

This proves the new tests are load-bearing and the old `synthetic_run` tests were inert w.r.t. the no-op bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790044138&installation_model_id=21489&pr_number=1541&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1541&signature=8b4440d959e5779e67e2982035941b2c268e44e1a212ec13231a20b792eda0eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->