### PR TITLE
feat(status): surface annotation and discussion counts (heddle#1152 criterion 2)

### DIFF
--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -752,6 +752,7 @@ fn render_long_status(output: &StatusOutput, verbose: bool) {
     render_status_operation(output);
     render_status_thread(output, verbose);
     render_status_details(output, verbose);
+    render_status_context(output);
     render_status_advice(output);
     render_status_changes(output);
     render_status_submodules(output);
@@ -1177,6 +1178,35 @@ fn status_workspace_label(output: &StatusOutput, mode: &ThreadMode) -> &'static 
         ThreadMode::Materialized => "attached checkout",
         ThreadMode::Solid => "isolated checkout",
         ThreadMode::Virtualized => "virtual checkout",
+    }
+}
+
+/// Existing pinned context, per heddle#1152 criterion 2: a cold reader should
+/// learn from `status` alone that annotations and discussions exist. Silent
+/// when the repository has none — the same "no news is good news" shape as
+/// the materialized-thread advisory.
+fn render_status_context(output: &StatusOutput) {
+    if output.annotation_count == 0 && output.open_discussion_count == 0 {
+        return;
+    }
+    println!();
+    println!("{}", style::bold("Context"));
+    if output.annotation_count > 0 {
+        println!(
+            "Annotations: {} active — heddle context list",
+            style::bold(&output.annotation_count.to_string())
+        );
+    }
+    if output.open_discussion_count > 0 {
+        println!(
+            "Discussions: {} open{} — heddle discuss list",
+            style::bold(&output.open_discussion_count.to_string()),
+            if output.resolved_discussion_count > 0 {
+                format!(", {} resolved", output.resolved_discussion_count)
+            } else {
+                String::new()
+            }
+        );
     }
 }
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -358,6 +358,8 @@ mod remotes;
 mod shared_target;
 #[path = "cli_integration/state_id_acceptance.rs"]
 mod state_id_acceptance;
+#[path = "cli_integration/status_context_surface.rs"]
+mod status_context_surface;
 #[path = "cli_integration/stdout_stderr_split.rs"]
 mod stdout_stderr_split;
 #[path = "cli_integration/submodule_status.rs"]

--- a/crates/cli/tests/cli_integration/status_context_surface.rs
+++ b/crates/cli/tests/cli_integration/status_context_surface.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+//! heddle#1152 criterion 2: `heddle status` surfaces existing context.
+//!
+//! A repository with 1 annotation and 1 open discussion must report both in
+//! `status` — text and JSON — so a cold reader (or a resumed agent) learns
+//! pinned context exists without being told.
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle;
+
+fn setup_with_context() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("main.rs"), "fn main() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+
+    // One context annotation on main.rs.
+    heddle(
+        &[
+            "--output",
+            "json",
+            "context",
+            "set",
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "invariant",
+            "-m",
+            "returns false on timing mismatch",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    // One open discussion anchored to main.rs.
+    heddle(
+        &[
+            "--output", "json", "discuss", "open", "main.rs", "main", "review q",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    temp
+}
+
+#[test]
+fn status_json_reports_annotation_and_discussion_counts() {
+    let temp = setup_with_context();
+
+    let output = heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(output.trim()).expect("status output should be JSON");
+    assert_eq!(
+        parsed["annotation_count"].as_u64(),
+        Some(1),
+        "status JSON should count the 1 active annotation: {parsed}"
+    );
+    assert_eq!(
+        parsed["open_discussion_count"].as_u64(),
+        Some(1),
+        "status JSON should count the 1 open discussion: {parsed}"
+    );
+}
+
+#[test]
+fn status_text_names_annotations_and_discussions() {
+    let temp = setup_with_context();
+
+    let output = heddle(&["--output", "text", "status"], Some(temp.path())).unwrap();
+    assert!(
+        output.contains("Context"),
+        "status should have a Context section: {output}"
+    );
+    assert!(
+        output.contains("Annotations: 1 active"),
+        "status should surface the annotation count: {output}"
+    );
+    assert!(
+        output.contains("Discussions: 1 open"),
+        "status should surface the open-discussion count: {output}"
+    );
+    // The verbs must be named so a cold reader can act on the hint.
+    assert!(
+        output.contains("heddle context list") && output.contains("heddle discuss list"),
+        "status should point at the discovery verbs: {output}"
+    );
+}
+
+#[test]
+fn status_stays_silent_when_no_context_exists() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("main.rs"), "fn main() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+
+    let output = heddle(&["--output", "text", "status"], Some(temp.path())).unwrap();
+    assert!(
+        !output.contains("Context\n"),
+        "status should not print an empty Context section: {output}"
+    );
+
+    let json_output = heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(json_output.trim()).unwrap();
+    assert_eq!(parsed["annotation_count"].as_u64(), Some(0));
+    assert_eq!(parsed["open_discussion_count"].as_u64(), Some(0));
+}
+
+#[test]
+fn resolved_discussions_are_counted_separately() {
+    let temp = setup_with_context();
+    let listed = heddle(&["--output", "json", "discuss", "list"], Some(temp.path())).unwrap();
+    let listed_json: Value = serde_json::from_str(listed.trim()).unwrap();
+    let id = listed_json["discussions"][0]["id"]
+        .as_str()
+        .expect("discuss list should carry discussion id")
+        .to_string();
+    heddle(
+        &["discuss", "resolve", "--mode", "by-edit", &id],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    let output = heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(parsed["open_discussion_count"].as_u64(), Some(0));
+    assert_eq!(parsed["resolved_discussion_count"].as_u64(), Some(1));
+}

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -15,18 +15,18 @@ use chrono::Utc;
 use objects::{
     HeddleError,
     error::Result,
-    object::{Principal, State, ThreadName, Tree},
+    object::{Principal, State, StateAttachmentBody, ThreadName, Tree},
     store::{ActorPresence, ActorPresenceStatus, ActorPresenceStore},
     worktree::{WorktreeStatus, build_worktree_ignore},
 };
 use refs::Head;
 use repo::{
-    AgentUsageSummary, CommitGraphIndex, GitImportGuidance, GitOverlayBranchTip,
-    GitOverlayOutOfBandCommits, GitRemoteTrackingStatus, RepoConfig, Repository,
-    RepositoryCapability, RepositoryOperationStatus, Thread, ThreadFreshness, ThreadImpactCategory,
-    ThreadManager, ThreadMode, ThreadState, WorktreeCompareProfile,
-    describe_thread_advice_with_initial, discover_heddle_root, is_synthetic_root,
-    refresh_thread_freshness,
+    AgentUsageSummary, CollaborationStore, CommitGraphIndex, GitImportGuidance,
+    GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitRemoteTrackingStatus, RepoConfig,
+    Repository, RepositoryCapability, RepositoryOperationStatus, StateAttachmentKind, Thread,
+    ThreadFreshness, ThreadImpactCategory, ThreadManager, ThreadMode, ThreadState,
+    WorktreeCompareProfile, describe_thread_advice_with_initial, discover_heddle_root,
+    is_synthetic_root, refresh_thread_freshness,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -208,6 +208,13 @@ pub struct StatusReport {
     pub submodules: Vec<SubmoduleInfo>,
     #[serde(default)]
     pub materialized_threads: Vec<MaterializedThreadInfo>,
+    /// Existing context surface, per heddle#1152 criterion 2: a cold reader
+    /// (or a resumed agent) should learn from `status` alone that pinned
+    /// context exists in this repository. Zero counts are still reported so
+    /// "none" is distinguishable from "unknown".
+    pub open_discussion_count: usize,
+    pub resolved_discussion_count: usize,
+    pub annotation_count: usize,
     #[serde(skip)]
     #[schemars(skip)]
     pub profile: StatusProfile,
@@ -2186,6 +2193,10 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
     let worktree_status_ms =
         native_worktree_status_ms + worktree_status_start.elapsed().as_millis();
 
+    // Context counts ride along on the short path too: `heddle status
+    // --short` is the prompt/resume surface and must still reveal existing
+    // context (heddle#1152 criterion 2).
+    let context_counts = repository_context_counts(repo);
     if opts.detail.short_path() {
         return Ok(build_short_path_report(ShortPathInputs {
             repo,
@@ -2413,6 +2424,9 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
         changes,
         submodules,
         materialized_threads,
+        open_discussion_count: context_counts.0,
+        resolved_discussion_count: context_counts.1,
+        annotation_count: context_counts.2,
         profile: StatusProfile::default(),
     };
     let late_state_ms = late_state_start.elapsed().as_millis();
@@ -2472,6 +2486,7 @@ fn build_short_path_report(input: ShortPathInputs<'_>) -> StatusReport {
         .with_verification(&input.trust),
     );
     let worktree_clean = input.changes.is_empty();
+    let context_counts = repository_context_counts(input.repo);
     let recommended_action =
         first_save_recommendation(input.repo, input.current_state, worktree_clean)
             .unwrap_or(recommended_action);
@@ -2559,6 +2574,9 @@ fn build_short_path_report(input: ShortPathInputs<'_>) -> StatusReport {
         changes: input.changes,
         submodules: Vec::new(),
         materialized_threads: assess_materialized_threads(input.repo),
+        open_discussion_count: context_counts.0,
+        resolved_discussion_count: context_counts.1,
+        annotation_count: context_counts.2,
         profile: input.profile,
     }
 }
@@ -3125,6 +3143,54 @@ fn fast_remote_health_for_pair(
 
 fn sley_error(err: sley::GitError) -> HeddleError {
     HeddleError::Config(err.to_string())
+}
+
+/// Existing-context counts for `heddle status` (heddle#1152 criterion 2).
+///
+/// Reads the collaboration store for open/resolved discussion counts and the
+/// current state's context attachment for the active annotation count. Any
+/// read failure degrades to zeros rather than failing `status`: surfacing
+/// context is an advisory, never a blocker. A repository with no state yet
+/// still reports its discussions.
+pub fn repository_context_counts(repo: &Repository) -> (usize, usize, usize) {
+    let mut open = 0usize;
+    let mut resolved = 0usize;
+    let mut annotations = 0usize;
+
+    if let Ok(store) = CollaborationStore::open(repo.heddle_dir())
+        && let Ok(collaboration) = store.materialize()
+    {
+        for discussion in collaboration.discussions.values() {
+            if discussion.resolution.is_some() {
+                resolved += 1;
+            } else {
+                open += 1;
+            }
+        }
+    }
+
+    if let Ok(Some(state)) = repo.current_state_for_worktree_status()
+        && let Ok(Some(attachment)) =
+            repo.latest_state_attachment(&state.state_id, StateAttachmentKind::Context)
+        && let StateAttachmentBody::Context(context_root) = attachment.body
+        && let Ok(entries) = repo.list_context_entries(&context_root, None)
+    {
+        annotations = entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .blob
+                    .annotations
+                    .iter()
+                    .filter(|annotation| {
+                        annotation.status == objects::object::AnnotationStatus::Active
+                    })
+                    .count()
+            })
+            .sum();
+    }
+
+    (open, resolved, annotations)
 }
 
 pub fn assess_materialized_threads(repo: &Repository) -> Vec<MaterializedThreadInfo> {


### PR DESCRIPTION
Fixes the remaining acceptance criterion of #1152: `heddle status` now surfaces existing context.

## Problem
Verification on main reproduced it: with 1 annotation + 1 open discussion present, `heddle status` reported neither. A cold reader (or a resumed agent) got no signal that pinned context exists.

## Change
- **core** (`heddle-core::status`): `StatusReport` gains `open_discussion_count`, `resolved_discussion_count`, and `annotation_count`. A new `repository_context_counts()` reads the collaboration store (materialized discussion resolutions) plus the current state's context attachment (active annotations). Read failures degrade to zeros — surfacing context is advisory, never a blocker. Counts are computed on both the full and short paths.
- **cli**: long text output gains a `Context` section, silent when empty (same no-news-is-good-news shape as the materialized-threads advisory), naming the discovery verbs so a cold reader can act:
  ```
  Context
  Annotations: 1 active — heddle context list
  Discussions: 1 open — heddle discuss list
  ```
  JSON output carries the counts for machine consumers.

## Verification
- New integration suite `status_context_surface` (4 tests): red without the fix (0 passed / 4 failed via stash), green with it.
- Full `cli_integration` run: 934 passed; the 22 failures (git_overlay_matrix land-recovery set, identity_resolution::heddle_home_isolates_concurrent_user_configs, clone_output_contract) fail identically on stashed main — pre-existing, unrelated.
- `cargo check`, `clippy`, `fmt --check` clean on touched crates; core status unit tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790062378&installation_model_id=21489&pr_number=1549&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1549&signature=e30c0516801ade7a301d199adc599eb50d5e5d383fda634db3292f22b7d23b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->