### PR TITLE
Add last-turn as a diff base

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -16899,6 +16899,12 @@
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "base": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "broader_guidance": {
           "items": {
             "$ref": "#/$defs/ContextSnippet"
@@ -30024,6 +30030,13 @@
             "$ref": "#/$defs/SignalView"
           },
           "type": "array"
+        },
+        "base": {
+          "description": "Named comparison base selected for the existing review payload.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "discussions": {
           "items": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -977,6 +977,7 @@ export interface DiffChangesGroupedSchema {
 export type DiffChangesSchema = DiffChangesGroupedSchema | FileChange[];
 
 export interface DiffReport {
+  base?: string | null;
   broader_guidance?: ContextSnippet[] | null;
   changed_path_count: number;
   changes: DiffChangesSchema;
@@ -2165,6 +2166,8 @@ export interface ReviewNextSchema {
 export interface ReviewShowSchema {
   agent_narrative?: string | null;
   all_signals: SignalView[];
+  /** Named comparison base selected for the existing review payload. */
+  base?: string | null;
   discussions: DiscussionView[];
   files_changed: number;
   headline: string;

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -501,6 +501,7 @@ pub struct TimelineRecordFinishArgs {
 #[command(after_help = "\
 Examples:
   heddle diff                     # worktree vs HEAD
+  heddle diff --base last-turn    # worktree vs this agent peer's turn start
   heddle diff NOTES.md            # only that path
   heddle diff -- NOTES.md         # same, after the path separator
   heddle diff --path NOTES.md     # same, explicit path filter
@@ -524,6 +525,12 @@ pub struct DiffArgs {
 
     /// Target state (default: worktree). A path-shaped value is a worktree filter.
     pub to: Option<String>,
+
+    /// Select an additional diff base. `last-turn` uses the first capture in
+    /// the live harness session on this thread. With this set, one state
+    /// positional names the target rather than another base.
+    #[arg(long, value_enum)]
+    pub base: Option<DiffBaseArg>,
 
     /// Restrict the diff to these repository-relative paths.
     #[arg(long = "path", value_name = "PATH")]
@@ -556,6 +563,21 @@ pub struct DiffArgs {
     /// Output a Git-compatible unified diff.
     #[arg(short = 'p', long = "patch")]
     pub patch: bool,
+}
+
+/// Named bases shared by `diff` and review change selection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum DiffBaseArg {
+    /// First capture in the current harness session on this thread.
+    LastTurn,
+}
+
+impl DiffBaseArg {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LastTurn => "last-turn",
+        }
+    }
 }
 
 /// Arguments for the `revert` command.

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -260,6 +260,7 @@ Examples:
     #[command(after_help = "\
 Examples:
   heddle review show HEAD                                # render the review payload for HEAD
+  heddle review show HEAD --base last-turn               # review this agent peer's turn
   heddle review sign HEAD --kind read --public-key <hex> --signature <hex> --signed-at-unix <ts>
   heddle review health --window 7                       # signal fire-rates over recent states
 ")]

--- a/crates/cli-args/src/cli/cli_args/commands_review.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_review.rs
@@ -3,6 +3,8 @@
 
 use clap::{Args, Subcommand, ValueEnum};
 
+use super::DiffBaseArg;
+
 #[derive(Clone, Debug, Subcommand)]
 pub enum ReviewCommands {
     /// Render the review payload for a state.
@@ -19,6 +21,10 @@ pub enum ReviewCommands {
 pub struct ReviewShowArgs {
     /// State to review. Defaults to HEAD.
     pub state: Option<String>,
+    /// Select the change-list base. `last-turn` uses the first capture in the
+    /// live harness session on this thread.
+    #[arg(long, value_enum)]
+    pub base: Option<DiffBaseArg>,
     /// Include hidden signals beyond the in-budget set.
     #[arg(long)]
     pub all_signals: bool,

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -41,7 +41,7 @@ pub use commands_args::{
     AgentProvenanceListArgs, AgentProvenanceSegmentArgs, AgentProvenanceShowArgs, AgentReadyArgs,
     AgentReleaseArgs, AgentReleaseStatusArg, AgentReserveArgs, AgentTaskCreateArgs,
     AgentTaskListArgs, AgentTaskShowArgs, AgentTaskStatusArg, AgentTaskUpdateArgs, CloneArgs,
-    CollapseArgs, CommitArgs, DiffArgs, DoctorArgs, DoctorCommands, DoctorDocsArgs,
+    CollapseArgs, CommitArgs, DiffArgs, DiffBaseArg, DoctorArgs, DoctorCommands, DoctorDocsArgs,
     DoctorSchemasArgs, ExpandArgs, INIT_VERB, InitArgs, LandArgs, LogArgs, PullArgs, PushArgs,
     ReadyArgs, ResolveArgs, RevertArgs, SnapshotArgs, SyncArgs, ThreadAbsorbArgs,
     ThreadApprovalsArgs, ThreadApproveArgs, ThreadCapturesArgs, ThreadCheckMergeArgs,

--- a/crates/cli-contract/src/cli/commands/wire/collab.rs
+++ b/crates/cli-contract/src/cli/commands/wire/collab.rs
@@ -45,15 +45,23 @@ pub enum AnchorOutput {
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum ResolutionOutput {
-    AddressedByState { state_id: String },
-    AddressedByChange { change_id: String },
-    Dismissed { reason: String },
+    AddressedByState {
+        state_id: String,
+    },
+    AddressedByChange {
+        change_id: String,
+    },
+    Dismissed {
+        reason: String,
+    },
     IntoAnnotation {
         annotation_kind: String,
         content: String,
         tags: Vec<String>,
     },
-    Annotation { annotation_id: String },
+    Annotation {
+        annotation_id: String,
+    },
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -97,6 +105,9 @@ pub struct DiscussionListOutput {
 pub struct ReviewShowOutput {
     pub output_kind: &'static str,
     pub state_id: String,
+    /// Named comparison base selected for the existing review payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
     pub headline: String,
     pub agent_narrative: Option<String>,
     pub files_changed: u32,

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -25,7 +25,9 @@ use super::{
     diff_paths::classify_diff_refs,
 };
 use crate::{
-    cli::{Cli, execution_context_from_cli_parts, output_is_compact, should_output_json},
+    cli::{
+        Cli, DiffBaseArg, execution_context_from_cli_parts, output_is_compact, should_output_json,
+    },
     config::UserConfig,
 };
 
@@ -34,6 +36,7 @@ pub fn cmd_diff(
     cli: &Cli,
     from: Option<String>,
     to: Option<String>,
+    base: Option<DiffBaseArg>,
     path_filters: Vec<String>,
     trailing_paths: Vec<String>,
     semantic: bool,
@@ -49,15 +52,22 @@ pub fn cmd_diff(
     let mut extra_paths = path_filters;
     extra_paths.extend(trailing_paths);
     let classified = classify_diff_refs(start, opened.as_ref(), from, to, extra_paths);
-    let from = classified.from;
-    let to = classified.to;
+    let mut from = classified.from;
+    let mut to = classified.to;
+    // With a named base, the first state positional is the target. This keeps
+    // the existing positional grammar useful without making `last-turn` look
+    // like a state id. Path-shaped values were moved into `classified.paths`.
+    if base.is_some() && to.is_none() {
+        to = from.take();
+    }
     let paths = classified.paths;
     let from_is_head_or_default = from
         .as_deref()
         .map(|spec| matches!(spec, "HEAD" | "@"))
         .unwrap_or(true);
 
-    if opened.is_none()
+    if base.is_none()
+        && opened.is_none()
         && to.is_none()
         && from_is_head_or_default
         && let Some(probe) = build_plain_git_verification_probe(start)?
@@ -68,6 +78,7 @@ pub fn cmd_diff(
         let options = diff_options(
             from,
             to,
+            base,
             paths,
             semantic,
             stat,
@@ -97,6 +108,7 @@ pub fn cmd_diff(
     let options = diff_options(
         from.clone(),
         to.clone(),
+        base,
         paths,
         semantic,
         stat,
@@ -107,7 +119,8 @@ pub fn cmd_diff(
         json,
     );
 
-    if let Some(trust) = trust.as_ref()
+    if base.is_none()
+        && let Some(trust) = trust.as_ref()
         && to.is_none()
         && from_is_head_or_default
         && let Some(status) = trust_visible_worktree_status(&repo, trust)?
@@ -123,7 +136,8 @@ pub fn cmd_diff(
             patch,
         );
     }
-    if to.is_none()
+    if base.is_none()
+        && to.is_none()
         && from_is_head_or_default
         && trust
             .as_ref()
@@ -172,6 +186,7 @@ pub fn cmd_diff(
 fn diff_options(
     from: Option<String>,
     to: Option<String>,
+    base: Option<DiffBaseArg>,
     paths: Vec<String>,
     semantic: bool,
     stat: bool,
@@ -184,6 +199,9 @@ fn diff_options(
     DiffOptions {
         from,
         to,
+        base: base.map(|base| match base {
+            DiffBaseArg::LastTurn => verbs::DiffBase::LastTurn,
+        }),
         semantic,
         stat,
         name_only,

--- a/crates/cli/src/cli/commands/review.rs
+++ b/crates/cli/src/cli/commands/review.rs
@@ -8,9 +8,12 @@ use objects::object::{
     Discussion, DiscussionResolution, ReviewKind, ReviewScope, StateId, SymbolAnchor,
 };
 use repo::{HistoryQuery, operation_dedup::OperationDedupStore};
-use verbs::review::{
-    LocalReviewContext, LocalStateReview, ReviewSignal, ReviewSignalKind, ReviewSignalVisibility,
-    SignReviewRequest, get_repo_signal_health,
+use verbs::{
+    resolve_last_turn_base,
+    review::{
+        LocalReviewContext, LocalStateReview, ReviewSignal, ReviewSignalKind,
+        ReviewSignalVisibility, SignReviewRequest, get_repo_signal_health,
+    },
 };
 
 use super::{
@@ -20,7 +23,8 @@ use super::{
 };
 use crate::cli::{
     cli_args::{
-        Cli, ReviewCommands, ReviewHealthArgs, ReviewNextArgs, ReviewShowArgs, ReviewSignArgs,
+        Cli, DiffBaseArg, ReviewCommands, ReviewHealthArgs, ReviewNextArgs, ReviewShowArgs,
+        ReviewSignArgs,
     },
     should_output_json,
 };
@@ -47,7 +51,14 @@ pub async fn run(cli: &Cli, command: &ReviewCommands) -> Result<()> {
 async fn run_show(cli: &Cli, args: &ReviewShowArgs) -> Result<()> {
     let review = open_local_review(cli)?;
     let state_id = resolve_state(cli, args.state.as_deref())?;
-    let payload = review.get_review_payload(state_id, args.all_signals)?;
+    let base_state_id = match args.base {
+        Some(DiffBaseArg::LastTurn) => {
+            let repo = cli.open_repo()?;
+            Some(resolve_last_turn_base(&repo, state_id)?)
+        }
+        None => None,
+    };
+    let payload = review.get_review_payload_from(state_id, args.all_signals, base_state_id)?;
     let stored_signatures = review.list_signatures(state_id)?;
 
     let signatures: Vec<SignatureView> = stored_signatures
@@ -82,6 +93,7 @@ async fn run_show(cli: &Cli, args: &ReviewShowArgs) -> Result<()> {
     let output = ReviewShowOutput {
         output_kind: "review_show",
         state_id: payload.state_id.to_string_full(),
+        base: args.base.map(|base| base.as_str().to_string()),
         headline: payload.summary.headline,
         agent_narrative: payload.agent_narrative,
         files_changed: payload.summary.files_changed,
@@ -108,6 +120,9 @@ async fn run_show(cli: &Cli, args: &ReviewShowArgs) -> Result<()> {
 
 fn render_text(out: &ReviewShowOutput, all_signals: bool) {
     println!("review of state {}", out.state_id);
+    if let Some(base) = &out.base {
+        println!("  base: {base}");
+    }
     if !out.headline.is_empty() {
         println!("  {}", out.headline);
     }

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -884,6 +884,7 @@ fn build_capture_attribution(
         return Ok(verbs::CaptureAttribution {
             attribution: Attribution::human(principal),
             principal_source,
+            harness_session_id: None,
         });
     }
 
@@ -891,6 +892,7 @@ fn build_capture_attribution(
     // repo/user `agent.model` after a cursor miss. Cursor/Grok stay
     // `agent=null`. Never invent a model.
     let frozen = crate::identity_freeze::freeze_identity_for_capture(repo).unwrap_or_default();
+    let harness_session_id = frozen.session.clone();
     let current_session = SessionManager::new(repo.root()).get_current_session()?;
     let provider = agent
         .provider
@@ -959,6 +961,7 @@ fn build_capture_attribution(
     Ok(verbs::CaptureAttribution {
         attribution,
         principal_source,
+        harness_session_id,
     })
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -524,6 +524,7 @@ async fn async_main() -> Result<()> {
         Commands::Diff(DiffArgs {
             from,
             to,
+            base,
             path_filters,
             paths,
             semantic,
@@ -536,6 +537,7 @@ async fn async_main() -> Result<()> {
             &cli,
             from.clone(),
             to.clone(),
+            *base,
             path_filters.clone(),
             paths.clone(),
             *semantic,

--- a/crates/cli/tests/cli_basics.rs
+++ b/crates/cli/tests/cli_basics.rs
@@ -24,6 +24,8 @@ mod harness_error_surface;
 mod identity_resolution;
 #[path = "cli_integration/ignore_mechanics.rs"]
 mod ignore_mechanics;
+#[path = "cli_integration/last_turn_diff.rs"]
+mod last_turn_diff;
 #[path = "cli_integration/misc.rs"]
 mod misc;
 #[path = "cli_integration/perf_adopt.rs"]

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -260,6 +260,12 @@ fn diff_help_explains_git_compatible_patch_headers() {
             && help.contains("extended headers for type and mode changes"),
         "diff help should explain its patch format and extended headers: {help}"
     );
+    assert!(
+        help.contains("--base <BASE>")
+            && help.contains("last-turn")
+            && help.contains("this agent peer's turn start"),
+        "diff help should name the last-turn base and its meaning: {help}"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/last_turn_diff.rs
+++ b/crates/cli/tests/cli_integration/last_turn_diff.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Last-turn diff/review bases are anchored by the live harness session stamp.
+
+use std::{fs, path::Path};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{heddle_env, heddle_output_env, heddle_output_with_stdin};
+
+fn init_with_human_base() -> TempDir {
+    let temp = TempDir::new().expect("tempdir");
+    heddle_env(&["init"], Some(temp.path()), &[]).expect("init");
+    fs::write(temp.path().join("base.txt"), "base\n").expect("write human base");
+    heddle_env(&["capture", "-m", "human base"], Some(temp.path()), &[]).expect("capture base");
+    temp
+}
+
+fn stamp_session(repo: &Path, session_id: &str) {
+    let payload = format!(r#"{{"model":"gpt-5.6-sol","session_id":"{session_id}"}}"#);
+    let output =
+        heddle_output_with_stdin(&["integration", "stamp", "codex"], repo, payload.as_str())
+            .expect("run harness stamp");
+    assert!(
+        output.status.success(),
+        "stamp failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn capture_json(repo: &Path, path: &str, message: &str) -> Value {
+    fs::write(repo.join(path), format!("{message}\n")).expect("write capture file");
+    let raw = heddle_env(
+        &["capture", "-m", message, "--output", "json"],
+        Some(repo),
+        &[],
+    )
+    .expect("capture");
+    serde_json::from_str(&raw).expect("capture JSON")
+}
+
+fn changed_paths(diff: &Value) -> Vec<&str> {
+    let changes = &diff["changes"];
+    let entries: Vec<&Value> = if let Some(flat) = changes.as_array() {
+        flat.iter().collect()
+    } else {
+        ["modified", "added", "deleted"]
+            .into_iter()
+            .flat_map(|kind| {
+                changes[kind]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    };
+    entries
+        .into_iter()
+        .filter_map(|entry| entry["path"].as_str())
+        .collect()
+}
+
+#[test]
+fn two_agent_captures_in_one_session_anchor_last_turn_to_the_first() {
+    let temp = init_with_human_base();
+    stamp_session(temp.path(), "session-a");
+    let first = capture_json(temp.path(), "first.txt", "first agent capture");
+    capture_json(temp.path(), "second.txt", "second agent capture");
+    fs::write(temp.path().join("dirty.txt"), "dirty\n").expect("write dirty file");
+
+    let raw = heddle_env(
+        &["diff", "--base", "last-turn", "--output", "json"],
+        Some(temp.path()),
+        &[],
+    )
+    .expect("last-turn diff");
+    let diff: Value = serde_json::from_str(&raw).expect("diff JSON");
+    assert_eq!(diff["base"], "last-turn");
+    assert_eq!(diff["from_state"], first["state_id"]);
+    let paths = changed_paths(&diff);
+    assert!(
+        paths.contains(&"second.txt"),
+        "second capture missing: {diff}"
+    );
+    assert!(paths.contains(&"dirty.txt"), "dirty change missing: {diff}");
+    assert!(!paths.contains(&"first.txt"), "base capture leaked: {diff}");
+
+    let raw = heddle_env(
+        &["diff", "--base", "last-turn", "HEAD", "--output", "json"],
+        Some(temp.path()),
+        &[],
+    )
+    .expect("last-turn state target diff");
+    let captured_diff: Value = serde_json::from_str(&raw).expect("target diff JSON");
+    assert_eq!(captured_diff["from_state"], first["state_id"]);
+    assert_eq!(changed_paths(&captured_diff), vec!["second.txt"]);
+
+    let raw = heddle_env(
+        &[
+            "review",
+            "show",
+            "HEAD",
+            "--base",
+            "last-turn",
+            "--output",
+            "json",
+        ],
+        Some(temp.path()),
+        &[],
+    )
+    .expect("last-turn review");
+    let review: Value = serde_json::from_str(&raw).expect("review JSON");
+    assert_eq!(review["base"], "last-turn");
+    assert_eq!(review["files_changed"], 1);
+}
+
+#[test]
+fn new_harness_session_starts_a_new_last_turn_base() {
+    let temp = init_with_human_base();
+    stamp_session(temp.path(), "session-a");
+    capture_json(temp.path(), "session-a.txt", "session a capture");
+
+    stamp_session(temp.path(), "session-b");
+    let session_b = capture_json(temp.path(), "session-b.txt", "session b capture");
+    fs::write(temp.path().join("after-b.txt"), "after b\n").expect("write dirty file");
+
+    let raw = heddle_env(
+        &["diff", "--base", "last-turn", "--output", "json"],
+        Some(temp.path()),
+        &[],
+    )
+    .expect("session b last-turn diff");
+    let diff: Value = serde_json::from_str(&raw).expect("diff JSON");
+    assert_eq!(diff["from_state"], session_b["state_id"]);
+    let paths = changed_paths(&diff);
+    assert_eq!(paths, vec!["after-b.txt"]);
+}
+
+#[test]
+fn human_only_dirty_worktree_has_no_last_turn_base() {
+    let temp = init_with_human_base();
+    fs::write(temp.path().join("human-dirty.txt"), "dirty\n").expect("write dirty file");
+
+    let output = heddle_output_env(&["diff", "--base", "last-turn"], Some(temp.path()), &[])
+        .expect("run refused diff");
+    assert!(!output.status.success(), "last-turn must fail closed");
+    let diagnostic = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        diagnostic.contains("no agent turn") && diagnostic.contains("last-turn"),
+        "refusal should name the missing base: {diagnostic}"
+    );
+}

--- a/crates/cli/tests/support/mod.rs
+++ b/crates/cli/tests/support/mod.rs
@@ -32,6 +32,7 @@ pub fn heddle_output_env(
         if key.starts_with("CODEX_")
             || key.starts_with("CLAUDE")
             || key.starts_with("OPENCODE_")
+            || key.starts_with("PI_")
             || matches!(key.as_ref(), "HEDDLE_AGENT_PROVIDER" | "HEDDLE_AGENT_MODEL")
         {
             command.env_remove(key.as_ref());
@@ -98,10 +99,9 @@ pub use objects::store::ObjectStore;
 pub use repo::Repository;
 pub use serde_json::Value;
 pub use sley::{
-    CommitObject, EntryKind, GitObjectType, GitTime, ObjectId, RefPrecondition, ReferenceTarget,
-    Repository as SleyRepository, Signature, TagObject,
+    BString as GitByteString, CommitObject, EntryKind, GitObjectType, GitTime, ObjectId,
+    RefPrecondition, ReferenceTarget, Repository as SleyRepository, Signature, TagObject,
     plumbing::{sley_object::EncodedObject, sley_refs::ReflogEntry},
-    BString as GitByteString,
 };
 pub use tempfile::TempDir;
 

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -18,10 +18,11 @@
 //! write `**/<name>` explicitly.
 //!
 //! Root `.heddle/` and pointer-checkout cursor files (`.heddle.identity`,
-//! `.identity.lock`, `.identity.tmp.*`) are reserved-path hard-denies
-//! evaluated after user rules. A later `!.heddle/` (or similar) cannot
-//! un-ignore identity material. Nested fixture `.heddle/` trees are not
-//! reserved.
+//! `.heddle.last-turn`,
+//! `.identity.lock`, `.identity.tmp.*`, `.last-turn.tmp.*`) are reserved-path
+//! hard-denies evaluated after user rules. A later `!.heddle/` (or similar)
+//! cannot un-ignore identity material. Nested fixture `.heddle/` trees are
+//! not reserved.
 
 use std::path::Path;
 

--- a/crates/objects/src/worktree/worktree_reserved.rs
+++ b/crates/objects/src/worktree/worktree_reserved.rs
@@ -3,10 +3,10 @@
 //!
 //! Root `.heddle/` holds identity material (`identity.toml`), credentials,
 //! and repository-engine state. Pointer checkout also writes cursor files
-//! beside the `.heddle` file (`.heddle.identity`, `.identity.lock`,
-//! `.identity.tmp.*`). Gitignore last-match-wins would otherwise let
-//! `!.heddle/` pull that tree into capture. Nested `.heddle/` directories
-//! (fixtures) stay ordinary content.
+//! beside the `.heddle` file (`.heddle.identity`, `.heddle.last-turn`,
+//! `.identity.lock`, `.identity.tmp.*`, `.last-turn.tmp.*`). Gitignore
+//! last-match-wins would otherwise let `!.heddle/` pull that tree into
+//! capture. Nested `.heddle/` directories (fixtures) stay ordinary content.
 
 use std::path::{Component, Path};
 
@@ -37,9 +37,11 @@ fn is_reserved_root_name(name: &std::ffi::OsStr) -> bool {
     };
     name == ".heddle"
         || name == ".heddle.identity"
+        || name == ".heddle.last-turn"
         || name == ".identity.lock"
         || name == ".identity.tmp"
         || name.starts_with(".identity.tmp.")
+        || name.starts_with(".last-turn.tmp.")
 }
 
 fn is_worktree_root(path: &Path) -> bool {
@@ -84,9 +86,11 @@ mod tests {
         for path in [
             ".heddle.identity",
             "./.heddle.identity",
+            ".heddle.last-turn",
             ".identity.lock",
             ".identity.tmp.123.0",
             ".identity.tmp",
+            ".last-turn.tmp.123.0",
         ] {
             assert!(
                 is_reserved_worktree_path(Path::new(path)),
@@ -106,6 +110,7 @@ mod tests {
             "examples/calculator/.heddle/identity.toml",
             "examples/calculator/.heddle",
             "examples/foo/.heddle.identity",
+            "examples/foo/.heddle.last-turn",
             "examples/foo/.identity.lock",
             "src/.identity.tmp.1.2",
             "../.heddle/identity.toml",

--- a/crates/repo/src/overlay.rs
+++ b/crates/repo/src/overlay.rs
@@ -43,8 +43,10 @@ const GIT_CHECKPOINT_INTENT_FILE: &str = "git-checkpoint-intent.json";
 const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[
     ".heddle/",
     ".heddle.identity",
+    ".heddle.last-turn",
     ".identity.lock",
     ".identity.tmp.*",
+    ".last-turn.tmp.*",
 ];
 
 #[derive(Debug)]

--- a/crates/verbs/src/diff/mod.rs
+++ b/crates/verbs/src/diff/mod.rs
@@ -10,6 +10,7 @@ use anyhow::{Result, anyhow};
 use merge::RenameCandidateIndex;
 use objects::{
     HeddleError, RecoveryDetails,
+    lock::RepositoryLockExt,
     object::{
         Blob, ContentHash, DiffKind, EntryType, FileChangeSet, FileMode, SemanticChange, State,
         StateId, Tree, TreeEntry,
@@ -24,7 +25,10 @@ use repo::{
 use semantic::diff::{SemanticDiffOptions, WorktreeStatus as SemanticWorktreeStatus};
 use sley::{EntryKind, Repository as SleyRepository};
 
-use crate::ExecutionContext;
+use crate::{
+    ExecutionContext, LastTurnAnchor, read_identity_cursor, read_last_turn_anchor,
+    write_last_turn_anchor,
+};
 
 mod context;
 mod patch;
@@ -38,6 +42,20 @@ pub use types::*;
 const BINARY_DIFF_ERROR: &str = "binary file";
 const RENAME_SIMILARITY_THRESHOLD: f64 = 0.75;
 
+/// A named comparison base that is resolved from repository metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiffBase {
+    LastTurn,
+}
+
+impl DiffBase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::LastTurn => "last-turn",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 struct SemanticDiffResult {
     changes: Vec<SemanticChange>,
@@ -49,6 +67,7 @@ struct SemanticDiffResult {
 pub struct DiffOptions {
     pub from: Option<String>,
     pub to: Option<String>,
+    pub base: Option<DiffBase>,
     pub semantic: bool,
     pub stat: bool,
     pub name_only: bool,
@@ -67,6 +86,7 @@ impl Default for DiffOptions {
         Self {
             from: None,
             to: None,
+            base: None,
             semantic: false,
             stat: false,
             name_only: false,
@@ -91,10 +111,30 @@ pub fn diff(ctx: &ExecutionContext, options: DiffOptions) -> Result<DiffReport> 
     let to = options.to.as_ref();
     let git_overlay_head_worktree_diff = repo.current_state()?.is_none()
         && to.is_none()
+        && options.base.is_none()
         && matches!(options.from.as_deref(), Some("HEAD" | "@"));
+
+    let to_state = if let Some(to_spec) = to {
+        let to_id = resolve_state_id(repo, to_spec)?;
+        Some(require_resolved_state(repo, &to_id)?)
+    } else {
+        None
+    };
 
     let from_id = if git_overlay_head_worktree_diff {
         None
+    } else if options.base == Some(DiffBase::LastTurn) {
+        if options.from.is_some() {
+            return Err(anyhow!(
+                "--base last-turn cannot be combined with an explicit from state"
+            ));
+        }
+        let target = to_state
+            .as_ref()
+            .map(|state| state.state_id)
+            .or(repo.head()?)
+            .ok_or_else(|| anyhow!("no agent turn is available for the last-turn base"))?;
+        Some(resolve_last_turn_base(repo, target)?)
     } else if let Some(ref spec) = options.from {
         Some(resolve_state_id(repo, spec)?)
     } else {
@@ -109,12 +149,6 @@ pub fn diff(ctx: &ExecutionContext, options: DiffOptions) -> Result<DiffReport> 
 
     let from_tree = if let Some(ref state) = from_state {
         repo.store().get_tree(&state.tree)?
-    } else {
-        None
-    };
-    let to_state = if let Some(to_spec) = to {
-        let to_id = resolve_state_id(repo, to_spec)?;
-        Some(require_resolved_state(repo, &to_id)?)
     } else {
         None
     };
@@ -198,12 +232,76 @@ pub fn diff(ctx: &ExecutionContext, options: DiffOptions) -> Result<DiffReport> 
         None,
         stats,
     );
+    output.base = options.base.map(DiffBase::as_str);
     output.worktree_mode = options.to.is_none();
     let mut output = finalize_diff_report(output, &options)?;
     if let Some(state) = context_state.as_ref() {
         attach_show_context(repo, &mut output, state, &options.paths)?;
     }
     Ok(output)
+}
+
+/// Record the first successful capture in a live harness session. A matching
+/// anchor is retained only while it remains on this thread's first-parent
+/// chain; a new session or unrelated thread starts a new turn anchor.
+pub fn record_last_turn_capture(
+    repo: &Repository,
+    session_id: &str,
+    captured_state: StateId,
+) -> Result<()> {
+    let _guard = repo.locker().write()?;
+    let keep_existing = match read_last_turn_anchor(repo.root()) {
+        Some(anchor) if anchor.session_id == session_id => {
+            first_parent_contains(repo, captured_state, anchor.state_id)?
+        }
+        Some(_) | None => false,
+    };
+    if keep_existing {
+        return Ok(());
+    }
+    write_last_turn_anchor(
+        repo.root(),
+        &LastTurnAnchor {
+            session_id: session_id.to_string(),
+            state_id: captured_state,
+        },
+    )?;
+    Ok(())
+}
+
+/// Resolve `last-turn` against the live workspace stamp and the selected
+/// target's thread history. Every missing or stale link is refused.
+pub fn resolve_last_turn_base(repo: &Repository, target: StateId) -> Result<StateId> {
+    let session_id = read_identity_cursor(repo.root())
+        .session
+        .filter(|session| !session.trim().is_empty())
+        .ok_or_else(|| anyhow!("no agent turn is available for the last-turn base"))?;
+    let anchor = read_last_turn_anchor(repo.root())
+        .filter(|anchor| anchor.session_id == session_id)
+        .ok_or_else(|| anyhow!("no captured agent turn matches the last-turn session stamp"))?;
+    if repo.store().get_state(&anchor.state_id)?.is_none() {
+        return Err(anyhow!("the captured last-turn base state is unavailable"));
+    }
+    if !first_parent_contains(repo, target, anchor.state_id)? {
+        return Err(anyhow!(
+            "the last-turn base is not on the selected thread history"
+        ));
+    }
+    Ok(anchor.state_id)
+}
+
+fn first_parent_contains(repo: &Repository, start: StateId, expected: StateId) -> Result<bool> {
+    let mut current = Some(start);
+    while let Some(state_id) = current {
+        if state_id == expected {
+            return Ok(true);
+        }
+        let Some(state) = repo.store().get_state(&state_id)? else {
+            return Ok(false);
+        };
+        current = state.parents.first().copied();
+    }
+    Ok(false)
 }
 
 fn file_changes_from_change_set(

--- a/crates/verbs/src/diff/types.rs
+++ b/crates/verbs/src/diff/types.rs
@@ -15,6 +15,7 @@ use crate::{
 pub struct DiffReport {
     pub output_kind: &'static str,
     pub status: &'static str,
+    pub base: Option<&'static str>,
     pub from_state: Option<String>,
     pub to_state: Option<String>,
     pub changed_path_count: usize,
@@ -40,6 +41,8 @@ impl Serialize for DiffReport {
         struct DiffReportView<'a> {
             output_kind: &'static str,
             status: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            base: Option<&'static str>,
             from_state: &'a Option<String>,
             to_state: &'a Option<String>,
             changed_path_count: usize,
@@ -58,6 +61,7 @@ impl Serialize for DiffReport {
         DiffReportView {
             output_kind: self.output_kind,
             status: self.status,
+            base: self.base,
             from_state: &self.from_state,
             to_state: &self.to_state,
             changed_path_count: self.changed_path_count,
@@ -149,6 +153,7 @@ impl DiffReport {
         Self {
             output_kind: "diff",
             status: "completed",
+            base: None,
             changed_path_count: changes.len(),
             from_state,
             to_state,
@@ -182,6 +187,7 @@ impl HeddleReport for DiffReport {
 struct DiffReportSchema {
     pub output_kind: String,
     pub status: String,
+    pub base: Option<String>,
     pub from_state: Option<String>,
     pub to_state: Option<String>,
     pub changed_path_count: usize,

--- a/crates/verbs/src/identity_cursor.rs
+++ b/crates/verbs/src/identity_cursor.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use fs2::FileExt;
+use objects::object::StateId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -21,6 +22,14 @@ use crate::harness_json::{first_value_string, value_string};
 
 /// Sidecar file name under `.heddle/` (not `identity.toml`, the signing key).
 pub const IDENTITY_CURSOR_FILE: &str = "identity";
+const LAST_TURN_ANCHOR_FILE: &str = "last-turn";
+
+/// Workspace-local link between a live harness session and its first capture.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LastTurnAnchor {
+    pub session_id: String,
+    pub state_id: StateId,
+}
 
 /// ACP-named current identity. Omit unpublished fields.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,6 +135,46 @@ pub fn identity_cursor_path(repo_root: &Path) -> std::path::PathBuf {
     } else {
         marker.join(IDENTITY_CURSOR_FILE)
     }
+}
+
+/// Workspace-local last-turn anchor path. Pointer checkouts keep it beside
+/// `.heddle`, matching the identity cursor's isolation behavior.
+pub fn last_turn_anchor_path(repo_root: &Path) -> std::path::PathBuf {
+    let marker = repo_root.join(".heddle");
+    if marker.is_file() {
+        repo_root.join(".heddle.last-turn")
+    } else {
+        marker.join(LAST_TURN_ANCHOR_FILE)
+    }
+}
+
+/// Read the current last-turn anchor. Missing or malformed reconstructible
+/// metadata is treated as absent so callers fail closed.
+pub fn read_last_turn_anchor(repo_root: &Path) -> Option<LastTurnAnchor> {
+    let bytes = fs::read(last_turn_anchor_path(repo_root)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Atomically publish the first capture for a harness session.
+pub fn write_last_turn_anchor(repo_root: &Path, anchor: &LastTurnAnchor) -> io::Result<()> {
+    let dest = last_turn_anchor_path(repo_root);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    static LAST_TURN_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+    let tmp = dest.with_file_name(format!(
+        ".last-turn.tmp.{}.{}",
+        std::process::id(),
+        LAST_TURN_TMP_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let body = serde_json::to_vec(anchor)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    fs::write(&tmp, body)?;
+    let renamed = fs::rename(&tmp, &dest);
+    if renamed.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    renamed
 }
 
 /// Read the current cursor. Missing or unreadable → empty cursor.

--- a/crates/verbs/src/lib.rs
+++ b/crates/verbs/src/lib.rs
@@ -126,13 +126,14 @@ pub use context_plan::{
 pub use contract::{
     HeddleReport, MachineOutputKind, OutputDiscriminator, ReportContract, schema_for_report,
 };
+// The diff facade includes named bases so CLI and review consumers share one resolver.
 pub use diff::{
-    ContextSnippet, DiffOptions, DiffReport, DiffStats, FileChange, FileContextEntry, FileEolState,
-    LineCounts, LineDiff, PlainGitDiffProbe, SemanticChangeEntry, SymlinkChange,
+    ContextSnippet, DiffBase, DiffOptions, DiffReport, DiffStats, FileChange, FileContextEntry,
+    FileEolState, LineCounts, LineDiff, PlainGitDiffProbe, SemanticChangeEntry, SymlinkChange,
     attach_show_context, change_line_counts, compute_state_diff, compute_tree_diff, diff,
-    diff_worktree_status, plain_git_head_diff, render_diff_patch, render_diff_patch_bytes,
-    should_render_modified_pair, trim_added_decorations_for_display, worktree_context_state,
-    write_diff_patch,
+    diff_worktree_status, plain_git_head_diff, record_last_turn_capture, render_diff_patch,
+    render_diff_patch_bytes, resolve_last_turn_base, should_render_modified_pair,
+    trim_added_decorations_for_display, worktree_context_state, write_diff_patch,
 };
 pub use fsck::{FsckError, FsckOptions, FsckRepair, FsckReport, fsck};
 pub use gc_plan::{
@@ -160,9 +161,10 @@ pub use hook_plan::{
     hook_install_source_required_kind, hook_unknown_kind, plan_hook_install_source,
 };
 pub use identity_cursor::{
-    IDENTITY_CURSOR_FILE, IdentityCursor, expire_identity_cursor, harness_kind_from_basename,
-    identity_cursor_path, published_field, read_identity_cursor, stamp_identity_cursor,
-    thought_level_from_payload, value_string_or_named, write_identity_cursor,
+    IDENTITY_CURSOR_FILE, IdentityCursor, LastTurnAnchor, expire_identity_cursor,
+    harness_kind_from_basename, identity_cursor_path, last_turn_anchor_path, published_field,
+    read_identity_cursor, read_last_turn_anchor, stamp_identity_cursor, thought_level_from_payload,
+    value_string_or_named, write_identity_cursor, write_last_turn_anchor,
 };
 pub use identity_payload::{
     claude_cursor_patch, codex_cursor_patch, cursor_event_expires, cursor_patch_from_child_env,

--- a/crates/verbs/src/review/state_review.rs
+++ b/crates/verbs/src/review/state_review.rs
@@ -127,6 +127,17 @@ impl LocalStateReview {
         state_id: StateId,
         include_all_signals: bool,
     ) -> Result<ReviewPayload, LocalReviewError> {
+        self.get_review_payload_from(state_id, include_all_signals, None)
+    }
+
+    /// Build the existing review payload with an optional named change-list
+    /// base. `None` preserves state-vs-first-parent review behavior.
+    pub fn get_review_payload_from(
+        &self,
+        state_id: StateId,
+        include_all_signals: bool,
+        base_state_id: Option<StateId>,
+    ) -> Result<ReviewPayload, LocalReviewError> {
         let repo = self.inner.repo();
         let state = repo
             .store()
@@ -144,8 +155,8 @@ impl LocalStateReview {
         // signal registry / budgeter will eventually layer on top of
         // this; until then `files_changed` is the most useful single
         // number an agent can use for self-review.
-        let diff_summary =
-            compute_state_diff_summary(repo, &state).map_err(map_repository_error)?;
+        let diff_summary = compute_state_diff_summary(repo, &state, base_state_id)
+            .map_err(map_repository_error)?;
 
         let summary = ReviewSummary {
             headline: state.intent.clone().unwrap_or_default(),
@@ -726,9 +737,11 @@ struct DiffSummary {
 fn compute_state_diff_summary(
     repo: &Repository,
     state: &State,
+    base_state_id: Option<StateId>,
 ) -> objects::error::Result<DiffSummary> {
     use objects::object::Tree;
-    let parent_tree_hash = if let Some(parent_id) = state.parents.first() {
+    let parent_id = base_state_id.as_ref().or_else(|| state.parents.first());
+    let parent_tree_hash = if let Some(parent_id) = parent_id {
         match repo.store().get_state(parent_id)? {
             Some(parent_state) => parent_state.tree,
             None => Tree::new().hash(),

--- a/crates/verbs/src/save.rs
+++ b/crates/verbs/src/save.rs
@@ -64,6 +64,9 @@ pub struct CaptureOptions {
 pub struct CaptureAttribution {
     pub attribution: Attribution,
     pub principal_source: String,
+    /// Native harness session from the workspace identity stamp. This remains
+    /// distinct from Heddle `Session.id` and only advances the last-turn cursor.
+    pub harness_session_id: Option<String>,
 }
 
 /// Capture-specific timings owned by the operation implementation.
@@ -576,6 +579,12 @@ pub fn capture(
     let preflight_ms = preflight_started.elapsed().as_millis();
     let attribution_started = Instant::now();
     let resolved_attribution = resolve_attribution(repo)?;
+    let harness_session_id = resolved_attribution
+        .attribution
+        .agent
+        .is_some()
+        .then(|| resolved_attribution.harness_session_id.clone())
+        .flatten();
     let attribution_ms = attribution_started.elapsed().as_millis();
 
     let plan = SavePlan {
@@ -604,6 +613,11 @@ pub fn capture(
     let execute_save_started = Instant::now();
     let save = execute_save(repo, plan).map_err(map_capture_error)?;
     let execute_save_ms = execute_save_started.elapsed().as_millis();
+    if let Some(session_id) = harness_session_id
+        && let Err(error) = crate::record_last_turn_capture(repo, &session_id, save.state_id)
+    {
+        tracing::warn!(%error, "could not update reconstructible last-turn anchor");
+    }
 
     let manual_resolution_action = if complete_thread_resolution {
         complete_current_thread_manual_resolution(repo)?
@@ -1645,6 +1659,7 @@ mod tests {
                 Ok(CaptureAttribution {
                     attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
                     principal_source: "embedder".into(),
+                    harness_session_id: None,
                 })
             },
         )
@@ -1710,6 +1725,7 @@ mod tests {
                 Ok(CaptureAttribution {
                     attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
                     principal_source: "embedder".into(),
+                    harness_session_id: None,
                 })
             },
         )

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -675,10 +675,16 @@ flat `array<object>`:
 }
 ```
 
+`heddle diff --base last-turn [<to>]` resolves the first capture made by the
+live harness session on this thread and echoes `"base": "last-turn"`. If the
+live session stamp, captured anchor, or thread ancestry cannot be proven, the
+command refuses instead of substituting HEAD or another branch base.
+
 ### Fields
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
+| `base` | string | optional | Named comparison base. Present as `last-turn` only when explicitly selected. |
 | `from_state`, `to_state` | string \| null | required | State identifiers resolved for the comparison. Worktree-mode diffs leave `to_state` null. |
 | `changes` | object \| array<object> | required | Worktree mode: `{modified, added, deleted}` category arrays (each entry carries `path`, `kind`, and the other per-file diff fields; a `renamed` entry buckets under `modified`). State-to-state mode: a flat `array<object>` of file-level or semantic changes. Empty when there are no changes. |
 | `semantic_changes` | array<object> \| null | optional | Semantic diff entries when semantic analysis is requested and available. |
@@ -2835,6 +2841,7 @@ Hosted-review payload for a single state.
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
 | `state_id` | string | required | Physical state identifier. |
+| `base` | string | optional | Named change-list base. Present as `last-turn` only when explicitly selected. |
 | `headline` | string | required | |
 | `agent_narrative` | string \| null | required | |
 | `files_changed` | int | required | |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4720,10 +4720,16 @@ flat `array<object>`:
 }
 ```
 
+`heddle diff --base last-turn [<to>]` resolves the first capture made by the
+live harness session on this thread and echoes `"base": "last-turn"`. If the
+live session stamp, captured anchor, or thread ancestry cannot be proven, the
+command refuses instead of substituting HEAD or another branch base.
+
 ### Fields
 
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
+| `base` | string | optional | Named comparison base. Present as `last-turn` only when explicitly selected. |
 | `from_state`, `to_state` | string \| null | required | State identifiers resolved for the comparison. Worktree-mode diffs leave `to_state` null. |
 | `changes` | object \| array<object> | required | Worktree mode: `{modified, added, deleted}` category arrays (each entry carries `path`, `kind`, and the other per-file diff fields; a `renamed` entry buckets under `modified`). State-to-state mode: a flat `array<object>` of file-level or semantic changes. Empty when there are no changes. |
 | `semantic_changes` | array<object> \| null | optional | Semantic diff entries when semantic analysis is requested and available. |
@@ -6880,6 +6886,7 @@ Hosted-review payload for a single state.
 | Field | Type | Optionality | Semantics |
 |-------|------|-------------|-----------|
 | `state_id` | string | required | Physical state identifier. |
+| `base` | string | optional | Named change-list base. Present as `last-turn` only when explicitly selected. |
 | `headline` | string | required | |
 | `agent_narrative` | string \| null | required | |
 | `files_changed` | int | required | |


### PR DESCRIPTION
Closes #1577

## Summary
- add `--base last-turn` to `heddle diff` and `heddle review show`
- anchor the first agent capture in each live harness session using a workspace-local sidecar and validate thread ancestry when resolving it
- expose the selected base in existing JSON review/diff messages and regenerate docs and TypeScript schemas
- fail closed when no stamped agent turn can be proven

## Tests
- `cargo test -p heddle-cli --test cli_basics last_turn_diff -- --nocapture`
- `cargo test -p heddle-verbs diff -- --nocapture`
- `cargo test -p heddle-cli --test cli_output_contracts diff_help_explains_git_compatible_patch_headers -- --nocapture`
- `cargo test -p heddle-cli --test cli_workflow diff_json_output_matches_registered_schema_top_level -- --nocapture`
- `cargo test -p heddle-objects worktree_reserved -- --nocapture`
- `cargo test -p heddle-docsgen committed_corpus_is_fresh -- --nocapture`
- `cargo test -p heddle-cli --test ts_types_in_sync generated_typescript_is_in_sync -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790397110&installation_model_id=21489&pr_number=1582&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1582&signature=17efd4420e8a74627e96c62404941c2a89d9f18662c3a204d0ba257445ea0881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->