### PR TITLE
Stop claim links from following unbound remote web_origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.1",
  "prost-types 0.14.1",
+ "psl",
  "rand 0.10.2",
  "rcgen",
  "reqwest",
@@ -5195,6 +5196,21 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "psl"
+version = "2.1.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc88482eea924ca3a2f56a547454169af58deef35567965eb4fc2392a834841"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ prost = "0.14"
 prost-reflect = "0.16"
 prost-types = "0.14"
 protoc-bin-vendored = "3"
+psl = "2"
 opentelemetry = "0.32"
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"] }
 opentelemetry_sdk = "0.32"

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -14,8 +14,9 @@ pub struct ClaimArgs {
     #[arg(long)]
     pub server: Option<String>,
 
-    /// Web origin used to build the human claim link. Defaults to
-    /// `https://app.heddle.sh`.
+    /// HTTPS origin used to build the human claim link. Defaults to
+    /// `https://app.heddle.sh`. This flag is the only override; a hosted
+    /// response cannot choose the destination.
     #[arg(long, value_name = "ORIGIN")]
     pub web_origin: Option<String>,
 

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -14,9 +14,11 @@ pub struct ClaimArgs {
     #[arg(long)]
     pub server: Option<String>,
 
-    /// HTTPS origin used to build the human claim link. Defaults to
-    /// `https://app.heddle.sh`. This flag is the only override; a hosted
-    /// response cannot choose the destination.
+    /// HTTPS origin used to build the human claim link. Highest precedence;
+    /// must be https (scheme, host, optional port). When omitted, a
+    /// server-advertised origin is used only if it shares the hosted
+    /// server's registrable domain. `https://app.heddle.sh` is the fallback
+    /// only for `api.heddle.sh`.
     #[arg(long, value_name = "ORIGIN")]
     pub web_origin: Option<String>,
 

--- a/crates/hosted-client/Cargo.toml
+++ b/crates/hosted-client/Cargo.toml
@@ -44,6 +44,7 @@ heddle-cli-contract.workspace = true
 heddle-cli-render.workspace = true
 prost = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
+psl = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 repo.workspace = true
@@ -86,6 +87,7 @@ client = [
     "dep:noq-udp",
     "dep:prost",
     "dep:prost-types",
+    "dep:psl",
     "dep:rand",
     "dep:reqwest",
     "dep:rustls",

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -89,6 +89,10 @@ fn finish_invite_create(
 ) -> Result<AgentAccountCreatedOutput> {
     let owner_id = uuid::Uuid::parse_str(&response.account_id)
         .context("server returned a non-UUID account identity")?;
+    let web_origin = match response.web_origin.trim() {
+        "" => None,
+        value => Some(value.to_string()),
+    };
     let subject = minted.subject.clone();
     store_agent_root(
         server,
@@ -99,15 +103,15 @@ fn finish_invite_create(
     )?;
     let account_id = response.account_id;
     let pet_name = response.pet_name;
-    // Remote `web_origin` is not a trusted destination for the local claim
-    // bearer. `heddle claim` uses https://app.heddle.sh unless the human
-    // passes an explicit `--web-origin`.
+    // Stored for later routing. `heddle claim` binds this to the configured
+    // hosted server before minting the local claim bearer.
     identity_state::store(&ClaimState::new(
         server.to_string(),
         owner_id,
         subject.clone(),
         pet_name.clone(),
         hex::encode(minted.public_key),
+        web_origin,
     ))?;
     Ok(AgentAccountCreatedOutput {
         output_kind: "agent_account_created",

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -89,10 +89,6 @@ fn finish_invite_create(
 ) -> Result<AgentAccountCreatedOutput> {
     let owner_id = uuid::Uuid::parse_str(&response.account_id)
         .context("server returned a non-UUID account identity")?;
-    let web_origin = match response.web_origin.trim() {
-        "" => None,
-        value => Some(value.to_string()),
-    };
     let subject = minted.subject.clone();
     store_agent_root(
         server,
@@ -103,13 +99,15 @@ fn finish_invite_create(
     )?;
     let account_id = response.account_id;
     let pet_name = response.pet_name;
+    // Remote `web_origin` is not a trusted destination for the local claim
+    // bearer. `heddle claim` uses https://app.heddle.sh unless the human
+    // passes an explicit `--web-origin`.
     identity_state::store(&ClaimState::new(
         server.to_string(),
         owner_id,
         subject.clone(),
         pet_name.clone(),
         hex::encode(minted.public_key),
-        web_origin,
     ))?;
     Ok(AgentAccountCreatedOutput {
         output_kind: "agent_account_created",

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -334,7 +334,6 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         "subject-1".to_string(),
         "quiet-otter".to_string(),
         identity.node_id().to_string(),
-        None,
     ))
     .expect("store claim state");
     login(&TextCtx, server, false, None, false)

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -314,9 +314,12 @@ fn login_invite_create_succeeds_with_a_claim_next_directive() {
     let state = identity_state::load()
         .expect("load claim state")
         .expect("claim state was stored");
-    assert_eq!(
-        state.web_origin.as_deref(),
-        Some("https://claims.heddle.test/")
+    assert_eq!(state.server, server);
+    assert_eq!(state.pet_name, "quiet-otter");
+    let stored = std::fs::read_to_string(identity_state::state_path()).expect("read claim state");
+    assert!(
+        !stored.contains("web_origin") && !stored.contains("claims.heddle.test"),
+        "server-supplied web_origin must not be persisted as a claim destination: {stored}"
     );
 }
 

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -316,10 +316,9 @@ fn login_invite_create_succeeds_with_a_claim_next_directive() {
         .expect("claim state was stored");
     assert_eq!(state.server, server);
     assert_eq!(state.pet_name, "quiet-otter");
-    let stored = std::fs::read_to_string(identity_state::state_path()).expect("read claim state");
-    assert!(
-        !stored.contains("web_origin") && !stored.contains("claims.heddle.test"),
-        "server-supplied web_origin must not be persisted as a claim destination: {stored}"
+    assert_eq!(
+        state.web_origin.as_deref(),
+        Some("https://claims.heddle.test/")
     );
 }
 
@@ -334,6 +333,7 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         "subject-1".to_string(),
         "quiet-otter".to_string(),
         identity.node_id().to_string(),
+        None,
     ))
     .expect("store claim state");
     login(&TextCtx, server, false, None, false)

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -40,6 +40,7 @@ fn state(node_id: String) -> ClaimState {
         "subject-7".into(),
         "steady-heron".into(),
         node_id,
+        None,
     )
 }
 
@@ -494,6 +495,7 @@ fn store_production_claim_state(activate: bool) -> (Vec<u8>, Ed25519Signer) {
         root.subject,
         "steady-heron".to_string(),
         identity.node_id().to_string(),
+        None,
     );
     let secret = if activate {
         claim

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -40,7 +40,6 @@ fn state(node_id: String) -> ClaimState {
         "subject-7".into(),
         "steady-heron".into(),
         node_id,
-        None,
     )
 }
 
@@ -495,7 +494,6 @@ fn store_production_claim_state(activate: bool) -> (Vec<u8>, Ed25519Signer) {
         root.subject,
         "steady-heron".to_string(),
         identity.node_id().to_string(),
-        None,
     );
     let secret = if activate {
         claim

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -34,7 +34,7 @@ enum ClaimWaitOutcome {
 pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     let server = resolve_server(args.server.as_deref())?;
     let state = claimable_state(&server)?;
-    let web_origin = resolve_web_origin(args.web_origin.as_deref(), state.web_origin.as_deref())?;
+    let web_origin = resolve_web_origin(args.web_origin.as_deref())?;
     validate_stored_claim_signer(&state)?;
 
     let identity = agent_node_identity::load()?
@@ -208,7 +208,7 @@ fn deactivate_offer(authorization_hash: &str) -> Result<()> {
 
 fn normalized_web_origin(value: &str) -> Result<String> {
     let parsed = reqwest::Url::parse(value).context("--web-origin must be an absolute URL")?;
-    if !matches!(parsed.scheme(), "http" | "https")
+    if parsed.scheme() != "https"
         || parsed.host_str().is_none()
         || !parsed.username().is_empty()
         || parsed.password().is_some()
@@ -216,17 +216,18 @@ fn normalized_web_origin(value: &str) -> Result<String> {
         || parsed.query().is_some()
         || parsed.fragment().is_some()
     {
-        bail!("--web-origin must contain only an http(s) scheme, host, and optional port");
+        bail!("--web-origin must be an https origin (scheme, host, and optional port only)");
     }
     Ok(parsed.origin().ascii_serialization())
 }
 
-fn resolve_web_origin(explicit: Option<&str>, server_supplied: Option<&str>) -> Result<String> {
-    normalized_web_origin(
-        explicit
-            .or(server_supplied)
-            .unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN),
-    )
+/// Claim-link destination for the local bearer secret.
+///
+/// Remote `CreateAgentAccountResponse.web_origin` is not consulted. The
+/// trusted default is [`DEFAULT_CLAIM_WEB_ORIGIN`]; only an explicit
+/// `--web-origin` may override it, and that override must be `https`.
+fn resolve_web_origin(explicit: Option<&str>) -> Result<String> {
+    normalized_web_origin(explicit.unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN))
 }
 
 fn claim_link(web_origin: &str, node_id: &str, secret: &str) -> String {
@@ -283,16 +284,11 @@ mod tests {
     #[test]
     fn claim_link_origin_is_explicit_https_or_the_trusted_hosted_default() {
         assert_eq!(
-            resolve_web_origin(Some("https://explicit.heddle.test/"), Some("https://evil.example"))
-                .expect("explicit origin"),
+            resolve_web_origin(Some("https://explicit.heddle.test/")).expect("explicit origin"),
             "https://explicit.heddle.test"
         );
         assert_eq!(
-            resolve_web_origin(None, Some("https://evil.example/")).expect("ignore unbound remote"),
-            DEFAULT_CLAIM_WEB_ORIGIN
-        );
-        assert_eq!(
-            resolve_web_origin(None, None).expect("hosted default"),
+            resolve_web_origin(None).expect("hosted default"),
             DEFAULT_CLAIM_WEB_ORIGIN
         );
         assert_eq!(DEFAULT_CLAIM_WEB_ORIGIN, "https://app.heddle.sh");
@@ -301,7 +297,7 @@ mod tests {
     #[test]
     fn claim_link_refuses_http_even_when_explicit() {
         for invalid in ["http://evil.example", "http://app.heddle.sh"] {
-            let error = resolve_web_origin(Some(invalid), None).expect_err("http origin");
+            let error = resolve_web_origin(Some(invalid)).expect_err("http origin");
             assert!(
                 error.to_string().contains("https"),
                 "http refusal should name the https requirement: {error}"

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -10,9 +10,11 @@ use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
     auth::resolve_server,
     claim_authorization::validate_stored_claim_signer,
-    hosted::server_keys_match,
+    hosted::{canonical_server_authority, server_keys_match},
     identity_state::{self, ClaimIssuanceStatus, ClaimSecret, ClaimState},
 };
+
+const HEDDLE_SAAS_API: &str = "https://api.heddle.sh";
 
 const CLAIM_STATUS_POLL: Duration = Duration::from_millis(200);
 
@@ -34,7 +36,12 @@ enum ClaimWaitOutcome {
 pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     let server = resolve_server(args.server.as_deref())?;
     let state = claimable_state(&server)?;
-    let web_origin = resolve_web_origin(args.web_origin.as_deref())?;
+    // Bind the destination before activate_offer mints the local bearer.
+    let web_origin = resolve_web_origin(
+        args.web_origin.as_deref(),
+        state.web_origin.as_deref(),
+        &server,
+    )?;
     validate_stored_claim_signer(&state)?;
 
     let identity = agent_node_identity::load()?
@@ -207,7 +214,7 @@ fn deactivate_offer(authorization_hash: &str) -> Result<()> {
 }
 
 fn normalized_web_origin(value: &str) -> Result<String> {
-    let parsed = reqwest::Url::parse(value).context("--web-origin must be an absolute URL")?;
+    let parsed = reqwest::Url::parse(value).context("claim web origin must be an absolute URL")?;
     if parsed.scheme() != "https"
         || parsed.host_str().is_none()
         || !parsed.username().is_empty()
@@ -216,18 +223,84 @@ fn normalized_web_origin(value: &str) -> Result<String> {
         || parsed.query().is_some()
         || parsed.fragment().is_some()
     {
-        bail!("--web-origin must be an https origin (scheme, host, and optional port only)");
+        bail!("claim web origin must be an https origin (scheme, host, and optional port only)");
     }
     Ok(parsed.origin().ascii_serialization())
 }
 
 /// Claim-link destination for the local bearer secret.
 ///
-/// Remote `CreateAgentAccountResponse.web_origin` is not consulted. The
-/// trusted default is [`DEFAULT_CLAIM_WEB_ORIGIN`]; only an explicit
-/// `--web-origin` may override it, and that override must be `https`.
-fn resolve_web_origin(explicit: Option<&str>) -> Result<String> {
-    normalized_web_origin(explicit.unwrap_or(DEFAULT_CLAIM_WEB_ORIGIN))
+/// Precedence: explicit `--web-origin` (https origin-only, any host), then a
+/// server-advertised origin that binds to the configured hosted server
+/// (same host or same Public Suffix registrable domain), then
+/// [`DEFAULT_CLAIM_WEB_ORIGIN`] only when that server is `api.heddle.sh`.
+fn resolve_web_origin(
+    explicit: Option<&str>,
+    advertised: Option<&str>,
+    server: &str,
+) -> Result<String> {
+    if let Some(explicit) = explicit {
+        return normalized_web_origin(explicit).with_context(
+            || "--web-origin must be an https origin (scheme, host, and optional port only)",
+        );
+    }
+    if let Some(advertised) = advertised.map(str::trim).filter(|value| !value.is_empty()) {
+        let origin = normalized_web_origin(advertised).with_context(|| {
+            "server-advertised claim origin is not a valid https origin; pass --web-origin <https origin> to override"
+        })?;
+        bind_origin_to_server(&origin, server)?;
+        return Ok(origin);
+    }
+    if is_heddle_saas_api(server)? {
+        return normalized_web_origin(DEFAULT_CLAIM_WEB_ORIGIN);
+    }
+    bail!(
+        "hosted server {server} is not {HEDDLE_SAAS_API} and has no bound claim web origin; pass --web-origin <https origin>"
+    )
+}
+
+fn is_heddle_saas_api(server: &str) -> Result<bool> {
+    Ok(canonical_server_authority(server)? == HEDDLE_SAAS_API)
+}
+
+fn bind_origin_to_server(origin: &str, server: &str) -> Result<()> {
+    let origin_host = origin_host(origin)?;
+    let server_host = hosted_server_host(server)?;
+    if origin_host == server_host || same_registrable_domain(&origin_host, &server_host) {
+        return Ok(());
+    }
+    bail!(
+        "server-advertised claim origin {origin} is not bound to hosted server {server}; pass --web-origin <https origin> to override"
+    )
+}
+
+fn origin_host(origin: &str) -> Result<String> {
+    let parsed = reqwest::Url::parse(origin).context("claim web origin is not a valid URL")?;
+    parsed
+        .host_str()
+        .map(ascii_host)
+        .context("claim web origin has no host")
+}
+
+fn hosted_server_host(server: &str) -> Result<String> {
+    let canonical = canonical_server_authority(server)?;
+    let parsed = reqwest::Url::parse(&canonical)
+        .context("configured hosted server is not a valid HTTPS authority")?;
+    parsed
+        .host_str()
+        .map(ascii_host)
+        .context("configured hosted server has no host")
+}
+
+fn ascii_host(host: &str) -> String {
+    host.to_ascii_lowercase()
+}
+
+fn same_registrable_domain(left_host: &str, right_host: &str) -> bool {
+    match (psl::domain_str(left_host), psl::domain_str(right_host)) {
+        (Some(left), Some(right)) => left.as_bytes() == right.as_bytes(),
+        _ => false,
+    }
 }
 
 fn claim_link(web_origin: &str, node_id: &str, secret: &str) -> String {
@@ -282,26 +355,119 @@ mod tests {
     }
 
     #[test]
-    fn claim_link_origin_is_explicit_https_or_the_trusted_hosted_default() {
+    fn explicit_https_origin_wins_even_when_cross_site() {
         assert_eq!(
-            resolve_web_origin(Some("https://explicit.heddle.test/")).expect("explicit origin"),
-            "https://explicit.heddle.test"
+            resolve_web_origin(
+                Some("https://explicit.example:8443/"),
+                Some("https://app.acme.example"),
+                "api.acme.example",
+            )
+            .expect("explicit origin"),
+            "https://explicit.example:8443"
+        );
+    }
+
+    #[test]
+    fn saas_api_falls_back_to_app_heddle_sh() {
+        assert_eq!(
+            resolve_web_origin(None, None, "api.heddle.sh").expect("saas default"),
+            DEFAULT_CLAIM_WEB_ORIGIN
         );
         assert_eq!(
-            resolve_web_origin(None).expect("hosted default"),
+            resolve_web_origin(None, None, "https://api.heddle.sh").expect("canonical saas"),
             DEFAULT_CLAIM_WEB_ORIGIN
         );
         assert_eq!(DEFAULT_CLAIM_WEB_ORIGIN, "https://app.heddle.sh");
     }
 
     #[test]
+    fn self_hosted_without_a_bound_origin_refuses_the_saas_default() {
+        let error = resolve_web_origin(None, None, "api.acme.example")
+            .expect_err("self-hosted must not fall back to SaaS");
+        let message = error.to_string();
+        assert!(
+            message.contains("--web-origin"),
+            "refusal should name the override: {message}"
+        );
+        assert!(
+            !message.contains(DEFAULT_CLAIM_WEB_ORIGIN) || message.contains("pass --web-origin"),
+            "refusal must not silently select the SaaS app origin: {message}"
+        );
+    }
+
+    #[test]
+    fn bound_server_advertised_origin_is_accepted() {
+        assert_eq!(
+            resolve_web_origin(None, Some("https://app.acme.example/"), "api.acme.example")
+                .expect("same registrable domain"),
+            "https://app.acme.example"
+        );
+        assert_eq!(
+            resolve_web_origin(None, Some("https://api.acme.example"), "api.acme.example")
+                .expect("same host"),
+            "https://api.acme.example"
+        );
+        assert_eq!(
+            resolve_web_origin(None, Some("https://app.acme.co.uk/"), "api.acme.co.uk")
+                .expect("psl multi-part suffix"),
+            "https://app.acme.co.uk"
+        );
+    }
+
+    #[test]
+    fn leftover_unbound_web_origin_cannot_become_a_claim_link() {
+        for advertised in [
+            "https://evil.com",
+            "http://evil.com",
+            "https://evil.com/claim",
+            "https://notacme.example",
+            "https://bar.github.io",
+        ] {
+            let error = resolve_web_origin(None, Some(advertised), "api.acme.example")
+                .expect_err("unbound leftover origin");
+            let message = error.to_string();
+            assert!(
+                !message.contains("https://evil.com/claim/")
+                    && !claim_link_would_use_host(&message, "evil.com"),
+                "refused origin must not be formatted as a claim link: {message}"
+            );
+            assert!(
+                message.contains("--web-origin") || message.contains("https"),
+                "refusal should be actionable: {message}"
+            );
+        }
+        let error = resolve_web_origin(None, Some("https://bar.github.io"), "api.foo.github.io")
+            .expect_err("public suffix is not a string suffix");
+        assert!(
+            error.to_string().contains("--web-origin"),
+            "github.io siblings must not share a registrable domain: {error}"
+        );
+    }
+
+    #[test]
+    fn string_suffix_is_not_a_registrable_domain_bind() {
+        let error = resolve_web_origin(None, Some("https://evil.com"), "api.notevil.com")
+            .expect_err("ends-with is not a bind");
+        assert!(
+            error.to_string().contains("--web-origin"),
+            "string-suffix trap must fail closed: {error}"
+        );
+    }
+
+    #[test]
     fn claim_link_refuses_http_even_when_explicit() {
         for invalid in ["http://evil.example", "http://app.heddle.sh"] {
-            let error = resolve_web_origin(Some(invalid)).expect_err("http origin");
+            let error =
+                resolve_web_origin(Some(invalid), None, "api.heddle.sh").expect_err("http origin");
             assert!(
                 error.to_string().contains("https"),
                 "http refusal should name the https requirement: {error}"
             );
         }
+    }
+
+    fn claim_link_would_use_host(message: &str, host: &str) -> bool {
+        message.contains(&format!("https://{host}/claim/"))
+            || message.contains(&format!("http://{host}/claim/"))
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -267,8 +267,11 @@ mod tests {
         for invalid in [
             "heddle.example",
             "ftp://heddle.example",
+            "http://heddle.example",
+            "http://localhost:3000",
             "https://heddle.example/path",
             "https://heddle.example/?query=1",
+            "https://user:pass@heddle.example",
         ] {
             assert!(
                 normalized_web_origin(invalid).is_err(),
@@ -278,22 +281,31 @@ mod tests {
     }
 
     #[test]
-    fn web_origin_precedence_is_explicit_then_server_then_hosted_default() {
+    fn claim_link_origin_is_explicit_https_or_the_trusted_hosted_default() {
         assert_eq!(
-            resolve_web_origin(
-                Some("https://explicit.heddle.test/"),
-                Some("https://server.heddle.test")
-            )
-            .expect("explicit origin"),
+            resolve_web_origin(Some("https://explicit.heddle.test/"), Some("https://evil.example"))
+                .expect("explicit origin"),
             "https://explicit.heddle.test"
         );
         assert_eq!(
-            resolve_web_origin(None, Some("https://server.heddle.test/")).expect("server origin"),
-            "https://server.heddle.test"
+            resolve_web_origin(None, Some("https://evil.example/")).expect("ignore unbound remote"),
+            DEFAULT_CLAIM_WEB_ORIGIN
         );
         assert_eq!(
             resolve_web_origin(None, None).expect("hosted default"),
             DEFAULT_CLAIM_WEB_ORIGIN
         );
+        assert_eq!(DEFAULT_CLAIM_WEB_ORIGIN, "https://app.heddle.sh");
+    }
+
+    #[test]
+    fn claim_link_refuses_http_even_when_explicit() {
+        for invalid in ["http://evil.example", "http://app.heddle.sh"] {
+            let error = resolve_web_origin(Some(invalid), None).expect_err("http origin");
+            assert!(
+                error.to_string().contains("https"),
+                "http refusal should name the https requirement: {error}"
+            );
+        }
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -49,6 +49,10 @@ pub(crate) struct ClaimState {
     pub(crate) subject: String,
     pub(crate) pet_name: String,
     pub(crate) node_id: String,
+    /// Server-advertised claim page origin. Not trusted until `heddle claim`
+    /// binds it to the configured hosted server.
+    #[serde(default)]
+    pub(crate) web_origin: Option<String>,
     pub(crate) created_at: String,
     secret_hash: String,
     pub(crate) expires_at_millis: i64,
@@ -64,6 +68,7 @@ impl ClaimState {
         subject: String,
         pet_name: String,
         node_id: String,
+        web_origin: Option<String>,
     ) -> Self {
         Self {
             format: STATE_FORMAT.to_string(),
@@ -73,6 +78,7 @@ impl ClaimState {
             subject,
             pet_name,
             node_id,
+            web_origin,
             created_at: chrono::Utc::now().to_rfc3339(),
             secret_hash: String::new(),
             expires_at_millis: 0,
@@ -303,6 +309,7 @@ mod tests {
             "subject-1".into(),
             "quiet-otter".into(),
             "11".repeat(32),
+            None,
         )
     }
 
@@ -364,19 +371,19 @@ mod tests {
     }
 
     #[test]
-    fn leftover_remote_web_origin_is_ignored_on_load() {
+    fn leftover_remote_web_origin_still_deserializes() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let path = directory.path().join("claim.toml");
         let contents = format!(
             "\
 format = \"heddle-agent-claim\"
 version = 2
-server = \"api.heddle.test\"
+server = \"api.acme.example\"
 owner_id = \"7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28\"
 subject = \"subject-1\"
 pet_name = \"quiet-otter\"
 node_id = \"{node_id}\"
-web_origin = \"http://evil.example\"
+web_origin = \"https://evil.com\"
 created_at = \"2026-08-26T00:00:00Z\"
 secret_hash = \"\"
 expires_at_millis = 0
@@ -388,13 +395,8 @@ status = \"dormant\"
         let state = load_at(&path)
             .expect("load leftover claim state")
             .expect("claim state present");
-        assert_eq!(state.server, "api.heddle.test");
-        assert_eq!(state.pet_name, "quiet-otter");
-        let encoded = toml::to_string(&state).expect("serialize without leftover field");
-        assert!(
-            !encoded.contains("web_origin"),
-            "re-serialized claim state must not carry a remote web_origin: {encoded}"
-        );
+        assert_eq!(state.server, "api.acme.example");
+        assert_eq!(state.web_origin.as_deref(), Some("https://evil.com"));
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -49,8 +49,6 @@ pub(crate) struct ClaimState {
     pub(crate) subject: String,
     pub(crate) pet_name: String,
     pub(crate) node_id: String,
-    #[serde(default)]
-    pub(crate) web_origin: Option<String>,
     pub(crate) created_at: String,
     secret_hash: String,
     pub(crate) expires_at_millis: i64,
@@ -66,7 +64,6 @@ impl ClaimState {
         subject: String,
         pet_name: String,
         node_id: String,
-        web_origin: Option<String>,
     ) -> Self {
         Self {
             format: STATE_FORMAT.to_string(),
@@ -76,7 +73,6 @@ impl ClaimState {
             subject,
             pet_name,
             node_id,
-            web_origin,
             created_at: chrono::Utc::now().to_rfc3339(),
             secret_hash: String::new(),
             expires_at_millis: 0,
@@ -307,7 +303,6 @@ mod tests {
             "subject-1".into(),
             "quiet-otter".into(),
             "11".repeat(32),
-            None,
         )
     }
 
@@ -366,6 +361,40 @@ mod tests {
         let replacement_hash = state.authorization_hash().to_string();
         assert!(state.deactivate_issuance(&replacement_hash));
         assert!(!state.accepts(b"replacement-secret", 2_000));
+    }
+
+    #[test]
+    fn leftover_remote_web_origin_is_ignored_on_load() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("claim.toml");
+        let contents = format!(
+            "\
+format = \"heddle-agent-claim\"
+version = 2
+server = \"api.heddle.test\"
+owner_id = \"7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28\"
+subject = \"subject-1\"
+pet_name = \"quiet-otter\"
+node_id = \"{node_id}\"
+web_origin = \"http://evil.example\"
+created_at = \"2026-08-26T00:00:00Z\"
+secret_hash = \"\"
+expires_at_millis = 0
+status = \"dormant\"
+",
+            node_id = "11".repeat(32)
+        );
+        write_file_atomic_secret(&path, contents.as_bytes()).expect("write leftover claim state");
+        let state = load_at(&path)
+            .expect("load leftover claim state")
+            .expect("claim state present");
+        assert_eq!(state.server, "api.heddle.test");
+        assert_eq!(state.pet_name, "quiet-otter");
+        let encoded = toml::to_string(&state).expect("serialize without leftover field");
+        assert!(
+            !encoded.contains("web_origin"),
+            "re-serialized claim state must not carry a remote web_origin: {encoded}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Claim-link destination is now a four-step bind, not a blanket ignore of `CreateAgentAccountResponse.web_origin`.
- Precedence: explicit `--web-origin` (https origin-only, any host the caller chose) → server-advertised origin (https origin-only, same host or same Public Suffix registrable domain as the configured hosted server) → `https://app.heddle.sh` **only** when that server is `api.heddle.sh`. Self-hosted with no bound origin fails with an actionable `--web-origin` message instead of shipping a secret to Heddle SaaS.
- The bind runs at the claim-link sink (`cmd_claim`) **before** `activate_offer` mints the bearer. Leftover or tampered `web_origin` in `agent-claim.toml` still deserializes; it is not used until it passes this bind. `https://evil.com` advertised from `api.acme.example` is refused; `https://app.acme.example` is accepted.

## Closes

Closes HeddleCo/heddle#1574

## Red commit
`d74bab7fe66470fd6ee74a5ee2360582b285d66e`

## Test evidence

Commands run on HEAD `54a97a9c3c61fada3d57eb09d7d0148af04abd06` (branch `cursor/claim-origin-bind-482c`, already on current `main` `29875f5d`):

```
cargo test --locked -p heddle-hosted-client --features client
cargo test --locked -p heddle-cli-args --features client
```

`heddle-hosted-client` (client):

```
     Running unittests src/lib.rs (target/debug/deps/hosted_client-48bb0112bfc4b31d)

running 306 tests
...
test hosted_runtime::auth_login_tests::login_invite_create_succeeds_with_a_claim_next_directive ... ok
test hosted_runtime::claim_offer::tests::bound_server_advertised_origin_is_accepted ... ok
test hosted_runtime::claim_offer::tests::explicit_https_origin_wins_even_when_cross_site ... ok
test hosted_runtime::claim_offer::tests::leftover_unbound_web_origin_cannot_become_a_claim_link ... ok
test hosted_runtime::claim_offer::tests::saas_api_falls_back_to_app_heddle_sh ... ok
test hosted_runtime::claim_offer::tests::self_hosted_without_a_bound_origin_refuses_the_saas_default ... ok
test hosted_runtime::claim_offer::tests::string_suffix_is_not_a_registrable_domain_bind ... ok
test hosted_runtime::identity_state::tests::leftover_remote_web_origin_still_deserializes ... ok
...
test hosted_runtime::hosted::connection_path_tests::hosted_endpoint_close_release_contract ... ignored, release-only hosted endpoint close performance contract
...
test result: ok. 305 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 15.85s

   Doc-tests hosted_client
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`heddle-cli-args` (client):

```
     Running unittests src/lib.rs (target/debug/deps/heddle_cli_args-a903a2ade672a496)

running 24 tests
...
test cli::cli_args::commands_client::tests::claim_is_one_top_level_resident_command ... ok
...
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests heddle_cli_args
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

The one ignored hosted-client test is pre-existing (`hosted_endpoint_close_release_contract`, release-only). No new `#[ignore]`.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Surfaces

- **The verb.** `--web-origin` help describes the bind: highest precedence, https-only; advertised origin must share the hosted server's registrable domain; SaaS fallback only for `api.heddle.sh`.
- **Human and agent.** Text help updated. No JSON contract change (`promotion_uri` stays unset; login is not a claim-link write).
- **Git interop.** None.
- **The wire.** `CreateAgentAccountResponse.web_origin` is stored again for self-hosted routing and bound at `heddle claim`. No proto change. Server authority uses `canonical_server_authority`. Registrable-domain compare uses the `psl` crate (Mozilla Public Suffix List), not a string suffix.
- **Reverse states.** Existing claim files with `web_origin` still deserialize; leftover `https://evil.com` cannot become a claim link against `api.acme.example`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9658aa2-99da-4af2-8135-a9ce70d9482c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9658aa2-99da-4af2-8135-a9ce70d9482c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790387466&installation_model_id=21489&pr_number=1575&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1575&signature=290da8086152ee35ef574672d2a8f8e13da0e7a20c17b048e0c04cf89444c6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->