### PR TITLE
fix(release): HEddleCo regex typo in check-release-pipeline.sh ruby heredoc

### DIFF
--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -531,7 +531,7 @@ if !vt.is_a?(Hash)
   errors << "validate-tag job missing or malformed"
 else
   uses = vt["uses"].to_s
-  if uses.match?(/\AHEddleCo\/heddle\/\.github\/workflows\/validate-release-tag\.yml@[0-9a-f]{40}\z/)
+  if uses.match?(/\AHeddleCo\/heddle\/\.github\/workflows\/validate-release-tag\.yml@[0-9a-f]{40}\z/)
     oks << "validate-tag is a SHA-pinned reusable workflow"
   else
     errors << "validate-tag must use HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha>, got '#{uses}'"


### PR DESCRIPTION
## Summary

- One-character fix in the ruby heredoc of `scripts/check-release-pipeline.sh` (line 534): `\AHEddleCo\/...` → `\AHeddleCo\/...`.
- The typo made the gate's own evidence command fail on main whenever ruby+Psych are available (the preferred path): `::error::validate-tag must use ...@<40-char-sha>, got 'HeddleCo/heddle/.github/workflows/validate-release-tag.yml@e847f41b...'`. The Python fallback branch already had the correct pattern.
- Follow-up to #1432 (flagged in its review thread); closes out the residual gate item from #1415.

## Red commit

N/A — shell script only, no Rust change.

## Test evidence

Before (stashed fix, current main):

```
$ bash scripts/check-release-pipeline.sh
::error::validate-tag must use HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha>, got 'HeddleCo/heddle/.github/workflows/validate-release-tag.yml@e847f41b146e42e5bd688039469ed0a5ab9eff21'
release-pipeline check FAILED
```

After (this branch), full checker passes:

```
$ bash scripts/check-release-pipeline.sh
ok: validate-tag calls HeddleCo/heddle/.github/workflows/validate-release-tag.yml@e847f41b146e42e5bd688039469ed0a5ab9eff21
ok: pinned SHA e847f41b146e42e5bd688039469ed0a5ab9eff21 contains .github/workflows/validate-release-tag.yml
... (89 ok lines)
release-pipeline check passed
EXIT=0
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790060056&installation_model_id=21489&pr_number=1547&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1547&signature=c965c833e7172fd79246f2b806ed6dc339e4a7420523c3baa2324c131aabc94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->