### PR TITLE
fix(release): keep internal dev-deps path-only so cargo publish strips them (unblock 0.15.0 publish)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -248,7 +248,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { workspace = true, features = ["test-utils"] }
+heddle-cli-render = { path = "../cli-render", default-features = false, features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -22,7 +22,7 @@ state_review.workspace = true
 semantic = { workspace = true, optional = true }
 
 [dev-dependencies]
-objects = { workspace = true, features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }
 proptest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -22,4 +22,4 @@ sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { workspace = true, features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format.workspace = true
+heddle-format = { path = "../format" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -91,7 +91,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { workspace = true, features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -35,6 +35,6 @@ name = "wire"
 # Circular: heddle-repo depends on heddle-wire. We keep the path-dep
 # for local testing but omit `version` so cargo strips this entry from
 # the published manifest (dev-deps without version are not packaged).
-repo = { workspace = true, features = ["git-overlay", "native", "zstd"] }
+repo = { path = "../repo", package = "heddle-repo", default-features = false, features = ["git-overlay", "native", "zstd"] }
 tempfile.workspace = true
 sley.workspace = true


### PR DESCRIPTION
## Problem

heddle 0.15.0's crates-publish is half-failed. `cargo publish -p heddle-wire` fails with:

```
failed to select a version for the requirement heddle-repo = "^0.15.0"
```

A recent cleanup converted heddle's **internal dev-dependencies** to workspace inheritance (`{ workspace = true }`), which gave them a version (0.15.0) via the root `[workspace.dependencies]` table.

`heddle-wire` has a **dev-dependency** on `heddle-repo`, while `heddle-repo` **normal-depends** on `heddle-wire` — a cycle. A *versioned* dev-dep on `repo` means `cargo publish` of `wire` requires `heddle-repo@0.15.0` to already exist on crates.io before `repo` is published → deadlock.

The 0.14 release avoided this by keeping internal dev-deps **path-only** (no version), so `cargo publish` strips them from the packaged manifest (dev-deps without a version are not packaged).

## Fix

Restore the pre-cleanup convention: every **internal** heddle dev-dependency is made path-only (drop `workspace = true` / the inherited version), preserving `package`, `features`, and `default-features`. External dev-deps (tempfile, proptest, sley, …) and all normal `[dependencies]` are untouched — normal deps *need* the version for publish.

**No version bump needed** — dev-deps are stripped from published crates.

Converted internal dev-deps:

| Crate | Dev-dep | Note |
|---|---|---|
| `crates/wire` | `repo` (heddle-repo) | the failing wire↔repo cycle |
| `crates/daemon` | `objects` (heddle-objects) | |
| `crates/merge` | `objects` (heddle-objects) | |
| `crates/repo` | `objects` (heddle-objects) | |
| `crates/mount` | `heddle-format` | |
| `crates/cli` | `heddle-cli-render` | |

## Verification

- `cargo check --workspace` (isolated target) exits 0.
- `cargo package -p heddle-wire --no-verify` succeeds, and the generated `heddle-wire-0.15.0/Cargo.toml` carries **no `heddle-repo`/`repo` dependency entry** — the dev-dep is stripped, so the wire↔repo publish cycle is broken. The only remaining dev-deps in the packaged manifest are `sley` and `tempfile` (both external, versioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790105703&installation_model_id=21489&pr_number=1554&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1554&signature=961c36174a6a7936b403620a0ca3bbff122ca500b287d51e3261a4063dc671a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->