### PR TITLE
Headless agent create succeeds with claim directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adb09d15d8c9fa157eab86f6c96c3d4f5bc025093548e28b171128477574254"
+checksum = "62fe575ff77dc9181bc08a04be060a1b876cb86dbc1778b01ffda050215f1ff0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2d66374ad9dde01e17f5a3c84a9b15e531847b1d8b1ed97e00914c923b9333"
+checksum = "9e21a209952178ff354b92b050859051e60f4caafff9edc6f94dd2049fbdd279"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
+api = { package = "heddle-api", version = "0.17.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -13513,6 +13513,80 @@
       "title": "AuthCreateServiceTokenSchema",
       "type": "object"
     },
+    "auth login": {
+      "$defs": {
+        "HumanPromotionDirective": {
+          "properties": {
+            "account_id": {
+              "type": "string"
+            },
+            "command": {
+              "description": "Agent-native command that starts the short-lived human claim ceremony.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "promotion_uri": {
+              "description": "Reserved for a concrete server-provided promotion affordance.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "summary",
+            "account_id",
+            "command"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "account_id": {
+          "type": "string"
+        },
+        "authenticated": {
+          "type": "boolean"
+        },
+        "credential_saved": {
+          "type": "boolean"
+        },
+        "next": {
+          "$ref": "#/$defs/HumanPromotionDirective"
+        },
+        "output_kind": {
+          "enum": [
+            "agent_account_created"
+          ],
+          "type": "string"
+        },
+        "pet_name": {
+          "type": "string"
+        },
+        "subject": {
+          "description": "Subject carried by the client-minted, persisted agent capability.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "account_id",
+        "pet_name",
+        "subject",
+        "authenticated",
+        "credential_saved",
+        "next"
+      ],
+      "title": "AgentAccountCreatedSchema",
+      "type": "object"
+    },
     "auth logout": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -109,6 +109,17 @@ export interface AdoptSchema {
   verification: RepositoryVerificationState;
 }
 
+export interface AgentAccountCreatedSchema {
+  account_id: string;
+  authenticated: boolean;
+  credential_saved: boolean;
+  next: HumanPromotionDirective;
+  output_kind: "agent_account_created";
+  pet_name: string;
+  /** Subject carried by the client-minted, persisted agent capability. */
+  subject: string;
+}
+
 /** JSON payload for `heddle capture` / `heddle agent capture`. */
 export interface AgentCaptureSchema {
   action: string;
@@ -1284,6 +1295,16 @@ export interface HookUninstallSchema {
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   replayed?: boolean | null;
   [key: string]: unknown;
+}
+
+export interface HumanPromotionDirective {
+  account_id: string;
+  /** Agent-native command that starts the short-lived human claim ceremony. */
+  command: string;
+  kind: string;
+  /** Reserved for a concrete server-provided promotion affordance. */
+  promotion_uri?: string | null;
+  summary: string;
 }
 
 /** JSON payload for `bridge git import`. */
@@ -3449,6 +3470,7 @@ export interface HeddleVerbOutputs {
   "agent timeline reset": AgentTimelineResetSchema;
   "agent timeline status": TimelineStatusSchema;
   "auth create-service-token": AuthCreateServiceTokenSchema;
+  "auth login": AgentAccountCreatedSchema;
   "auth logout": AuthLogoutSchema;
   "auth status": AuthStatusSchema;
   "auth trust replace": AuthTrustReplaceSchema;
@@ -3610,6 +3632,7 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "agent timeline reset",
   "agent timeline status",
   "auth create-service-token",
+  "auth login",
   "auth logout",
   "auth status",
   "auth trust replace",

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.15.0" }
+api = { workspace = true }
 clap.workspace = true
 config.workspace = true
 objects.workspace = true

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -817,6 +817,12 @@ const NETWORK_CONFIG_MUTATION_TEXT: CommandContract = CommandContract {
     ..CONFIG_MUTATION
 };
 
+const NETWORK_CONFIG_MUTATION_NO_OP_ID: CommandContract = CommandContract {
+    supports_op_id: false,
+    network_io: true,
+    ..CONFIG_MUTATION
+};
+
 const INIT: CommandContract = CommandContract {
     may_initialize: true,
     may_move_ref: false,
@@ -1420,7 +1426,20 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(&["auth"], feature_gated(user_scoped(GROUP), "client")),
     entry(
         &["auth", "login"],
-        feature_gated(user_scoped(NETWORK_CONFIG_MUTATION_TEXT), "client"),
+        feature_gated(
+            json_discriminators(
+                documented_schemas(
+                    user_scoped(NETWORK_CONFIG_MUTATION_NO_OP_ID),
+                    &["auth login"],
+                ),
+                &[json_discriminator(
+                    Some("auth login"),
+                    "output_kind",
+                    "agent_account_created",
+                )],
+            ),
+            "client",
+        ),
     ),
     entry(
         &["auth", "logout"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -1722,6 +1722,9 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "agent presence show",
             "agent presence explain",
             "agent presence complete",
+            // heddle#1567: invite-based headless account creation emits the
+            // agent-native promotion directive.
+            "auth login",
             "auth logout",
             "auth status",
             // heddle#1130: descriptor-trust inspection and explicit

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -45,7 +45,8 @@ use super::{
             SessionListOutput,
         },
         auth::{
-            AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, ServiceTokenOutput, WhoamiOutput,
+            AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput,
+            ServiceTokenOutput, WhoamiOutput,
         },
         thread::{
             ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, ThreadAbsorbOutput,
@@ -170,6 +171,7 @@ schema_registry! {
     (&["agent task create", "agent task show", "agent task update"], AgentTaskEnvelope),
     (&["agent task list"], AgentTaskListOutput),
     (&["agent fanout plan", "agent fanout start"], AgentFanoutOutput),
+    (&["auth login"], AgentAccountCreatedOutput),
     (&["auth logout"], AuthLogoutOutput),
     (&["auth status"], AuthStatusOutput),
     (&["auth trust show", "auth trust replace"], AuthTrustOutput),

--- a/crates/cli-contract/src/cli/commands/wire/auth.rs
+++ b/crates/cli-contract/src/cli/commands/wire/auth.rs
@@ -8,6 +8,30 @@
 use schemars::JsonSchema;
 use serde::Serialize;
 
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "AgentAccountCreatedSchema")]
+pub struct AgentAccountCreatedOutput {
+    pub output_kind: &'static str,
+    pub account_id: String,
+    pub pet_name: String,
+    /// Subject carried by the client-minted, persisted agent capability.
+    pub subject: String,
+    pub authenticated: bool,
+    pub credential_saved: bool,
+    pub next: HumanPromotionDirective,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HumanPromotionDirective {
+    pub kind: &'static str,
+    pub summary: &'static str,
+    pub account_id: String,
+    /// Agent-native command that starts the short-lived human claim ceremony.
+    pub command: &'static str,
+    /// Reserved for a concrete server-provided promotion affordance.
+    pub promotion_uri: Option<String>,
+}
+
 /// How a server's descriptor trust was established.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]

--- a/crates/cli-contract/src/cli/commands/wire/mod.rs
+++ b/crates/cli-contract/src/cli/commands/wire/mod.rs
@@ -35,8 +35,8 @@ pub use agent::{
     SegmentOutput, SessionEnvelope, SessionListOutput, SessionOutput,
 };
 pub use auth::{
-    AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, CaptureActor, ServiceTokenOutput,
-    WhoamiIdentity, WhoamiOutput, WhoamiRole,
+    AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, CaptureActor,
+    HumanPromotionDirective, ServiceTokenOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
 };
 pub use bridge::{
     ExportGitOutput, ExportedRefOutput, ImportGitOutput, IntegrationStatusOutput,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,7 +39,7 @@ crypto.workspace = true
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge.workspace = true
-api = { package = "heddle-api", version = "0.15.0" }
+api = { workspace = true }
 config.workspace = true
 hosted-client.workspace = true
 heddle-cli-args.workspace = true

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -69,6 +69,7 @@ const SWEPT: &[&str] = &[
     "agent presence show",
     "agent presence explain",
     "agent presence complete",
+    "auth login",
     "auth logout",
     "auth status",
     "auth trust show",
@@ -261,6 +262,8 @@ fn output_kind_override(display: &str) -> Option<&'static str> {
         "agent presence show" => Some("presence_show"),
         "agent presence explain" => Some("presence_explain"),
         "agent presence complete" => Some("presence_complete"),
+        // Headless invite login emits the created account, not the command path.
+        "auth login" => Some("agent_account_created"),
         // Expand folded under `thread`; wire value keeps the root spelling.
         "thread expand" => Some("expand"),
         // Oplog recover folded under `maintenance`; wire value unchanged.

--- a/crates/hosted-client/Cargo.toml
+++ b/crates/hosted-client/Cargo.toml
@@ -16,7 +16,7 @@ name = "hosted_client"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-api = { package = "heddle-api", version = "0.15.0", optional = true }
+api = { workspace = true, optional = true }
 base64.workspace = true
 biscuit-auth = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }

--- a/crates/hosted-client/src/hosted_runtime/auth_login.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login.rs
@@ -151,10 +151,6 @@ pub(crate) fn print_success(subject: &str) {
     println!("Authenticated as {subject}. Credentials saved.");
 }
 
-pub(crate) fn print_claim_link(claim_link: &str) {
-    println!("\nOpen this short-lived claim link:\n\n{claim_link}\n");
-}
-
 pub(crate) fn store_agent_root(
     server: &str,
     token: String,

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -5,11 +5,14 @@ use api::heddle::api::v1alpha1::{CreateAgentAccountRequest, CreateAgentAccountRe
 use config::UserConfig;
 use crypto::{Ed25519Signer, Signer as _};
 use heddle_cli_args::CliContext;
+use heddle_cli_contract::cli::commands::wire::auth::{
+    AgentAccountCreatedOutput, HumanPromotionDirective,
+};
 
 use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
     auth::headless_token_metadata,
-    auth_login::{print_claim_link, print_success, store_agent_root},
+    auth_login::{print_success, store_agent_root},
     device_flow::restrict_agent_account_root,
     identity_state::{self, ClaimState},
     root_mint::{is_local_agent_root, mint_agent_root},
@@ -60,28 +63,37 @@ pub(crate) async fn create_with_invite(
         });
     client.close().await;
     let response = response?;
-    let subject = minted.subject.clone();
-    let claim_link = finish_invite_create(server, minted, response)?;
-    print_success(&subject);
-    print_claim_link(&claim_link);
+    let output = finish_invite_create(server, minted, response)?;
+    emit_created(ctx, &output)?;
     Ok(())
 }
 
-pub(crate) fn invite_created_claim_link(claim_token: &str) -> Result<&str> {
-    match claim_token.trim() {
-        "" => bail!("CreateAgentAccount returned no claim token; the human has no claim link"),
-        token => Ok(token),
+fn emit_created(ctx: &dyn CliContext, output: &AgentAccountCreatedOutput) -> Result<()> {
+    if ctx.should_output_json(None) {
+        println!("{}", serde_json::to_string(output)?);
+    } else {
+        print_success(&output.subject);
+        println!(
+            "Agent account {} is active; a human can claim it later.",
+            output.pet_name
+        );
+        println!("Next: {}", output.next.command);
     }
+    Ok(())
 }
 
 fn finish_invite_create(
     server: &str,
     minted: RestrictedAgentRoot,
     response: CreateAgentAccountResponse,
-) -> Result<String> {
+) -> Result<AgentAccountCreatedOutput> {
     let owner_id = uuid::Uuid::parse_str(&response.account_id)
         .context("server returned a non-UUID account identity")?;
-    let claim_link = invite_created_claim_link(&response.claim_token).map(str::to_string);
+    let web_origin = match response.web_origin.trim() {
+        "" => None,
+        value => Some(value.to_string()),
+    };
+    let subject = minted.subject.clone();
     store_agent_root(
         server,
         minted.token,
@@ -89,21 +101,38 @@ fn finish_invite_create(
         minted.private_key_pem,
         minted.expires_at,
     )?;
+    let account_id = response.account_id;
+    let pet_name = response.pet_name;
     identity_state::store(&ClaimState::new(
         server.to_string(),
         owner_id,
-        minted.subject,
-        response.pet_name,
+        subject.clone(),
+        pet_name.clone(),
         hex::encode(minted.public_key),
+        web_origin,
     ))?;
-    claim_link
+    Ok(AgentAccountCreatedOutput {
+        output_kind: "agent_account_created",
+        account_id: account_id.clone(),
+        pet_name,
+        subject,
+        authenticated: true,
+        credential_saved: true,
+        next: HumanPromotionDirective {
+            kind: "human_promotion_required",
+            summary: "Account is active and usable now; a human must complete the claim ceremony to bind ownership.",
+            account_id,
+            command: "heddle claim",
+            promotion_uri: None,
+        },
+    })
 }
 
 #[cfg(test)]
 pub(crate) fn finish_invite_create_from_response(
     server: &str,
     response: CreateAgentAccountResponse,
-) -> Result<String> {
+) -> Result<AgentAccountCreatedOutput> {
     finish_invite_create(server, mint_restricted_agent_root()?, response)
 }
 

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -11,7 +11,7 @@ use super::{
     agent_node_identity,
     auth::headless_token_metadata,
     auth_login::{LoginInputs, LoginPath, login, login_path, store_agent_root},
-    auth_login_agent::{finish_invite_create_from_response, invite_created_claim_link},
+    auth_login_agent::finish_invite_create_from_response,
     device_flow::restrict_agent_account_root,
     identity_state::{self, ClaimState},
     root_mint::mint_agent_root,
@@ -283,33 +283,40 @@ async fn login_with_invite_does_not_take_the_fail_closed_path() {
 }
 
 #[test]
-fn login_invite_create_exposes_the_server_claim_token() {
+fn login_invite_create_succeeds_with_a_claim_next_directive() {
     let _home = IsolatedHome::new();
-    let token = "hcl1.node.one-time-claim";
-    let claim_link = finish_invite_create_from_response(
-        "api.claim-token.test",
+    let server = "api.claim-next.test";
+    let output = finish_invite_create_from_response(
+        server,
         CreateAgentAccountResponse {
             account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
             pet_name: "quiet-otter".into(),
             agent_capability: Vec::new(),
-            claim_token: token.into(),
+            web_origin: "https://claims.heddle.test/".into(),
         },
     )
-    .expect("invite create must expose the server claim token");
-    assert_eq!(claim_link, token);
-}
-
-#[test]
-fn login_invite_create_refuses_to_drop_an_empty_claim_token() {
-    let error = invite_created_claim_link("").expect_err("empty claim token must not be dropped");
+    .expect("invite create must succeed without a server claim token");
+    assert_eq!(output.output_kind, "agent_account_created");
+    assert!(output.authenticated);
+    assert!(output.credential_saved);
+    assert_eq!(output.next.kind, "human_promotion_required");
+    assert_eq!(output.next.command, "heddle claim");
+    assert_eq!(output.next.account_id, output.account_id);
+    let json = serde_json::to_value(&output).expect("serialize machine contract");
+    assert_eq!(json["next"]["kind"], "human_promotion_required");
+    assert_eq!(json["next"]["command"], "heddle claim");
     assert!(
-        error.to_string().contains("claim token"),
-        "missing token must stay visible: {error}"
+        credentials::get_server_credential(server)
+            .expect("load credential")
+            .is_some(),
+        "successful create must persist its agent credential"
     );
-    let error = invite_created_claim_link("   ").expect_err("whitespace is not a claim token");
-    assert!(
-        error.to_string().contains("claim token"),
-        "whitespace token must stay visible: {error}"
+    let state = identity_state::load()
+        .expect("load claim state")
+        .expect("claim state was stored");
+    assert_eq!(
+        state.web_origin.as_deref(),
+        Some("https://claims.heddle.test/")
     );
 }
 
@@ -324,6 +331,7 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         "subject-1".to_string(),
         "quiet-otter".to_string(),
         identity.node_id().to_string(),
+        None,
     ))
     .expect("store claim state");
     login(&TextCtx, server, false, None, false)

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -40,6 +40,7 @@ fn state(node_id: String) -> ClaimState {
         "subject-7".into(),
         "steady-heron".into(),
         node_id,
+        None,
     )
 }
 
@@ -494,6 +495,7 @@ fn store_production_claim_state(activate: bool) -> (Vec<u8>, Ed25519Signer) {
         root.subject,
         "steady-heron".to_string(),
         identity.node_id().to_string(),
+        None,
     );
     let secret = if activate {
         claim

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -33,14 +33,8 @@ enum ClaimWaitOutcome {
 
 pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     let server = resolve_server(args.server.as_deref())?;
-    // TODO(weft#1839): persist CreateAgentAccountResponse.web_origin and use
-    // explicit --web-origin > server-supplied origin > Heddle hosted default.
-    let web_origin = normalized_web_origin(
-        args.web_origin
-            .as_deref()
-            .unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN),
-    )?;
     let state = claimable_state(&server)?;
+    let web_origin = resolve_web_origin(args.web_origin.as_deref(), state.web_origin.as_deref())?;
     validate_stored_claim_signer(&state)?;
 
     let identity = agent_node_identity::load()?
@@ -227,6 +221,14 @@ fn normalized_web_origin(value: &str) -> Result<String> {
     Ok(parsed.origin().ascii_serialization())
 }
 
+fn resolve_web_origin(explicit: Option<&str>, server_supplied: Option<&str>) -> Result<String> {
+    normalized_web_origin(
+        explicit
+            .or(server_supplied)
+            .unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN),
+    )
+}
+
 fn claim_link(web_origin: &str, node_id: &str, secret: &str) -> String {
     format!("{web_origin}/claim/{node_id}.{secret}")
 }
@@ -273,5 +275,25 @@ mod tests {
                 "accepted {invalid}"
             );
         }
+    }
+
+    #[test]
+    fn web_origin_precedence_is_explicit_then_server_then_hosted_default() {
+        assert_eq!(
+            resolve_web_origin(
+                Some("https://explicit.heddle.test/"),
+                Some("https://server.heddle.test")
+            )
+            .expect("explicit origin"),
+            "https://explicit.heddle.test"
+        );
+        assert_eq!(
+            resolve_web_origin(None, Some("https://server.heddle.test/")).expect("server origin"),
+            "https://server.heddle.test"
+        );
+        assert_eq!(
+            resolve_web_origin(None, None).expect("hosted default"),
+            DEFAULT_CLAIM_WEB_ORIGIN
+        );
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -49,6 +49,8 @@ pub(crate) struct ClaimState {
     pub(crate) subject: String,
     pub(crate) pet_name: String,
     pub(crate) node_id: String,
+    #[serde(default)]
+    pub(crate) web_origin: Option<String>,
     pub(crate) created_at: String,
     secret_hash: String,
     pub(crate) expires_at_millis: i64,
@@ -64,6 +66,7 @@ impl ClaimState {
         subject: String,
         pet_name: String,
         node_id: String,
+        web_origin: Option<String>,
     ) -> Self {
         Self {
             format: STATE_FORMAT.to_string(),
@@ -73,6 +76,7 @@ impl ClaimState {
             subject,
             pet_name,
             node_id,
+            web_origin,
             created_at: chrono::Utc::now().to_rfc3339(),
             secret_hash: String::new(),
             expires_at_millis: 0,
@@ -303,6 +307,7 @@ mod tests {
             "subject-1".into(),
             "quiet-otter".into(),
             "11".repeat(32),
+            None,
         )
     }
 

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -12,11 +12,11 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 base32.workspace = true
-api = { package = "heddle-api", version = "0.15.0" }
+api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.5"
+heddleco-capability-verifier = "0.6"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1868,6 +1868,32 @@ the same ready envelope.
 
 ---
 
+## `heddle auth login --output json`
+
+```json
+{
+  "output_kind": "agent_account_created",
+  "account_id": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+  "pet_name": "quiet-otter",
+  "subject": "agent:11e64d7c...",
+  "authenticated": true,
+  "credential_saved": true,
+  "next": {
+    "kind": "human_promotion_required",
+    "summary": "Account is active and usable now; a human must complete the claim ceremony to bind ownership.",
+    "account_id": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+    "command": "heddle claim",
+    "promotion_uri": null
+  }
+}
+```
+
+The created account and stored agent credential are usable immediately. The
+`next` directive tells an agent how to start the separate, short-lived human
+claim ceremony; account creation itself does not wait for a human.
+
+---
+
 ## `heddle auth logout --output json`
 
 ```json
@@ -3150,26 +3176,26 @@ as one; no `help advanced`).
       "visibility set",
       "visibility promote"
     ],
-    "advanced_scope_json_commands_total": 98,
+    "advanced_scope_json_commands_total": 99,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 55,
+    "advanced_scope_mutating_commands_total": 56,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
     "catalog_commands_total": 184,
     "catalog_mutating_commands_total": 89,
-    "json_commands_total": 146,
+    "json_commands_total": 147,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 107,
+    "json_commands_with_schema": 108,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 85,
+    "json_mutating_commands_total": 86,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 85,
+    "mutating_commands_total": 86,
     "mutating_commands_with_accepted_opaque_schema": 21,
-    "mutating_commands_with_schema": 64,
+    "mutating_commands_with_schema": 65,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3207,7 +3233,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5913,6 +5913,32 @@ the same ready envelope.
 
 ---
 
+## `heddle auth login --output json`
+
+```json
+{
+  "output_kind": "agent_account_created",
+  "account_id": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+  "pet_name": "quiet-otter",
+  "subject": "agent:11e64d7c...",
+  "authenticated": true,
+  "credential_saved": true,
+  "next": {
+    "kind": "human_promotion_required",
+    "summary": "Account is active and usable now; a human must complete the claim ceremony to bind ownership.",
+    "account_id": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+    "command": "heddle claim",
+    "promotion_uri": null
+  }
+}
+```
+
+The created account and stored agent credential are usable immediately. The
+`next` directive tells an agent how to start the separate, short-lived human
+claim ceremony; account creation itself does not wait for a human.
+
+---
+
 ## `heddle auth logout --output json`
 
 ```json
@@ -7195,26 +7221,26 @@ as one; no `help advanced`).
       "visibility set",
       "visibility promote"
     ],
-    "advanced_scope_json_commands_total": 98,
+    "advanced_scope_json_commands_total": 99,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 55,
+    "advanced_scope_mutating_commands_total": 56,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
     "catalog_commands_total": 184,
     "catalog_mutating_commands_total": 89,
-    "json_commands_total": 146,
+    "json_commands_total": 147,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 107,
+    "json_commands_with_schema": 108,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 85,
+    "json_mutating_commands_total": 86,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 85,
+    "mutating_commands_total": 86,
     "mutating_commands_with_accepted_opaque_schema": 21,
-    "mutating_commands_with_schema": 64,
+    "mutating_commands_with_schema": 65,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -7252,7 +7278,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "186 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
Closes #1567

## Summary

- centralize the heddle-api 0.17.0 alias in workspace dependencies and retain the hosted-client optional edge
- treat CreateAgentAccount as success after persisting credentials and emit agent_account_created with a human_promotion_required next directive to run heddle claim
- persist the server web_origin and resolve claim origins as explicit flag, then server value, then the hosted default
- register and document the new machine contract and update the output-kind invariants

## Verification

- cargo build --workspace
- cargo test -p heddle-hosted-client --features client auth_login_tests
- cargo test -p heddle-hosted-client --features client claim_offer::tests
- cargo test -p heddle-hosted-client --features client claim_authorization_tests
- cargo test -p heddle-cli-contract --features client
- cargo test -p heddle-cli --test cli_output_contracts output_kind
- heddle doctor schemas --update-docs
- cargo clippy --workspace --all-targets -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790378862&installation_model_id=21489&pr_number=1572&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1572&signature=86539ea2d096b2a144f72c74171ae2ce63659f8f52433088edf4d759f0abb3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->