### PR TITLE
chore(release): heddle 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "heddle-crypto",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-iroh-transport-experiment"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "heddle-api 0.2.1",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2665,11 +2665,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2728,14 +2728,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -8112,7 +8112,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,44 @@ webpki-roots = "1.0"
 windows-sys = "0.61"
 zstd = "0.13"
 
+# Internal heddle crates. Declared here so a release version bump only edits
+# this table; member crates inherit via `<name>.workspace = true` and keep their
+# own `features`/`optional`. `version` is required so `cargo publish` (which
+# strips `path`) records the dependency version. `default-features = false` is
+# set here for crates that at least one member consumes with defaults off —
+# Cargo forbids a member from turning a workspace dependency's defaults off, so
+# the baseline lives here and the few members that want the defaults re-list
+# them explicitly under `features`.
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.0", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.0", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.0", default-features = false }
+heddle-core = { path = "crates/core", version = "0.15.0", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.0" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.0" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.0", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.0" }
+heddle-pack = { path = "crates/pack", version = "0.15.0" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.0" }
+heddle-schema = { path = "crates/schema", version = "0.15.0" }
+weft-client-shim = { path = "crates/weft-client-shim", version = "0.15.0" }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.0" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.0" }
+cli-shared = { path = "crates/cli-shared", package = "heddle-cli-shared", version = "0.15.0" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.0" }
+daemon = { path = "crates/daemon", package = "heddle-daemon", version = "0.15.0" }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.0", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.0" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.0" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.0" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.0", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.0" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.0", default-features = false }
+runtime-bridge = { path = "crates/runtime-bridge", package = "heddle-runtime-bridge", version = "0.15.0" }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.0" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.0" }
+state_review = { path = "crates/state_review", package = "heddle-state-review", version = "0.15.0" }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.0", default-features = false }
+
 [profile.dev]
 debug = "line-tables-only"
 split-debuginfo = "unpacked"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/crates/ci-config/Cargo.toml
+++ b/crates/ci-config/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-heddle-object-model = { path = "../object-model", version = "0.15" }
+heddle-object-model.workspace = true
 regex.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/ci-config/Cargo.toml
+++ b/crates/ci-config/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-heddle-object-model = { path = "../object-model", version = "0.14" }
+heddle-object-model = { path = "../object-model", version = "0.15" }
 regex.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 blake3.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.14" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.15" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 blake3.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.15" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
+ci-config.workspace = true
+crypto.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -13,10 +13,10 @@ categories.workspace = true
 anyhow.workspace = true
 api = { package = "heddle-api", version = "0.15.0" }
 clap.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.15" }
+cli-shared.workspace = true
+objects.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native"] }
+weft-client-shim.workspace = true
 
 [features]
 default = []

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -13,10 +13,10 @@ categories.workspace = true
 anyhow.workspace = true
 api = { package = "heddle-api", version = "0.15.0" }
 clap.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.14" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.15" }
 
 [features]
 default = []

--- a/crates/cli-contract/Cargo.toml
+++ b/crates/cli-contract/Cargo.toml
@@ -12,13 +12,13 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.15", default-features = false }
-heddle-core = { path = "../core", version = "0.15", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false }
+heddle-cli-args.workspace = true
+heddle-cli-render.workspace = true
+heddle-core.workspace = true
+heddle-git-projection.workspace = true
+objects.workspace = true
+refs.workspace = true
+repo.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-contract/Cargo.toml
+++ b/crates/cli-contract/Cargo.toml
@@ -12,13 +12,13 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.14", default-features = false }
-heddle-core = { path = "../core", version = "0.14", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.15", default-features = false }
+heddle-core = { path = "../core", version = "0.15", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-render/Cargo.toml
+++ b/crates/cli-render/Cargo.toml
@@ -15,11 +15,11 @@ anstyle = "1"
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
-heddle-core = { path = "../core", version = "0.14", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
+heddle-core = { path = "../core", version = "0.15", default-features = false }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cli-render/Cargo.toml
+++ b/crates/cli-render/Cargo.toml
@@ -15,11 +15,11 @@ anstyle = "1"
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
-heddle-core = { path = "../core", version = "0.15", default-features = false }
+heddle-cli-args.workspace = true
+heddle-core.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
+objects.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -13,12 +13,12 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+objects.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
+wire.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -13,12 +13,12 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,8 +25,8 @@ biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.14" }
-ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.14" }
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.15" }
+ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.15" }
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true
@@ -37,35 +37,35 @@ iroh-base = { workspace = true, optional = true }
 libc.workspace = true
 n0-watcher = { workspace = true, optional = true }
 noq-udp = { workspace = true, optional = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.15" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
 api = { package = "heddle-api", version = "0.15.0" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
-heddle-cli-args = { path = "../cli-args", version = "0.14", default-features = false }
-heddle-cli-contract = { path = "../cli-contract", version = "0.14", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.14", default-features = false }
-heddle-core = { path = "../core", version = "0.14", default-features = false }
-heddle-format = { path = "../format", version = "0.14" }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.14" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
+heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
+heddle-cli-contract = { path = "../cli-contract", version = "0.15", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.15", default-features = false }
+heddle-core = { path = "../core", version = "0.15", default-features = false }
+heddle-format = { path = "../format", version = "0.15" }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.15" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.14", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.15", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -78,7 +78,7 @@ rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
 sha2.workspace = true
 sley.workspace = true
 tempfile.workspace = true
@@ -107,13 +107,13 @@ webpki-roots = { workspace = true, optional = true }
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.14", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
 
 [features]
 # The default `heddle` build ships the full workflow: local
@@ -248,7 +248,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { path = "../cli-render", version = "0.14", features = ["test-utils"] }
+heddle-cli-render = { path = "../cli-render", version = "0.15", features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,8 +25,8 @@ biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
-ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.15" }
-ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.15" }
+ci-config.workspace = true
+ci-engine.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true
@@ -37,35 +37,35 @@ iroh-base = { workspace = true, optional = true }
 libc.workspace = true
 n0-watcher = { workspace = true, optional = true }
 noq-udp = { workspace = true, optional = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.15" }
+objects = { workspace = true, features = ["memory-backend"] }
+crypto.workspace = true
+daemon.workspace = true
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
+merge.workspace = true
 api = { package = "heddle-api", version = "0.15.0" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
-heddle-cli-args = { path = "../cli-args", version = "0.15", default-features = false }
-heddle-cli-contract = { path = "../cli-contract", version = "0.15", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.15", default-features = false }
-heddle-core = { path = "../core", version = "0.15", default-features = false }
-heddle-format = { path = "../format", version = "0.15" }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.15" }
+cli-shared.workspace = true
+heddle-cli-args.workspace = true
+heddle-cli-contract.workspace = true
+heddle-cli-render.workspace = true
+heddle-core.workspace = true
+heddle-format.workspace = true
+weft-client-shim.workspace = true
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.15", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
+ingest.workspace = true
+heddle-git-projection.workspace = true
+oplog.workspace = true
+wire.workspace = true
+refs.workspace = true
+repo.workspace = true
+semantic = { workspace = true, optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -78,7 +78,7 @@ rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+heddle-perf-contract.workspace = true
 sha2.workspace = true
 sley.workspace = true
 tempfile.workspace = true
@@ -107,13 +107,13 @@ webpki-roots = { workspace = true, optional = true }
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
+mount = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
+mount = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.15", optional = true }
+mount = { workspace = true, optional = true }
 
 [features]
 # The default `heddle` build ships the full workflow: local
@@ -248,7 +248,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { path = "../cli-render", version = "0.15", features = ["test-utils"] }
+heddle-cli-render = { workspace = true, features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,21 +12,21 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.14" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
-merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
 ignore.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-heddle-git-projection = { path = "../git-projection", version = "0.14", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
 sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,21 +12,21 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.15" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
-merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
+cli-shared.workspace = true
+crypto.workspace = true
+merge.workspace = true
 ignore.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-heddle-git-projection = { path = "../git-projection", version = "0.15", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15" }
+objects.workspace = true
+heddle-git-projection.workspace = true
+oplog.workspace = true
+refs.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native", "zstd"] }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
+semantic = { workspace = true, optional = true }
 sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+objects.workspace = true
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.14" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.15" }
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,18 +11,18 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
+crypto.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
+objects.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.15" }
+state_review.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
+semantic = { workspace = true, optional = true }
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }
+objects = { workspace = true, features = ["memory-backend"] }
 proptest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true

--- a/crates/fs-prims/Cargo.toml
+++ b/crates/fs-prims/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 fs2.workspace = true
-heddle-object-model = { path = "../object-model", version = "0.15" }
+heddle-object-model.workspace = true
 libc.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 

--- a/crates/fs-prims/Cargo.toml
+++ b/crates/fs-prims/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 fs2.workspace = true
-heddle-object-model = { path = "../object-model", version = "0.14" }
+heddle-object-model = { path = "../object-model", version = "0.15" }
 libc.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/lib.rs"
 name = "heddle_git_projection"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+objects = { workspace = true, features = ["memory-backend"] }
+refs.workspace = true
 # `default-features = false` so this crate's `zstd` feature controls the
 # cascade end-to-end (same pattern as ingest/cli).
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay"] }
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.15", default-features = false }
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
+repo = { workspace = true, features = ["git-overlay"] }
+ingest.workspace = true
+heddle-perf-contract.workspace = true
+wire.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/lib.rs"
 name = "heddle_git_projection"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
 # `default-features = false` so this crate's `zstd` feature controls the
 # cascade end-to-end (same pattern as ingest/cli).
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay"] }
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.14", default-features = false }
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay"] }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.15", default-features = false }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay"] }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
+objects = { workspace = true, features = ["memory-backend"] }
+refs.workspace = true
+oplog.workspace = true
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay"] }
+repo = { workspace = true, features = ["git-overlay"] }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,11 +15,11 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.14" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+heddle-format = { path = "../format", version = "0.15" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 similar.workspace = true
 sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,11 +15,11 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.15" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+heddle-format.workspace = true
+objects.workspace = true
 similar.workspace = true
 sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
+objects = { workspace = true, features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.15" }
+objects.workspace = true
+oplog.workspace = true
+refs.workspace = true
+repo = { workspace = true, features = ["git-overlay", "native", "zstd"] }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.15" }
+heddle-format.workspace = true
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.14" }
+heddle-format = { path = "../format", version = "0.15" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -16,7 +16,7 @@ blake3.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.15" }
+heddle-format.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -16,7 +16,7 @@ blake3.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.14" }
+heddle-format = { path = "../format", version = "0.15" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,11 +17,11 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
-heddle-format = { path = "../format", version = "0.15" }
-heddle-object-model = { path = "../object-model", version = "0.15" }
-heddle-pack = { path = "../pack", version = "0.15" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+heddle-fs-prims.workspace = true
+heddle-format.workspace = true
+heddle-object-model.workspace = true
+heddle-pack.workspace = true
+heddle-perf-contract.workspace = true
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,11 +17,11 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
-heddle-format = { path = "../format", version = "0.14" }
-heddle-object-model = { path = "../object-model", version = "0.14" }
-heddle-pack = { path = "../pack", version = "0.14" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
+heddle-format = { path = "../format", version = "0.15" }
+heddle-object-model = { path = "../object-model", version = "0.15" }
+heddle-pack = { path = "../pack", version = "0.15" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.14" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+heddle-schema = { path = "../schema", version = "0.15" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.14", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.15", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.15" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+heddle-schema.workspace = true
+heddle-perf-contract.workspace = true
+objects.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.15", optional = true }
+runtime-bridge = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 bytes.workspace = true
-heddle-format = { path = "../format", version = "0.14" }
-heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
-heddle-object-model = { path = "../object-model", version = "0.14" }
+heddle-format = { path = "../format", version = "0.15" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
+heddle-object-model = { path = "../object-model", version = "0.15" }
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 bytes.workspace = true
-heddle-format = { path = "../format", version = "0.15" }
-heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
-heddle-object-model = { path = "../object-model", version = "0.15" }
+heddle-format.workspace = true
+heddle-fs-prims.workspace = true
+heddle-object-model.workspace = true
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,16 +12,16 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.14" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+heddle-schema = { path = "../schema", version = "0.15" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.14", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.15", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,16 +12,16 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.15" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+heddle-schema.workspace = true
+heddle-perf-contract.workspace = true
+objects.workspace = true
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.15", optional = true }
+runtime-bridge = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -17,20 +17,20 @@ chrono.workspace = true
 hex.workspace = true
 heddleco-capability-verifier = "0.5"
 ignore.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.14" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.14" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
 prost.workspace = true
-wire = { path = "../wire", package = "heddle-wire", version = "0.14", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.14" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14", optional = true }
-semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.14", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.14", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
+semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.15", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.15", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -91,7 +91,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -17,20 +17,20 @@ chrono.workspace = true
 hex.workspace = true
 heddleco-capability-verifier = "0.5"
 ignore.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.15" }
+heddle-perf-contract.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.15" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.15" }
+objects.workspace = true
+crypto.workspace = true
+oplog.workspace = true
 prost.workspace = true
-wire = { path = "../wire", package = "heddle-wire", version = "0.15", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.15" }
+wire.workspace = true
+refs.workspace = true
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15", optional = true }
-semantic-recovery = { path = "../semantic-recovery", package = "heddle-semantic-recovery", version = "0.15", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.15", optional = true }
+semantic = { workspace = true, optional = true }
+semantic-recovery = { workspace = true, optional = true }
+state_review = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -91,7 +91,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["async-source", "memory-backend"] }
+objects = { workspace = true, features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+objects.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic-recovery/Cargo.toml
+++ b/crates/semantic-recovery/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 fastembed.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.14" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
 rmp-serde.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/semantic-recovery/Cargo.toml
+++ b/crates/semantic-recovery/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 fastembed.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.15" }
+heddle-fs-prims.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -29,8 +29,8 @@ lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.14" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.14", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -29,8 +29,8 @@ lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.15" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.15", features = ["memory-backend"] }
+merge.workspace = true
+objects = { workspace = true, features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15" }
 serde.workspace = true
 
 [lib]

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.15" }
+objects.workspace = true
+semantic.workspace = true
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
+repo = { workspace = true, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.14", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.15", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,7 +18,7 @@ chrono.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
+objects.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
@@ -35,6 +35,6 @@ name = "wire"
 # Circular: heddle-repo depends on heddle-wire. We keep the path-dep
 # for local testing but omit `version` so cargo strips this entry from
 # the published manifest (dev-deps without version are not packaged).
-repo = { path = "../repo", package = "heddle-repo" }
+repo = { workspace = true, features = ["git-overlay", "native", "zstd"] }
 tempfile.workspace = true
 sley.workspace = true

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,7 +18,7 @@ chrono.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.14" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.15" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/experiments/iroh-transport/Cargo.toml
+++ b/experiments/iroh-transport/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 api = { package = "heddle-api", version = "0.2.1" }
 bytes.workspace = true
 iroh.workspace = true
-objects = { path = "../../crates/objects", package = "heddle-objects" }
+objects.workspace = true
 prost.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-wire = { path = "../../crates/wire", package = "heddle-wire" }
+wire = { workspace = true, features = ["zstd"] }
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
Bumps the workspace version to **0.15.0** to publish heddle's crates rebuilt on heddle-api 0.15 + cv 0.5 + sley 0.8 (landed in #1548), for the weft 0.15 consumer bump.

Also bundles a manifest cleanup (per owner request): heddle's internal inter-crate dependencies are consolidated into the root `[workspace.dependencies]` table, so future release bumps touch only the root `Cargo.toml` instead of every crate manifest. Verified the resolved feature graph is byte-identical before/after (no feature/optional/default-feature dropped); `cargo check --workspace` clean. Manifest-only — no source changes.