### PR TITLE
Rematch context anchors across file renames

### DIFF
--- a/crates/agent-relay/src/claude_hook.rs
+++ b/crates/agent-relay/src/claude_hook.rs
@@ -416,6 +416,7 @@ mod tests {
             supersedes_rewrite_pct: None,
             visibility: objects::object::VisibilityTier::default(),
             resolved_from_discussion: None,
+            anchor_status: objects::object::AnnotationAnchorStatus::default(),
         }
     }
 

--- a/crates/cli/src/cli/commands/context/context_query.rs
+++ b/crates/cli/src/cli/commands/context/context_query.rs
@@ -17,10 +17,9 @@ use verbs::{
 
 use super::{
     AnnotationHistoryOutput, AnnotationOutput, ContextListRow, RevisionOutput,
-    context_root_for_state, parse_scope, print_context_get, resolve_state, resolve_state_id,
-    target_label,
+    annotation_anchor_candidates, annotation_anchor_status_label, context_root_for_state,
+    parse_scope, print_context_get, resolve_state, resolve_state_id, target_label,
 };
-use crate::cli::commands::next_action::{NextActionValidationContext, write_full_command_json};
 use crate::cli::{
     Cli,
     commands::{
@@ -28,6 +27,7 @@ use crate::cli::{
         native_scope::{
             AnnotationStore, AnnotationSurface, open_annotation_store, report_absent_store,
         },
+        next_action::{NextActionValidationContext, write_full_command_json},
     },
     should_output_json,
 };
@@ -191,6 +191,26 @@ pub async fn cmd_context_list(
                 annotations.len(),
                 if annotations.len() == 1 { "" } else { "s" }
             );
+            for annotation in annotations {
+                if annotation_anchor_status_label(&annotation.anchor_status) == "resolved" {
+                    continue;
+                }
+                let candidates = annotation_anchor_candidates(&annotation.anchor_status);
+                if candidates.is_empty() {
+                    println!(
+                        "    {} anchor: {}",
+                        annotation.annotation_id,
+                        annotation_anchor_status_label(&annotation.anchor_status)
+                    );
+                } else {
+                    println!(
+                        "    {} anchor: {} ({})",
+                        annotation.annotation_id,
+                        annotation_anchor_status_label(&annotation.anchor_status),
+                        candidates.join(", ")
+                    );
+                }
+            }
         }
     }
 
@@ -344,22 +364,31 @@ pub async fn cmd_context_check(
                 StalenessStatus::Unknown => unknown += 1,
                 StalenessStatus::SourceChanged { .. }
                 | StalenessStatus::SymbolMissing { .. }
+                | StalenessStatus::AmbiguousFileMove { .. }
                 | StalenessStatus::FileMissing => {
                     stale += 1;
                     let reason = match &status {
                         StalenessStatus::SourceChanged { .. } => "source_changed",
                         StalenessStatus::SymbolMissing { .. } => "symbol_missing",
+                        StalenessStatus::AmbiguousFileMove { .. } => "ambiguous_file_move",
                         StalenessStatus::FileMissing => "file_missing",
                         StalenessStatus::Unknown | StalenessStatus::Fresh => unreachable!(),
                     };
                     let (_, target_label) = target_label(&entry.target);
                     if should_output_json(cli, None) {
+                        let candidate_paths = match &status {
+                            StalenessStatus::AmbiguousFileMove { candidate_paths } => {
+                                candidate_paths.clone()
+                            }
+                            _ => Vec::new(),
+                        };
                         issues.push(serde_json::json!({
                             "target": target_label,
                             "scope": annotation.scope.to_string(),
                             "reason": reason,
                             "annotation_id": annotation.annotation_id,
                             "content": current.content.chars().take(80).collect::<String>(),
+                            "candidate_paths": candidate_paths,
                         }));
                     } else {
                         println!("  ✗ {}  {}  {}", target_label, annotation.scope, reason,);

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -10,8 +10,8 @@ pub use context_query::*;
 use objects::{
     error::HeddleError,
     object::{
-        Annotation, AnnotationKind, AnnotationScope, AnnotationStatus, ContentHash, ContextTarget,
-        State,
+        Annotation, AnnotationAnchorStatus, AnnotationKind, AnnotationScope, AnnotationStatus,
+        ContentHash, ContextTarget, State,
     },
     store::ObjectStore,
 };
@@ -52,6 +52,8 @@ pub(crate) struct AnnotationOutput {
     pub(crate) revision_count: usize,
     pub(crate) supersedes_annotation_id: Option<String>,
     pub(crate) supersedes_rewrite_pct: Option<u32>,
+    pub(crate) anchor_status: String,
+    pub(crate) anchor_candidates: Vec<String>,
 }
 
 impl AnnotationOutput {
@@ -72,7 +74,24 @@ impl AnnotationOutput {
             revision_count: annotation.revisions.len(),
             supersedes_annotation_id: annotation.supersedes_annotation_id.clone(),
             supersedes_rewrite_pct: annotation.supersedes_rewrite_pct,
+            anchor_status: annotation_anchor_status_label(&annotation.anchor_status).to_string(),
+            anchor_candidates: annotation_anchor_candidates(&annotation.anchor_status).to_vec(),
         }
+    }
+}
+
+pub(crate) fn annotation_anchor_status_label(status: &AnnotationAnchorStatus) -> &'static str {
+    match status {
+        AnnotationAnchorStatus::Resolved => "resolved",
+        AnnotationAnchorStatus::Ambiguous { .. } => "ambiguous",
+        AnnotationAnchorStatus::Orphaned => "orphaned",
+    }
+}
+
+pub(crate) fn annotation_anchor_candidates(status: &AnnotationAnchorStatus) -> &[String] {
+    match status {
+        AnnotationAnchorStatus::Ambiguous { candidate_paths } => candidate_paths,
+        AnnotationAnchorStatus::Resolved | AnnotationAnchorStatus::Orphaned => &[],
     }
 }
 
@@ -379,6 +398,21 @@ pub(crate) fn print_context_get(
             if !current.tags.is_empty() {
                 println!("tags: {}", current.tags.join(", "));
             }
+            if !matches!(annotation.anchor_status, AnnotationAnchorStatus::Resolved) {
+                let candidates = annotation_anchor_candidates(&annotation.anchor_status);
+                if candidates.is_empty() {
+                    println!(
+                        "anchor: {}",
+                        annotation_anchor_status_label(&annotation.anchor_status)
+                    );
+                } else {
+                    println!(
+                        "anchor: {} ({})",
+                        annotation_anchor_status_label(&annotation.anchor_status),
+                        candidates.join(", ")
+                    );
+                }
+            }
             println!("by: {}", current.attribution);
             println!("{}", current.content);
             println!();
@@ -396,11 +430,34 @@ fn extract_scope_bytes(source: &[u8], range: Option<(u32, u32)>) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use objects::object::Tree;
-
+    use objects::object::{AnnotationAnchorStatus, Tree};
     use repo::StateAttachmentKind;
 
     use super::*;
+
+    #[test]
+    fn annotation_output_surfaces_ambiguous_anchor_candidates() {
+        let mut annotation = Annotation::new(
+            AnnotationScope::File,
+            AnnotationKind::Invariant,
+            "Keep the guard".to_string(),
+            vec![],
+            "test@example.com".to_string(),
+            1_700_000_000,
+            None,
+            None,
+        );
+        annotation.anchor_status = AnnotationAnchorStatus::Ambiguous {
+            candidate_paths: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+        };
+
+        let value = serde_json::to_value(AnnotationOutput::from_annotation(&annotation)).unwrap();
+        assert_eq!(value["anchor_status"], "ambiguous");
+        assert_eq!(
+            value["anchor_candidates"],
+            serde_json::json!(["src/a.rs", "src/b.rs"])
+        );
+    }
 
     /// `heddle context get --state <short>` must accept the short prefix that
     /// the rest of the CLI emits, not just the full StateId.

--- a/crates/hosted-client/src/client/context_sync.rs
+++ b/crates/hosted-client/src/client/context_sync.rs
@@ -839,6 +839,7 @@ async fn pull_one_rpc(
         supersedes_rewrite_pct: server.supersedes_rewrite_pct,
         visibility: objects::object::VisibilityTier::default(),
         resolved_from_discussion: None,
+        anchor_status: objects::object::AnnotationAnchorStatus::default(),
     };
     pull_one_annotation(
         repo,
@@ -927,6 +928,7 @@ fn pull_one_annotation(
                 supersedes_rewrite_pct: server.supersedes_rewrite_pct,
                 visibility: server.visibility.clone(),
                 resolved_from_discussion: server.resolved_from_discussion.clone(),
+                anchor_status: server.anchor_status.clone(),
             });
             true
         }

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -118,8 +118,8 @@ pub use state_attachment::{
 };
 pub use state_attribution::{Agent, Attribution, Principal};
 pub use state_context::{
-    Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus, ContextBlob,
-    ContextError, ContextTarget,
+    Annotation, AnnotationAnchorStatus, AnnotationKind, AnnotationRevision, AnnotationScope,
+    AnnotationStatus, ContextBlob, ContextError, ContextTarget,
 };
 pub use state_core::{
     ChangeLineage, ChangeLineageKind, SignatureStatus, State, StateSignature, Status, Verification,

--- a/crates/object-model/src/object/staleness_core.rs
+++ b/crates/object-model/src/object/staleness_core.rs
@@ -19,6 +19,8 @@ pub enum StalenessStatus {
     FileMissing,
     /// Symbol referenced by annotation no longer exists in the file.
     SymbolMissing { symbol: String },
+    /// More than one file passed the rename confidence threshold.
+    AmbiguousFileMove { candidate_paths: Vec<String> },
     /// No provenance data stored -- staleness cannot be determined.
     Unknown,
 }

--- a/crates/object-model/src/object/state_context.rs
+++ b/crates/object-model/src/object/state_context.rs
@@ -42,6 +42,10 @@ pub struct Annotation {
     /// discussion that produced it.
     #[serde(default)]
     pub resolved_from_discussion: Option<String>,
+    /// Materialized health of the annotation's file anchor. Lifecycle status
+    /// remains separate: an active annotation can need anchor attention.
+    #[serde(default)]
+    pub anchor_status: AnnotationAnchorStatus,
 }
 
 /// A single revision of a logical annotation.
@@ -68,6 +72,18 @@ pub struct AnnotationRevision {
 pub enum AnnotationStatus {
     Active,
     Superseded,
+}
+
+/// Snapshot-time resolution state for a file-backed context annotation.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnnotationAnchorStatus {
+    /// The target path currently resolves, including after a confident move.
+    #[default]
+    Resolved,
+    /// More than one path passed the rename confidence threshold.
+    Ambiguous { candidate_paths: Vec<String> },
+    /// The target disappeared and no path passed the rename threshold.
+    Orphaned,
 }
 
 /// The canonical annotation taxonomy the product surfaces.
@@ -170,6 +186,7 @@ impl Annotation {
             supersedes_rewrite_pct: None,
             visibility: VisibilityTier::default(),
             resolved_from_discussion: None,
+            anchor_status: AnnotationAnchorStatus::default(),
         }
     }
 
@@ -564,6 +581,58 @@ mod tests {
         let bytes = blob.encode().unwrap();
         let decoded = ContextBlob::decode(&bytes).unwrap();
         assert_eq!(blob, decoded);
+    }
+
+    #[test]
+    fn legacy_annotation_without_anchor_status_decodes_as_resolved() {
+        #[derive(Serialize)]
+        struct LegacyAnnotation {
+            annotation_id: String,
+            scope: AnnotationScope,
+            status: AnnotationStatus,
+            revisions: Vec<AnnotationRevision>,
+            supersedes_annotation_id: Option<String>,
+            supersedes_rewrite_pct: Option<u32>,
+            visibility: VisibilityTier,
+            resolved_from_discussion: Option<String>,
+        }
+
+        #[derive(Serialize)]
+        struct LegacyContextBlob {
+            format_version: u8,
+            annotations: Vec<LegacyAnnotation>,
+        }
+
+        let revision = AnnotationRevision {
+            revision_id: "legacy-revision".to_string(),
+            kind: AnnotationKind::Invariant,
+            content: "legacy context".to_string(),
+            tags: vec![],
+            attribution: "test@example.com".to_string(),
+            created_at: 1_700_000_000,
+            source_hash: None,
+            created_at_state: None,
+        };
+        let bytes = rmp_serde::to_vec(&LegacyContextBlob {
+            format_version: ContextBlob::FORMAT_VERSION,
+            annotations: vec![LegacyAnnotation {
+                annotation_id: "legacy-annotation".to_string(),
+                scope: AnnotationScope::File,
+                status: AnnotationStatus::Active,
+                revisions: vec![revision],
+                supersedes_annotation_id: None,
+                supersedes_rewrite_pct: None,
+                visibility: VisibilityTier::default(),
+                resolved_from_discussion: None,
+            }],
+        })
+        .unwrap();
+
+        let decoded = ContextBlob::decode(&bytes).unwrap();
+        assert_eq!(
+            decoded.annotations[0].anchor_status,
+            AnnotationAnchorStatus::Resolved
+        );
     }
 
     #[test]

--- a/crates/repo/src/context_anchor_travel.rs
+++ b/crates/repo/src/context_anchor_travel.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+//! File-level rename decisions for context annotation anchors.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::{collections::HashMap, path::PathBuf};
+
+use semantic::analysis::{SimilarityMethod, detect_file_renames};
+
+use crate::discussion_anchor_travel::RENAME_CONFIDENCE_FOR_ANCHOR_TRAVEL;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ContextFileTravel {
+    Present,
+    Moved(String),
+    Ambiguous(Vec<String>),
+    Orphaned,
+}
+
+/// Resolve one vanished context target through the same semantic file-rename
+/// detector and confidence threshold used by discussion anchor travel.
+///
+/// The detector's batch API chooses a one-to-one assignment. Context must
+/// surface multiple plausible destinations instead, so each added file is
+/// checked independently with the shared primitive and the accepted paths are
+/// collected before making a decision.
+pub(crate) fn context_file_travel(
+    old_path: &str,
+    old_files: &HashMap<String, Vec<u8>>,
+    new_files: &HashMap<String, Vec<u8>>,
+) -> ContextFileTravel {
+    if new_files.contains_key(old_path) {
+        return ContextFileTravel::Present;
+    }
+    let Some(old_source) = old_files.get(old_path) else {
+        return ContextFileTravel::Orphaned;
+    };
+    let deleted = vec![(
+        PathBuf::from(old_path),
+        String::from_utf8_lossy(old_source).into_owned(),
+    )];
+    let mut added_paths: Vec<&String> = new_files
+        .keys()
+        .filter(|path| !old_files.contains_key(*path))
+        .collect();
+    added_paths.sort();
+
+    let mut candidates = Vec::new();
+    for path in added_paths {
+        let Some(source) = new_files.get(path) else {
+            continue;
+        };
+        let added = vec![(
+            PathBuf::from(path),
+            String::from_utf8_lossy(source).into_owned(),
+        )];
+        if !detect_file_renames(
+            &deleted,
+            &added,
+            RENAME_CONFIDENCE_FOR_ANCHOR_TRAVEL as f64,
+            SimilarityMethod::Tokens,
+        )
+        .is_empty()
+        {
+            candidates.push(path.clone());
+        }
+    }
+
+    match candidates.as_slice() {
+        [] => ContextFileTravel::Orphaned,
+        [path] => ContextFileTravel::Moved(path.clone()),
+        _ => ContextFileTravel::Ambiguous(candidates),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files(entries: &[(&str, &str)]) -> HashMap<String, Vec<u8>> {
+        entries
+            .iter()
+            .map(|(path, source)| (path.to_string(), source.as_bytes().to_vec()))
+            .collect()
+    }
+
+    const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
+
+    #[test]
+    fn unique_candidate_moves() {
+        assert_eq!(
+            context_file_travel(
+                "src/old.rs",
+                &files(&[("src/old.rs", SOURCE)]),
+                &files(&[("src/new.rs", SOURCE)]),
+            ),
+            ContextFileTravel::Moved("src/new.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn two_candidates_are_ambiguous() {
+        assert_eq!(
+            context_file_travel(
+                "src/old.rs",
+                &files(&[("src/old.rs", SOURCE)]),
+                &files(&[("src/a.rs", SOURCE), ("src/b.rs", SOURCE)]),
+            ),
+            ContextFileTravel::Ambiguous(vec!["src/a.rs".to_string(), "src/b.rs".to_string(),])
+        );
+    }
+
+    #[test]
+    fn delete_is_orphaned() {
+        assert_eq!(
+            context_file_travel(
+                "src/old.rs",
+                &files(&[("src/old.rs", SOURCE)]),
+                &HashMap::new(),
+            ),
+            ContextFileTravel::Orphaned
+        );
+    }
+}

--- a/crates/repo/src/context_snapshot_travel.rs
+++ b/crates/repo/src/context_snapshot_travel.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Snapshot-time persistence for context annotation anchor travel.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
+
+use objects::{
+    object::{
+        Annotation, AnnotationAnchorStatus, AnnotationScope, AnnotationStatus, ContentHash,
+        ContextBlob, ContextTarget, EntryType, State, StateAttachmentBody, Tree,
+    },
+    store::ObjectStore,
+};
+
+use crate::{
+    HeddleError, Repository, Result,
+    context_anchor_travel::{ContextFileTravel, context_file_travel},
+};
+
+impl Repository {
+    pub(crate) fn compute_and_persist_context_anchor_travel(
+        &self,
+        parent_state: &State,
+        new_tree: &Tree,
+        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+    ) -> Result<Option<ContentHash>> {
+        let Some(parent_context_hash) = self
+            .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Context)?
+            .and_then(|attachment| match attachment.body {
+                StateAttachmentBody::Context(hash) => Some(hash),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let entries = self.list_context_entries(&parent_context_hash, None)?;
+        if !entries.iter().any(|entry| {
+            matches!(entry.target, ContextTarget::File { .. })
+                && entry.blob.annotations.iter().any(is_live_durable_anchor)
+        }) {
+            return Ok(Some(parent_context_hash));
+        }
+
+        let parent_tree = self
+            .store()
+            .get_tree(&parent_state.tree)?
+            .ok_or_else(|| missing_context_travel_object("tree", parent_state.tree))?;
+        let old_files = self.collect_context_travel_file_bytes(&parent_tree, None)?;
+        let new_files = self.collect_context_travel_file_bytes(new_tree, source_blobs)?;
+        let mut grouped: BTreeMap<String, (ContextTarget, Vec<Annotation>)> = BTreeMap::new();
+        let mut changed = false;
+
+        for entry in entries {
+            let decision = match &entry.target {
+                ContextTarget::File { path } => {
+                    Some(context_file_travel(path.as_str(), &old_files, &new_files))
+                }
+                ContextTarget::State { .. } => None,
+            };
+            for mut annotation in entry.blob.annotations {
+                let mut destination = entry.target.clone();
+                if is_live_durable_anchor(&annotation)
+                    && let Some(decision) = decision.as_ref()
+                {
+                    let decision = carry_forward_ambiguity(decision, &annotation, &new_files);
+                    let next_status = match &decision {
+                        ContextFileTravel::Present => AnnotationAnchorStatus::Resolved,
+                        ContextFileTravel::Moved(path) => {
+                            destination = ContextTarget::file(path.clone()).map_err(|error| {
+                                HeddleError::InvalidObject(format!(
+                                    "invalid context anchor destination: {error}"
+                                ))
+                            })?;
+                            AnnotationAnchorStatus::Resolved
+                        }
+                        ContextFileTravel::Ambiguous(candidate_paths) => {
+                            AnnotationAnchorStatus::Ambiguous {
+                                candidate_paths: candidate_paths.clone(),
+                            }
+                        }
+                        ContextFileTravel::Orphaned => AnnotationAnchorStatus::Orphaned,
+                    };
+                    if annotation.anchor_status != next_status {
+                        annotation.anchor_status = next_status;
+                        changed = true;
+                    }
+                    if destination != entry.target {
+                        changed = true;
+                    }
+                }
+                let key = destination.storage_path().to_string_lossy().into_owned();
+                grouped
+                    .entry(key)
+                    .or_insert_with(|| (destination, Vec::new()))
+                    .1
+                    .push(annotation);
+            }
+        }
+
+        if !changed {
+            return Ok(Some(parent_context_hash));
+        }
+
+        let mut root = None;
+        for (_, (target, annotations)) in grouped {
+            let next =
+                self.set_context_blob(root.as_ref(), &target, &ContextBlob::new(annotations))?;
+            root = Some(next);
+        }
+        Ok(root)
+    }
+
+    fn collect_context_travel_file_bytes(
+        &self,
+        tree: &Tree,
+        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+    ) -> Result<HashMap<String, Vec<u8>>> {
+        let mut files = HashMap::new();
+        self.collect_context_travel_file_bytes_inner(
+            tree,
+            PathBuf::new(),
+            source_blobs,
+            &mut files,
+        )?;
+        Ok(files)
+    }
+
+    fn collect_context_travel_file_bytes_inner(
+        &self,
+        tree: &Tree,
+        prefix: PathBuf,
+        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        files: &mut HashMap<String, Vec<u8>>,
+    ) -> Result<()> {
+        for entry in tree.entries() {
+            let path = prefix.join(entry.name());
+            match entry.entry_type() {
+                EntryType::Blob => {
+                    let Some(path) = path.to_str() else {
+                        continue;
+                    };
+                    let Some(hash) = entry.blob_hash() else {
+                        continue;
+                    };
+                    let bytes = match source_blobs.and_then(|blobs| blobs.get(&hash).copied()) {
+                        Some(bytes) => bytes.to_vec(),
+                        None => self
+                            .store()
+                            .get_blob(&hash)?
+                            .ok_or_else(|| missing_context_travel_object("blob", hash))?
+                            .content()
+                            .to_vec(),
+                    };
+                    files.insert(path.to_string(), bytes);
+                }
+                EntryType::Tree => {
+                    let Some(hash) = entry.tree_hash() else {
+                        continue;
+                    };
+                    let subtree = self
+                        .store()
+                        .get_tree(&hash)?
+                        .ok_or_else(|| missing_context_travel_object("tree", hash))?;
+                    self.collect_context_travel_file_bytes_inner(
+                        &subtree,
+                        path,
+                        source_blobs,
+                        files,
+                    )?;
+                }
+                EntryType::Symlink | EntryType::Gitlink | EntryType::Spoollink => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_live_durable_anchor(annotation: &Annotation) -> bool {
+    annotation.status == AnnotationStatus::Active
+        && matches!(
+            annotation.scope,
+            AnnotationScope::File | AnnotationScope::Symbol { .. }
+        )
+}
+
+fn carry_forward_ambiguity(
+    decision: &ContextFileTravel,
+    annotation: &Annotation,
+    new_files: &HashMap<String, Vec<u8>>,
+) -> ContextFileTravel {
+    if !matches!(decision, ContextFileTravel::Orphaned) {
+        return decision.clone();
+    }
+    let AnnotationAnchorStatus::Ambiguous { candidate_paths } = &annotation.anchor_status else {
+        return ContextFileTravel::Orphaned;
+    };
+    let surviving: Vec<String> = candidate_paths
+        .iter()
+        .filter(|path| new_files.contains_key(*path))
+        .cloned()
+        .collect();
+    match surviving.as_slice() {
+        [] => ContextFileTravel::Orphaned,
+        [path] => ContextFileTravel::Moved(path.clone()),
+        _ => ContextFileTravel::Ambiguous(surviving),
+    }
+}
+
+fn missing_context_travel_object(object_type: &str, hash: ContentHash) -> HeddleError {
+    HeddleError::MissingObject {
+        object_type: object_type.to_string(),
+        id: hash.to_hex(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::AnnotationKind;
+
+    use super::*;
+
+    #[test]
+    fn persisted_ambiguity_stays_ambiguous_until_one_candidate_survives() {
+        let mut annotation = Annotation::new(
+            AnnotationScope::File,
+            AnnotationKind::Invariant,
+            "context".to_string(),
+            vec![],
+            "test@example.com".to_string(),
+            1_700_000_000,
+            None,
+            None,
+        );
+        annotation.anchor_status = AnnotationAnchorStatus::Ambiguous {
+            candidate_paths: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+        };
+
+        let both = HashMap::from([
+            ("src/a.rs".to_string(), b"a".to_vec()),
+            ("src/b.rs".to_string(), b"b".to_vec()),
+        ]);
+        assert_eq!(
+            carry_forward_ambiguity(&ContextFileTravel::Orphaned, &annotation, &both),
+            ContextFileTravel::Ambiguous(vec!["src/a.rs".to_string(), "src/b.rs".to_string(),])
+        );
+
+        let one = HashMap::from([("src/b.rs".to_string(), b"b".to_vec())]);
+        assert_eq!(
+            carry_forward_ambiguity(&ContextFileTravel::Orphaned, &annotation, &one),
+            ContextFileTravel::Moved("src/b.rs".to_string())
+        );
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -24,6 +24,10 @@ mod ci_runner_trust;
 pub mod clone_intent;
 mod collaboration_migration;
 mod collaboration_store;
+#[cfg(feature = "tree-sitter-symbols")]
+mod context_anchor_travel;
+#[cfg(feature = "tree-sitter-symbols")]
+mod context_snapshot_travel;
 pub mod daemon;
 #[cfg(feature = "tree-sitter-symbols")]
 mod discussion_anchor_travel;

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -446,7 +446,12 @@ fn split_path(path: &Path) -> Option<(&str, &Path)> {
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{Annotation, AnnotationKind, StateAttachment, StateAttachmentBody};
+    use std::fs;
+
+    use objects::object::{
+        Annotation, AnnotationAnchorStatus, AnnotationKind, StalenessStatus, StateAttachment,
+        StateAttachmentBody,
+    };
     use tempfile::TempDir;
 
     use super::{Repository, *};
@@ -613,6 +618,70 @@ mod tests {
         a
     }
 
+    #[cfg(feature = "tree-sitter-symbols")]
+    fn travel_annotation(
+        state: &State,
+        scope: AnnotationScope,
+        source_hash: Option<ContentHash>,
+    ) -> Annotation {
+        Annotation::new(
+            scope,
+            AnnotationKind::Invariant,
+            "Keep this guard intact".to_string(),
+            vec![],
+            "test@example.com".to_string(),
+            1_700_000_000,
+            source_hash,
+            Some(state.id()),
+        )
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    fn attach_context(repo: &Repository, state: &State, path: &str, annotations: Vec<Annotation>) {
+        let target = ContextTarget::file(path).unwrap();
+        let root = repo
+            .set_context_blob(None, &target, &ContextBlob::new(annotations))
+            .unwrap();
+        repo.put_state_attachment(&StateAttachment {
+            state_id: state.id(),
+            body: StateAttachmentBody::Context(root),
+            attribution: state.attribution.clone(),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .unwrap();
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    fn snapshot_src_files(repo: &Repository, files: &[(&str, &str)], message: &str) -> State {
+        let mut blobs = Vec::new();
+        let mut entries = Vec::new();
+        for (name, source) in files {
+            let blob = Blob::from_slice(source.as_bytes());
+            entries.push(TreeEntry::file(*name, blob.hash(), false).unwrap());
+            blobs.push(blob);
+        }
+        let root = if entries.is_empty() {
+            Tree::new()
+        } else {
+            let src = Tree::from_entries(entries);
+            let src_hash = repo.store().put_tree(&src).unwrap();
+            Tree::from_entries(vec![TreeEntry::directory("src", src_hash).unwrap()])
+        };
+        repo.snapshot_tree_with_blobs_with_attribution_profiled(
+            root,
+            blobs,
+            Some(message.to_string()),
+            None,
+            objects::object::Attribution::human(objects::object::Principal::new(
+                "test",
+                "test@example.com",
+            )),
+        )
+        .unwrap()
+        .state
+    }
+
     #[test]
     fn inherit_parent_context_passes_through_pointer() {
         let (_dir, repo) = setup();
@@ -722,5 +791,167 @@ mod tests {
             .current_revision()
             .expect("annotation has a revision");
         assert_eq!(revision.content, "newer content");
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    #[test]
+    fn context_symbol_annotation_rebinds_across_file_rename() {
+        let (dir, repo) = setup();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(
+            dir.path().join("src/old.rs"),
+            "fn guarded() {\n    let value = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap();
+        let annotation = travel_annotation(
+            &first,
+            AnnotationScope::Symbol {
+                name: "guarded".to_string(),
+                resolved_lines: Some((1, 3)),
+            },
+            None,
+        );
+        attach_context(
+            &repo,
+            &first,
+            "src/old.rs",
+            vec![
+                annotation,
+                travel_annotation(&first, AnnotationScope::File, None),
+                travel_annotation(&first, AnnotationScope::Lines(1, 2), None),
+            ],
+        );
+
+        let second = snapshot_src_files(
+            &repo,
+            &[("new.rs", "fn guarded() {\n    let value = 1;\n}\n")],
+            "rename",
+        );
+        let moved_root = repo
+            .inherit_parent_context(&second)
+            .unwrap()
+            .expect("renamed snapshot context");
+
+        let stale_lines = repo
+            .get_context_blob(&moved_root, &ContextTarget::file("src/old.rs").unwrap())
+            .unwrap()
+            .expect("line ranges stay on their original target");
+        assert_eq!(stale_lines.annotations.len(), 1);
+        assert!(matches!(
+            stale_lines.annotations[0].scope,
+            AnnotationScope::Lines(1, 2)
+        ));
+        let moved = repo
+            .get_context_blob(&moved_root, &ContextTarget::file("src/new.rs").unwrap())
+            .unwrap()
+            .expect("context moved to renamed path");
+        assert_eq!(moved.annotations.len(), 2);
+        assert!(matches!(
+            moved.annotations[0].scope,
+            AnnotationScope::Symbol { ref name, .. } if name == "guarded"
+        ));
+        assert!(matches!(moved.annotations[1].scope, AnnotationScope::File));
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    #[test]
+    fn context_file_rename_with_two_candidates_is_ambiguous() {
+        const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
+        let (dir, repo) = setup();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/old.rs"), SOURCE).unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap();
+        attach_context(
+            &repo,
+            &first,
+            "src/old.rs",
+            vec![travel_annotation(
+                &first,
+                AnnotationScope::Symbol {
+                    name: "guarded".to_string(),
+                    resolved_lines: Some((1, 3)),
+                },
+                Some(ContentHash::compute(
+                    b"fn guarded() {\n    let value = 1;\n}",
+                )),
+            )],
+        );
+
+        let second = snapshot_src_files(&repo, &[("a.rs", SOURCE), ("b.rs", SOURCE)], "ambiguous");
+        let root = repo
+            .inherit_parent_context(&second)
+            .unwrap()
+            .expect("context root");
+        let target = ContextTarget::file("src/old.rs").unwrap();
+        let blob = repo
+            .get_context_blob(&root, &target)
+            .unwrap()
+            .expect("ambiguous context stays at its prior target");
+
+        assert_eq!(
+            blob.annotations[0].anchor_status,
+            AnnotationAnchorStatus::Ambiguous {
+                candidate_paths: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+            }
+        );
+        assert_eq!(
+            crate::staleness::check_annotation_staleness(
+                &repo,
+                &blob.annotations[0],
+                &target,
+                &second,
+            )
+            .unwrap(),
+            StalenessStatus::AmbiguousFileMove {
+                candidate_paths: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+            }
+        );
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    #[test]
+    fn deleted_context_target_remains_file_missing() {
+        const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
+        let (dir, repo) = setup();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/old.rs"), SOURCE).unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap();
+        attach_context(
+            &repo,
+            &first,
+            "src/old.rs",
+            vec![travel_annotation(
+                &first,
+                AnnotationScope::File,
+                Some(ContentHash::compute(SOURCE.as_bytes())),
+            )],
+        );
+
+        let second = snapshot_src_files(&repo, &[], "delete");
+        let root = repo
+            .inherit_parent_context(&second)
+            .unwrap()
+            .expect("context root");
+        let target = ContextTarget::file("src/old.rs").unwrap();
+        let blob = repo
+            .get_context_blob(&root, &target)
+            .unwrap()
+            .expect("orphaned context remains addressable");
+
+        assert_eq!(
+            blob.annotations[0].anchor_status,
+            AnnotationAnchorStatus::Orphaned
+        );
+        assert_eq!(
+            crate::staleness::check_annotation_staleness(
+                &repo,
+                &blob.annotations[0],
+                &target,
+                &second,
+            )
+            .unwrap(),
+            StalenessStatus::FileMissing
+        );
     }
 }

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -442,7 +442,7 @@ impl SnapshotMutation<'_> {
             state = state.with_lineage(self.details.lineage.clone());
         }
 
-        let inherited_context = if let Some(parent_id) = self.prev_head
+        let mut inherited_context = if let Some(parent_id) = self.prev_head
             && let Some(parent_state) = self.repo.store.get_state(&parent_id)?
         {
             self.repo.inherit_parent_context(&parent_state)?
@@ -539,6 +539,17 @@ impl SnapshotMutation<'_> {
                         .map(|(hash, bytes)| (*hash, bytes.as_slice()))
                         .collect::<std::collections::HashMap<_, _>>()
                 });
+                match self.repo.compute_and_persist_context_anchor_travel(
+                    parent_state,
+                    &tree,
+                    source_blobs.as_ref(),
+                ) {
+                    Ok(Some(hash)) => inherited_context = Some(hash),
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(error = %err, "context anchor travel failed; inheriting prior context");
+                    }
+                }
                 match self.repo.compute_and_persist_discussion_anchor_travel(
                     parent_state,
                     &tree,

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -15,7 +15,7 @@ pub use objects::object::{
 use objects::store::AsyncObjectSource;
 use objects::{
     object::{
-        Annotation, Blob, ContextTarget, LeafPolicy, State, Tree,
+        Annotation, AnnotationAnchorStatus, Blob, ContextTarget, LeafPolicy, State, Tree,
         annotation_status_for_source_with_symbol_resolver, resolve_tree_path,
     },
     store::ObjectSource,
@@ -36,6 +36,11 @@ pub fn check_annotation_staleness(
     let Some(file_path) = target.path() else {
         return Ok(StalenessStatus::Unknown);
     };
+    if let AnnotationAnchorStatus::Ambiguous { candidate_paths } = &annotation.anchor_status {
+        return Ok(StalenessStatus::AmbiguousFileMove {
+            candidate_paths: candidate_paths.clone(),
+        });
+    }
     let file_path = Path::new(file_path);
     if annotation
         .current_revision()

--- a/crates/repo/src/visibility.rs
+++ b/crates/repo/src/visibility.rs
@@ -89,6 +89,7 @@ mod tests {
             supersedes_rewrite_pct: None,
             visibility: vis,
             resolved_from_discussion: None,
+            anchor_status: objects::object::AnnotationAnchorStatus::default(),
         }
     }
 


### PR DESCRIPTION
Closes #1579

Summary:
- rematch active file- and symbol-scoped context annotations during snapshot persistence
- reuse the existing semantic file-rename detector and 0.85 discussion threshold without modifying the shared primitive
- rewrite unique matches, persist ambiguous candidates, preserve FileMissing for deletes, and leave line scopes at the stale original path
- surface anchor health in context get/list/check JSON and human output

Tests:
- RUSTFLAGS='-C metadata=heddle1579' cargo test -p heddle-repo --features tree-sitter-symbols context_ -- --nocapture
- RUSTFLAGS='-C metadata=heddle1579' cargo test -p heddle-repo --features tree-sitter-symbols discussion_anchor_travel -- --nocapture
- RUSTFLAGS='-C metadata=heddle1579' cargo test -p heddle-cli annotation_output_surfaces_ambiguous_anchor_candidates --lib -- --nocapture
- cargo test -p heddle-object-model legacy_annotation_without_anchor_status_decodes_as_resolved -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790396564&installation_model_id=21489&pr_number=1580&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1580&signature=29defc64d82587654a40b9d4c0c345211783cdcf04c423bc2db79340bf57cbc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->