### PR TITLE
Discuss anchors: rebind on in-file symbol rename

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -17082,6 +17082,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -17136,6 +17139,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -17453,6 +17457,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -17507,6 +17514,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -17779,6 +17787,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -17833,6 +17844,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -18158,6 +18170,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -18212,6 +18227,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -18537,6 +18553,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -18591,6 +18610,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -18908,6 +18928,9 @@
             "anchor": {
               "$ref": "#/$defs/AnchorOutput"
             },
+            "anchor_status": {
+              "type": "string"
+            },
             "conflict_operation_ids": {
               "items": {
                 "type": "string"
@@ -18962,6 +18985,7 @@
             "id",
             "title",
             "anchor",
+            "anchor_status",
             "visibility",
             "status",
             "conflict_operation_ids",
@@ -29907,6 +29931,9 @@
       "$defs": {
         "DiscussionView": {
           "properties": {
+            "anchor_ambiguous": {
+              "type": "boolean"
+            },
             "body_changed_since_open": {
               "type": "boolean"
             },
@@ -29932,6 +29959,7 @@
             "symbol",
             "status",
             "body_changed_since_open",
+            "anchor_ambiguous",
             "orphaned"
           ],
           "type": "object"

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1049,6 +1049,7 @@ export interface DiscussionListSchema {
 
 export interface DiscussionOutput {
   anchor: AnchorOutput;
+  anchor_status: string;
   conflict_operation_ids: string[];
   display_head_operation_id: string;
   head_operation_ids: string[];
@@ -1067,6 +1068,7 @@ export interface DiscussionShowSchema {
 }
 
 export interface DiscussionView {
+  anchor_ambiguous: boolean;
   body_changed_since_open: boolean;
   file: string;
   id: string;

--- a/crates/cli-contract/src/cli/commands/wire/collab.rs
+++ b/crates/cli-contract/src/cli/commands/wire/collab.rs
@@ -11,6 +11,7 @@ pub struct DiscussionOutput {
     pub id: String,
     pub title: String,
     pub anchor: AnchorOutput,
+    pub anchor_status: &'static str,
     pub visibility: String,
     pub thread_ref: Option<String>,
     pub status: &'static str,
@@ -45,15 +46,23 @@ pub enum AnchorOutput {
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ResolutionOutput {
-    AddressedByState { state_id: String },
-    AddressedByChange { change_id: String },
-    Dismissed { reason: String },
+    AddressedByState {
+        state_id: String,
+    },
+    AddressedByChange {
+        change_id: String,
+    },
+    Dismissed {
+        reason: String,
+    },
     IntoAnnotation {
         annotation_kind: String,
         content: String,
         tags: Vec<String>,
     },
-    Annotation { annotation_id: String },
+    Annotation {
+        annotation_id: String,
+    },
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -124,6 +133,7 @@ pub struct DiscussionView {
     pub symbol: String,
     pub status: String,
     pub body_changed_since_open: bool,
+    pub anchor_ambiguous: bool,
     pub orphaned: bool,
 }
 

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -11,9 +11,10 @@ pub(crate) use heddle_cli_contract::cli::commands::wire::collab::{
     DiscussionWriteOutput, ResolutionOutput, TurnOutput,
 };
 use objects::object::{
-    AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
-    CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
-    DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, StateId, VisibilityTier,
+    AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationAnchorStatus,
+    CollaborationIdempotencyKey, CollaborationOperationBodyV1, CollaborationOperationEnvelope,
+    CollaborationResolution, DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, StateId,
+    VisibilityTier,
 };
 use repo::{
     CollaborationStore, CollaborationWriteDisposition, CollaborationWriteOutcome,
@@ -77,7 +78,7 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
         DiscussCommands::Resolve(args) => run_resolve(cli, &repo, &store, args),
         DiscussCommands::Reopen(args) => run_reopen(cli, &repo, &store, args),
         DiscussCommands::List(args) => run_list(cli, &repo, &store, args),
-        DiscussCommands::Show(args) => run_show(cli, &repo, &store, args),
+        DiscussCommands::Show(args) => run_show(cli, &store, args),
     }
 }
 
@@ -140,7 +141,7 @@ fn run_open(
     )?;
     let outcome = store.write_operation(&operation)?;
     emit_locality_notice_once(repo, AnnotationSurface::Discuss);
-    emit_write(cli, repo, "discuss_open", store, discussion_id, outcome)
+    emit_write(cli, "discuss_open", store, discussion_id, outcome)
 }
 
 fn open_inputs(args: &DiscussOpenArgs) -> Result<(&str, &str, &str)> {
@@ -268,7 +269,7 @@ fn write_descendant(
         body,
     )?;
     let outcome = store.write_operation(&operation)?;
-    emit_write(cli, repo, output_kind, store, discussion_id, outcome)
+    emit_write(cli, output_kind, store, discussion_id, outcome)
 }
 
 fn run_list(
@@ -327,26 +328,20 @@ fn run_list(
     Ok(())
 }
 
-fn run_show(
-    cli: &Cli,
-    repo: &repo::Repository,
-    store: &CollaborationStore,
-    args: &DiscussShowArgs,
-) -> Result<()> {
+fn run_show(cli: &Cli, store: &CollaborationStore, args: &DiscussShowArgs) -> Result<()> {
     let discussion_id = parse_discussion_id(&args.discussion_id)?;
     let discussion = store
         .materialize_discussion(&discussion_id)?
         .ok_or_else(|| anyhow!("discussion {discussion_id} not found"))?;
     let output = DiscussionShowOutput {
         output_kind: "discuss_show",
-        discussion: to_resolved_view(repo, store, &discussion)?,
+        discussion: to_view(store, &discussion)?,
     };
     emit_show(cli, &output)
 }
 
 fn emit_write(
     cli: &Cli,
-    repo: &repo::Repository,
     output_kind: &'static str,
     store: &CollaborationStore,
     discussion_id: DiscussionRecordId,
@@ -359,7 +354,7 @@ fn emit_write(
         output_kind,
         operation_id: outcome.operation_id.to_string_full(),
         disposition: outcome.disposition,
-        discussion: to_resolved_view(repo, store, &discussion)?,
+        discussion: to_view(store, &discussion)?,
     };
     if should_output_json(cli, None) {
         let emitting = match output_kind {
@@ -445,7 +440,7 @@ fn to_view(store: &CollaborationStore, value: &MaterializedDiscussion) -> Result
         id: value.discussion_id.to_string(),
         title: value.title.clone(),
         anchor: anchor_output(&value.anchor),
-        anchor_status: "current",
+        anchor_status: anchor_status_token(value.anchor_status),
         visibility: visibility_token(&value.visibility),
         thread_ref: value.thread_ref.clone(),
         status,
@@ -461,68 +456,13 @@ fn to_view(store: &CollaborationStore, value: &MaterializedDiscussion) -> Result
     })
 }
 
-fn to_resolved_view(
-    repo: &repo::Repository,
-    store: &CollaborationStore,
-    value: &MaterializedDiscussion,
-) -> Result<DiscussionOutput> {
-    let mut output = to_view(store, value)?;
-    (output.anchor, output.anchor_status) = resolved_anchor_output(repo, &value.anchor)?;
-    Ok(output)
-}
-
-#[cfg(feature = "semantic")]
-fn resolved_anchor_output(
-    repo: &repo::Repository,
-    anchor: &CollaborationAnchor,
-) -> Result<(AnchorOutput, &'static str)> {
-    let CollaborationAnchor::Symbol {
-        state_id,
-        path,
-        symbol,
-    } = anchor
-    else {
-        return Ok((anchor_output(anchor), "current"));
-    };
-    let Some(current_state) = repo.current_state()? else {
-        return Ok((anchor_output(anchor), "orphaned"));
-    };
-    if current_state.id() == *state_id {
-        return Ok((anchor_output(anchor), "current"));
+fn anchor_status_token(status: CollaborationAnchorStatus) -> &'static str {
+    match status {
+        CollaborationAnchorStatus::Current => "current",
+        CollaborationAnchorStatus::Moved => "moved",
+        CollaborationAnchorStatus::Ambiguous => "ambiguous",
+        CollaborationAnchorStatus::Orphaned => "orphaned",
     }
-    let original = objects::object::SymbolAnchor::new(path, symbol);
-    let (new_anchor, ambiguous, orphaned) =
-        repo.resolve_discussion_symbol_anchor(*state_id, &current_state, &original)?;
-    let status = if ambiguous {
-        "ambiguous"
-    } else if orphaned {
-        "orphaned"
-    } else if new_anchor != original {
-        "moved"
-    } else {
-        "current"
-    };
-    let resolved_state = if matches!(status, "current" | "moved") {
-        current_state.id()
-    } else {
-        *state_id
-    };
-    Ok((
-        AnchorOutput::Symbol {
-            state_id: resolved_state.to_string_full(),
-            path: new_anchor.file,
-            symbol: new_anchor.symbol,
-        },
-        status,
-    ))
-}
-
-#[cfg(not(feature = "semantic"))]
-fn resolved_anchor_output(
-    _repo: &repo::Repository,
-    anchor: &CollaborationAnchor,
-) -> Result<(AnchorOutput, &'static str)> {
-    Ok((anchor_output(anchor), "current"))
 }
 
 fn matches_filters(

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -4,6 +4,12 @@
 use std::time::SystemTime;
 
 use anyhow::{Context, Result, anyhow};
+// The discussion wire payloads live in cli-contract so the schema registry
+// registers the real serialization types.
+pub(crate) use heddle_cli_contract::cli::commands::wire::collab::{
+    AnchorOutput, DiscussionListOutput, DiscussionOutput, DiscussionShowOutput,
+    DiscussionWriteOutput, ResolutionOutput, TurnOutput,
+};
 use objects::object::{
     AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
     CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
@@ -36,13 +42,6 @@ use crate::{
         should_output_json,
     },
     config::UserConfig,
-};
-
-// The discussion wire payloads live in cli-contract so the schema registry
-// registers the real serialization types.
-pub(crate) use heddle_cli_contract::cli::commands::wire::collab::{
-    AnchorOutput, DiscussionListOutput, DiscussionOutput, DiscussionShowOutput,
-    DiscussionWriteOutput, ResolutionOutput, TurnOutput,
 };
 
 pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
@@ -78,7 +77,7 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
         DiscussCommands::Resolve(args) => run_resolve(cli, &repo, &store, args),
         DiscussCommands::Reopen(args) => run_reopen(cli, &repo, &store, args),
         DiscussCommands::List(args) => run_list(cli, &repo, &store, args),
-        DiscussCommands::Show(args) => run_show(cli, &store, args),
+        DiscussCommands::Show(args) => run_show(cli, &repo, &store, args),
     }
 }
 
@@ -141,7 +140,7 @@ fn run_open(
     )?;
     let outcome = store.write_operation(&operation)?;
     emit_locality_notice_once(repo, AnnotationSurface::Discuss);
-    emit_write(cli, "discuss_open", store, discussion_id, outcome)
+    emit_write(cli, repo, "discuss_open", store, discussion_id, outcome)
 }
 
 fn open_inputs(args: &DiscussOpenArgs) -> Result<(&str, &str, &str)> {
@@ -269,7 +268,7 @@ fn write_descendant(
         body,
     )?;
     let outcome = store.write_operation(&operation)?;
-    emit_write(cli, output_kind, store, discussion_id, outcome)
+    emit_write(cli, repo, output_kind, store, discussion_id, outcome)
 }
 
 fn run_list(
@@ -328,20 +327,26 @@ fn run_list(
     Ok(())
 }
 
-fn run_show(cli: &Cli, store: &CollaborationStore, args: &DiscussShowArgs) -> Result<()> {
+fn run_show(
+    cli: &Cli,
+    repo: &repo::Repository,
+    store: &CollaborationStore,
+    args: &DiscussShowArgs,
+) -> Result<()> {
     let discussion_id = parse_discussion_id(&args.discussion_id)?;
     let discussion = store
         .materialize_discussion(&discussion_id)?
         .ok_or_else(|| anyhow!("discussion {discussion_id} not found"))?;
     let output = DiscussionShowOutput {
         output_kind: "discuss_show",
-        discussion: to_view(store, &discussion)?,
+        discussion: to_resolved_view(repo, store, &discussion)?,
     };
     emit_show(cli, &output)
 }
 
 fn emit_write(
     cli: &Cli,
+    repo: &repo::Repository,
     output_kind: &'static str,
     store: &CollaborationStore,
     discussion_id: DiscussionRecordId,
@@ -354,7 +359,7 @@ fn emit_write(
         output_kind,
         operation_id: outcome.operation_id.to_string_full(),
         disposition: outcome.disposition,
-        discussion: to_view(store, &discussion)?,
+        discussion: to_resolved_view(repo, store, &discussion)?,
     };
     if should_output_json(cli, None) {
         let emitting = match output_kind {
@@ -385,7 +390,15 @@ fn emit_show(cli: &Cli, output: &DiscussionShowOutput) -> Result<()> {
     let discussion = &output.discussion;
     println!("discussion {} [{}]", discussion.id, discussion.status);
     println!("  title: {}", discussion.title);
-    println!("  anchor: {}", anchor_label(&discussion.anchor));
+    let anchor_status = match discussion.anchor_status {
+        "current" => String::new(),
+        status => format!(" [{status}]"),
+    };
+    println!(
+        "  anchor: {}{}",
+        anchor_label(&discussion.anchor),
+        anchor_status
+    );
     println!("  visibility: {}", discussion.visibility);
     if let Some(thread_ref) = &discussion.thread_ref {
         println!("  thread: {thread_ref}");
@@ -432,6 +445,7 @@ fn to_view(store: &CollaborationStore, value: &MaterializedDiscussion) -> Result
         id: value.discussion_id.to_string(),
         title: value.title.clone(),
         anchor: anchor_output(&value.anchor),
+        anchor_status: "current",
         visibility: visibility_token(&value.visibility),
         thread_ref: value.thread_ref.clone(),
         status,
@@ -445,6 +459,70 @@ fn to_view(store: &CollaborationStore, value: &MaterializedDiscussion) -> Result
         display_head_operation_id: value.display_head.to_string_full(),
         turns,
     })
+}
+
+fn to_resolved_view(
+    repo: &repo::Repository,
+    store: &CollaborationStore,
+    value: &MaterializedDiscussion,
+) -> Result<DiscussionOutput> {
+    let mut output = to_view(store, value)?;
+    (output.anchor, output.anchor_status) = resolved_anchor_output(repo, &value.anchor)?;
+    Ok(output)
+}
+
+#[cfg(feature = "semantic")]
+fn resolved_anchor_output(
+    repo: &repo::Repository,
+    anchor: &CollaborationAnchor,
+) -> Result<(AnchorOutput, &'static str)> {
+    let CollaborationAnchor::Symbol {
+        state_id,
+        path,
+        symbol,
+    } = anchor
+    else {
+        return Ok((anchor_output(anchor), "current"));
+    };
+    let Some(current_state) = repo.current_state()? else {
+        return Ok((anchor_output(anchor), "orphaned"));
+    };
+    if current_state.id() == *state_id {
+        return Ok((anchor_output(anchor), "current"));
+    }
+    let original = objects::object::SymbolAnchor::new(path, symbol);
+    let (new_anchor, ambiguous, orphaned) =
+        repo.resolve_discussion_symbol_anchor(*state_id, &current_state, &original)?;
+    let status = if ambiguous {
+        "ambiguous"
+    } else if orphaned {
+        "orphaned"
+    } else if new_anchor != original {
+        "moved"
+    } else {
+        "current"
+    };
+    let resolved_state = if matches!(status, "current" | "moved") {
+        current_state.id()
+    } else {
+        *state_id
+    };
+    Ok((
+        AnchorOutput::Symbol {
+            state_id: resolved_state.to_string_full(),
+            path: new_anchor.file,
+            symbol: new_anchor.symbol,
+        },
+        status,
+    ))
+}
+
+#[cfg(not(feature = "semantic"))]
+fn resolved_anchor_output(
+    _repo: &repo::Repository,
+    anchor: &CollaborationAnchor,
+) -> Result<(AnchorOutput, &'static str)> {
+    Ok((anchor_output(anchor), "current"))
 }
 
 fn matches_filters(

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -146,6 +146,9 @@ fn render_text(out: &ReviewShowOutput, all_signals: bool) {
             if d.body_changed_since_open {
                 suffix.push_str(" [body changed]");
             }
+            if d.anchor_ambiguous {
+                suffix.push_str(" [ambiguous anchor]");
+            }
             if d.orphaned {
                 suffix.push_str(" [orphaned]");
             }
@@ -408,6 +411,7 @@ fn discussion_view(discussion: &Discussion) -> DiscussionView {
         symbol: discussion.anchor.symbol.clone(),
         status,
         body_changed_since_open: discussion.body_changed_since_open,
+        anchor_ambiguous: discussion.anchor_ambiguous,
         orphaned: discussion.orphaned,
     }
 }

--- a/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//! CLI coverage for semantic discussion-anchor projection.
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle;
+
+fn json(output: &str) -> Value {
+    serde_json::from_str(output.trim()).expect("valid JSON output")
+}
+
+#[test]
+fn discuss_show_follows_an_in_file_symbol_rename() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn foo() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "main.rs", "foo", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn bar() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "rename foo"], Some(temp.path())).unwrap();
+
+    let shown = json(
+        &heddle(
+            &["--output", "json", "discuss", "show", id],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    assert_eq!(shown["discussion"]["anchor"]["path"], "main.rs");
+    assert_eq!(shown["discussion"]["anchor"]["symbol"], "bar");
+    assert_eq!(shown["discussion"]["anchor_status"], "moved");
+}

--- a/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-//! CLI coverage for semantic discussion-anchor projection.
+//! CLI coverage for durable semantic discussion-anchor travel.
 
+use objects::object::{CollaborationAnchor, CollaborationAnchorStatus, DiscussionRecordId};
+use repo::{CollaborationStore, Repository};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -10,8 +12,60 @@ fn json(output: &str) -> Value {
     serde_json::from_str(output.trim()).expect("valid JSON output")
 }
 
+struct PersistedAnchor {
+    path: String,
+    symbol: String,
+    status: CollaborationAnchorStatus,
+    body_changed_since_open: bool,
+    operation_count: usize,
+}
+
+fn assert_views_and_get(
+    dir: &std::path::Path,
+    id: &str,
+    expected_path: &str,
+    expected_symbol: &str,
+    expected_status: &str,
+) -> PersistedAnchor {
+    let listed = json(&heddle(&["--output", "json", "discuss", "list"], Some(dir)).unwrap());
+    let listed = listed["discussions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|discussion| discussion["id"] == id)
+        .expect("opened discussion should be listed");
+    let shown = json(&heddle(&["--output", "json", "discuss", "show", id], Some(dir)).unwrap());
+    for discussion in [listed, &shown["discussion"]] {
+        assert_eq!(discussion["anchor"]["path"], expected_path);
+        assert_eq!(discussion["anchor"]["symbol"], expected_symbol);
+        assert_eq!(discussion["anchor_status"], expected_status);
+    }
+
+    let repo = Repository::open(dir).unwrap();
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion_id: DiscussionRecordId = id.parse().unwrap();
+    let discussion = store
+        .materialize_discussion(&discussion_id)
+        .unwrap()
+        .expect("opened discussion should materialize");
+    let CollaborationAnchor::Symbol { path, symbol, .. } = discussion.anchor else {
+        panic!("discussion should retain a symbol anchor");
+    };
+    let operation_count = store
+        .discussion_operation_ids(&discussion_id)
+        .unwrap()
+        .len();
+    PersistedAnchor {
+        path,
+        symbol,
+        status: discussion.anchor_status,
+        body_changed_since_open: discussion.body_changed_since_open,
+        operation_count,
+    }
+}
+
 #[test]
-fn discuss_show_follows_an_in_file_symbol_rename() {
+fn discuss_views_follow_an_in_file_symbol_rename() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
     std::fs::write(
@@ -38,14 +92,153 @@ fn discuss_show_follows_an_in_file_symbol_rename() {
     .unwrap();
     heddle(&["capture", "-m", "rename foo"], Some(temp.path())).unwrap();
 
-    let shown = json(
+    let persisted = assert_views_and_get(temp.path(), id, "main.rs", "bar", "moved");
+    assert_eq!(persisted.path, "main.rs");
+    assert_eq!(persisted.symbol, "bar");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
+    assert!(!persisted.body_changed_since_open);
+    assert_eq!(persisted.operation_count, 2);
+}
+
+#[test]
+fn discuss_anchor_stays_rebound_after_a_later_body_edit() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn foo() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
         &heddle(
-            &["--output", "json", "discuss", "show", id],
+            &[
+                "--output", "json", "discuss", "open", "main.rs", "foo", "review q",
+            ],
             Some(temp.path()),
         )
         .unwrap(),
     );
-    assert_eq!(shown["discussion"]["anchor"]["path"], "main.rs");
-    assert_eq!(shown["discussion"]["anchor"]["symbol"], "bar");
-    assert_eq!(shown["discussion"]["anchor_status"], "moved");
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn bar() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "rename foo"], Some(temp.path())).unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn bar() {\n    let value = 43;\n    println!(\"changed {}\", value);\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "edit bar"], Some(temp.path())).unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "main.rs", "bar", "current");
+    assert_eq!(persisted.path, "main.rs");
+    assert_eq!(persisted.symbol, "bar");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Current);
+    assert!(persisted.body_changed_since_open);
+    assert_eq!(persisted.operation_count, 3);
+}
+
+#[test]
+fn discuss_ambiguous_symbol_rename_requires_attention_without_picking() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn foo() {\n    let x = 1;\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "main.rs", "foo", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rs"),
+        concat!(
+            "fn bar() {\n    let x = 1;\n}\n",
+            "fn baz() {\n    let x = 1;\n}\n",
+        ),
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "ambiguous rename"], Some(temp.path())).unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "main.rs", "foo", "ambiguous");
+    assert_eq!(persisted.path, "main.rs");
+    assert_eq!(persisted.symbol, "foo");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Ambiguous);
+    assert_eq!(persisted.operation_count, 2);
+}
+
+#[test]
+fn discuss_deleted_symbol_becomes_orphaned() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn foo() {\n    let x = 1;\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "main.rs", "foo", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::write(temp.path().join("main.rs"), "// foo was deleted\n").unwrap();
+    heddle(&["capture", "-m", "delete foo"], Some(temp.path())).unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "main.rs", "foo", "orphaned");
+    assert_eq!(persisted.path, "main.rs");
+    assert_eq!(persisted.symbol, "foo");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Orphaned);
+    assert_eq!(persisted.operation_count, 2);
+}
+
+#[test]
+fn discuss_anchor_still_follows_a_file_rename() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("main.rs"),
+        "fn foo() {\n    let x = 1;\n}\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "main.rs", "foo", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::rename(temp.path().join("main.rs"), temp.path().join("moved.rs")).unwrap();
+    heddle(&["capture", "-m", "move file"], Some(temp.path())).unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "moved.rs", "foo", "moved");
+    assert_eq!(persisted.path, "moved.rs");
+    assert_eq!(persisted.symbol, "foo");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
+    assert_eq!(persisted.operation_count, 2);
 }

--- a/crates/cli/tests/cli_workflow.rs
+++ b/crates/cli/tests/cli_workflow.rs
@@ -18,6 +18,8 @@ mod context_rides_diff;
 mod current_context_advice;
 #[path = "cli_integration/diff_patch_conformance.rs"]
 mod diff_patch_conformance;
+#[path = "cli_integration/discuss_anchor_travel.rs"]
+mod discuss_anchor_travel;
 #[path = "cli_integration/discuss_carry_forward.rs"]
 mod discuss_carry_forward;
 #[path = "cli_integration/dry_run_preview.rs"]

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -1064,6 +1064,7 @@ mod tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: VisibilityTier::Internal,
             resolved_annotation_id: None,

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -3471,6 +3471,7 @@ mod pull_bootstrap_tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: VisibilityTier::Public,
             resolved_annotation_id: None,

--- a/crates/object-model/src/object/collaboration/codec/mod.rs
+++ b/crates/object-model/src/object/collaboration/codec/mod.rs
@@ -60,10 +60,11 @@ mod tests {
 
     use super::*;
     use crate::object::{
-        AnnotationKind, Attribution, ChangeId, CollaborationAnchor, CollaborationIdempotencyKey,
-        CollaborationOperationBodyV1, CollaborationResolution, ContentHash, DiscussionRecordId,
-        DiscussionTurnV1, LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator,
-        Principal, StateAttachmentId, StateId, VisibilityTier,
+        AnnotationKind, Attribution, ChangeId, CollaborationAnchor, CollaborationAnchorStatus,
+        CollaborationIdempotencyKey, CollaborationOperationBodyV1, CollaborationResolution,
+        ContentHash, DiscussionRecordId, DiscussionTurnV1, LegacyDiscussionId,
+        LegacyDiscussionResolutionV1, LegacySourceLocator, Principal, StateAttachmentId, StateId,
+        VisibilityTier,
     };
 
     #[derive(Serialize)]
@@ -178,6 +179,18 @@ mod tests {
                 CollaborationOperationBodyV1::AppendTurn { turn: turn() },
             ),
             golden_operation(
+                "rebind_anchor",
+                CollaborationOperationBodyV1::RebindAnchor {
+                    anchor: CollaborationAnchor::Symbol {
+                        state_id: state,
+                        path: "p".to_string(),
+                        symbol: "s2".to_string(),
+                    },
+                    status: CollaborationAnchorStatus::Moved,
+                    body_changed_since_open: true,
+                },
+            ),
+            golden_operation(
                 "resolve_state",
                 CollaborationOperationBodyV1::Resolve {
                     resolution: CollaborationResolution::AddressedByState { state_id: state },
@@ -277,6 +290,10 @@ mod tests {
             (
                 "append_turn",
                 "b542d7f781fed9266dd557a8a422af1f3fce98b4fd834c0e88cc867787e32d1f",
+            ),
+            (
+                "rebind_anchor",
+                "105cff08ce66523d98a47a8f384aa4f2a3e91eada886e11c8c7a45a6d4a7aca6",
             ),
             (
                 "resolve_state",

--- a/crates/object-model/src/object/collaboration/codec/v1.rs
+++ b/crates/object-model/src/object/collaboration/codec/v1.rs
@@ -7,9 +7,9 @@ use crate::object::{
     AnnotationKind, Attribution, ChangeId, ContentHash, StateId, VisibilityTier,
     collaboration::{
         COLLABORATION_OPERATION_SCHEMA_VERSION, CollabOpId, CollaborationAnchor,
-        CollaborationIdempotencyKey, CollaborationOperationBodyV1, CollaborationOperationEnvelope,
-        CollaborationResolution, DiscussionRecordId, DiscussionTurnV1, LegacyDiscussionId,
-        LegacyDiscussionResolutionV1, LegacySourceLocator,
+        CollaborationAnchorStatus, CollaborationIdempotencyKey, CollaborationOperationBodyV1,
+        CollaborationOperationEnvelope, CollaborationResolution, DiscussionRecordId,
+        DiscussionTurnV1, LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator,
     },
 };
 
@@ -43,6 +43,15 @@ enum WireAnchorV1 {
         path: String,
         symbol: String,
     },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum WireAnchorStatusV1 {
+    Current,
+    Moved,
+    Ambiguous,
+    Orphaned,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -95,6 +104,11 @@ enum WireBodyV1 {
     },
     AppendTurn {
         turn: WireTurnV1,
+    },
+    RebindAnchor {
+        anchor: WireAnchorV1,
+        status: WireAnchorStatusV1,
+        body_changed_since_open: bool,
     },
     Resolve {
         resolution: WireResolutionV1,
@@ -185,6 +199,28 @@ impl From<WireAnchorV1> for CollaborationAnchor {
                 path,
                 symbol,
             },
+        }
+    }
+}
+
+impl From<CollaborationAnchorStatus> for WireAnchorStatusV1 {
+    fn from(value: CollaborationAnchorStatus) -> Self {
+        match value {
+            CollaborationAnchorStatus::Current => Self::Current,
+            CollaborationAnchorStatus::Moved => Self::Moved,
+            CollaborationAnchorStatus::Ambiguous => Self::Ambiguous,
+            CollaborationAnchorStatus::Orphaned => Self::Orphaned,
+        }
+    }
+}
+
+impl From<WireAnchorStatusV1> for CollaborationAnchorStatus {
+    fn from(value: WireAnchorStatusV1) -> Self {
+        match value {
+            WireAnchorStatusV1::Current => Self::Current,
+            WireAnchorStatusV1::Moved => Self::Moved,
+            WireAnchorStatusV1::Ambiguous => Self::Ambiguous,
+            WireAnchorStatusV1::Orphaned => Self::Orphaned,
         }
     }
 }
@@ -304,6 +340,15 @@ impl From<CollaborationOperationBodyV1> for WireBodyV1 {
             CollaborationOperationBodyV1::AppendTurn { turn } => {
                 Self::AppendTurn { turn: turn.into() }
             }
+            CollaborationOperationBodyV1::RebindAnchor {
+                anchor,
+                status,
+                body_changed_since_open,
+            } => Self::RebindAnchor {
+                anchor: anchor.into(),
+                status: status.into(),
+                body_changed_since_open,
+            },
             CollaborationOperationBodyV1::Resolve { resolution } => Self::Resolve {
                 resolution: resolution.into(),
             },
@@ -355,6 +400,15 @@ impl From<WireBodyV1> for CollaborationOperationBodyV1 {
                 thread_ref,
             },
             WireBodyV1::AppendTurn { turn } => Self::AppendTurn { turn: turn.into() },
+            WireBodyV1::RebindAnchor {
+                anchor,
+                status,
+                body_changed_since_open,
+            } => Self::RebindAnchor {
+                anchor: anchor.into(),
+                status: status.into(),
+                body_changed_since_open,
+            },
             WireBodyV1::Resolve { resolution } => Self::Resolve {
                 resolution: resolution.into(),
             },

--- a/crates/object-model/src/object/collaboration/materialize.rs
+++ b/crates/object-model/src/object/collaboration/materialize.rs
@@ -5,9 +5,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    CollabOpId, CollaborationAnchor, CollaborationCodecError, CollaborationOperationBodyV1,
-    CollaborationResolution, DecodedCollaborationOperation, DiscussionRecordId, DiscussionTurnV1,
-    LegacyDiscussionResolutionV1,
+    CollabOpId, CollaborationAnchor, CollaborationAnchorStatus, CollaborationCodecError,
+    CollaborationOperationBodyV1, CollaborationResolution, DecodedCollaborationOperation,
+    DiscussionRecordId, DiscussionTurnV1, LegacyDiscussionResolutionV1,
 };
 use crate::object::VisibilityTier;
 
@@ -96,6 +96,8 @@ pub struct MaterializedDiscussion {
     pub discussion_id: DiscussionRecordId,
     pub title: String,
     pub anchor: CollaborationAnchor,
+    pub anchor_status: CollaborationAnchorStatus,
+    pub body_changed_since_open: bool,
     pub visibility: VisibilityTier,
     pub thread_ref: Option<String>,
     pub turns: Vec<(CollabOpId, DiscussionTurnV1)>,
@@ -192,7 +194,7 @@ fn materialize_discussion(
     }
     let root_id = roots[0];
     let root = &all[&root_id].operation.body;
-    let (title, anchor, visibility, thread_ref, root_turns, base_resolution) = match root {
+    let (title, root_anchor, visibility, thread_ref, root_turns, base_resolution) = match root {
         CollaborationOperationBodyV1::Open {
             title,
             anchor,
@@ -234,9 +236,13 @@ fn materialize_discussion(
         .map(|turn| (root_id, turn))
         .collect::<Vec<_>>();
     let mut state_operations = BTreeSet::new();
+    let mut anchor_operations = BTreeSet::new();
     for id in ids.iter().copied().filter(|id| *id != root_id) {
         match &all[&id].operation.body {
             CollaborationOperationBodyV1::AppendTurn { turn } => turns.push((id, turn.clone())),
+            CollaborationOperationBodyV1::RebindAnchor { .. } => {
+                anchor_operations.insert(id);
+            }
             CollaborationOperationBodyV1::Resolve { .. }
             | CollaborationOperationBodyV1::Reopen { .. }
             | CollaborationOperationBodyV1::ResolveConflict { .. } => {
@@ -250,6 +256,9 @@ fn materialize_discussion(
             }
         }
     }
+
+    let (anchor, anchor_status, body_changed_since_open) =
+        materialize_anchor(root_anchor, &anchor_operations, all)?;
 
     let maximal_state = state_operations
         .iter()
@@ -294,6 +303,8 @@ fn materialize_discussion(
         discussion_id,
         title,
         anchor,
+        anchor_status,
+        body_changed_since_open,
         visibility,
         thread_ref,
         turns,
@@ -302,6 +313,49 @@ fn materialize_discussion(
         heads,
         display_head,
     })
+}
+
+fn materialize_anchor(
+    root_anchor: CollaborationAnchor,
+    anchor_operations: &BTreeSet<CollabOpId>,
+    all: &BTreeMap<CollabOpId, DecodedCollaborationOperation>,
+) -> Result<(CollaborationAnchor, CollaborationAnchorStatus, bool), CollaborationCodecError> {
+    let maximal = anchor_operations
+        .iter()
+        .filter(|candidate| {
+            !anchor_operations
+                .iter()
+                .any(|other| candidate != &other && precedes(**candidate, *other, all))
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let mut outcomes = Vec::with_capacity(maximal.len());
+    for id in maximal {
+        let CollaborationOperationBodyV1::RebindAnchor {
+            anchor,
+            status,
+            body_changed_since_open,
+        } = &all[&id].operation.body
+        else {
+            return Err(CollaborationCodecError::Invalid(format!(
+                "anchor operation {id} is not an anchor rebind"
+            )));
+        };
+        outcomes.push((anchor.clone(), *status, *body_changed_since_open));
+    }
+    let Some(first) = outcomes.first().cloned() else {
+        return Ok((root_anchor, CollaborationAnchorStatus::Current, false));
+    };
+    if outcomes.iter().all(|outcome| outcome == &first) {
+        return Ok(first);
+    }
+    Ok((
+        root_anchor,
+        CollaborationAnchorStatus::Ambiguous,
+        outcomes
+            .iter()
+            .any(|(_, _, body_changed_since_open)| *body_changed_since_open),
+    ))
 }
 
 fn resolution_outcome(
@@ -381,6 +435,7 @@ mod tests {
     use super::*;
     use crate::object::{
         Attribution, CollaborationIdempotencyKey, CollaborationOperationEnvelope, Principal,
+        StateId,
     };
 
     fn discussion_id() -> DiscussionRecordId {
@@ -425,6 +480,25 @@ mod tests {
         )
     }
 
+    fn symbol_root() -> DecodedCollaborationOperation {
+        decoded(
+            vec![],
+            "symbol-root",
+            1,
+            CollaborationOperationBodyV1::Open {
+                title: "Review".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: StateId::from_bytes([1; 32]),
+                    path: "main.rs".to_string(),
+                    symbol: "foo".to_string(),
+                },
+                visibility: VisibilityTier::default(),
+                turn: DiscussionTurnV1::new("first").unwrap(),
+                thread_ref: None,
+            },
+        )
+    }
+
     #[test]
     fn op_set_union_converges_independent_of_arrival_order() {
         let root = root();
@@ -454,6 +528,73 @@ mod tests {
         assert_eq!(
             discussion.display_head,
             *discussion.heads.iter().next().unwrap()
+        );
+    }
+
+    #[test]
+    fn anchor_rebind_materializes_as_the_durable_anchor() {
+        let root = symbol_root();
+        let rebound = decoded(
+            vec![root.operation_id],
+            "rebind",
+            2,
+            CollaborationOperationBodyV1::RebindAnchor {
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: StateId::from_bytes([2; 32]),
+                    path: "main.rs".to_string(),
+                    symbol: "bar".to_string(),
+                },
+                status: CollaborationAnchorStatus::Moved,
+                body_changed_since_open: true,
+            },
+        );
+        let view = materialize_repository_collaboration(vec![root, rebound]).unwrap();
+        let discussion = &view.discussions[&discussion_id()];
+        assert_eq!(
+            discussion.anchor,
+            CollaborationAnchor::Symbol {
+                state_id: StateId::from_bytes([2; 32]),
+                path: "main.rs".to_string(),
+                symbol: "bar".to_string(),
+            }
+        );
+        assert_eq!(discussion.anchor_status, CollaborationAnchorStatus::Moved);
+        assert!(discussion.body_changed_since_open);
+    }
+
+    #[test]
+    fn concurrent_different_anchor_rebinds_materialize_as_ambiguous() {
+        let root = symbol_root();
+        let rebind = |key: &str, symbol: &str| {
+            decoded(
+                vec![root.operation_id],
+                key,
+                2,
+                CollaborationOperationBodyV1::RebindAnchor {
+                    anchor: CollaborationAnchor::Symbol {
+                        state_id: StateId::from_bytes([2; 32]),
+                        path: "main.rs".to_string(),
+                        symbol: symbol.to_string(),
+                    },
+                    status: CollaborationAnchorStatus::Moved,
+                    body_changed_since_open: false,
+                },
+            )
+        };
+        let left = rebind("left", "bar");
+        let right = rebind("right", "baz");
+        let view = materialize_repository_collaboration(vec![root.clone(), left, right]).unwrap();
+        let discussion = &view.discussions[&discussion_id()];
+        assert_eq!(
+            discussion.anchor,
+            match root.operation.body {
+                CollaborationOperationBodyV1::Open { anchor, .. } => anchor,
+                _ => unreachable!(),
+            }
+        );
+        assert_eq!(
+            discussion.anchor_status,
+            CollaborationAnchorStatus::Ambiguous
         );
     }
 

--- a/crates/object-model/src/object/collaboration/mod.rs
+++ b/crates/object-model/src/object/collaboration/mod.rs
@@ -15,8 +15,9 @@ pub use materialize::{
     materialize_repository_collaboration,
 };
 pub use operation::{
-    CollaborationAnchor, CollaborationOperationBodyV1, CollaborationOperationEnvelope,
-    CollaborationResolution, DiscussionTurnV1, LegacyDiscussionResolutionV1,
+    CollaborationAnchor, CollaborationAnchorStatus, CollaborationOperationBodyV1,
+    CollaborationOperationEnvelope, CollaborationResolution, DiscussionTurnV1,
+    LegacyDiscussionResolutionV1,
 };
 
 pub const COLLABORATION_OPERATION_SCHEMA_VERSION: u16 = 1;

--- a/crates/object-model/src/object/collaboration/operation.rs
+++ b/crates/object-model/src/object/collaboration/operation.rs
@@ -29,6 +29,16 @@ pub enum CollaborationAnchor {
     },
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CollaborationAnchorStatus {
+    #[default]
+    Current,
+    Moved,
+    Ambiguous,
+    Orphaned,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscussionTurnV1 {
     pub body: String,
@@ -100,6 +110,11 @@ pub enum CollaborationOperationBodyV1 {
     AppendTurn {
         turn: DiscussionTurnV1,
     },
+    RebindAnchor {
+        anchor: CollaborationAnchor,
+        status: CollaborationAnchorStatus,
+        body_changed_since_open: bool,
+    },
     Resolve {
         resolution: CollaborationResolution,
     },
@@ -127,6 +142,7 @@ impl CollaborationOperationBodyV1 {
         match self {
             Self::Open { .. } => "open",
             Self::AppendTurn { .. } => "append_turn",
+            Self::RebindAnchor { .. } => "rebind_anchor",
             Self::Resolve { .. } => "resolve",
             Self::Reopen { .. } => "reopen",
             Self::ResolveConflict { .. } => "resolve_conflict",
@@ -151,6 +167,7 @@ impl CollaborationOperationBodyV1 {
                 turn.validate()
             }
             Self::AppendTurn { turn } => turn.validate(),
+            Self::RebindAnchor { anchor, .. } => validate_anchor(anchor),
             Self::Resolve { resolution } => validate_resolution(resolution),
             Self::Reopen { reason } => require_text(reason, "reopen reason"),
             Self::ResolveConflict {

--- a/crates/object-model/src/object/discussion.rs
+++ b/crates/object-model/src/object/discussion.rs
@@ -58,6 +58,11 @@ pub struct Discussion {
     /// proceeds normally.
     #[serde(default)]
     pub body_changed_since_open: bool,
+    /// Set by anchor-travel when semantic analysis found plausible targets but
+    /// no single high-confidence winner. The durable symbol anchor remains
+    /// unchanged for human triage.
+    #[serde(default)]
+    pub anchor_ambiguous: bool,
     /// Set by anchor-travel when the symbol can't be resolved in the new
     /// state (deleted or unreachable rename). The discussion stays open with
     /// this marker for a human to triage.
@@ -223,6 +228,7 @@ mod tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: VisibilityTier::default(),
             resolved_annotation_id: None,

--- a/crates/repo/src/collaboration_migration.rs
+++ b/crates/repo/src/collaboration_migration.rs
@@ -387,6 +387,7 @@ mod tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: VisibilityTier::default(),
             resolved_annotation_id: None,

--- a/crates/repo/src/discussion_anchor_travel.rs
+++ b/crates/repo/src/discussion_anchor_travel.rs
@@ -11,11 +11,9 @@
 //!    `body_changed_since_open = true`. Reviewers see a marker;
 //!    resolution still proceeds normally.
 //! 3. **Renamed within file** — symbol no longer resolves at the old
-//!    name, but a structurally-similar definition exists in the same
-//!    file. Out of scope for now: function-level rename detection
-//!    requires a tree-sitter call-graph diff that hasn't been wired
-//!    yet. Falls through to the cross-file path with the old file
-//!    kept in scope.
+//!    name, but semantic rename analysis finds one high-confidence,
+//!    structurally-similar definition in the same file. Equally plausible
+//!    or low-confidence candidates are marked ambiguous, never selected.
 //! 4. **Cross-file move** — file moved (rename detected by
 //!    [`detect_file_renames`] with confidence above
 //!    [`RENAME_CONFIDENCE_FOR_ANCHOR_TRAVEL`]); re-anchor to the new
@@ -34,7 +32,9 @@ use std::{collections::HashMap, path::Path};
 
 use objects::object::{Discussion, SymbolAnchor};
 use semantic::{
-    analysis::{SimilarityMethod, detect_file_renames},
+    analysis::{
+        FunctionRenameResolution, SimilarityMethod, detect_file_renames, resolve_function_rename,
+    },
     symbol_resolver::resolve_symbol_lines,
 };
 
@@ -55,6 +55,9 @@ pub struct DiscussionAnchorUpdate {
     /// Set when the resolved body bytes differ from the body at the
     /// state the discussion was opened against.
     pub body_changed_since_open: bool,
+    /// Set when semantic analysis found plausible targets but could not
+    /// identify one high-confidence winner.
+    pub ambiguous: bool,
     /// Set when no resolution path produced a hit — neither original
     /// location, nor renamed file, nor cross-file move.
     pub orphaned: bool,
@@ -79,20 +82,40 @@ pub fn travel_anchors(
 
     open_discussions
         .iter()
-        .map(|d| travel_one(d, old_files, new_files, &renamed))
+        .map(|discussion| {
+            travel_one(
+                &discussion.id,
+                &discussion.anchor,
+                old_files,
+                new_files,
+                &renamed,
+            )
+        })
         .collect()
+}
+
+/// Resolve one symbol anchor between two file maps. This is also used by the
+/// append-only collaboration view, whose durable anchor keeps its opening
+/// state while the displayed location is derived against current state.
+pub fn travel_symbol_anchor(
+    old_files: &HashMap<String, Vec<u8>>,
+    new_files: &HashMap<String, Vec<u8>>,
+    anchor: &SymbolAnchor,
+) -> DiscussionAnchorUpdate {
+    let renamed = compute_renames(old_files, new_files);
+    travel_one("", anchor, old_files, new_files, &renamed)
 }
 
 /// Resolve a single discussion against the new tree. Mirrors the five
 /// cases above; lifted out of [`travel_anchors`] so each case is its own
 /// expression and the batch loop stays readable.
 fn travel_one(
-    discussion: &Discussion,
+    discussion_id: &str,
+    original: &SymbolAnchor,
     old_files: &HashMap<String, Vec<u8>>,
     new_files: &HashMap<String, Vec<u8>>,
     renamed: &HashMap<String, String>,
 ) -> DiscussionAnchorUpdate {
-    let original = &discussion.anchor;
     let old_body = old_files.get(&original.file).and_then(|src| {
         match resolve_symbol_lines(src, Path::new(&original.file), &original.symbol) {
             Ok((start, end)) => Some(extract_body(src, start, end)),
@@ -113,11 +136,55 @@ fn travel_one(
             None => true,
         };
         return DiscussionAnchorUpdate {
-            discussion_id: discussion.id.clone(),
+            discussion_id: discussion_id.to_string(),
             new_anchor: original.clone(),
             body_changed_since_open: body_changed,
+            ambiguous: false,
             orphaned: false,
         };
+    }
+
+    // Case 3: the file survived but the symbol name did not. Ask semantic
+    // rename analysis for a conservative, structure-backed resolution.
+    if let (Some(old_src), Some(new_src)) =
+        (old_files.get(&original.file), new_files.get(&original.file))
+        && let (Ok(old_text), Ok(new_text)) =
+            (std::str::from_utf8(old_src), std::str::from_utf8(new_src))
+    {
+        match resolve_function_rename(
+            Path::new(&original.file),
+            old_text,
+            new_text,
+            &original.symbol,
+            SimilarityMethod::Lines,
+        ) {
+            FunctionRenameResolution::Renamed(candidate) => {
+                if let Ok((start, end)) =
+                    resolve_symbol_lines(new_src, Path::new(&original.file), &candidate.new_name)
+                {
+                    let new_body = extract_body(new_src, start, end);
+                    return DiscussionAnchorUpdate {
+                        discussion_id: discussion_id.to_string(),
+                        new_anchor: SymbolAnchor::new(original.file.clone(), candidate.new_name),
+                        body_changed_since_open: old_body
+                            .as_ref()
+                            .is_none_or(|old| old != &new_body),
+                        ambiguous: false,
+                        orphaned: false,
+                    };
+                }
+            }
+            FunctionRenameResolution::Ambiguous(_) => {
+                return DiscussionAnchorUpdate {
+                    discussion_id: discussion_id.to_string(),
+                    new_anchor: original.clone(),
+                    body_changed_since_open: false,
+                    ambiguous: true,
+                    orphaned: false,
+                };
+            }
+            FunctionRenameResolution::NotRenamed => {}
+        }
     }
 
     // Case 4: file rename. The detector returned (old_path, new_path);
@@ -133,9 +200,10 @@ fn travel_one(
             None => true,
         };
         return DiscussionAnchorUpdate {
-            discussion_id: discussion.id.clone(),
+            discussion_id: discussion_id.to_string(),
             new_anchor: SymbolAnchor::new(new_path.clone(), original.symbol.clone()),
             body_changed_since_open: body_changed,
+            ambiguous: false,
             orphaned: false,
         };
     }
@@ -144,9 +212,10 @@ fn travel_one(
     // anchor in place so the discussion is still addressable in
     // history.
     DiscussionAnchorUpdate {
-        discussion_id: discussion.id.clone(),
+        discussion_id: discussion_id.to_string(),
         new_anchor: original.clone(),
         body_changed_since_open: false,
+        ambiguous: false,
         orphaned: true,
     }
 }
@@ -243,6 +312,7 @@ mod tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: objects::object::VisibilityTier::default(),
             resolved_annotation_id: None,
@@ -310,16 +380,43 @@ mod tests {
     }
 
     #[test]
-    fn case_5_orphaned_when_symbol_renamed_in_place() {
+    fn case_3_symbol_renamed_in_place_rebinds() {
         let old = files(&[("src/lib.rs", FOO_RS)]);
-        // File present, but the original symbol no longer exists. We
-        // don't have function-level rename detection yet, so this falls
-        // through to orphaned — better than silently following a wrong
-        // symbol.
         let new = files(&[("src/lib.rs", "fn renamed() {\n    let x = 1;\n}\n")]);
         let d = vec![discussion("d1", "src/lib.rs", "foo")];
         let updates = travel_anchors(&old, &new, &d);
         assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].new_anchor.symbol, "renamed");
+        assert!(!updates[0].ambiguous);
+        assert!(!updates[0].orphaned);
+    }
+
+    #[test]
+    fn case_3_equal_symbol_rename_candidates_are_ambiguous() {
+        let old = files(&[("src/lib.rs", FOO_RS)]);
+        let new = files(&[(
+            "src/lib.rs",
+            concat!(
+                "fn bar() {\n    let x = 1;\n}\n",
+                "fn baz() {\n    let x = 1;\n}\n",
+            ),
+        )]);
+        let d = vec![discussion("d1", "src/lib.rs", "foo")];
+        let updates = travel_anchors(&old, &new, &d);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].new_anchor.symbol, "foo");
+        assert!(updates[0].ambiguous);
+        assert!(!updates[0].orphaned);
+    }
+
+    #[test]
+    fn case_5_orphaned_when_symbol_is_deleted() {
+        let old = files(&[("src/lib.rs", FOO_RS)]);
+        let new = files(&[("src/lib.rs", "// foo is gone\n")]);
+        let d = vec![discussion("d1", "src/lib.rs", "foo")];
+        let updates = travel_anchors(&old, &new, &d);
+        assert_eq!(updates.len(), 1);
+        assert!(!updates[0].ambiguous);
         assert!(updates[0].orphaned);
     }
 }

--- a/crates/repo/src/discussion_anchor_travel.rs
+++ b/crates/repo/src/discussion_anchor_travel.rs
@@ -159,16 +159,13 @@ fn travel_one(
             SimilarityMethod::Lines,
         ) {
             FunctionRenameResolution::Renamed(candidate) => {
-                if let Ok((start, end)) =
-                    resolve_symbol_lines(new_src, Path::new(&original.file), &candidate.new_name)
+                if resolve_symbol_lines(new_src, Path::new(&original.file), &candidate.new_name)
+                    .is_ok()
                 {
-                    let new_body = extract_body(new_src, start, end);
                     return DiscussionAnchorUpdate {
                         discussion_id: discussion_id.to_string(),
                         new_anchor: SymbolAnchor::new(original.file.clone(), candidate.new_name),
-                        body_changed_since_open: old_body
-                            .as_ref()
-                            .is_none_or(|old| old != &new_body),
+                        body_changed_since_open: candidate.body_changed,
                         ambiguous: false,
                         orphaned: false,
                     };

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -15,7 +15,10 @@ use objects::{
 use oplog::OpLogBackend;
 use refs::RefBackend;
 
-use crate::{HeddleError, Repository, Result, discussion_anchor_travel::travel_anchors};
+use crate::{
+    HeddleError, Repository, Result,
+    discussion_anchor_travel::{travel_anchors, travel_symbol_anchor},
+};
 
 impl<R, O, S> Repository<R, O, S>
 where
@@ -23,6 +26,32 @@ where
     O: OpLogBackend,
     S: ObjectStore,
 {
+    /// Derive the current resolution of an append-only discussion's durable
+    /// opening anchor without rewriting that collaboration record.
+    pub fn resolve_discussion_symbol_anchor(
+        &self,
+        opened_against_state: StateId,
+        current_state: &State,
+        anchor: &objects::object::SymbolAnchor,
+    ) -> Result<(objects::object::SymbolAnchor, bool, bool)> {
+        let baseline_state = self
+            .store()
+            .get_state(&opened_against_state)?
+            .ok_or_else(|| missing_state(opened_against_state))?;
+        let baseline_tree = self
+            .store()
+            .get_tree(&baseline_state.tree)?
+            .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
+        let current_tree = self
+            .store()
+            .get_tree(&current_state.tree)?
+            .ok_or_else(|| missing_object("tree", current_state.tree))?;
+        let old_files = self.collect_tree_file_bytes(&baseline_tree, None)?;
+        let new_files = self.collect_tree_file_bytes(&current_tree, None)?;
+        let update = travel_symbol_anchor(&old_files, &new_files, anchor);
+        Ok((update.new_anchor, update.ambiguous, update.orphaned))
+    }
+
     pub(crate) fn compute_and_persist_discussion_anchor_travel(
         &self,
         parent_state: &State,
@@ -78,6 +107,7 @@ where
             {
                 discussion.anchor = update.new_anchor;
                 discussion.body_changed_since_open = update.body_changed_since_open;
+                discussion.anchor_ambiguous = update.ambiguous;
                 discussion.orphaned = update.orphaned;
             }
         }
@@ -231,6 +261,7 @@ mod tests {
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,
+            anchor_ambiguous: false,
             orphaned: false,
             visibility: VisibilityTier::default(),
             resolved_annotation_id: None,
@@ -429,6 +460,41 @@ mod tests {
             vec![discussion("d1", first.id(), "src.rs", "foo")],
         );
 
+        fs::write(temp.path().join("src.rs"), "// foo was deleted\n").unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("second".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted = read_discussions(&repo, &second);
+        assert!(!persisted.discussions[0].body_changed_since_open);
+        assert!(persisted.discussions[0].orphaned);
+    }
+
+    #[test]
+    fn snapshot_persists_in_file_symbol_rename() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        attach_discussions_to_main_head(
+            &repo,
+            &first,
+            vec![discussion("d1", first.id(), "src.rs", "foo")],
+        );
+
         fs::write(
             temp.path().join("src.rs"),
             "fn bar() {\n    let x = 1;\n}\n",
@@ -443,7 +509,51 @@ mod tests {
             .unwrap();
 
         let persisted = read_discussions(&repo, &second);
-        assert!(!persisted.discussions[0].body_changed_since_open);
-        assert!(persisted.discussions[0].orphaned);
+        assert_eq!(persisted.discussions[0].anchor.symbol, "bar");
+        assert!(!persisted.discussions[0].anchor_ambiguous);
+        assert!(!persisted.discussions[0].orphaned);
+    }
+
+    #[test]
+    fn snapshot_persists_ambiguous_symbol_rename_without_picking() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        attach_discussions_to_main_head(
+            &repo,
+            &first,
+            vec![discussion("d1", first.id(), "src.rs", "foo")],
+        );
+
+        fs::write(
+            temp.path().join("src.rs"),
+            concat!(
+                "fn bar() {\n    let x = 1;\n}\n",
+                "fn baz() {\n    let x = 1;\n}\n",
+            ),
+        )
+        .unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("ambiguous rename".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted = read_discussions(&repo, &second);
+        assert_eq!(persisted.discussions[0].anchor.symbol, "foo");
+        assert!(persisted.discussions[0].anchor_ambiguous);
+        assert!(!persisted.discussions[0].orphaned);
     }
 }

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -7,7 +7,9 @@ use std::{collections::HashMap, path::PathBuf};
 
 use objects::{
     object::{
-        Blob, ContentHash, Discussion, DiscussionResolution, DiscussionsBlob, EntryType, State,
+        Blob, CollaborationAnchor, CollaborationAnchorStatus, CollaborationIdempotencyKey,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, ContentHash, Discussion,
+        DiscussionResolution, DiscussionsBlob, EntryType, MaterializedDiscussion, State,
         StateAttachmentBody, StateId, Tree,
     },
     store::ObjectStore,
@@ -16,7 +18,7 @@ use oplog::OpLogBackend;
 use refs::RefBackend;
 
 use crate::{
-    HeddleError, Repository, Result,
+    CollaborationStore, HeddleError, Repository, Result,
     discussion_anchor_travel::{travel_anchors, travel_symbol_anchor},
 };
 
@@ -26,45 +28,53 @@ where
     O: OpLogBackend,
     S: ObjectStore,
 {
-    /// Derive the current resolution of an append-only discussion's durable
-    /// opening anchor without rewriting that collaboration record.
-    pub fn resolve_discussion_symbol_anchor(
-        &self,
-        opened_against_state: StateId,
-        current_state: &State,
-        anchor: &objects::object::SymbolAnchor,
-    ) -> Result<(objects::object::SymbolAnchor, bool, bool)> {
-        let baseline_state = self
-            .store()
-            .get_state(&opened_against_state)?
-            .ok_or_else(|| missing_state(opened_against_state))?;
-        let baseline_tree = self
-            .store()
-            .get_tree(&baseline_state.tree)?
-            .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
-        let current_tree = self
-            .store()
-            .get_tree(&current_state.tree)?
-            .ok_or_else(|| missing_object("tree", current_state.tree))?;
-        let old_files = self.collect_tree_file_bytes(&baseline_tree, None)?;
-        let new_files = self.collect_tree_file_bytes(&current_tree, None)?;
-        let update = travel_symbol_anchor(&old_files, &new_files, anchor);
-        Ok((update.new_anchor, update.ambiguous, update.orphaned))
-    }
-
     pub(crate) fn compute_and_persist_discussion_anchor_travel(
         &self,
         parent_state: &State,
+        new_state: &State,
         new_tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
     ) -> Result<Option<ContentHash>> {
-        let Some(parent_discussions_hash) = self
+        let parent_discussions_hash = self
             .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Discussions)?
             .and_then(|attachment| match attachment.body {
                 StateAttachmentBody::Discussions(hash) => Some(hash),
                 _ => None,
-            })
-        else {
+            });
+        let collaboration_store = self
+            .heddle_dir()
+            .join("collaboration")
+            .exists()
+            .then(|| CollaborationStore::open(self.heddle_dir()))
+            .transpose()?;
+        let collaboration_discussions = match &collaboration_store {
+            Some(store) => store
+                .materialize()?
+                .discussions
+                .into_values()
+                .filter(|discussion| {
+                    discussion.resolution.is_none()
+                        && matches!(discussion.anchor, CollaborationAnchor::Symbol { .. })
+                })
+                .collect::<Vec<_>>(),
+            None => Vec::new(),
+        };
+
+        if parent_discussions_hash.is_none() && collaboration_discussions.is_empty() {
+            return Ok(None);
+        }
+
+        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs)?;
+        if let Some(store) = &collaboration_store {
+            self.persist_collaboration_anchor_travel(
+                store,
+                new_state,
+                &new_files,
+                collaboration_discussions,
+            )?;
+        }
+
+        let Some(parent_discussions_hash) = parent_discussions_hash else {
             return Ok(None);
         };
         let parent_blob = self
@@ -85,7 +95,6 @@ where
             return Ok(Some(parent_discussions_hash));
         }
 
-        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs)?;
         let baseline_files = self.collect_discussion_baseline_file_bytes(&open_discussions)?;
         let mut updates = Vec::new();
         for (opened_against_state, discussions) in
@@ -117,6 +126,88 @@ where
             .map_err(|err| HeddleError::Serialization(format!("encode discussions blob: {err}")))?;
         let hash = self.store().put_blob(&Blob::new(bytes))?;
         Ok(Some(hash))
+    }
+
+    fn persist_collaboration_anchor_travel(
+        &self,
+        store: &CollaborationStore,
+        new_state: &State,
+        new_files: &HashMap<String, Vec<u8>>,
+        discussions: Vec<MaterializedDiscussion>,
+    ) -> Result<()> {
+        let mut baseline_files = HashMap::new();
+        for discussion in discussions {
+            let CollaborationAnchor::Symbol {
+                state_id,
+                path,
+                symbol,
+            } = &discussion.anchor
+            else {
+                continue;
+            };
+            if *state_id == new_state.id() {
+                continue;
+            }
+            if !baseline_files.contains_key(state_id) {
+                let baseline_state = self
+                    .store()
+                    .get_state(state_id)?
+                    .ok_or_else(|| missing_state(*state_id))?;
+                let baseline_tree = self
+                    .store()
+                    .get_tree(&baseline_state.tree)?
+                    .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
+                baseline_files.insert(
+                    *state_id,
+                    self.collect_tree_file_bytes(&baseline_tree, None)?,
+                );
+            }
+            let old_files = baseline_files.get(state_id).ok_or_else(|| {
+                HeddleError::Config(format!(
+                    "missing collaboration discussion baseline files for state {state_id}"
+                ))
+            })?;
+            let original = objects::object::SymbolAnchor::new(path, symbol);
+            let update = travel_symbol_anchor(old_files, new_files, &original);
+            let status = if update.ambiguous {
+                CollaborationAnchorStatus::Ambiguous
+            } else if update.orphaned {
+                CollaborationAnchorStatus::Orphaned
+            } else if update.new_anchor != original {
+                CollaborationAnchorStatus::Moved
+            } else {
+                CollaborationAnchorStatus::Current
+            };
+            let resolved_state_id = if matches!(
+                status,
+                CollaborationAnchorStatus::Current | CollaborationAnchorStatus::Moved
+            ) {
+                new_state.id()
+            } else {
+                *state_id
+            };
+            let operation = CollaborationOperationEnvelope::new(
+                discussion.discussion_id,
+                discussion.heads.iter().copied().collect(),
+                CollaborationIdempotencyKey::new(format!("anchor-travel:{}", new_state.id()))
+                    .map_err(|error| HeddleError::InvalidObject(error.to_string()))?,
+                new_state.attribution.clone(),
+                new_state.created_at.timestamp_millis(),
+                CollaborationOperationBodyV1::RebindAnchor {
+                    anchor: CollaborationAnchor::Symbol {
+                        state_id: resolved_state_id,
+                        path: update.new_anchor.file,
+                        symbol: update.new_anchor.symbol,
+                    },
+                    status,
+                    body_changed_since_open: discussion.body_changed_since_open
+                        || update.body_changed_since_open,
+                },
+            )
+            .map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+            store.write_operation(&operation)?;
+        }
+        Ok(())
     }
 
     fn collect_tree_file_bytes(

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -541,6 +541,7 @@ impl SnapshotMutation<'_> {
                 });
                 match self.repo.compute_and_persist_discussion_anchor_travel(
                     parent_state,
+                    &state,
                     &tree,
                     source_blobs.as_ref(),
                 ) {

--- a/crates/repo/tests/transfer_planning_tests.rs
+++ b/crates/repo/tests/transfer_planning_tests.rs
@@ -1012,6 +1012,7 @@ fn enumerate_state_closure_emits_state_metadata_blobs() {
         }],
         resolution: DiscussionResolution::Open,
         body_changed_since_open: false,
+        anchor_ambiguous: false,
         orphaned: false,
         visibility: VisibilityTier::default(),
         resolved_annotation_id: None,

--- a/crates/semantic/src/analysis/analysis_functions.rs
+++ b/crates/semantic/src/analysis/analysis_functions.rs
@@ -9,6 +9,28 @@ use super::analysis_similarity::{SimilarityMethod, compute_similarity_with_langu
 use crate::parser::{FunctionDef, Language, ParsedFile};
 
 const FUNCTION_RENAME_SIMILARITY_THRESHOLD: f64 = 0.58;
+const FUNCTION_RENAME_CANDIDATE_THRESHOLD: f64 = 0.30;
+const FUNCTION_RENAME_CONFIDENCE_MARGIN: f64 = 0.05;
+
+/// One structurally plausible target for a function that disappeared under
+/// its old name.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FunctionRenameCandidate {
+    pub new_name: String,
+    pub confidence: f64,
+}
+
+/// Conservative result for resolving one function rename.
+///
+/// The general semantic diff may choose a stable best pairing so it can
+/// describe a whole file. Durable anchors have a stricter contract: only a
+/// high-confidence candidate with a clear lead may move the anchor.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FunctionRenameResolution {
+    Renamed(FunctionRenameCandidate),
+    Ambiguous(Vec<FunctionRenameCandidate>),
+    NotRenamed,
+}
 
 /// Multi-map: function name → all definitions on this side with that
 /// name, in source order.
@@ -113,6 +135,96 @@ pub fn detect_function_changes(
         new_parsed.as_ref(),
         similarity_method,
     )
+}
+
+/// Resolve the new name of one function within a single file.
+///
+/// Candidates come from parsed function definitions that are new under their
+/// qualified identity and share the original definition's container. This
+/// deliberately excludes text search and existing, unchanged neighbours.
+pub fn resolve_function_rename(
+    path: &std::path::Path,
+    old_content: &str,
+    new_content: &str,
+    old_name: &str,
+    similarity_method: SimilarityMethod,
+) -> FunctionRenameResolution {
+    let language = Language::from_path(path);
+    let Some(old_parsed) = ParsedFile::parse(old_content, language) else {
+        return FunctionRenameResolution::NotRenamed;
+    };
+    let Some(new_parsed) = ParsedFile::parse(new_content, language) else {
+        return FunctionRenameResolution::NotRenamed;
+    };
+    let old_functions = old_parsed.extract_functions();
+    let new_functions = new_parsed.extract_functions();
+    let qualified = old_name.contains("::");
+    let old_matches = old_functions
+        .iter()
+        .filter(|function| {
+            if qualified {
+                function.qualified_name() == old_name
+            } else {
+                function.name == old_name
+            }
+        })
+        .collect::<Vec<_>>();
+    let [old_function] = old_matches.as_slice() else {
+        return if old_matches.is_empty() {
+            FunctionRenameResolution::NotRenamed
+        } else {
+            FunctionRenameResolution::Ambiguous(Vec::new())
+        };
+    };
+
+    let old_identities = old_functions
+        .iter()
+        .map(FunctionDef::qualified_name)
+        .collect::<BTreeSet<_>>();
+    let old_normalized =
+        normalized_function_for_matching(&old_function.content, &old_function.name);
+    let mut candidates = new_functions
+        .iter()
+        .filter(|function| function.container == old_function.container)
+        .filter(|function| function.name != old_function.name)
+        .filter(|function| !old_identities.contains(&function.qualified_name()))
+        .filter_map(|function| {
+            let new_normalized =
+                normalized_function_for_matching(&function.content, &function.name);
+            let confidence = compute_similarity_with_language(
+                &old_normalized,
+                &new_normalized,
+                similarity_method,
+                language,
+            );
+            (confidence >= FUNCTION_RENAME_CANDIDATE_THRESHOLD).then(|| FunctionRenameCandidate {
+                new_name: if qualified {
+                    function.qualified_name()
+                } else {
+                    function.name.clone()
+                },
+                confidence,
+            })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        right
+            .confidence
+            .total_cmp(&left.confidence)
+            .then_with(|| left.new_name.cmp(&right.new_name))
+    });
+
+    let Some(best) = candidates.first() else {
+        return FunctionRenameResolution::NotRenamed;
+    };
+    let clear_lead = candidates.get(1).is_none_or(|runner_up| {
+        best.confidence - runner_up.confidence >= FUNCTION_RENAME_CONFIDENCE_MARGIN
+    });
+    if best.confidence >= FUNCTION_RENAME_SIMILARITY_THRESHOLD && clear_lead {
+        FunctionRenameResolution::Renamed(best.clone())
+    } else {
+        FunctionRenameResolution::Ambiguous(candidates)
+    }
 }
 
 pub(crate) fn detect_function_changes_with_parsed(

--- a/crates/semantic/src/analysis/analysis_functions.rs
+++ b/crates/semantic/src/analysis/analysis_functions.rs
@@ -18,6 +18,8 @@ const FUNCTION_RENAME_CONFIDENCE_MARGIN: f64 = 0.05;
 pub struct FunctionRenameCandidate {
     pub new_name: String,
     pub confidence: f64,
+    /// Whether bytes other than the consistently renamed function name changed.
+    pub body_changed: bool,
 }
 
 /// Conservative result for resolving one function rename.
@@ -204,6 +206,8 @@ pub fn resolve_function_rename(
                     function.name.clone()
                 },
                 confidence,
+                body_changed: renamed_function_content(&old_function.content, &old_function.name)
+                    != renamed_function_content(&function.content, &function.name),
             })
         })
         .collect::<Vec<_>>();
@@ -562,11 +566,14 @@ fn stable_order_moved_names(
 }
 
 fn normalized_function_for_matching(content: &str, name: &str) -> String {
-    content
-        .replace(name, "__function_name__")
+    renamed_function_content(content, name)
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn renamed_function_content(content: &str, name: &str) -> String {
+    content.replace(name, "__function_name__")
 }

--- a/crates/semantic/src/analysis/analysis_tests.rs
+++ b/crates/semantic/src/analysis/analysis_tests.rs
@@ -504,8 +504,27 @@ fn discussion_anchor_function_rename_requires_one_clear_semantic_target() {
             "foo",
             SimilarityMethod::Lines,
         ),
-        FunctionRenameResolution::Renamed(FunctionRenameCandidate { new_name, .. })
-            if new_name == "bar"
+        FunctionRenameResolution::Renamed(FunctionRenameCandidate {
+            new_name,
+            body_changed: false,
+            ..
+        }) if new_name == "bar"
+    ));
+
+    let renamed_and_edited = "fn bar() {\n    let value = 43;\n    println!(\"{}\", value);\n}\n";
+    assert!(matches!(
+        resolve_function_rename(
+            std::path::Path::new("test.rs"),
+            old,
+            renamed_and_edited,
+            "foo",
+            SimilarityMethod::Lines,
+        ),
+        FunctionRenameResolution::Renamed(FunctionRenameCandidate {
+            new_name,
+            body_changed: true,
+            ..
+        }) if new_name == "bar"
     ));
 
     let ambiguous = concat!(

--- a/crates/semantic/src/analysis/analysis_tests.rs
+++ b/crates/semantic/src/analysis/analysis_tests.rs
@@ -493,6 +493,49 @@ fn test_detect_function_changes_rename() {
 }
 
 #[test]
+fn discussion_anchor_function_rename_requires_one_clear_semantic_target() {
+    let old = "fn foo() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n";
+    let renamed = "fn bar() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n";
+    assert!(matches!(
+        resolve_function_rename(
+            std::path::Path::new("test.rs"),
+            old,
+            renamed,
+            "foo",
+            SimilarityMethod::Lines,
+        ),
+        FunctionRenameResolution::Renamed(FunctionRenameCandidate { new_name, .. })
+            if new_name == "bar"
+    ));
+
+    let ambiguous = concat!(
+        "fn bar() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+        "fn baz() {\n    let value = 42;\n    println!(\"{}\", value);\n}\n",
+    );
+    assert!(matches!(
+        resolve_function_rename(
+            std::path::Path::new("test.rs"),
+            old,
+            ambiguous,
+            "foo",
+            SimilarityMethod::Lines,
+        ),
+        FunctionRenameResolution::Ambiguous(candidates) if candidates.len() == 2
+    ));
+
+    assert_eq!(
+        resolve_function_rename(
+            std::path::Path::new("test.rs"),
+            old,
+            "",
+            "foo",
+            SimilarityMethod::Lines,
+        ),
+        FunctionRenameResolution::NotRenamed
+    );
+}
+
+#[test]
 fn test_detect_function_changes_prefers_stable_best_rename_candidate() {
     let old = concat!(
         "fn alpha() {\n",

--- a/crates/semantic/src/analysis/mod.rs
+++ b/crates/semantic/src/analysis/mod.rs
@@ -17,8 +17,11 @@ pub use analysis_aggregate::{
 };
 pub(crate) use analysis_classify::classify_with_parsed;
 pub use analysis_classify::{classify_modification, classify_modification_with_confidence};
-pub use analysis_functions::detect_function_changes;
 pub(crate) use analysis_functions::detect_function_changes_with_parsed;
+pub use analysis_functions::{
+    FunctionRenameCandidate, FunctionRenameResolution, detect_function_changes,
+    resolve_function_rename,
+};
 pub(crate) use analysis_imports::detect_import_changes_with_parsed;
 pub use analysis_imports::{detect_import_changes, detect_import_changes_with_manifest};
 pub use analysis_renames::detect_file_renames;

--- a/crates/semantic/src/lib.rs
+++ b/crates/semantic/src/lib.rs
@@ -14,11 +14,11 @@ pub mod semantic_index;
 pub mod symbol_resolver;
 
 pub use analysis::{
-    AggregateKind, AggregatedChange, AggregationResult, HotEventKind, HotSpot, HotSpotKey,
-    HotSpotKeyValue, HotSpotParams, HotSpotsReport, SimilarityMethod, aggregate_changes,
-    analyze_actor_histogram, analyze_hot_spots, classify_modification,
-    classify_modification_with_confidence, compute_similarity, detect_file_renames,
-    detect_function_changes,
+    AggregateKind, AggregatedChange, AggregationResult, FunctionRenameCandidate,
+    FunctionRenameResolution, HotEventKind, HotSpot, HotSpotKey, HotSpotKeyValue, HotSpotParams,
+    HotSpotsReport, SimilarityMethod, aggregate_changes, analyze_actor_histogram,
+    analyze_hot_spots, classify_modification, classify_modification_with_confidence,
+    compute_similarity, detect_file_renames, detect_function_changes, resolve_function_rename,
 };
 pub use cache::{SemanticParseCache, SemanticParseCacheStats};
 pub use diff::{


### PR DESCRIPTION
Closes #1578

## Summary

- add a conservative semantic function-rename resolver with explicit ambiguous and not-renamed outcomes
- rebind and persist discussion anchors for high-confidence in-file renames while preserving the original anchor for ambiguous matches
- project append-only discussion anchors against current state so discuss show follows the renamed symbol
- surface ambiguous/current/moved/orphaned anchor state and regenerate client schemas

The shared file-rename detector and context records are unchanged.

## Tests

- cargo test -p heddle-object-model -p heddle-semantic -p heddle-repo --features heddle-repo/tree-sitter-symbols discussion -- --nocapture
- cargo test -p heddle-cli --test cli_workflow discuss_anchor_travel::discuss_show_follows_an_in_file_symbol_rename -- --exact --nocapture
- cargo test -p heddle-cli --test cli_workflow discuss_carry_forward::discussion_identity_survives_source_state_advance -- --exact --nocapture
- cargo test -p heddle-docsgen committed_corpus_is_fresh -- --nocapture
- cargo test -p heddle-cli --test ts_types_in_sync generated_typescript_is_in_sync -- --nocapture
- cargo check -p heddle-cli --no-default-features --features git-overlay,native,local,zstd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790396735&installation_model_id=21489&pr_number=1581&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1581&signature=bb6b31fb1c55048807bcff6891458a60fea661bee7d7fb67a4b448390cec7964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->