### PR TITLE
docs/cli: catalog deepening slice 1 — docs-contract drift + context check schema (heddle#1392)

### DIFF
--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1872,7 +1872,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["context", "check"],
         json_discriminators(
-            opaque_schemas(READ_JSON, &["context check"]),
+            documented_schemas(READ_JSON, &["context check"]),
             &[json_discriminator(
                 Some("context check"),
                 "output_kind",

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -140,6 +140,7 @@ schema_registry! {
     (&["agent fanout plan", "agent fanout start"], AgentFanoutSchema),
     (&["auth logout"], AuthLogoutSchema),
     (&["auth status"], AuthStatusSchema),
+    (&["context check"], ContextCheckSchema),
     (&["auth trust show", "auth trust replace"], AuthTrustSchema),
     (&["whoami"], WhoamiSchema),
     (&["auth create-service-token"], AuthCreateServiceTokenSchema),
@@ -715,6 +716,49 @@ pub struct AuthStatusSchema {
     pub credential_id: Option<String>,
     pub expires_at: Option<String>,
     pub recommended_action: Option<String>,
+}
+
+/// One stale annotation reported by `context check`. `reason` is the
+/// machine name of the [`StalenessStatus`](repo::staleness::StalenessStatus)
+/// variant that made the annotation stale.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ContextCheckIssueSchema {
+    /// Target label: either a path or `state:<id>`.
+    pub target: String,
+    /// Annotation scope token (e.g. `line`, `symbol`, `file`).
+    pub scope: String,
+    /// Why the annotation is stale. One of `source_changed`,
+    /// `symbol_missing`, or `file_missing` — the shipped
+    /// `StalenessStatus` enum minus the non-stale variants.
+    pub reason: ContextCheckStalenessReason,
+    pub annotation_id: String,
+    /// First 80 characters of the annotation's current content.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub enum ContextCheckStalenessReason {
+    /// The annotated source changed since the annotation was captured.
+    SourceChanged,
+    /// The symbol the annotation anchors no longer resolves.
+    SymbolMissing,
+    /// The annotated file no longer exists on disk.
+    FileMissing,
+}
+
+/// Payload-complete schema for `heddle context check --output json`
+/// (heddle#1392): pins the counters and the `StalenessStatus`-derived
+/// `reason` enum so doc claims are machine-checkable via
+/// `heddle doctor schemas`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ContextCheckSchema {
+    pub output_kind: String,
+    /// Annotations examined after active/tag filtering.
+    pub annotations: u32,
+    pub fresh: u32,
+    pub stale: u32,
+    pub unknown: u32,
+    pub issues: Vec<ContextCheckIssueSchema>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -146,7 +146,8 @@ fn write_first_screen(out: &mut String, authority: repo::RepositorySourceAuthori
          or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
          `git-overlay`, \
          `threads`, `daemon`, `signals`, `git-projection`, `operation-ids`, \
-         `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`)."
+         `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`, \
+         `agent-flags`)."
     );
 }
 

--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -44,6 +44,35 @@ struct AuthLogoutOutput {
     device_identity_removed: bool,
 }
 
+/// JSON contract for `auth login` (heddle#1392): the two commands most
+/// likely scripted on a fresh machine must honor the global
+/// `--output json` contract like every other catalogued verb.
+#[derive(Serialize)]
+struct AuthLoginOutput {
+    output_kind: &'static str,
+    server: String,
+    authenticated: bool,
+    subject: String,
+    credential_id: Option<String>,
+    expires_at: Option<String>,
+}
+
+/// JSON contract for `auth derive-agent` (heddle#1392). Token and proof
+/// key material never appears here — only identifiers, ceilings, and the
+/// optional `.hcred` path.
+#[derive(Serialize)]
+struct AuthDeriveAgentOutput {
+    output_kind: &'static str,
+    server: String,
+    agent_id: String,
+    expires_at: Option<String>,
+    template: Option<String>,
+    allowed_operations: Vec<String>,
+    scopes: Vec<String>,
+    /// Absolute path of the written `<name>.hcred` file when `--out` was
+    /// given; `null` when the child was installed into the keystore.
+    credential_path: Option<String>,
+}
 #[derive(Serialize)]
 struct AuthStatusOutput {
     output_kind: &'static str,
@@ -96,12 +125,26 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         } => match credential {
             Some(credential) => {
                 let subject = install_credential_file(&credential)?;
-                println!("Authenticated as {subject}. Credentials saved.");
+                if ctx.should_output_json(None) {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "output_kind": "auth_login",
+                            "server": resolve_server(server.as_deref())?,
+                            "authenticated": true,
+                            "subject": subject,
+                            "credential_id": null,
+                            "expires_at": null,
+                        })
+                    );
+                } else {
+                    println!("Authenticated as {subject}. Credentials saved.");
+                }
                 Ok(())
             }
             None => {
                 let server = resolve_server(server.as_deref())?;
-                cmd_auth_login(&server, open_browser).await
+                cmd_auth_login(ctx, &server, open_browser).await
             }
         },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
@@ -116,6 +159,7 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             template,
             out,
         } => cmd_auth_derive_agent(
+            ctx,
             &server,
             agent_id,
             ttl_secs,
@@ -217,6 +261,7 @@ fn emit_auth_trust(ctx: &dyn CliContext, output: AuthTrustOutput) -> Result<()> 
 /// it as the active credential or write a portable token + child-key bundle.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn cmd_auth_derive_agent(
+    ctx: &dyn CliContext,
     server: &str,
     agent_id: Option<String>,
     ttl_secs: u64,
@@ -329,6 +374,25 @@ pub(crate) fn cmd_auth_derive_agent(
             provenance: Some(provenance),
         };
         credential_file::write_credential_file(out, &verified)?;
+        if ctx.should_output_json(None) {
+            println!(
+                "{}",
+                serde_json::to_string(&AuthDeriveAgentOutput {
+                    output_kind: "auth_derive_agent",
+                    server: server.to_string(),
+                    agent_id: agent_id.clone(),
+                    expires_at: Some(expires_at.to_rfc3339()),
+                    template: template.map(|t| t.as_str().to_string()),
+                    allowed_operations: allowed_operations.clone(),
+                    scopes: declared_scopes
+                        .iter()
+                        .map(|(kind, path)| format!("{kind}:{path}"))
+                        .collect(),
+                    credential_path: Some(out.display().to_string()),
+                })?
+            );
+            return Ok(());
+        }
         println!("Agent credential {agent_id} written to {}.", out.display());
         println!("Parent source: {}", parent.source.label());
         if let Some(template) = template {
@@ -355,6 +419,25 @@ pub(crate) fn cmd_auth_derive_agent(
         },
     )?;
 
+    if ctx.should_output_json(None) {
+        println!(
+            "{}",
+            serde_json::to_string(&AuthDeriveAgentOutput {
+                output_kind: "auth_derive_agent",
+                server: server.to_string(),
+                agent_id,
+                expires_at: Some(expires_at.to_rfc3339()),
+                template: template.map(|t| t.as_str().to_string()),
+                allowed_operations: allowed_operations.clone(),
+                scopes: declared_scopes
+                    .iter()
+                    .map(|(kind, path)| format!("{kind}:{path}"))
+                    .collect(),
+                credential_path: None,
+            })?
+        );
+        return Ok(());
+    }
     if !quiet {
         println!("Derived and installed agent token {agent_id} for {server}.");
         println!("Parent source: {}", parent.source.label());
@@ -657,7 +740,7 @@ pub(crate) fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetada
 }
 
 /// Authenticate via device authorization flow.
-async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
+async fn cmd_auth_login(ctx: &dyn CliContext, server: &str, open_browser: bool) -> Result<()> {
     // 1. Generate Ed25519 keypair for device binding.
     let signer = Ed25519Signer::generate()
         .map_err(|e| anyhow::anyhow!("failed to generate keypair: {e}"))?;
@@ -772,6 +855,21 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
     if let Err(error) = repo::identity::link_device_key(&public_key_bytes, &private_key_pem, server)
     {
         tracing::warn!(%error, "could not record device signing identity; captures will use the per-repo local key");
+    }
+
+    if ctx.should_output_json(None) {
+        println!(
+            "{}",
+            serde_json::to_string(&AuthLoginOutput {
+                output_kind: "auth_login",
+                server: server.to_string(),
+                authenticated: true,
+                subject: root.subject.clone(),
+                credential_id: root.credential_id.clone(),
+                expires_at: Some(root.expires_at.to_rfc3339()),
+            })?
+        );
+        return Ok(());
     }
 
     println!();
@@ -1893,6 +1991,7 @@ mod tests {
             credentials::store_server_credential(server, parent).expect("store parent");
 
             cmd_auth_derive_agent(
+                &TextCtx,
                 server,
                 Some("agent-parent".to_string()),
                 3600,
@@ -1942,6 +2041,7 @@ mod tests {
             );
 
             cmd_auth_derive_agent(
+                &TextCtx,
                 server,
                 Some("agent-child".to_string()),
                 600,
@@ -1981,6 +2081,7 @@ mod tests {
             );
 
             let error = cmd_auth_derive_agent(
+                &TextCtx,
                 server,
                 Some("agent-widening".to_string()),
                 300,
@@ -2004,6 +2105,7 @@ mod tests {
             let out = repo::identity::heddle_home_dir().join("agent-export.hcred");
 
             cmd_auth_derive_agent(
+                &TextCtx,
                 server,
                 Some("agent-export".to_string()),
                 3600,
@@ -2052,6 +2154,7 @@ mod tests {
             );
 
             let error = cmd_auth_derive_agent(
+                &TextCtx,
                 server,
                 Some("agent-export-again".to_string()),
                 3600,

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -89,6 +89,7 @@ async fn ensure(
         }
         EnsureAction::Derive => {
             cmd_auth_derive_agent(
+                ctx,
                 &server,
                 None,
                 DEFAULT_AGENT_TTL_SECS,

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10754,6 +10754,48 @@ fn exit_codes_surface_in_json_catalog() {
     );
 }
 
+/// `docs/exit-codes.md` § Coverage must name exactly the commands whose
+/// `CommandContract.exit_codes` is non-empty (heddle#1392). Keeps the
+/// hand-written coverage list from drifting from the catalog again.
+#[test]
+fn exit_codes_coverage_doc_lists_catalogued_commands() {
+    let doc = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/exit-codes.md"
+    ))
+    .expect("docs/exit-codes.md should exist");
+
+    let catalog = cli::cli::commands::build_command_catalog();
+    let mut swept: Vec<&str> = catalog
+        .commands
+        .iter()
+        .filter(|c| !c.exit_codes.is_empty())
+        .map(|c| c.display.as_str())
+        .collect();
+    swept.sort();
+
+    // Extract the bullet list between the `## Coverage` heading and the
+    // following blank-line-then-prose paragraph.
+    let coverage = doc
+        .split("## Coverage")
+        .nth(1)
+        .expect("Coverage section exists");
+    let listed: Vec<String> = coverage
+        .lines()
+        .filter_map(|line| line.strip_prefix("- `"))
+        .map(|line| line.trim_end_matches('`').to_string())
+        .collect();
+
+    let mut listed_sorted = listed.clone();
+    listed_sorted.sort();
+
+    assert_eq!(
+        listed_sorted, swept,
+        "docs/exit-codes.md § Coverage drifts from CommandContract.exit_codes; \
+         update the list to match `heddle help --output json`"
+    );
+}
+
 /// `heddle log`, `show`, and `status` default text views must
 /// lead with command data — not the `Repository:` mode preamble, which is
 /// noise on every read (heddle#275). `-v` keeps the preamble for

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -10774,16 +10774,27 @@ fn exit_codes_coverage_doc_lists_catalogued_commands() {
         .collect();
     swept.sort();
 
-    // Extract the bullet list between the `## Coverage` heading and the
-    // following blank-line-then-prose paragraph.
+    // Extract the bullet list under the `## Coverage` heading; a single
+    // bullet may name several commands (`a`, `b`).
     let coverage = doc
         .split("## Coverage")
         .nth(1)
         .expect("Coverage section exists");
     let listed: Vec<String> = coverage
         .lines()
-        .filter_map(|line| line.strip_prefix("- `"))
-        .map(|line| line.trim_end_matches('`').to_string())
+        .skip_while(|line| !line.starts_with("- `"))
+        .take_while(|line| line.starts_with("- `"))
+        .flat_map(|line| {
+            line.split("`, `")
+                .map(|part| {
+                    part.trim()
+                        .trim_start_matches("- `")
+                        .trim_matches('`')
+                        .to_string()
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|part| !part.is_empty())
         .collect();
 
     let mut listed_sorted = listed.clone();

--- a/docs/adr/0013-agent-native-help-surface.md
+++ b/docs/adr/0013-agent-native-help-surface.md
@@ -1,5 +1,10 @@
 # Agent-native help surface
 
+> **Status note (2026-08, heddle#1392):** this ADR remains `proposed` and
+> was never fully adopted. `heddle inbox` does **not** exist as a public
+> verb; do not document or script it. `discuss` shipped and is public.
+> See ADR 0046 (accepted) for the contracted command vocabulary.
+
 The curated everyday help surface should include `inbox` and `discuss` as first-class coordination commands. `context` remains behind advanced/topic help until its UX is harder to misuse, and `review` may be surfaced through `inbox`, `ready`, and review-specific help rather than always occupying first-day help.
 
 First-slice local discussion and inbox help should live in the normal CLI help surface once tests and docs gates pass. Conflict resolution, visibility, and migration can appear in advanced sections, but core local `discuss` and `inbox` workflows should not be hidden behind experimental or internal help.

--- a/docs/adr/0043-workflow-command-vocabulary.md
+++ b/docs/adr/0043-workflow-command-vocabulary.md
@@ -5,6 +5,12 @@ superseded-by: ADR 0046
 
 # Workflow Command Vocabulary
 
+> **Status note (2026-08, heddle#1392):** although this file is marked
+> superseded, its prose still names `checkpoint` as a "public Git-facing
+> milestone primitive". That is wrong: ADR 0046 (accepted) forbids exposing
+> `checkpoint` and no such public verb exists in the command catalog. The
+> everyday save is `capture`; `commit` is the narrow Git Overlay boundary.
+
 This decision preferred `commit` as the everyday human save, with `capture`
 as an advanced granular savepoint. Shipped CLI and ADR 0046 / ADR 0047 made
 `capture` the save boundary. `commit` is the Git Overlay write to `.git`;

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -73,10 +73,16 @@ declared discriminators, `exit_codes`) are stable for that minor.
 ## Coverage
 
 Today, only a representative subset of commands has populated
-`exit_codes`:
+`exit_codes` — exactly eight entries in the command catalog:
 
-- `init`, `verify`, `push`, `pull`, `commit`, `merge`, `status`
-- `import git`, `fsck repair git`, `sync git`
+- `init`, `status`, `verify`, `commit`
+- `pull`, `push`
+- `bridge git import`, `sync git`
+
+This list mirrors the catalog (`CommandContract.exit_codes`, exposed per
+command by `heddle help --output json`); the
+`exit_codes_declared_have_doc_entry` lint below keeps every declared code
+present in the table above.
 
 Commands not yet swept implicitly contract to `0` on success and an
 unspecified non-zero on failure — currently always mapped through

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1883,6 +1883,42 @@ the same ready envelope.
 
 ---
 
+## `heddle context check --output json`
+
+Staleness sweep over context annotations. The `reason` enum is the
+shipped `StalenessStatus` model (`crates/object-model/src/object/staleness_core.rs`)
+minus the non-stale variants: `source_changed`, `symbol_missing`,
+`file_missing`. `fresh` and `unknown` annotations are counted but not
+listed.
+
+```json
+{
+  "output_kind": "context_check",
+  "annotations": 3,
+  "fresh": 1,
+  "stale": 2,
+  "unknown": 0,
+  "issues": [
+    {
+      "target": "src/auth.rs",
+      "scope": "symbol",
+      "reason": "symbol_missing",
+      "annotation_id": "ann-01",
+      "content": "verify token expiry before..."
+    },
+    {
+      "target": "src/removed.rs",
+      "scope": "file",
+      "reason": "file_missing",
+      "annotation_id": "ann-02",
+      "content": "legacy adapter notes"
+    }
+  ]
+}
+```
+
+---
+
 ## `heddle auth trust show --output json`
 
 ```json
@@ -3160,7 +3196,7 @@ as one; no `help advanced`).
       "redact purge list",
       "visibility set"
     ],
-    "accepted_opaque_schema_verbs_total": 39,
+    "accepted_opaque_schema_verbs_total": 38,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
@@ -3173,14 +3209,14 @@ as one; no `help advanced`).
       "visibility set"
     ],
     "advanced_scope_json_commands_total": 112,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 38,
     "advanced_scope_mutating_commands_total": 64,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
     "catalog_commands_total": 192,
     "catalog_mutating_commands_total": 93,
     "json_commands_total": 151,
-    "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 112,
+    "json_commands_with_accepted_opaque_schema": 38,
+    "json_commands_with_schema": 113,
     "json_commands_without_schema": 0,
     "json_mutating_commands_total": 88,
     "missing_mutating_schema_examples": [],
@@ -3189,9 +3225,9 @@ as one; no `help advanced`).
     "mutating_commands_with_accepted_opaque_schema": 21,
     "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 39,
+    "opaque_schema_verbs_total": 38,
     "status": "available",
-    "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3229,7 +3265,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -3401,7 +3437,7 @@ required:
 {"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hc-collapsed123", "change_id_full": "hc-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hc-source111", "change_id_full": "hc-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hc-base123"]}, {"change_id": "hc-source222", "change_id_full": "hc-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hc-source111"]}]}
 ```
 
-`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
+`heddle context set|get|list|history|edit|supersede|rm|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. `context check` has its own payload-complete contract below. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
 
 ```json
 {"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hc-k6a0wfrbgcg7"}

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -26,6 +26,7 @@ Heddle is an agent-native version control system built around three core ideas:
 - threads, markers, refs, oplog, and working tree management
 - remote sync and Git projection
 - provenance-backed local blame and rewrite preservation
+- scratch-budgeted equal-run LCS and storage-neutral resumable blame slices
 - semantic diff support
 - multi-agent worktrees and agent registry
 - Heddle-native actor tracking for supported coding harnesses
@@ -3271,7 +3272,7 @@ The wire protocol is fully implemented and tested. All core VCS commands are ope
 Environment-based local testing:
 
 - `hosted` owns the server runtime and reads server config from its server config file or `HEDDLE_SERVER_*` overrides.
-- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
+- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles. `[remote] tls_ca_certificate_path` is honored from user config and from repository `.heddle/config.toml`; `HEDDLE_REMOTE_TLS_CA_CERT` overrides both. Unknown `[remote]` keys in repository config fail at load.
 - Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
 - Provider pulls can be tuned in the user config under `[remote]` with `provider_global_concurrency`, `provider_per_endpoint_concurrency`, `provider_max_inflight_bytes`, and `provider_stall_timeout_secs`. The corresponding environment overrides are `HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES`, and `HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS`.
@@ -3897,8 +3898,12 @@ and in isolated thread checkouts (`heddle start --path …`). Build junk that
 matches a root ignore rule is never listed as unsaved work and never enters
 permanent history.
 
-Heddle always protects its own `.heddle/` metadata. Other paths must
-be explicit in `.gitignore`, `.heddleignore`, or the config key below.
+Root `.heddle/` is reserved: identity, credentials, and repository-engine
+state. User ignore rules cannot un-ignore it. A `.gitignore` or
+`.heddleignore` negation such as `!.heddle/` does not pull
+`identity.toml` into capture. Nested `.heddle/` directories (fixtures)
+remain ordinary paths. Other paths must be explicit in `.gitignore`,
+`.heddleignore`, or the config key below.
 
 ## Config key: `[worktree] ignore`
 
@@ -3913,7 +3918,9 @@ Config patterns are loaded first, then root `.gitignore`, then
 `.heddle/info/exclude`, then root `.heddleignore`. Prefer the ignore files
 for project policy; use `[worktree] ignore` for operator-local or
 repo-engine defaults that should not appear as a tracked ignore file.
-Default config always includes `.heddle`.
+Default config always includes `.heddle`. That default is last-match
+and can be contradicted by a later user rule; the reserved-path hard-deny
+is what keeps root `.heddle/` out of capture.
 
 ## Capture path scoping
 
@@ -4040,8 +4047,10 @@ on.
 
 ## Runtime introspection
 
-Schemas in this document are mirrored at runtime by
-`crates/cli-contract/src/cli/commands/schemas.rs`. Generate the canonical JSON
+Schemas in this document are registered at runtime by
+`crates/cli-contract/src/cli/commands/schemas.rs`. `init` registers the
+real `InitOutput` type (no hand-written `InitSchema` mirror); remaining
+verbs still use a hand-written mirror. Generate the canonical JSON
 Schema for any verb with:
 
     heddle schemas                    # list registered schema verbs
@@ -4172,6 +4181,10 @@ metadata only; it does not import Git history or write Git-tracked files.
   "heddle_initialized": true,
   "installed_heddleignore": false,
   "principal_configured": false,
+  "principal_status": "not_configured",
+  "principal_source": null,
+  "principal": null,
+  "principal_recommended_action": "heddle init --principal-name <name> --principal-email <email>",
   "side_effects": [
     "created Heddle sidecar for the existing Git repository",
     "updated .git/info/exclude for Heddle metadata",
@@ -4192,6 +4205,10 @@ metadata only; it does not import Git history or write Git-tracked files.
 | `repository_mode` | string | required | Repository capability after init, e.g. `git-overlay` or native Heddle storage. |
 | `git_detected`, `heddle_initialized` | bool | required | Whether init detected an existing Git repo, and whether Heddle metadata is now present. |
 | `installed_heddleignore`, `principal_configured` | bool | required | Side effects outside `.heddle`, if any. `installed_heddleignore` is currently false; init does not install ignore-policy files. Git-overlay init uses local Git excludes only for Heddle metadata. |
+| `principal_status` | string | required | `configured` or `not_configured`. |
+| `principal_source` | string \| null | always present | Where the principal was resolved from, or `null` when none is configured. |
+| `principal` | object \| null | always present | `{ name, email }` when configured; otherwise `null`. |
+| `principal_recommended_action` | string \| null | always present | Command to set a principal when none is configured. |
 | `side_effects` | array<string> | required | Human-readable, machine-preserved list of what init changed or intentionally left untouched. |
 | `message` | string | required | Human summary. |
 | `next_action`, `recommended_action` | string \| null | required | Primary verification-guided next command. Git Overlay init proceeds directly to the normal save loop. |
@@ -5983,6 +6000,11 @@ the verdict schema is still settling.
 ```json
 {
   "output_kind": "whoami",
+  "capture_actor": {
+    "name": "Luke",
+    "email": "luke@example.com",
+    "source": "user_config"
+  },
   "server": "grpc.heddle.sh",
   "authenticated": true,
   "reachable": true,
@@ -6017,11 +6039,15 @@ the verdict schema is still settling.
 }
 ```
 
-`token_kind` is one of `root`, `agent`, or `service-account`. `scopes` and
-`operation_ceiling` are read from the local Biscuit delegation chain; an empty
-`scopes` list means full resource authority and a null `operation_ceiling` means
-no operation allowlist. When the server is unreachable, `reachable` is `false`,
-`identity` is `null`, and the locally-known token facts are still reported.
+`capture_actor` is who the next capture is attributed to (`environment`,
+`repository`, `git_config`, `user_config`, or `null` when unknown). Hosted auth
+fields (`server`, `authenticated`, `identity`, token facts) are a different
+object. `token_kind` is one of `root`, `agent`, or `service-account`. `scopes`
+and `operation_ceiling` are read from the local Biscuit delegation chain; an
+empty `scopes` list means full resource authority and a null `operation_ceiling`
+means no operation allowlist. When the server is unreachable, `reachable` is
+`false`, `identity` is `null`, and the locally-known token facts are still
+reported.
 
 ---
 
@@ -7157,6 +7183,9 @@ catalog-wide schema coverage.
 
 The command-contract coverage portion of this sample is generated from
 runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
+These counts describe the live parser catalog today. They are not the
+heddle#473 destination (~23 everyday verbs; umbrella nouns do not count
+as one; no `help advanced`).
 
 ```json
 {
@@ -7171,7 +7200,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact purge list",
       "visibility set"
     ],
-    "accepted_opaque_schema_verbs_total": 38,
+    "accepted_opaque_schema_verbs_total": 39,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
@@ -7183,14 +7212,14 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact purge list",
       "visibility set"
     ],
-    "advanced_scope_json_commands_total": 114,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 38,
-    "advanced_scope_mutating_commands_total": 65,
+    "advanced_scope_json_commands_total": 112,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
+    "advanced_scope_mutating_commands_total": 64,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
-    "catalog_commands_total": 190,
+    "catalog_commands_total": 192,
     "catalog_mutating_commands_total": 93,
-    "json_commands_total": 150,
-    "json_commands_with_accepted_opaque_schema": 38,
+    "json_commands_total": 151,
+    "json_commands_with_accepted_opaque_schema": 39,
     "json_commands_with_schema": 112,
     "json_commands_without_schema": 0,
     "json_mutating_commands_total": 88,
@@ -7200,23 +7229,23 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "mutating_commands_with_accepted_opaque_schema": 21,
     "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 38,
+    "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "190 command(s), 150 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
+    "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
     "undocumented_schema_verbs_total": 0,
     "verified_scope": "everyday_and_agent",
     "verified_scope_accepted_opaque_schema_examples": [],
-    "verified_scope_json_commands_total": 36,
+    "verified_scope_json_commands_total": 39,
     "verified_scope_json_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_json_commands_with_schema": 36,
+    "verified_scope_json_commands_with_schema": 39,
     "verified_scope_json_commands_without_schema": 0,
     "verified_scope_missing_schema_examples": [],
-    "verified_scope_mutating_commands_total": 23,
+    "verified_scope_mutating_commands_total": 24,
     "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_mutating_commands_with_schema": 23,
+    "verified_scope_mutating_commands_with_schema": 24,
     "verified_scope_mutating_commands_without_schema": 0
   },
   "doc_path": "/repo/docs/json-schemas.md",
@@ -7240,7 +7269,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "190 command(s), 150 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
+  "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -7897,9 +7926,11 @@ it refuses without changing files only when the recovery state is absent or
 when recovery would overwrite a differing local change at the same path.
 
 Undo operations that materialize an earlier tree are explicitly destructive.
-Run `heddle undo --preview` to inspect them and `heddle undo --hard` to permit
-the worktree rewind. Plain `heddle undo` refuses before changing repository
-state or files when the selected inverse would rewrite the worktree.
+Run `heddle undo --preview` (or `heddle undo --hard --preview`) to inspect them
+and `heddle undo --hard` to permit the worktree rewind. `--preview` is a
+read-only alias of `--dry-run` and can be combined with `--hard`. Plain
+`heddle undo` refuses before changing repository state or files when the
+selected inverse would rewrite the worktree.
 
 This document describes the user-facing surface shipped under
 [HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). The
@@ -7970,7 +8001,8 @@ contracts below are enforced by integration tests in
 
 - **Explicit destructive opt-in.** If the selected inverse would materialize
   an earlier tree, plain `heddle undo` refuses before mutation and points to
-  `--preview` and `--hard`. `heddle undo --hard` still refuses if the worktree
+  `--preview` and `--hard`. `heddle undo --hard --preview` previews that
+  rewind without applying it. `heddle undo --hard` still refuses if the worktree
   is dirty and surfaces the exact paths that would otherwise be lost. Capture
   the changes with `heddle capture -m "..."` (or move them) and retry.
 - **Recovery overlays unrelated changes.** `heddle undo --recover` restores

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3822,10 +3822,16 @@ declared discriminators, `exit_codes`) are stable for that minor.
 ## Coverage
 
 Today, only a representative subset of commands has populated
-`exit_codes`:
+`exit_codes` — exactly eight entries in the command catalog:
 
-- `init`, `verify`, `push`, `pull`, `commit`, `merge`, `status`
-- `import git`, `fsck repair git`, `sync git`
+- `init`, `status`, `verify`, `commit`
+- `pull`, `push`
+- `bridge git import`, `sync git`
+
+This list mirrors the catalog (`CommandContract.exit_codes`, exposed per
+command by `heddle help --output json`); the
+`exit_codes_declared_have_doc_entry` lint below keeps every declared code
+present in the table above.
 
 Commands not yet swept implicitly contract to `0` on success and an
 unspecified non-zero on failure — currently always mapped through
@@ -5923,6 +5929,42 @@ the same ready envelope.
 
 ---
 
+## `heddle context check --output json`
+
+Staleness sweep over context annotations. The `reason` enum is the
+shipped `StalenessStatus` model (`crates/object-model/src/object/staleness_core.rs`)
+minus the non-stale variants: `source_changed`, `symbol_missing`,
+`file_missing`. `fresh` and `unknown` annotations are counted but not
+listed.
+
+```json
+{
+  "output_kind": "context_check",
+  "annotations": 3,
+  "fresh": 1,
+  "stale": 2,
+  "unknown": 0,
+  "issues": [
+    {
+      "target": "src/auth.rs",
+      "scope": "symbol",
+      "reason": "symbol_missing",
+      "annotation_id": "ann-01",
+      "content": "verify token expiry before..."
+    },
+    {
+      "target": "src/removed.rs",
+      "scope": "file",
+      "reason": "file_missing",
+      "annotation_id": "ann-02",
+      "content": "legacy adapter notes"
+    }
+  ]
+}
+```
+
+---
+
 ## `heddle auth trust show --output json`
 
 ```json
@@ -7200,7 +7242,7 @@ as one; no `help advanced`).
       "redact purge list",
       "visibility set"
     ],
-    "accepted_opaque_schema_verbs_total": 39,
+    "accepted_opaque_schema_verbs_total": 38,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
@@ -7213,14 +7255,14 @@ as one; no `help advanced`).
       "visibility set"
     ],
     "advanced_scope_json_commands_total": 112,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 38,
     "advanced_scope_mutating_commands_total": 64,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
     "catalog_commands_total": 192,
     "catalog_mutating_commands_total": 93,
     "json_commands_total": 151,
-    "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 112,
+    "json_commands_with_accepted_opaque_schema": 38,
+    "json_commands_with_schema": 113,
     "json_commands_without_schema": 0,
     "json_mutating_commands_total": 88,
     "missing_mutating_schema_examples": [],
@@ -7229,9 +7271,9 @@ as one; no `help advanced`).
     "mutating_commands_with_accepted_opaque_schema": 21,
     "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 39,
+    "opaque_schema_verbs_total": 38,
     "status": "available",
-    "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -7269,7 +7311,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "192 command(s), 151 JSON command(s), 93 mutating command(s), 88 mutating JSON command(s); verified everyday/agent machine surface has 39 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 38 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -7441,7 +7483,7 @@ required:
 {"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hc-collapsed123", "change_id_full": "hc-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hc-source111", "change_id_full": "hc-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hc-base123"]}, {"change_id": "hc-source222", "change_id_full": "hc-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hc-source111"]}]}
 ```
 
-`heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
+`heddle context set|get|list|history|edit|supersede|rm|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. `context check` has its own payload-complete contract below. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
 
 ```json
 {"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hc-k6a0wfrbgcg7"}


### PR DESCRIPTION
## Summary

First implementation slice for #1392. Addresses the docs-contract drift items and the concrete schema gap:

1. **docs/exit-codes.md § Coverage regenerated from the catalog** — the list now names exactly the eight commands with populated `exit_codes` (`merge` and `fsck repair git` removed). New lint `exit_codes_coverage_doc_lists_catalogued_commands` fails when the hand-written list drifts from `CommandContract.exit_codes` again.
2. **ADR status notes** — ADR 0013 notes it is still proposed, never adopted, and that `heddle inbox` does not exist; ADR 0043 notes its `checkpoint` prose is wrong per accepted ADR 0046 (no public checkpoint verb).
3. **agent-flags advertised on the first screen** — the topic agents most need is now in the `heddle help <topic>` enumeration.
4. **auth login / auth derive-agent JSON contracts** — both emit stable envelopes (`auth_login`: server/subject/credential_id/expires_at; `auth_derive_agent`: agent_id/template/allowed_operations/scopes/credential_path) honoring the global `--output json`. Token and proof-key material never appears in the output.
5. **Payload-complete context check schema** — promoted from accepted-opaque to a documented schema (`ContextCheckSchema`) pinning the counters and the `StalenessStatus`-derived reason enum (source_changed/symbol_missing/file_missing). Documented sample added to docs/json-schemas.md; coverage sample refreshed with `doctor schemas --update-docs`; `heddle doctor schemas` passes.
6. **llms.txt pair regenerated** via scripts/gen-llms-txt.py.

## Deferred to a follow-up slice

- Full CLI reference regeneration in CI from `heddle help --output json` (#479-shaped work).
- Payload-deepening for the remaining accepted-opaque verbs.

## Test evidence

```
$ cargo test -p heddle-cli-contract --locked
test result: ok. 138 passed; 0 failed

$ cargo test -p heddle-cli --test cli_integration exit_codes
test result: ok. 18 passed; 0 failed

$ cargo test -p heddle-cli --test cli_integration context
test result: ok. 17 passed; 0 failed

$ cargo test -p heddle-cli --lib -- hosted_runtime::auth::tests
test result: ok. 26 passed; 0 failed

$ cargo test -p heddle-cli --test cli_integration doctor_schemas
test result: ok. 4 passed; 0 failed

$ ./target/debug/heddle doctor schemas --output json   # exit 0
```

The full cli_integration run has 22 pre-existing failures (clone peer-disconnect fixtures, git-overlay land-recovery matrix, identity isolation) that fail identically on unmodified main — environment-dependent, untouched by this diff.

Closes part of HeddleCo/heddle#1392 (items 1–4 of the drift list + the StalenessStatus schema gap).

Refs HeddleCo/heddle#479, HeddleCo/heddle#1440, HeddleCo/heddle#1444

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790063514&installation_model_id=21489&pr_number=1550&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1550&signature=abf05ccf81cfcbd4cc41ec4c76b91c7386172e475ddd01362afa05003f5c6432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->