### PR TITLE
Wire resident agent claim ceremony

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -3,6 +3,56 @@
 
 use clap::{Args, Subcommand, ValueEnum};
 
+const DEFAULT_CLAIM_TIMEOUT: &str = "15m";
+pub const DEFAULT_CLAIM_WEB_ORIGIN: &str = "https://app.heddle.sh";
+
+/// Offer the current agent-rooted account for a human to claim.
+#[derive(Args, Clone, Debug)]
+pub struct ClaimArgs {
+    /// Hosted Heddle server. Omit to use the configured default
+    /// (`api.heddle.sh` when none is stored).
+    #[arg(long)]
+    pub server: Option<String>,
+
+    /// Web origin used to build the human claim link. Defaults to
+    /// `https://app.heddle.sh`.
+    #[arg(long, value_name = "ORIGIN")]
+    pub web_origin: Option<String>,
+
+    /// How long to keep the claim listener resident (`s`, `m`, `h`, or `d`).
+    #[arg(
+        long,
+        default_value = DEFAULT_CLAIM_TIMEOUT,
+        value_name = "DURATION",
+        value_parser = parse_claim_timeout
+    )]
+    pub timeout: std::time::Duration,
+}
+
+fn parse_claim_timeout(value: &str) -> Result<std::time::Duration, String> {
+    let value = value.trim();
+    let (amount, multiplier) = match value.as_bytes().last().copied() {
+        Some(b's') => (&value[..value.len() - 1], 1),
+        Some(b'm') => (&value[..value.len() - 1], 60),
+        Some(b'h') => (&value[..value.len() - 1], 60 * 60),
+        Some(b'd') => (&value[..value.len() - 1], 24 * 60 * 60),
+        Some(byte) if byte.is_ascii_digit() => (value, 1),
+        _ => {
+            return Err("expected a positive duration such as 30s, 15m, 2h, or 1d".to_string());
+        }
+    };
+    let amount = amount
+        .parse::<u64>()
+        .map_err(|_| "claim timeout must be a positive whole number".to_string())?;
+    let seconds = amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| "claim timeout is too large".to_string())?;
+    if seconds == 0 {
+        return Err("claim timeout must be greater than zero".to_string());
+    }
+    Ok(std::time::Duration::from_secs(seconds))
+}
+
 /// Preset operation ceilings for `heddle auth derive-agent`.
 ///
 /// Each variant expands to a curated set of safe agent operations. `reviewer`
@@ -264,6 +314,28 @@ mod tests {
     fn interactive_login_needs_no_flags() {
         Cli::try_parse_from(["heddle", "auth", "login"])
             .expect("interactive login may resolve the configured default server");
+    }
+
+    #[test]
+    fn claim_is_one_top_level_resident_command() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "claim",
+            "--server",
+            "weft.example",
+            "--web-origin",
+            "https://heddle.example",
+            "--timeout",
+            "30m",
+        ])
+        .expect("claim flags parse");
+        let Commands::Claim(args) = cli.command else {
+            panic!("expected top-level claim");
+        };
+        assert_eq!(args.server.as_deref(), Some("weft.example"));
+        assert_eq!(args.web_origin.as_deref(), Some("https://heddle.example"));
+        assert_eq!(args.timeout, std::time::Duration::from_secs(30 * 60));
+        assert!(Cli::try_parse_from(["heddle", "claim", "--timeout", "0s"]).is_err());
     }
 
     #[test]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -3,8 +3,6 @@
 
 use clap::{Args, Subcommand};
 
-#[cfg(feature = "client")]
-use super::AuthCommands;
 #[cfg(feature = "git-overlay")]
 use super::BridgeCommands;
 #[cfg(feature = "semantic")]
@@ -19,6 +17,8 @@ use super::{
         ThreadStartArgs, UndoArgs, WatchArgs,
     },
 };
+#[cfg(feature = "client")]
+use super::{AuthCommands, ClaimArgs};
 
 #[derive(Clone, Debug, Args)]
 pub struct FsckArgs {
@@ -357,6 +357,19 @@ Examples:
         #[command(subcommand)]
         command: AuthCommands,
     },
+
+    /// Offer this agent account for a human to claim.
+    ///
+    /// Prints a short-lived bearer link, then keeps the agent's Iroh endpoint
+    /// online until the human finishes, the offer expires, or Ctrl-C stops it.
+    #[cfg(feature = "client")]
+    #[command(after_help = "\
+Examples:
+  heddle claim
+  heddle claim --timeout 30m
+  heddle claim --server weft.example --web-origin https://heddle.example
+")]
+    Claim(ClaimArgs),
 
     /// Report the capture actor, then hosted auth.
     ///

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -54,7 +54,9 @@ pub use commands_args::{
 #[cfg(feature = "ci")]
 pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
-pub use commands_client::{AgentTemplateArg, AuthCommands, AuthTrustCommands};
+pub use commands_client::{
+    AgentTemplateArg, AuthCommands, AuthTrustCommands, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN,
+};
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]
 pub use commands_context::ContextReasonCommands;

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1519,6 +1519,13 @@ const CONTRACTS: &[CommandContractEntry] = &[
             190,
         ),
     ),
+    entry(
+        &["claim"],
+        front_door(
+            feature_gated(user_scoped(NETWORK_CONFIG_MUTATION_TEXT), "client"),
+            191,
+        ),
+    ),
     entry(&["bridge"], surface(GROUP, "git_projection")),
     entry(&["bridge", "git"], surface(GROUP, "git_projection")),
     entry(
@@ -4506,6 +4513,8 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         },
         #[cfg(feature = "client")]
         Commands::Whoami { .. } => vec!["whoami"],
+        #[cfg(feature = "client")]
+        Commands::Claim(_) => vec!["claim"],
         Commands::Context { command } => match command {
             ContextCommands::Set(_) => vec!["context", "set"],
             ContextCommands::Get(_) => vec!["context", "get"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -172,6 +172,8 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     ),
     #[cfg(feature = "client")]
     sample(&["whoami"], &["whoami"]),
+    #[cfg(feature = "client")]
+    sample(&["claim"], &["claim"]),
     #[cfg(feature = "git-overlay")]
     sample(&["bridge", "git", "import"], &["bridge", "git", "import"]),
     #[cfg(feature = "git-overlay")]
@@ -1496,6 +1498,13 @@ fn credential_effect_sets_are_config_scoped() {
             CommandSideEffect::NetworkIo,
         ],
     );
+    assert_command_effects(
+        &["claim"],
+        &[
+            CommandSideEffect::WritesConfig,
+            CommandSideEffect::NetworkIo,
+        ],
+    );
 }
 
 #[test]
@@ -1506,6 +1515,7 @@ fn auth_commands_are_user_scoped() {
         &["auth", "status"],
         &["auth", "derive-agent"],
         &["auth", "create-service-token"],
+        &["claim"],
     ] {
         let contract = raw_command_contract_for_path(path.iter().copied())
             .unwrap_or_else(|| panic!("missing command contract for `{}`", path.join(" ")));
@@ -2420,5 +2430,8 @@ fn feature_gated_command_roots_are_catalog_owned() {
     // `#[cfg(feature = "client")]`, `ci` is
     // `#[cfg(feature = "ci")]`. Any new feature-gated root MUST be
     // listed here.
-    assert_eq!(feature_gated_command_roots(), &["auth", "ci", "whoami"]);
+    assert_eq!(
+        feature_gated_command_roots(),
+        &["auth", "ci", "claim", "whoami"]
+    );
 }

--- a/crates/cli-contract/src/cli/commands/surface_conformance.rs
+++ b/crates/cli-contract/src/cli/commands/surface_conformance.rs
@@ -20,6 +20,7 @@ pub const CANONICAL_ROOT_COMMANDS: &[&str] = &[
     "agent",
     "auth",
     "bridge",
+    "claim",
     "clean",
     "clone",
     "commit",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -643,6 +643,9 @@ async fn async_main() -> Result<()> {
         }
 
         #[cfg(feature = "client")]
+        Commands::Claim(args) => hosted.claim(args.clone()).await,
+
+        #[cfg(feature = "client")]
         Commands::Whoami { server } => {
             let server = server.clone();
             hosted.whoami(&cli, server).await

--- a/crates/hosted-client/src/extensions.rs
+++ b/crates/hosted-client/src/extensions.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use heddle_cli_args::{AgentTemplateArg, AuthCommands, AuthTrustCommands, CliContext};
+use heddle_cli_args::{AgentTemplateArg, AuthCommands, AuthTrustCommands, ClaimArgs, CliContext};
 
 use crate::hosted_runtime::{
     auth_requests::{AuthCommand, AuthTrustCommand},
@@ -24,6 +24,9 @@ pub trait HostedExtensions: Send + Sync {
     /// service account issuance.
     async fn auth(&self, ctx: &(dyn CliContext + 'static), command: AuthCommands) -> Result<()>;
 
+    /// `heddle claim` — activate and serve a resident agent-account offer.
+    async fn claim(&self, args: ClaimArgs) -> Result<()>;
+
     /// `heddle whoami` — resolve and report the acting identity without
     /// attaching or replacing a credential.
     async fn whoami(&self, ctx: &(dyn CliContext + 'static), server: Option<String>) -> Result<()>;
@@ -36,6 +39,10 @@ impl HostedExtensions for EnabledHostedExtensions {
     async fn auth(&self, ctx: &(dyn CliContext + 'static), command: AuthCommands) -> Result<()> {
         let command = auth_command(command);
         crate::hosted_runtime::auth::cmd_auth(ctx, command).await
+    }
+
+    async fn claim(&self, args: ClaimArgs) -> Result<()> {
+        crate::hosted_runtime::claim_offer::cmd_claim(args).await
     }
 
     async fn whoami(&self, ctx: &(dyn CliContext + 'static), server: Option<String>) -> Result<()> {

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
@@ -3,7 +3,7 @@
 // The transport contract owns `CallFailure` by value at this seam.
 #![allow(clippy::result_large_err)]
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{Ed25519Signer, Signer as _};
@@ -23,12 +23,21 @@ const PRE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-pre-consent-v1";
 const PROMOTE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-promote-consent-v1";
 
 #[derive(Clone, Debug)]
-pub(crate) struct StoredClaimAuthorization;
+pub(crate) struct StoredClaimAuthorization {
+    completion: tokio::sync::watch::Sender<bool>,
+}
+
+impl StoredClaimAuthorization {
+    pub(crate) fn new() -> (Self, tokio::sync::watch::Receiver<bool>) {
+        let (completion, receiver) = tokio::sync::watch::channel(false);
+        (Self { completion }, receiver)
+    }
+}
 
 impl ClaimSecretVerifier for StoredClaimAuthorization {
     async fn verify(
         &self,
-        _method: &str,
+        method: &str,
         context: &CallContext,
         _body: &[u8],
     ) -> Result<VerifiedClaimPrincipal, CallFailure> {
@@ -36,10 +45,11 @@ impl ClaimSecretVerifier for StoredClaimAuthorization {
         let Some(state) = state else {
             return Err(auth_failure());
         };
-        if !state.accepts(
-            &context.bearer_capability,
-            chrono::Utc::now().timestamp_millis(),
-        ) {
+        let now = chrono::Utc::now().timestamp_millis();
+        let authorized = state.accepts(&context.bearer_capability, now)
+            || (method == CLAIM_RESOLVE_METHOD
+                && state.accepts_claimed_resolve(&context.bearer_capability, now));
+        if !authorized {
             return Err(auth_failure());
         }
         Ok(VerifiedClaimPrincipal {
@@ -63,9 +73,15 @@ impl ClaimHandler for StoredClaimAuthorization {
         let mut state = identity_state::load_while_locked()
             .map_err(internal_failure)?
             .ok_or_else(auth_failure)?;
+        let now = chrono::Utc::now().timestamp_millis();
+        let method_is_available = if method == CLAIM_RESOLVE_METHOD {
+            state.is_active(now) || (state.is_claimed() && state.consent_unexpired(now))
+        } else {
+            state.is_active(now)
+        };
         if state.owner_id.to_string() != principal.subject
             || state.authorization_hash() != principal.authorization_hash
-            || !state.is_active(chrono::Utc::now().timestamp_millis())
+            || !method_is_available
         {
             return Err(auth_failure());
         }
@@ -81,6 +97,14 @@ impl ClaimHandler for StoredClaimAuthorization {
                 CallFailureCode::Unimplemented,
                 "unknown claim method",
             )),
+        }
+    }
+
+    async fn response_delivered(&self, method: &str, body: &[u8]) {
+        if method == CLAIM_CONSENT_METHOD
+            && matches!(parse_request(body), Ok(ClaimRequest::PromoteConsent { .. }))
+        {
+            self.completion.send_replace(true);
         }
     }
 }
@@ -237,14 +261,7 @@ pub(crate) fn pre_consent_message(
     handle: &str,
     nonce: &[u8],
 ) -> Result<Vec<u8>, CallFailure> {
-    encode_pre_consent(
-        &state.owner_id.to_string(),
-        handle,
-        &state.node_id,
-        nonce,
-        state.authorization_hash(),
-        state.expires_at_millis,
-    )
+    encode_pre_consent(&state.owner_id.to_string(), handle, &state.node_id, nonce)
 }
 
 pub(crate) fn promote_consent_message(
@@ -252,21 +269,15 @@ pub(crate) fn promote_consent_message(
     handle: &str,
     credential_id: &str,
 ) -> Result<Vec<u8>, CallFailure> {
-    encode_promote_consent(
-        &state.owner_id.to_string(),
-        handle,
-        credential_id,
-        state.authorization_hash(),
-        state.expires_at_millis,
-    )
+    encode_promote_consent(&state.owner_id.to_string(), handle, credential_id)
 }
 
 /// Verifies a pre/promote pair from the consent payload, not local claim TTL.
 ///
-/// Rejects when the bound `expiresAt` has elapsed, the pair is not the same
-/// issuance, or either signature fails over the counted statement that includes
-/// the claim-state id and expiry. This is the weft-matching check; the CLI
-/// only issues consents.
+/// Rejects when the locally bound `expiresAt` has elapsed, the pair is not the
+/// same issuance, or either signature fails over weft's exact counted tuple.
+/// The issuance hash/expiry remain local anti-replay metadata; weft's v1
+/// signature domains intentionally do not include them.
 #[cfg(test)]
 pub(crate) fn verify_promotion_consents(
     agent_public_key: &[u8],
@@ -287,35 +298,22 @@ pub(crate) fn verify_promotion_consents(
             "claim consents are not a matching pair",
         ));
     }
-    consent_binding_parts(&pre.authorization_hash, pre.expires_at)?;
+    validate_consent_binding(&pre.authorization_hash, pre.expires_at)?;
     if now_millis >= pre.expires_at {
         return Err(failure(
             CallFailureCode::Unauthenticated,
             "claim consent has expired",
         ));
     }
-    let pre_statement = encode_pre_consent(
-        &pre.account_id,
-        handle,
-        &pre.node_id,
-        nonce,
-        &pre.authorization_hash,
-        pre.expires_at,
-    )?;
-    let promote_statement = encode_promote_consent(
-        &promote.account_id,
-        handle,
-        credential_id,
-        &promote.authorization_hash,
-        promote.expires_at,
-    )?;
+    let pre_statement = encode_pre_consent(&pre.account_id, handle, &pre.node_id, nonce)?;
+    let promote_statement = encode_promote_consent(&promote.account_id, handle, credential_id)?;
     verify_consent_signature(&pre_statement, agent_public_key, &pre.signature)?;
     verify_consent_signature(&promote_statement, agent_public_key, &promote.signature)?;
     Ok(())
 }
 
 fn refuse_stale_consent(state: &ClaimState) -> Result<(), CallFailure> {
-    consent_binding_parts(state.authorization_hash(), state.expires_at_millis)?;
+    validate_consent_binding(state.authorization_hash(), state.expires_at_millis)?;
     if state.consent_unexpired(chrono::Utc::now().timestamp_millis()) {
         return Ok(());
     }
@@ -340,18 +338,13 @@ fn encode_pre_consent(
     handle: &str,
     node_id: &str,
     nonce: &[u8],
-    authorization_hash: &str,
-    expires_at_millis: i64,
 ) -> Result<Vec<u8>, CallFailure> {
-    let binding = consent_binding_parts(authorization_hash, expires_at_millis)?;
     encode_counted(&[
         PRE_CONSENT_DOMAIN,
         account_id.as_bytes(),
         handle.as_bytes(),
         node_id.as_bytes(),
         nonce,
-        binding.authorization_hash.as_bytes(),
-        &binding.expires_at,
     ])
 }
 
@@ -359,39 +352,26 @@ fn encode_promote_consent(
     account_id: &str,
     handle: &str,
     credential_id: &str,
-    authorization_hash: &str,
-    expires_at_millis: i64,
 ) -> Result<Vec<u8>, CallFailure> {
-    let binding = consent_binding_parts(authorization_hash, expires_at_millis)?;
     encode_counted(&[
         PROMOTE_CONSENT_DOMAIN,
         account_id.as_bytes(),
         handle.as_bytes(),
         credential_id.as_bytes(),
-        binding.authorization_hash.as_bytes(),
-        &binding.expires_at,
     ])
 }
 
-fn consent_binding_parts(
+fn validate_consent_binding(
     authorization_hash: &str,
     expires_at_millis: i64,
-) -> Result<ConsentBinding<'_>, CallFailure> {
+) -> Result<(), CallFailure> {
     if authorization_hash.is_empty() || expires_at_millis <= 0 {
         return Err(failure(
             CallFailureCode::FailedPrecondition,
             "claim consent is not bound to an issuance",
         ));
     }
-    Ok(ConsentBinding {
-        authorization_hash,
-        expires_at: expires_at_millis.to_be_bytes(),
-    })
-}
-
-struct ConsentBinding<'a> {
-    authorization_hash: &'a str,
-    expires_at: [u8; 8],
+    Ok(())
 }
 
 #[cfg(test)]
@@ -423,26 +403,41 @@ fn encode_counted(parts: &[&[u8]]) -> Result<Vec<u8>, CallFailure> {
 }
 
 fn claim_signer(state: &ClaimState) -> Result<Ed25519Signer, CallFailure> {
-    let store = config::credentials::load_credentials().map_err(internal_failure)?;
-    let credential = store.servers.get(&state.server).ok_or_else(auth_failure)?;
-    let metadata = headless_token_metadata(&credential.token).map_err(internal_failure)?;
+    stored_claim_signer(state).map_err(|error| {
+        tracing::warn!(%error, "stored claim signer is unavailable");
+        auth_failure()
+    })
+}
+
+pub(crate) fn validate_stored_claim_signer(state: &ClaimState) -> Result<()> {
+    stored_claim_signer(state).map(|_| ())
+}
+
+fn stored_claim_signer(state: &ClaimState) -> Result<Ed25519Signer> {
+    let store = config::credentials::load_credentials()?;
+    let credential = store
+        .servers
+        .get(&state.server)
+        .with_context(|| format!("no agent credential is stored for {}", state.server))?;
+    let metadata = headless_token_metadata(&credential.token)
+        .context("reading the stored agent credential")?;
     if metadata.subject != state.subject
         || !(metadata.is_derived
             || is_local_agent_root(&metadata.subject, &metadata.proof_public_key_hex))
     {
-        return Err(auth_failure());
+        bail!("the stored credential is not the agent root recorded by this claim account");
     }
     let pem = credential
         .private_key_pem
         .as_deref()
-        .ok_or_else(auth_failure)?;
-    let signer = Ed25519Signer::from_pem(pem).map_err(internal_failure)?;
+        .context("the stored agent credential has no consent-signing key")?;
+    let signer = Ed25519Signer::from_pem(pem).context("loading the agent consent-signing key")?;
     if hex::encode(signer.public_key()) != state.node_id
         || !metadata
             .proof_public_key_hex
             .eq_ignore_ascii_case(&state.node_id)
     {
-        return Err(auth_failure());
+        bail!("the stored agent credential does not match agent-node-identity.toml");
     }
     Ok(signer)
 }

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -1,4 +1,8 @@
-use std::{net::Ipv4Addr, sync::Arc};
+use std::{
+    ffi::OsString,
+    net::Ipv4Addr,
+    sync::{Arc, MutexGuard},
+};
 
 use api::{
     framing::{ResponseFrame, decode_response_frame, encode_request_frame},
@@ -10,16 +14,21 @@ use iroh::{Endpoint, RelayMode, endpoint::presets, protocol::Router};
 use tokio::sync::Mutex;
 
 use super::{
+    agent_node_identity,
+    auth_login::store_agent_root,
     claim_authorization::{
-        AgentConsent, consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
-        signed_pre_consent, signed_promote_consent, validate_credential_id, validate_handle,
-        verify_promotion_consents,
+        AgentConsent, StoredClaimAuthorization, consent_reply, pre_consent_message,
+        promote_consent_message, resolved_reply, signed_pre_consent, signed_promote_consent,
+        validate_credential_id, validate_handle, verify_promotion_consents,
     },
+    device_flow::restrict_agent_account_root,
     hosted::claim_protocol::{
         CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimProtocol,
         ClaimSecretVerifier, VerifiedClaimPrincipal,
     },
+    identity_state,
     identity_state::ClaimState,
+    root_mint::mint_agent_root,
 };
 
 const OWNER_ID: &str = "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28";
@@ -113,7 +122,7 @@ fn consent_signatures_round_trip_the_local_builders() {
 }
 
 #[test]
-fn consent_builders_encode_the_v1_counted_fields() {
+fn consent_builders_match_weft_v1_exact_bytes() {
     let mut claim = state("11".repeat(32));
     assert!(claim.reissue(b"claim-secret", 1_700_000_000_000));
     let nonce = b"0123456789abcdef";
@@ -122,27 +131,25 @@ fn consent_builders_encode_the_v1_counted_fields() {
         .expect("promote-consent bytes");
 
     assert_eq!(
-        pre,
-        counted(&[
-            b"heddle-agent-pre-consent-v1",
-            OWNER_ID.as_bytes(),
-            b"human-handle",
-            claim.node_id.as_bytes(),
-            nonce,
-            claim.authorization_hash().as_bytes(),
-            &claim.expires_at_millis.to_be_bytes(),
-        ])
+        hex::encode(pre),
+        concat!(
+            "0000001b686564646c652d6167656e742d7072652d636f6e73656e742d7631",
+            "0000002437656431623633332d363464642d346237382d623361382d376638653038666334613238",
+            "0000000c68756d616e2d68616e646c65",
+            "0000004031313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131",
+            "0000001030313233343536373839616263646566",
+        ),
+        "must match weft agent_consent::pre_consent_message byte-for-byte"
     );
     assert_eq!(
-        promote,
-        counted(&[
-            b"heddle-agent-promote-consent-v1",
-            OWNER_ID.as_bytes(),
-            b"human-handle",
-            b"Y3JlZGVudGlhbA",
-            claim.authorization_hash().as_bytes(),
-            &claim.expires_at_millis.to_be_bytes(),
-        ])
+        hex::encode(promote),
+        concat!(
+            "0000001f686564646c652d6167656e742d70726f6d6f74652d636f6e73656e742d7631",
+            "0000002437656431623633332d363464642d346237382d623361382d376638653038666334613238",
+            "0000000c68756d616e2d68616e646c65",
+            "0000000e59334a6c5a47567564476c686241",
+        ),
+        "must match weft agent_consent::promote_consent_message byte-for-byte"
     );
 }
 
@@ -265,26 +272,17 @@ fn expired_consent_signature_is_rejected_after_bound_expiry() {
     );
 }
 
-fn counted(parts: &[&[u8]]) -> Vec<u8> {
-    let mut encoded = Vec::new();
-    for part in parts {
-        let length = u32::try_from(part.len()).expect("test field fits in u32");
-        encoded.extend_from_slice(&length.to_be_bytes());
-        encoded.extend_from_slice(part);
-    }
-    encoded
-}
-
 #[test]
-fn unbound_claim_state_cannot_encode_consent() {
+fn dormant_claim_state_reproduces_activation_gap_and_refuses_to_sign() {
     let claim = state("11".repeat(32));
     assert!(
-        pre_consent_message(&claim, "human-handle", b"0123456789abcdef").is_err(),
-        "dormant state has no claim-state id or expiry to bind"
+        pre_consent_message(&claim, "human-handle", b"0123456789abcdef").is_ok(),
+        "weft-compatible bytes do not carry local issuance state"
     );
+    let signer = Ed25519Signer::generate().expect("signer");
     assert!(
-        promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA").is_err(),
-        "dormant state has no claim-state id or expiry to bind"
+        signed_pre_consent(&claim, "human-handle", b"0123456789abcdef", &signer,).is_err(),
+        "without production activation every consent call must fail closed"
     );
 }
 
@@ -312,15 +310,16 @@ impl std::fmt::Debug for MemoryClaimAuthorization {
 impl ClaimSecretVerifier for MemoryClaimAuthorization {
     async fn verify(
         &self,
-        _method: &str,
+        method: &str,
         context: &CallContext,
         _body: &[u8],
     ) -> Result<VerifiedClaimPrincipal, CallFailure> {
         let state = self.state.lock().await;
-        if !state.accepts(
-            &context.bearer_capability,
-            chrono::Utc::now().timestamp_millis(),
-        ) {
+        let now = chrono::Utc::now().timestamp_millis();
+        let authorized = state.accepts(&context.bearer_capability, now)
+            || (method == CLAIM_RESOLVE_METHOD
+                && state.accepts_claimed_resolve(&context.bearer_capability, now));
+        if !authorized {
             return Err(failure(
                 CallFailureCode::Unauthenticated,
                 "claim authorization failed",
@@ -341,9 +340,16 @@ impl ClaimHandler for MemoryClaimAuthorization {
         body: &[u8],
     ) -> Result<Vec<u8>, CallFailure> {
         let mut state = self.state.lock().await;
+        let now = chrono::Utc::now().timestamp_millis();
+        let method_is_available = if method == CLAIM_RESOLVE_METHOD {
+            state.is_active(now) || (state.is_claimed() && state.consent_unexpired(now))
+        } else {
+            state.is_active(now)
+        };
         if principal.subject != state.owner_id.to_string()
             || principal.authorization_hash != state.authorization_hash()
             || self.secret.is_empty()
+            || !method_is_available
         {
             return Err(failure(
                 CallFailureCode::Unauthenticated,
@@ -393,6 +399,117 @@ async fn endpoints(
     (router, client, address)
 }
 
+async fn stored_endpoints() -> (
+    Router,
+    Endpoint,
+    iroh::EndpointAddr,
+    tokio::sync::watch::Receiver<bool>,
+) {
+    let server = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let address = server.addr();
+    let (authorization, completion) = StoredClaimAuthorization::new();
+    let authorization = Arc::new(authorization);
+    let router = Router::builder(server)
+        .accept(
+            CLAIM_ALPN_V1,
+            ClaimProtocol::new(Arc::clone(&authorization), authorization),
+        )
+        .spawn();
+    let client = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    (router, client, address, completion)
+}
+
+struct IsolatedHeddleHome {
+    _guard: MutexGuard<'static, ()>,
+    _temp: tempfile::TempDir,
+    previous_home: Option<OsString>,
+    previous_credential: Option<OsString>,
+}
+
+impl IsolatedHeddleHome {
+    fn new() -> Self {
+        let guard = config::credentials::lock_test_env();
+        let temp = tempfile::TempDir::new().expect("temporary Heddle home");
+        let previous_home = std::env::var_os("HEDDLE_HOME");
+        let previous_credential = std::env::var_os("HEDDLE_CREDENTIAL");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", temp.path());
+            std::env::remove_var("HEDDLE_CREDENTIAL");
+        }
+        Self {
+            _guard: guard,
+            _temp: temp,
+            previous_home,
+            previous_credential,
+        }
+    }
+}
+
+impl Drop for IsolatedHeddleHome {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.previous_home {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match &self.previous_credential {
+                Some(value) => std::env::set_var("HEDDLE_CREDENTIAL", value),
+                None => std::env::remove_var("HEDDLE_CREDENTIAL"),
+            }
+        }
+    }
+}
+
+fn store_production_claim_state(activate: bool) -> (Vec<u8>, Ed25519Signer) {
+    let server = "api.heddle.test";
+    let identity = agent_node_identity::load_or_create().expect("agent node identity");
+    let seed = identity.secret_key().to_bytes();
+    let signer = Ed25519Signer::from_seed(&seed).expect("agent consent signer");
+    let root = mint_agent_root(&seed).expect("agent root");
+    let restricted = restrict_agent_account_root(&root.token, &signer, root.expires_at)
+        .expect("restricted agent root");
+    store_agent_root(
+        server,
+        restricted,
+        root.subject.clone(),
+        root.private_key_pem,
+        root.expires_at,
+    )
+    .expect("stored agent root");
+    let mut claim = ClaimState::new(
+        server.to_string(),
+        uuid::Uuid::parse_str(OWNER_ID).expect("owner id"),
+        root.subject,
+        "steady-heron".to_string(),
+        identity.node_id().to_string(),
+    );
+    let secret = if activate {
+        claim
+            .activate(chrono::Utc::now().timestamp_millis() + 60_000)
+            .expect("production activation")
+            .expect("unclaimed account")
+            .as_str()
+            .as_bytes()
+            .to_vec()
+    } else {
+        b"inactive-secret".to_vec()
+    };
+    identity_state::store(&claim).expect("stored claim state");
+    (secret, signer)
+}
+
 async fn call(
     client: &Endpoint,
     server: iroh::EndpointAddr,
@@ -426,7 +543,147 @@ enum OwnedResponse {
 }
 
 #[tokio::test]
-async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
+async fn production_activation_serves_full_iroh_browser_round_trip() {
+    let _home = IsolatedHeddleHome::new();
+    let (secret, signer) = store_production_claim_state(true);
+    let (router, client, address, mut completion) = stored_endpoints().await;
+
+    let OwnedResponse::Success(resolved) = call(
+        &client,
+        address.clone(),
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("production-activated claim must resolve");
+    };
+    let resolved: serde_json::Value = serde_json::from_slice(&resolved).unwrap();
+    assert_eq!(resolved["agent"]["petName"], "steady-heron");
+
+    let nonce = b"0123456789abcdef";
+    let pre_body = serde_json::json!({
+        "kind": "preConsent",
+        "handle": "human-handle",
+        "nonce": URL_SAFE_NO_PAD.encode(nonce),
+    });
+    let OwnedResponse::Success(pre) = call(
+        &client,
+        address.clone(),
+        CLAIM_CONSENT_METHOD,
+        &secret,
+        &serde_json::to_vec(&pre_body).unwrap(),
+    )
+    .await
+    else {
+        panic!("browser pre-consent must succeed");
+    };
+    let pre: serde_json::Value = serde_json::from_slice(&pre).unwrap();
+    let pre = consent_from_reply(&pre);
+    let pre_signature = URL_SAFE_NO_PAD.decode(&pre.signature).unwrap();
+    let prepared = identity_state::load().unwrap().unwrap();
+    Ed25519Signer::verify_with_public_key(
+        &pre_consent_message(&prepared, "human-handle", nonce).unwrap(),
+        signer.public_key(),
+        &pre_signature,
+    )
+    .expect("weft pre-consent tuple verifies under the agent key");
+
+    let credential_id = URL_SAFE_NO_PAD.encode(b"browser-created-credential-id");
+    let promote_body = serde_json::json!({
+        "kind": "promoteConsent",
+        "handle": "human-handle",
+        "credentialId": credential_id,
+    });
+    let OwnedResponse::Success(promote) = call(
+        &client,
+        address.clone(),
+        CLAIM_CONSENT_METHOD,
+        &secret,
+        &serde_json::to_vec(&promote_body).unwrap(),
+    )
+    .await
+    else {
+        panic!("browser promote-consent must succeed");
+    };
+    let promote: serde_json::Value = serde_json::from_slice(&promote).unwrap();
+    let promote = consent_from_reply(&promote);
+    tokio::time::timeout(std::time::Duration::from_secs(2), completion.changed())
+        .await
+        .expect("promote response delivery signal must not hang")
+        .expect("claim listener remains online");
+    assert!(*completion.borrow());
+    let promote_signature = URL_SAFE_NO_PAD.decode(&promote.signature).unwrap();
+    let claimed = identity_state::load().unwrap().unwrap();
+    Ed25519Signer::verify_with_public_key(
+        &promote_consent_message(&claimed, "human-handle", &credential_id).unwrap(),
+        signer.public_key(),
+        &promote_signature,
+    )
+    .expect("live browser credential id is covered by weft promote-consent bytes");
+    verify_promotion_consents(
+        signer.public_key(),
+        "human-handle",
+        nonce,
+        &credential_id,
+        &pre,
+        &promote,
+        chrono::Utc::now().timestamp_millis(),
+    )
+    .expect("the simulated weft promotion accepts the live consent pair");
+    assert!(claimed.is_claimed());
+
+    let OwnedResponse::Success(refused) = call(
+        &client,
+        address,
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("claimed account must return a terminal refusal");
+    };
+    let refused: serde_json::Value = serde_json::from_slice(&refused).unwrap();
+    assert_eq!(refused["kind"], "refused");
+    assert_eq!(refused["refusal"], "claimed");
+
+    client.close().await;
+    router.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dormant_stored_claim_state_reproduces_every_call_fail_closed() {
+    let _home = IsolatedHeddleHome::new();
+    let (inactive_secret, _signer) = store_production_claim_state(false);
+    let (router, client, address, _completion) = stored_endpoints().await;
+    let requests: [(&str, &[u8]); 3] = [
+        (CLAIM_RESOLVE_METHOD, br#"{"kind":"resolve"}"#),
+        (
+            CLAIM_CONSENT_METHOD,
+            br#"{"kind":"preConsent","handle":"human-handle","nonce":"MDEyMzQ1Njc4OWFiY2RlZg"}"#,
+        ),
+        (
+            CLAIM_CONSENT_METHOD,
+            br#"{"kind":"promoteConsent","handle":"human-handle","credentialId":"Y3JlZGVudGlhbA"}"#,
+        ),
+    ];
+    for (method, body) in requests {
+        let OwnedResponse::Failure(failure) =
+            call(&client, address.clone(), method, &inactive_secret, body).await
+        else {
+            panic!("dormant claim state must fail closed for {method}");
+        };
+        assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
+    }
+
+    client.close().await;
+    router.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn iroh_claim_happy_path_matches_live_weft_promotion_bytes() {
     let signer = Ed25519Signer::generate().unwrap();
     let secret = b"correct-link-secret".to_vec();
     let mut claim = state(hex::encode(signer.public_key()));
@@ -437,19 +694,6 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
         signer,
     });
     let (router, client, address) = endpoints(Arc::clone(&authorization)).await;
-
-    let OwnedResponse::Failure(wrong_link) = call(
-        &client,
-        address.clone(),
-        CLAIM_RESOLVE_METHOD,
-        b"wrong-link-secret",
-        br#"{"kind":"resolve"}"#,
-    )
-    .await
-    else {
-        panic!("wrong claim link must fail");
-    };
-    assert_eq!(wrong_link.code, CallFailureCode::Unauthenticated as i32);
 
     let OwnedResponse::Success(resolved) = call(
         &client,
@@ -563,29 +807,91 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
     assert!(state.is_claimed());
     drop(state);
 
-    let OwnedResponse::Failure(already_claimed) = call(
+    let OwnedResponse::Success(already_claimed) = call(
         &client,
         address,
-        CLAIM_CONSENT_METHOD,
+        CLAIM_RESOLVE_METHOD,
         &secret,
-        &serde_json::to_vec(&promote_body).unwrap(),
+        br#"{"kind":"resolve"}"#,
     )
     .await
     else {
-        panic!("already-claimed account must fail");
+        panic!("already-claimed account must resolve to a refusal");
     };
-    assert_eq!(
-        already_claimed.code,
-        CallFailureCode::Unauthenticated as i32,
-        "a consumed link must stop authenticating before a second consent"
-    );
+    let already_claimed: serde_json::Value = serde_json::from_slice(&already_claimed).unwrap();
+    assert_eq!(already_claimed["kind"], "refused");
+    assert_eq!(already_claimed["refusal"], "claimed");
 
     client.close().await;
     router.shutdown().await.unwrap();
 }
 
 #[tokio::test]
-async fn expired_iroh_claim_link_is_rejected_before_dispatch() {
+async fn wrong_claim_secret_is_rejected_before_resolve() {
+    let signer = Ed25519Signer::generate().unwrap();
+    let secret = b"correct-link-secret".to_vec();
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(&secret, chrono::Utc::now().timestamp_millis() + 60_000));
+    let authorization = Arc::new(MemoryClaimAuthorization {
+        state: Mutex::new(claim),
+        secret,
+        signer,
+    });
+    let (router, client, address) = endpoints(authorization).await;
+
+    let OwnedResponse::Failure(wrong_link) = call(
+        &client,
+        address,
+        CLAIM_RESOLVE_METHOD,
+        b"wrong-link-secret",
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("wrong claim secret must fail");
+    };
+    assert_eq!(wrong_link.code, CallFailureCode::Unauthenticated as i32);
+
+    client.close().await;
+    router.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn already_claimed_account_resolves_to_refused() {
+    let signer = Ed25519Signer::generate().unwrap();
+    let secret = b"consumed-link-secret".to_vec();
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(&secret, chrono::Utc::now().timestamp_millis() + 60_000));
+    assert!(claim.prepare("human-handle", b"0123456789abcdef"));
+    assert!(claim.claim("human-handle"));
+    let authorization = Arc::new(MemoryClaimAuthorization {
+        state: Mutex::new(claim),
+        secret: secret.clone(),
+        signer,
+    });
+    let (router, client, address) = endpoints(authorization).await;
+
+    let OwnedResponse::Success(response) = call(
+        &client,
+        address,
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("a consumed valid link must return the terminal refusal");
+    };
+    let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    assert_eq!(response["kind"], "refused");
+    assert_eq!(response["refusal"], "claimed");
+
+    client.close().await;
+    router.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn expired_claim_state_is_rejected_before_resolve() {
     let signer = Ed25519Signer::generate().unwrap();
     let secret = b"expired-link-secret".to_vec();
     let mut claim = state(hex::encode(signer.public_key()));

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -1,0 +1,277 @@
+//! Resident agent side of the human claim ceremony.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use config::UserConfig;
+use heddle_cli_args::{ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN};
+
+use super::{
+    HostedAuthMode, HostedSession, agent_node_identity,
+    auth::resolve_server,
+    claim_authorization::validate_stored_claim_signer,
+    hosted::server_keys_match,
+    identity_state::{self, ClaimIssuanceStatus, ClaimSecret, ClaimState},
+};
+
+const CLAIM_STATUS_POLL: Duration = Duration::from_millis(200);
+
+struct ActiveClaimOffer {
+    secret: ClaimSecret,
+    authorization_hash: String,
+    node_id: String,
+    pet_name: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClaimWaitOutcome {
+    Claimed,
+    Expired,
+    Interrupted,
+    Replaced,
+}
+
+pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
+    let server = resolve_server(args.server.as_deref())?;
+    // TODO(weft#1839): persist CreateAgentAccountResponse.web_origin and use
+    // explicit --web-origin > server-supplied origin > Heddle hosted default.
+    let web_origin = normalized_web_origin(
+        args.web_origin
+            .as_deref()
+            .unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN),
+    )?;
+    let state = claimable_state(&server)?;
+    validate_stored_claim_signer(&state)?;
+
+    let identity = agent_node_identity::load()?
+        .context("no agent node identity exists; create an agent account with `heddle auth login --invite <code>` first")?;
+    if identity.node_id().to_string() != state.node_id {
+        bail!("agent-node-identity.toml does not match the account waiting to be claimed");
+    }
+
+    let user_config = UserConfig::load_default()?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.clone()),
+        HostedAuthMode::CredentialFallback,
+    )?;
+    let client = session
+        .connect(([127, 0, 0, 1], 0).into())
+        .await
+        .with_context(|| {
+            format!("connecting to {server} and bringing the claim listener online")
+        })?;
+    let completion = client.claim_completion();
+
+    let offer = match activate_offer(&state, args.timeout) {
+        Ok(offer) => offer,
+        Err(error) => {
+            client.close().await;
+            return Err(error);
+        }
+    };
+    let claim_link = claim_link(&web_origin, &offer.node_id, offer.secret.as_str());
+    println!("Claim offer ready for {}.", offer.pet_name);
+    println!("\nOpen this short-lived claim link:\n\n{claim_link}\n");
+    println!(
+        "Waiting up to {} for a human to finish claiming this account. Press Ctrl-C to stop.",
+        display_duration(args.timeout)
+    );
+    drop(claim_link);
+    drop(offer.secret);
+
+    let outcome = wait_for_claim(&offer.authorization_hash, args.timeout, completion).await;
+    let cleanup = (!matches!(outcome, Ok(ClaimWaitOutcome::Claimed)))
+        .then(|| deactivate_offer(&offer.authorization_hash))
+        .transpose();
+    client.close().await;
+    cleanup?;
+
+    match outcome? {
+        ClaimWaitOutcome::Claimed => {
+            println!("Claim complete. This agent account now has a human owner.")
+        }
+        ClaimWaitOutcome::Expired => println!("Claim offer expired without changing the account."),
+        ClaimWaitOutcome::Interrupted => {
+            println!("Claim offer stopped; the link is no longer active.")
+        }
+        ClaimWaitOutcome::Replaced => {
+            bail!("this claim offer was replaced by another `heddle claim` process")
+        }
+    }
+    Ok(())
+}
+
+fn claimable_state(server: &str) -> Result<ClaimState> {
+    let state = identity_state::load()?.context(
+        "no agent account is waiting to be claimed; create one with `heddle auth login --invite <code>` first",
+    )?;
+    if !server_keys_match(&state.server, server) {
+        bail!(
+            "the stored agent account belongs to {}, but `heddle claim` targets {server}",
+            state.server
+        );
+    }
+    if state.is_claimed() {
+        bail!("this agent account has already been claimed");
+    }
+    Ok(state)
+}
+
+fn activate_offer(expected: &ClaimState, timeout: Duration) -> Result<ActiveClaimOffer> {
+    let timeout_millis = i64::try_from(timeout.as_millis())
+        .context("claim timeout is too large for a millisecond timestamp")?;
+    let expires_at_millis = chrono::Utc::now()
+        .timestamp_millis()
+        .checked_add(timeout_millis)
+        .context("claim expiry overflows the timestamp range")?;
+    let _guard = identity_state::write_lock()?;
+    let mut state = identity_state::load_while_locked()?
+        .context("agent claim state disappeared before the offer was activated")?;
+    if state.owner_id != expected.owner_id
+        || state.node_id != expected.node_id
+        || !server_keys_match(&state.server, &expected.server)
+    {
+        bail!("agent claim state changed before the offer was activated");
+    }
+    let secret = state
+        .activate(expires_at_millis)?
+        .context("this agent account has already been claimed")?;
+    let offer = ActiveClaimOffer {
+        secret,
+        authorization_hash: state.authorization_hash().to_string(),
+        node_id: state.node_id.clone(),
+        pet_name: state.pet_name.clone(),
+    };
+    identity_state::store_while_locked(&state)?;
+    Ok(offer)
+}
+
+async fn wait_for_claim(
+    authorization_hash: &str,
+    timeout: Duration,
+    mut completion: tokio::sync::watch::Receiver<bool>,
+) -> Result<ClaimWaitOutcome> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut poll = tokio::time::interval(CLAIM_STATUS_POLL);
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            biased;
+
+            delivered = completion.changed() => {
+                delivered.context("claim listener stopped before promotion was delivered")?;
+                if *completion.borrow() {
+                    let state = identity_state::load()?
+                        .context("agent claim state disappeared after promotion")?;
+                    if state.issuance_status(
+                        authorization_hash,
+                        chrono::Utc::now().timestamp_millis(),
+                    ) == ClaimIssuanceStatus::Claimed
+                    {
+                        return Ok(ClaimWaitOutcome::Claimed);
+                    }
+                }
+            }
+            result = tokio::signal::ctrl_c() => {
+                result.context("waiting for Ctrl-C")?;
+                return Ok(ClaimWaitOutcome::Interrupted);
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                return Ok(ClaimWaitOutcome::Expired);
+            }
+            _ = poll.tick() => {
+                let Some(state) = identity_state::load()? else {
+                    return Ok(ClaimWaitOutcome::Replaced);
+                };
+                match state.issuance_status(
+                    authorization_hash,
+                    chrono::Utc::now().timestamp_millis(),
+                ) {
+                    ClaimIssuanceStatus::Active => {}
+                    // ClaimState flips before the response is written. Wait
+                    // for the delivery signal so shutdown cannot race the
+                    // browser's PromoteConsent response.
+                    ClaimIssuanceStatus::Claimed => {}
+                    ClaimIssuanceStatus::Expired => return Ok(ClaimWaitOutcome::Expired),
+                    ClaimIssuanceStatus::Replaced => return Ok(ClaimWaitOutcome::Replaced),
+                }
+            }
+        }
+    }
+}
+
+fn deactivate_offer(authorization_hash: &str) -> Result<()> {
+    let _guard = identity_state::write_lock()?;
+    let Some(mut state) = identity_state::load_while_locked()? else {
+        return Ok(());
+    };
+    if state.deactivate_issuance(authorization_hash) {
+        identity_state::store_while_locked(&state)?;
+    }
+    Ok(())
+}
+
+fn normalized_web_origin(value: &str) -> Result<String> {
+    let parsed = reqwest::Url::parse(value).context("--web-origin must be an absolute URL")?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || !matches!(parsed.path(), "" | "/")
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        bail!("--web-origin must contain only an http(s) scheme, host, and optional port");
+    }
+    Ok(parsed.origin().ascii_serialization())
+}
+
+fn claim_link(web_origin: &str, node_id: &str, secret: &str) -> String {
+    format!("{web_origin}/claim/{node_id}.{secret}")
+}
+
+fn display_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds.is_multiple_of(24 * 60 * 60) {
+        format!("{}d", seconds / (24 * 60 * 60))
+    } else if seconds.is_multiple_of(60 * 60) {
+        format!("{}h", seconds / (60 * 60))
+    } else if seconds.is_multiple_of(60) {
+        format!("{}m", seconds / 60)
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claim_link_uses_the_origin_node_and_bearer_secret() {
+        let origin = normalized_web_origin("https://heddle.example:8443/").expect("origin");
+        assert_eq!(
+            claim_link(&origin, &"11".repeat(32), "short-lived-secret"),
+            format!(
+                "https://heddle.example:8443/claim/{}.short-lived-secret",
+                "11".repeat(32)
+            )
+        );
+    }
+
+    #[test]
+    fn claim_link_refuses_a_non_origin_base() {
+        for invalid in [
+            "heddle.example",
+            "ftp://heddle.example",
+            "https://heddle.example/path",
+            "https://heddle.example/?query=1",
+        ] {
+            assert!(
+                normalized_web_origin(invalid).is_err(),
+                "accepted {invalid}"
+            );
+        }
+    }
+}

--- a/crates/hosted-client/src/hosted_runtime/hosted/claim_protocol.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/claim_protocol.rs
@@ -52,6 +52,14 @@ pub(crate) trait ClaimHandler: Send + Sync + std::fmt::Debug + 'static {
         principal: VerifiedClaimPrincipal,
         body: &[u8],
     ) -> impl std::future::Future<Output = Result<Vec<u8>, CallFailure>> + Send;
+
+    fn response_delivered(
+        &self,
+        _method: &str,
+        _body: &[u8],
+    ) -> impl std::future::Future<Output = ()> + Send {
+        std::future::ready(())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -122,19 +130,24 @@ where
         .read_to_end(MAX_REQUEST_FRAME + 1)
         .await
         .map_err(ClaimProtocolError::transport)?;
+    let mut successful_call = None;
     let response = match decode_request_frame(&request) {
         Ok(frame) => match validate_auth_shape(frame.method, &frame.context) {
             Ok(()) => match verifier
                 .verify(frame.method, &frame.context, frame.body)
                 .await
             {
-                Ok(principal) => handler
-                    .call(frame.method, principal, frame.body)
-                    .await
-                    .and_then(|body| {
-                        encode_success_response(&body)
-                            .map_err(|error| failure(CallFailureCode::Internal, error.to_string()))
-                    }),
+                Ok(principal) => match handler.call(frame.method, principal, frame.body).await {
+                    Ok(body) => {
+                        let response = encode_success_response(&body)
+                            .map_err(|error| failure(CallFailureCode::Internal, error.to_string()));
+                        if response.is_ok() {
+                            successful_call = Some((frame.method, frame.body));
+                        }
+                        response
+                    }
+                    Err(failure) => Err(failure),
+                },
                 Err(failure) => Err(failure),
             },
             Err(failure) => Err(failure),
@@ -150,6 +163,11 @@ where
         .await
         .map_err(ClaimProtocolError::transport)?;
     send.finish().map_err(ClaimProtocolError::transport)?;
+    if let Some((method, body)) = successful_call
+        && matches!(send.stopped().await, Ok(None))
+    {
+        handler.response_delivered(method, body).await;
+    }
     Ok(())
 }
 

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -25,6 +25,7 @@ pub(super) struct HostedConnection {
     provider_transport: Option<ProviderWebSocketTransport>,
     provider_connections:
         Mutex<HashMap<EndpointId, Arc<Mutex<Option<iroh::endpoint::Connection>>>>>,
+    claim_completion: tokio::sync::watch::Receiver<bool>,
 }
 
 impl HostedConnection {
@@ -97,13 +98,14 @@ impl HostedConnection {
                 return Err(HostedError::transport(error));
             }
         };
-        let router = claim_router(endpoint.clone());
+        let (router, claim_completion) = claim_router(endpoint.clone());
         Ok(Arc::new(Self {
             router,
             endpoint,
             connection,
             provider_transport,
             provider_connections: Mutex::new(HashMap::new()),
+            claim_completion,
         }))
     }
 
@@ -113,6 +115,10 @@ impl HostedConnection {
 
     pub(super) fn supports_provider_transport(&self) -> bool {
         self.provider_transport.is_some()
+    }
+
+    pub(super) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.claim_completion.clone()
     }
 
     pub(super) async fn provider_connection(
@@ -181,15 +187,17 @@ async fn bind_endpoint(
     builder.bind().await.map_err(HostedError::transport)
 }
 
-fn claim_router(endpoint: Endpoint) -> Router {
-    let authorization =
-        Arc::new(crate::hosted_runtime::claim_authorization::StoredClaimAuthorization);
-    Router::builder(endpoint)
+fn claim_router(endpoint: Endpoint) -> (Router, tokio::sync::watch::Receiver<bool>) {
+    let (authorization, completion) =
+        crate::hosted_runtime::claim_authorization::StoredClaimAuthorization::new();
+    let authorization = Arc::new(authorization);
+    let router = Router::builder(endpoint)
         .accept(
             CLAIM_ALPN_V1,
             ClaimProtocol::new(Arc::clone(&authorization), authorization),
         )
-        .spawn()
+        .spawn();
+    (router, completion)
 }
 
 impl Drop for HostedConnection {

--- a/crates/hosted-client/src/hosted_runtime/hosted/credential.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/credential.rs
@@ -137,7 +137,7 @@ pub fn resolve_active_bearer() -> Result<Option<AuthToken>> {
     Ok(resolve_hosted_credential(server.as_deref())?.token)
 }
 
-pub(super) fn server_keys_match(left: &str, right: &str) -> bool {
+pub(crate) fn server_keys_match(left: &str, right: &str) -> bool {
     fn without_scheme(value: &str) -> &str {
         value
             .strip_prefix("http://")

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -53,6 +53,7 @@ use connection::HostedConnection;
 pub use context::CallContextFactory;
 #[cfg(test)]
 pub(crate) use credential::CredentialSource;
+pub(crate) use credential::server_keys_match;
 pub use credential::{ResolvedHostedCredential, resolve_active_bearer, resolve_hosted_credential};
 use crypto::{Ed25519Signer, Signer as _};
 pub use descriptor_trust::{
@@ -169,6 +170,10 @@ impl std::fmt::Debug for HostedClient {
 impl HostedClient {
     pub fn routes(&self) -> HostedRoutes<'_> {
         HostedRoutes::new(self)
+    }
+
+    pub(crate) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.connection.claim_completion()
     }
 
     pub async fn connect(descriptor: &VerifiedEndpointDescriptor) -> Result<Self> {

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use objects::{
     fs_atomic::write_file_atomic_secret,
     lock::{RepoLock, WriteLockGuard},
@@ -21,6 +22,22 @@ enum ClaimStatus {
     Active,
     Prepared,
     Claimed,
+}
+
+pub(crate) struct ClaimSecret(String);
+
+impl ClaimSecret {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ClaimIssuanceStatus {
+    Active,
+    Claimed,
+    Expired,
+    Replaced,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -65,16 +82,38 @@ impl ClaimState {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn reissue(&mut self, secret: &[u8], expires_at_millis: i64) -> bool {
+    /// Mint and activate a fresh one-time claim capability.
+    ///
+    /// Only the SHA-256 digest is retained by the state. The returned secret
+    /// exists solely long enough for the caller to render the claim link.
+    pub(crate) fn activate(&mut self, expires_at_millis: i64) -> Result<Option<ClaimSecret>> {
         if matches!(self.status, ClaimStatus::Claimed) {
-            return false;
+            return Ok(None);
         }
+        if expires_at_millis <= chrono::Utc::now().timestamp_millis() {
+            bail!("claim expiry must be in the future");
+        }
+        let mut random = [0u8; 32];
+        getrandom::fill(&mut random).context("minting claim secret")?;
+        let secret = ClaimSecret(URL_SAFE_NO_PAD.encode(random));
+        self.activate_with_secret(secret.as_str().as_bytes(), expires_at_millis);
+        Ok(Some(secret))
+    }
+
+    fn activate_with_secret(&mut self, secret: &[u8], expires_at_millis: i64) {
         self.secret_hash = hex::encode(Sha256::digest(secret));
         self.expires_at_millis = expires_at_millis;
         self.status = ClaimStatus::Active;
         self.prepared_handle = None;
         self.prepared_nonce_hash = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reissue(&mut self, secret: &[u8], expires_at_millis: i64) -> bool {
+        if matches!(self.status, ClaimStatus::Claimed) {
+            return false;
+        }
+        self.activate_with_secret(secret, expires_at_millis);
         true
     }
 
@@ -93,7 +132,17 @@ impl ClaimState {
     }
 
     pub(crate) fn accepts(&self, secret: &[u8], now: i64) -> bool {
-        if !self.is_active(now) {
+        self.is_active(now) && self.secret_matches(secret)
+    }
+
+    pub(crate) fn accepts_claimed_resolve(&self, secret: &[u8], now: i64) -> bool {
+        matches!(self.status, ClaimStatus::Claimed)
+            && self.consent_unexpired(now)
+            && self.secret_matches(secret)
+    }
+
+    fn secret_matches(&self, secret: &[u8]) -> bool {
+        if self.secret_hash.is_empty() {
             return false;
         }
         let Ok(expected) = hex::decode(&self.secret_hash) else {
@@ -108,6 +157,36 @@ impl ClaimState {
 
     pub(crate) fn is_claimed(&self) -> bool {
         matches!(self.status, ClaimStatus::Claimed)
+    }
+
+    pub(crate) fn issuance_status(
+        &self,
+        authorization_hash: &str,
+        now: i64,
+    ) -> ClaimIssuanceStatus {
+        if self.secret_hash != authorization_hash {
+            return ClaimIssuanceStatus::Replaced;
+        }
+        if self.is_claimed() {
+            return ClaimIssuanceStatus::Claimed;
+        }
+        if self.is_active(now) {
+            ClaimIssuanceStatus::Active
+        } else {
+            ClaimIssuanceStatus::Expired
+        }
+    }
+
+    pub(crate) fn deactivate_issuance(&mut self, authorization_hash: &str) -> bool {
+        if self.secret_hash != authorization_hash || self.is_claimed() {
+            return false;
+        }
+        self.secret_hash.clear();
+        self.expires_at_millis = 0;
+        self.status = ClaimStatus::Dormant;
+        self.prepared_handle = None;
+        self.prepared_nonce_hash = None;
+        true
     }
 
     pub(crate) fn prepare(&mut self, handle: &str, nonce: &[u8]) -> bool {
@@ -238,6 +317,24 @@ mod tests {
     }
 
     #[test]
+    fn production_activation_mints_a_persistable_bearer_without_storing_it() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("claim.toml");
+        let mut state = state();
+        let expires_at = chrono::Utc::now().timestamp_millis() + 60_000;
+        let secret = state
+            .activate(expires_at)
+            .expect("activate claim")
+            .expect("unclaimed account");
+        assert!(state.accepts(secret.as_str().as_bytes(), expires_at - 1));
+        assert_eq!(secret.as_str().len(), 43, "32 random bytes use base64url");
+        store_at(&path, &state).expect("store active claim state");
+        let contents = std::fs::read_to_string(path).expect("read claim state");
+        assert!(!contents.contains(secret.as_str()));
+        assert!(contents.contains("status = \"active\""));
+    }
+
+    #[test]
     fn prepared_claim_is_bound_to_one_handle_and_nonce() {
         let mut state = state();
         assert!(state.reissue(b"claim-secret", 2_000));
@@ -249,6 +346,21 @@ mod tests {
         assert!(state.claim("human-handle"));
         assert!(!state.accepts(b"claim-secret", 1_000));
         assert!(!state.reissue(b"third-secret", 3_000));
+    }
+
+    #[test]
+    fn shutdown_deactivates_only_its_own_unclaimed_issuance() {
+        let mut state = state();
+        assert!(state.reissue(b"first-secret", 2_000));
+        let first_hash = state.authorization_hash().to_string();
+        assert!(state.reissue(b"replacement-secret", 3_000));
+        assert!(
+            !state.deactivate_issuance(&first_hash),
+            "an older resident process must not revoke a replacement offer"
+        );
+        let replacement_hash = state.authorization_hash().to_string();
+        assert!(state.deactivate_issuance(&replacement_hash));
+        assert!(!state.accepts(b"replacement-secret", 2_000));
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod auth_requests;
 mod claim_authorization;
 #[cfg(test)]
 mod claim_authorization_tests;
+pub(crate) mod claim_offer;
 pub(crate) mod credential_file;
 pub(crate) mod device_flow;
 pub mod hosted;

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3154,8 +3154,8 @@ as one; no `help advanced`).
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
     "advanced_scope_mutating_commands_total": 55,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
-    "catalog_commands_total": 183,
-    "catalog_mutating_commands_total": 88,
+    "catalog_commands_total": 184,
+    "catalog_mutating_commands_total": 89,
     "json_commands_total": 146,
     "json_commands_with_accepted_opaque_schema": 39,
     "json_commands_with_schema": 107,
@@ -3169,7 +3169,7 @@ as one; no `help advanced`).
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "185 command(s), 146 JSON command(s), 88 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3207,7 +3207,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "185 command(s), 146 JSON command(s), 88 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7199,8 +7199,8 @@ as one; no `help advanced`).
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
     "advanced_scope_mutating_commands_total": 55,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
-    "catalog_commands_total": 183,
-    "catalog_mutating_commands_total": 88,
+    "catalog_commands_total": 184,
+    "catalog_mutating_commands_total": 89,
     "json_commands_total": 146,
     "json_commands_with_accepted_opaque_schema": 39,
     "json_commands_with_schema": 107,
@@ -7214,7 +7214,7 @@ as one; no `help advanced`).
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "185 command(s), 146 JSON command(s), 88 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -7252,7 +7252,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "185 command(s), 146 JSON command(s), 88 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
## Summary

- add the single top-level `heddle claim` resident command with hosted defaults plus self-hosted server and web-origin overrides
- activate claim state with a fresh short-lived bearer secret, persist only its hash, publish `{web_origin}/claim/{node_id}.{secret}`, and keep the Iroh listener online through delivered promotion consent
- sign pre-consent and live browser-supplied credential promotion bytes exactly as weft verifies them, with generation-safe cleanup and clear claimed, expired, interrupted, and replaced outcomes
- add local-Iroh browser simulation, exact byte fixtures, dormant/wrong-secret/expired/already-claimed negatives, CLI/catalog/docs coverage, and delivery-aware shutdown tests

## Closes

Closes #1568

## Test evidence

- `cargo build --locked --workspace --all-targets` — pass
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — pass
- `cargo test --locked --workspace --lib --bins --tests --examples` — pass
- `cargo test --locked -p heddle-hosted-client --features client claim_authorization -- --nocapture` — 12 passed, including local-Iroh full ceremony and all requested negatives
- `cargo test --locked -p heddle-hosted-client --features client identity_state::tests -- --nocapture` — 5 passed
- `heddle doctor docs --all --output json` — clean, 167 files, zero issues
- `heddle doctor schemas --output json` — verified, zero issues
- deliberate activation removal — full Iroh ceremony failed closed at Resolve as expected; restoring activation returned the 12-test claim suite to green
- `cargo test --locked --workspace --all-targets` passed every ordinary target; its `harness = false` Criterion tail was stopped during the known pre-existing 50k/100k refs benchmark rather than chasing the documented performance gate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348685&installation_model_id=21489&pr_number=1569&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1569&signature=9c5720f601786ba652fa7d1f26951181f1103457df03e9d25ab3ae266f218105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->