### PR TITLE
feat(objects): add block-compressed HTR4 trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.4+spec-1.1.0",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -26,9 +26,11 @@ sley.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 uuid.workspace = true
+zstd = { workspace = true, optional = true }
 
 [features]
 async-source = []
+zstd = ["dep:zstd"]
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -154,8 +154,8 @@ pub use tree::{
     validate_name as validate_tree_entry_name,
 };
 pub use tree_canonical::{
-    TREE_CANONICAL_MAGIC, TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header,
-    is_canonical_tree,
+    TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_MIN_ENTRIES, TREE_CANONICAL_MAGIC,
+    TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header, is_canonical_tree,
 };
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -1,23 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Streamable canonical Tree encoding (HTR4).
+//! Streamable canonical Tree encodings (HTR4).
 //!
 //! Each entry is a length-prefixed frame, so a reader can yield one entry or
-//! a caller-sized page and resume at a byte offset without decoding the prefix.
-//! Whole-object compression is not part of this encoding: a resume cursor must
-//! be able to seek without decompressing earlier frames.
+//! a caller-sized page and resume at a byte offset without decoding the whole
+//! tree. Version 4 stores frames raw. Version 5 groups frames into independently
+//! compressed blocks with raw restart anchors and a fixed-width range index.
 
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
-use super::tree::{git_format_from_tag, git_format_to_tag};
-use super::tree_stream::TreeStreamError;
-use super::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError};
+use super::{
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+    tree::{git_format_from_tag, git_format_to_tag},
+    tree_stream::TreeStreamError,
+};
 
 /// Durable encoding version stored in every HTR4 header and resume cursor.
 pub const TREE_ENCODING_VERSION: u8 = 4;
+/// Block-compressed HTR4 variant. Readers accept both v4 and v5.
+pub const TREE_BLOCK_ENCODING_VERSION: u8 = 5;
 /// Frame discriminator for a single canonical tree.
 pub const TREE_CANONICAL_MAGIC: &[u8; 4] = b"HTR4";
 /// Fixed header size: magic + version + tree id + counts.
 pub const TREE_HEADER_LEN: usize = 4 + 1 + 32 + 8 + 8 + 8;
+/// Small real trees do not repay block/index overhead.
+pub const TREE_BLOCK_MIN_ENTRIES: usize = 18;
+
+pub(crate) const TREE_BLOCK_ENTRIES: usize = 256;
+pub(crate) const TREE_BLOCK_PREAMBLE_LEN: usize = 16;
+pub(crate) const TREE_BLOCK_INDEX_LEN: usize = 24;
+const TREE_BLOCK_CODEC_ZSTD: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockHeader {
+    pub block_entries: usize,
+    pub block_count: usize,
+    pub raw_payload_len: u64,
+    pub index_end: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockIndex {
+    pub raw_offset: u64,
+    pub stored_offset: u64,
+    pub stored_len: usize,
+    pub raw_len: usize,
+}
 
 /// Parsed HTR4 header. Counts and payload length are known before any entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -66,6 +93,9 @@ impl Tree {
     /// Decode a complete HTR4 body, validating order incrementally.
     pub fn decode_canonical(data: &[u8]) -> Result<Self, TreeStreamError> {
         let header = decode_header(data)?;
+        if header.version == TREE_BLOCK_ENCODING_VERSION {
+            return Self::decode_canonical_streamed(data);
+        }
         let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
         if (data.len() as u64) < expected_len {
             return Err(TreeStreamError::TruncatedFrame {
@@ -111,6 +141,25 @@ impl Tree {
         }
         Ok(tree)
     }
+
+    /// Encode block-compressed HTR4, falling back to raw v4 when the complete
+    /// object would not be smaller. Callers apply the small-tree policy.
+    pub fn encode_canonical_blocked(
+        &self,
+        level: i32,
+        min_size: usize,
+    ) -> Result<Vec<u8>, TreeStreamError> {
+        let raw = self.encode_canonical()?;
+        if raw.len() < min_size {
+            return Ok(raw);
+        }
+        let blocked = encode_blocked_htr4(&raw, level)?;
+        if blocked.len() < raw.len() {
+            Ok(blocked)
+        } else {
+            Ok(raw)
+        }
+    }
 }
 
 /// Parse the fixed HTR4 header. Does not read entry frames.
@@ -124,7 +173,7 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         ));
     }
     let version = data[4];
-    if version != TREE_ENCODING_VERSION {
+    if version != TREE_ENCODING_VERSION && version != TREE_BLOCK_ENCODING_VERSION {
         return Err(TreeStreamError::UnsupportedVersion { found: version });
     }
     let tree_id = ContentHash::from_bytes(
@@ -152,6 +201,327 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         payload_len,
         logical_len,
     })
+}
+
+pub(crate) fn decode_block_header(
+    header: &TreeHeader,
+    preamble: &[u8],
+    object_len: u64,
+) -> Result<TreeBlockHeader, TreeStreamError> {
+    if header.version != TREE_BLOCK_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "tree does not use block compression".into(),
+        ));
+    }
+    if preamble.len() != TREE_BLOCK_PREAMBLE_LEN {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: TREE_HEADER_LEN as u64,
+        });
+    }
+    if preamble[0] != TREE_BLOCK_CODEC_ZSTD {
+        return Err(TreeStreamError::Malformed(format!(
+            "unsupported tree block codec {}",
+            preamble[0]
+        )));
+    }
+    if preamble[1] != 0 {
+        return Err(TreeStreamError::Malformed(
+            "unsupported tree block flags".into(),
+        ));
+    }
+    let block_entries = u16::from_le_bytes([preamble[2], preamble[3]]) as usize;
+    if block_entries == 0 {
+        return Err(TreeStreamError::Malformed(
+            "tree block size must be nonzero".into(),
+        ));
+    }
+    let block_count = u32::from_le_bytes(
+        preamble[4..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block count".into()))?,
+    ) as usize;
+    let raw_payload_len = u64::from_le_bytes(
+        preamble[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid raw tree payload length".into()))?,
+    );
+    let expected_blocks = header.entry_count.div_ceil(block_entries as u64);
+    if block_count as u64 != expected_blocks {
+        return Err(TreeStreamError::Malformed(
+            "tree block count does not match entry count".into(),
+        ));
+    }
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let index_end = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index end overflow".into()))?
+        as u64;
+    let expected_object_len = (TREE_HEADER_LEN as u64)
+        .checked_add(header.payload_len)
+        .ok_or_else(|| TreeStreamError::Malformed("tree object length overflow".into()))?;
+    if index_end > expected_object_len || expected_object_len != object_len {
+        return Err(TreeStreamError::TruncatedFrame { offset: object_len });
+    }
+    Ok(TreeBlockHeader {
+        block_entries,
+        block_count,
+        raw_payload_len,
+        index_end,
+    })
+}
+
+pub(crate) fn decode_block_index(
+    bytes: &[u8],
+    block: usize,
+    block_header: &TreeBlockHeader,
+    object_len: u64,
+) -> Result<TreeBlockIndex, TreeStreamError> {
+    if bytes.len() != TREE_BLOCK_INDEX_LEN || block >= block_header.block_count {
+        return Err(TreeStreamError::Malformed(
+            "invalid tree block index entry".into(),
+        ));
+    }
+    let raw_offset = u64::from_le_bytes(
+        bytes[0..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw offset".into()))?,
+    );
+    let stored_offset = u64::from_le_bytes(
+        bytes[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored offset".into()))?,
+    );
+    let stored_len = u32::from_le_bytes(
+        bytes[16..20]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored length".into()))?,
+    ) as usize;
+    let raw_len = u32::from_le_bytes(
+        bytes[20..24]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw length".into()))?,
+    ) as usize;
+    if stored_len == 0 || raw_len == 0 || stored_offset < block_header.index_end {
+        return Err(TreeStreamError::Malformed(
+            "invalid empty or overlapping tree block".into(),
+        ));
+    }
+    if stored_offset
+        .checked_add(stored_len as u64)
+        .is_none_or(|end| end > object_len)
+    {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: stored_offset,
+        });
+    }
+    Ok(TreeBlockIndex {
+        raw_offset,
+        stored_offset,
+        stored_len,
+        raw_len,
+    })
+}
+
+pub(crate) fn decode_block_payload(
+    stored: &[u8],
+    raw_len: usize,
+) -> Result<Vec<u8>, TreeStreamError> {
+    if stored.len() == raw_len {
+        return Ok(stored.to_vec());
+    }
+    let anchor_end = block_anchor_end(stored)?;
+    if anchor_end >= raw_len {
+        return Err(TreeStreamError::Malformed(
+            "compressed tree block has no tail".into(),
+        ));
+    }
+    let tail = decompress_block_tail(&stored[anchor_end..], raw_len - anchor_end)?;
+    let mut raw = Vec::with_capacity(raw_len);
+    raw.extend_from_slice(&stored[..anchor_end]);
+    raw.extend_from_slice(&tail);
+    if raw.len() != raw_len {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block length mismatch".into(),
+        ));
+    }
+    Ok(raw)
+}
+
+pub(crate) fn block_anchor_end(stored: &[u8]) -> Result<usize, TreeStreamError> {
+    let len_bytes = stored
+        .get(..4)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    let frame_len = u32::from_le_bytes(
+        len_bytes
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid anchor frame length".into()))?,
+    ) as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    if end > stored.len() {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    Ok(end)
+}
+
+fn encode_blocked_htr4(raw: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    let header = decode_header(raw)?;
+    if header.version != TREE_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "block encoder requires raw HTR4".into(),
+        ));
+    }
+    let ranges = entry_frame_ranges(raw, header.entry_count)?;
+    let block_count = ranges.len().div_ceil(TREE_BLOCK_ENTRIES);
+    let block_count_u32 = u32::try_from(block_count)
+        .map_err(|_| TreeStreamError::Malformed("tree has too many blocks".into()))?;
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(TREE_BLOCK_ENTRIES) {
+        let (start, anchor_end) = *chunk
+            .first()
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let end = chunk
+            .last()
+            .map(|range| range.1)
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let block = &raw[start..end];
+        let compressed_tail = compress_block_tail(&raw[anchor_end..end], level)?;
+        if anchor_end - start + compressed_tail.len() < block.len() {
+            let mut stored = Vec::with_capacity(anchor_end - start + compressed_tail.len());
+            stored.extend_from_slice(&raw[start..anchor_end]);
+            stored.extend_from_slice(&compressed_tail);
+            blocks.push(stored);
+        } else {
+            blocks.push(block.to_vec());
+        }
+    }
+
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let stored_payload_len = TREE_BLOCK_PREAMBLE_LEN
+        .checked_add(index_bytes)
+        .and_then(|len| {
+            blocks
+                .iter()
+                .try_fold(len, |total, block| total.checked_add(block.len()))
+        })
+        .ok_or_else(|| TreeStreamError::Malformed("blocked tree length overflow".into()))?;
+    let mut out = Vec::with_capacity(TREE_HEADER_LEN + stored_payload_len);
+    out.extend_from_slice(TREE_CANONICAL_MAGIC);
+    out.push(TREE_BLOCK_ENCODING_VERSION);
+    out.extend_from_slice(header.tree_id.as_bytes());
+    out.extend_from_slice(&header.entry_count.to_le_bytes());
+    out.extend_from_slice(&(stored_payload_len as u64).to_le_bytes());
+    out.extend_from_slice(&header.logical_len.to_le_bytes());
+    out.push(TREE_BLOCK_CODEC_ZSTD);
+    out.push(0);
+    out.extend_from_slice(&(TREE_BLOCK_ENTRIES as u16).to_le_bytes());
+    out.extend_from_slice(&block_count_u32.to_le_bytes());
+    out.extend_from_slice(&header.payload_len.to_le_bytes());
+
+    let mut stored_offset = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * TREE_BLOCK_ENTRIES;
+        let chunk = &ranges[first_entry..(first_entry + TREE_BLOCK_ENTRIES).min(ranges.len())];
+        let raw_offset = chunk[0].0 - TREE_HEADER_LEN;
+        let raw_len = chunk[chunk.len() - 1].1 - chunk[0].0;
+        let stored_len = u32::try_from(stored.len())
+            .map_err(|_| TreeStreamError::Malformed("stored tree block exceeds u32".into()))?;
+        let raw_len = u32::try_from(raw_len)
+            .map_err(|_| TreeStreamError::Malformed("raw tree block exceeds u32".into()))?;
+        out.extend_from_slice(&(raw_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored_offset as u64).to_le_bytes());
+        out.extend_from_slice(&stored_len.to_le_bytes());
+        out.extend_from_slice(&raw_len.to_le_bytes());
+        stored_offset = stored_offset
+            .checked_add(stored.len())
+            .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    Ok(out)
+}
+
+fn entry_frame_ranges(
+    raw: &[u8],
+    entry_count: u64,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let count = usize::try_from(entry_count)
+        .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?;
+    let mut ranges = Vec::with_capacity(count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..count {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid frame length".into()))?,
+        ) as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        if end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        ranges.push((offset, end));
+        offset = end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(ranges)
+}
+
+#[cfg(feature = "zstd")]
+fn compress_block_tail(data: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    zstd::bulk::compress(data, level)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))
+}
+
+#[cfg(not(feature = "zstd"))]
+fn compress_block_tail(_data: &[u8], _level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
+}
+
+#[cfg(feature = "zstd")]
+fn decompress_block_tail(data: &[u8], capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    let decoded = zstd::bulk::decompress(data, capacity)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))?;
+    if decoded.len() != capacity {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block tail length mismatch".into(),
+        ));
+    }
+    Ok(decoded)
+}
+
+#[cfg(not(feature = "zstd"))]
+fn decompress_block_tail(_data: &[u8], _capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
 }
 
 pub(crate) fn encode_entry_frame(entry: &TreeEntry) -> Result<Vec<u8>, TreeStreamError> {
@@ -323,4 +693,72 @@ fn decode_spoollink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStrea
             TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
         })?);
     TreeEntry::spoollink(name, spool_id, state).map_err(TreeStreamError::from)
+}
+
+#[cfg(all(test, feature = "zstd"))]
+mod block_tests {
+    use super::*;
+
+    fn fixture(entries: usize) -> Tree {
+        Tree::from_entries(
+            (0..entries)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:04}.rs"),
+                        ContentHash::compute(format!("blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .expect("fixture entry")
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn blocked_encoder_falls_back_for_the_complete_object() {
+        let tree = fixture(1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_ENCODING_VERSION);
+    }
+
+    #[test]
+    fn final_single_entry_block_is_stored_raw() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_BLOCK_ENCODING_VERSION);
+        let header = decode_header(&encoded).expect("header");
+        let preamble = &encoded[TREE_HEADER_LEN..TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN];
+        let block_header =
+            decode_block_header(&header, preamble, encoded.len() as u64).expect("block header");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let index = decode_block_index(
+            &encoded[second_index..second_index + TREE_BLOCK_INDEX_LEN],
+            1,
+            &block_header,
+            encoded.len() as u64,
+        )
+        .expect("second block");
+        assert_eq!(index.stored_len, index.raw_len);
+    }
+
+    #[test]
+    fn trailing_bytes_in_a_raw_block_are_rejected() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let mut encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let stored_len_offset = second_index + 16;
+        let stored_len = u32::from_le_bytes(
+            encoded[stored_len_offset..stored_len_offset + 4]
+                .try_into()
+                .expect("stored length"),
+        );
+        encoded[stored_len_offset..stored_len_offset + 4]
+            .copy_from_slice(&(stored_len + 1).to_le_bytes());
+        let payload_len =
+            u64::from_le_bytes(encoded[45..53].try_into().expect("stored payload length"));
+        encoded[45..53].copy_from_slice(&(payload_len + 1).to_le_bytes());
+        encoded.push(0);
+
+        assert!(Tree::decode_canonical(&encoded).is_err());
+    }
 }

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use super::{
     ContentHash, Tree, TreeEntry, TreeError,
     tree_canonical::{
-        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_entry_frame, decode_header,
+        TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_INDEX_LEN, TREE_BLOCK_PREAMBLE_LEN,
+        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeBlockHeader, TreeBlockIndex, TreeHeader,
+        decode_block_header, decode_block_index, decode_block_payload, decode_entry_frame,
+        decode_header,
     },
     tree_source::{TreeBodyIntegrity, TreeByteSource},
 };
@@ -17,7 +20,7 @@ pub enum TreeStreamError {
     #[error("invalid tree entry: {0}")]
     Invalid(#[from] TreeError),
     #[error(
-        "unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})"
+        "unsupported tree encoding version {found} (this binary supports {TREE_ENCODING_VERSION} and {TREE_BLOCK_ENCODING_VERSION})"
     )]
     UnsupportedVersion { found: u8 },
     #[error("tree resume cursor does not match this object: {0}")]
@@ -39,6 +42,8 @@ pub enum TreeStreamError {
     UnverifiedRange,
     #[error("malformed tree encoding: {0}")]
     Malformed(String),
+    #[error("tree compression failed: {0}")]
+    Compression(String),
     #[error("tree I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("decoded tree hash {found} does not match {expected}")]
@@ -89,9 +94,13 @@ pub struct TreeResumeCursor {
 
 impl TreeResumeCursor {
     pub fn start(tree_id: ContentHash) -> Self {
+        Self::start_for_version(tree_id, TREE_ENCODING_VERSION)
+    }
+
+    fn start_for_version(tree_id: ContentHash, encoding_version: u8) -> Self {
         Self {
             tree_id,
-            encoding_version: TREE_ENCODING_VERSION,
+            encoding_version,
             ordinal: 0,
             byte_offset: TREE_HEADER_LEN as u64,
             prev_name: None,
@@ -119,6 +128,23 @@ impl TreeResumeCursor {
     }
 }
 
+#[derive(Debug)]
+enum TreeReaderLayout {
+    Raw,
+    Blocked {
+        header: TreeBlockHeader,
+        cache: Option<DecodedBlock>,
+        validated_blocks: Vec<bool>,
+    },
+}
+
+#[derive(Debug)]
+struct DecodedBlock {
+    block: usize,
+    raw: Vec<u8>,
+    frames: Vec<(usize, usize)>,
+}
+
 /// One bounded page of decoded entries plus the cursor after the last entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TreePage {
@@ -131,9 +157,11 @@ pub struct TreePage {
 pub struct TreeEntryReader<S: TreeByteSource> {
     source: S,
     header: TreeHeader,
+    layout: TreeReaderLayout,
     cursor: TreeResumeCursor,
     hasher: Option<blake3::Hasher>,
     decoded_logical_len: u64,
+    started_at_zero: bool,
     pending: Option<(TreeEntry, usize)>,
     finished: bool,
 }
@@ -164,21 +192,36 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 extra: source.len() - expected_len,
             });
         }
+        let layout = if header.version == TREE_BLOCK_ENCODING_VERSION {
+            let mut preamble = [0u8; TREE_BLOCK_PREAMBLE_LEN];
+            source.read_exact_at(TREE_HEADER_LEN as u64, &mut preamble)?;
+            let block_header = decode_block_header(&header, &preamble, source.len())?;
+            TreeReaderLayout::Blocked {
+                header: block_header,
+                cache: None,
+                validated_blocks: vec![false; block_header.block_count],
+            }
+        } else {
+            TreeReaderLayout::Raw
+        };
         let cursor = resume
             .cloned()
-            .unwrap_or_else(|| TreeResumeCursor::start(expected_id));
-        validate_cursor(&header, &cursor)?;
+            .unwrap_or_else(|| TreeResumeCursor::start_for_version(expected_id, header.version));
+        validate_cursor(&header, &layout, &cursor)?;
         if cursor.ordinal > 0 && source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
         let hasher =
             (cursor.ordinal == 0).then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let started_at_zero = cursor.ordinal == 0;
         let mut reader = Self {
             source,
             header,
+            layout,
             cursor,
             hasher,
             decoded_logical_len: 0,
+            started_at_zero,
             pending: None,
             finished: false,
         };
@@ -249,7 +292,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 decoded: self.cursor.ordinal,
             });
         }
-        let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
+        let payload_end = self.logical_payload_end();
         if self.cursor.byte_offset != payload_end {
             return Err(TreeStreamError::TrailingBytes {
                 extra: payload_end.abs_diff(self.cursor.byte_offset),
@@ -271,6 +314,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         } else if self.source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
+        self.validate_complete_block_layout()?;
         self.finished = true;
         Ok(())
     }
@@ -283,6 +327,9 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
     }
 
     fn read_entry_at(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        if matches!(self.layout, TreeReaderLayout::Blocked { .. }) {
+            return self.read_blocked_entry();
+        }
         let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
         let mut len_buf = [0u8; 4];
         self.source.read_exact_at(offset, &mut len_buf)?;
@@ -302,6 +349,216 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         self.source.read_exact_at(frame_start, &mut frame)?;
         let entry = decode_entry_frame(&frame)?;
         Ok((entry, 4 + frame_len))
+    }
+
+    fn logical_payload_end(&self) -> u64 {
+        match &self.layout {
+            TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + self.header.payload_len,
+            TreeReaderLayout::Blocked { header, .. } => {
+                TREE_HEADER_LEN as u64 + header.raw_payload_len
+            }
+        }
+    }
+
+    fn read_blocked_entry(&mut self) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Blocked { header, .. } => *header,
+            TreeReaderLayout::Raw => {
+                return Err(TreeStreamError::Malformed(
+                    "raw tree entered blocked reader".into(),
+                ));
+            }
+        };
+        let ordinal = usize::try_from(self.cursor.ordinal)
+            .map_err(|_| TreeStreamError::Malformed("tree ordinal exceeds usize".into()))?;
+        let block = ordinal / block_header.block_entries;
+        let within_block = ordinal % block_header.block_entries;
+        let index = self.read_block_index(block, &block_header)?;
+        let block_logical_start = (TREE_HEADER_LEN as u64)
+            .checked_add(index.raw_offset)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block raw offset overflow".into()))?;
+
+        if within_block == 0 {
+            if self.cursor.byte_offset != block_logical_start {
+                return Err(TreeStreamError::CursorMismatch(
+                    "cursor byte offset is not the block restart boundary".into(),
+                ));
+            }
+            return self.read_block_anchor(index);
+        }
+
+        let needs_load = match &self.layout {
+            TreeReaderLayout::Blocked { cache, .. } => {
+                cache.as_ref().is_none_or(|cached| cached.block != block)
+            }
+            TreeReaderLayout::Raw => true,
+        };
+        if needs_load {
+            let decoded = self.load_block(index, block, &block_header)?;
+            if let TreeReaderLayout::Blocked {
+                cache,
+                validated_blocks,
+                ..
+            } = &mut self.layout
+            {
+                *cache = Some(decoded);
+                if let Some(validated) = validated_blocks.get_mut(block) {
+                    *validated = true;
+                }
+            }
+        }
+        let cached = match &self.layout {
+            TreeReaderLayout::Blocked {
+                cache: Some(cached),
+                ..
+            } => cached,
+            _ => {
+                return Err(TreeStreamError::Malformed(
+                    "tree block cache was not populated".into(),
+                ));
+            }
+        };
+        let (frame_start, frame_end) =
+            cached
+                .frames
+                .get(within_block)
+                .copied()
+                .ok_or(TreeStreamError::UnexpectedEof {
+                    expected: self.cursor.ordinal + 1,
+                    decoded: self.cursor.ordinal,
+                })?;
+        let frame =
+            cached
+                .raw
+                .get(frame_start + 4..frame_end)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: frame_start as u64,
+                })?;
+        let consumed = frame_end - frame_start;
+        let expected_offset = block_logical_start
+            .checked_add(frame_start as u64)
+            .ok_or_else(|| TreeStreamError::Malformed("tree cursor offset overflow".into()))?;
+        if self.cursor.byte_offset != expected_offset {
+            return Err(TreeStreamError::CursorMismatch(
+                "cursor byte offset is not an entry boundary".into(),
+            ));
+        }
+        Ok((decode_entry_frame(frame)?, consumed))
+    }
+
+    fn read_block_index(
+        &mut self,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<TreeBlockIndex, TreeStreamError> {
+        let relative = block
+            .checked_mul(TREE_BLOCK_INDEX_LEN)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index overflow".into()))?;
+        let offset = TREE_HEADER_LEN
+            .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+            .and_then(|start| start.checked_add(relative))
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index offset overflow".into()))?;
+        let mut bytes = [0u8; TREE_BLOCK_INDEX_LEN];
+        self.source.read_exact_at(offset as u64, &mut bytes)?;
+        decode_block_index(&bytes, block, block_header, self.source.len())
+    }
+
+    fn read_block_anchor(
+        &mut self,
+        index: TreeBlockIndex,
+    ) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let mut len_bytes = [0u8; 4];
+        self.source
+            .read_exact_at(index.stored_offset, &mut len_bytes)?;
+        let frame_len = u32::from_le_bytes(len_bytes) as usize;
+        let consumed = 4usize
+            .checked_add(frame_len)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            })?;
+        if consumed > index.stored_len || consumed > index.raw_len {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            });
+        }
+        let mut frame = vec![0u8; frame_len];
+        self.source
+            .read_exact_at(index.stored_offset + 4, &mut frame)?;
+        Ok((decode_entry_frame(&frame)?, consumed))
+    }
+
+    fn load_block(
+        &mut self,
+        index: TreeBlockIndex,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<DecodedBlock, TreeStreamError> {
+        let mut stored = vec![0u8; index.stored_len];
+        self.source
+            .read_exact_at(index.stored_offset, &mut stored)?;
+        let raw = decode_block_payload(&stored, index.raw_len)?;
+        let first_entry = block
+            .checked_mul(block_header.block_entries)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block ordinal overflow".into()))?;
+        let remaining = usize::try_from(self.header.entry_count)
+            .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?
+            .checked_sub(first_entry)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block starts past entries".into()))?;
+        let expected_entries = remaining.min(block_header.block_entries);
+        let frames = decode_block_frames(&raw, expected_entries)?;
+        Ok(DecodedBlock { block, raw, frames })
+    }
+
+    fn validate_complete_block_layout(&mut self) -> Result<(), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Raw => return Ok(()),
+            TreeReaderLayout::Blocked { header, .. } => *header,
+        };
+        let mut expected_raw_offset = 0u64;
+        let mut expected_stored_offset = block_header.index_end;
+        for block in 0..block_header.block_count {
+            let index = self.read_block_index(block, &block_header)?;
+            if index.raw_offset != expected_raw_offset
+                || index.stored_offset != expected_stored_offset
+            {
+                return Err(TreeStreamError::Malformed(
+                    "tree blocks are not contiguous".into(),
+                ));
+            }
+            expected_raw_offset = expected_raw_offset
+                .checked_add(index.raw_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("raw tree length overflow".into()))?;
+            expected_stored_offset = expected_stored_offset
+                .checked_add(index.stored_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("stored tree length overflow".into()))?;
+            let needs_payload_validation = self.started_at_zero
+                && match &self.layout {
+                    TreeReaderLayout::Blocked {
+                        validated_blocks, ..
+                    } => validated_blocks
+                        .get(block)
+                        .is_none_or(|validated| !validated),
+                    TreeReaderLayout::Raw => false,
+                };
+            if needs_payload_validation {
+                let _ = self.load_block(index, block, &block_header)?;
+                if let TreeReaderLayout::Blocked {
+                    validated_blocks, ..
+                } = &mut self.layout
+                    && let Some(validated) = validated_blocks.get_mut(block)
+                {
+                    *validated = true;
+                }
+            }
+        }
+        if expected_raw_offset != block_header.raw_payload_len
+            || expected_stored_offset != self.source.len()
+        {
+            return Err(TreeStreamError::Malformed(
+                "tree block lengths do not match the header".into(),
+            ));
+        }
+        Ok(())
     }
 
     fn commit_entry(&mut self, entry: &TreeEntry, consumed: usize) -> Result<(), TreeStreamError> {
@@ -350,11 +607,59 @@ mod tree_stream_proptests;
 #[path = "tree_stream_tests.rs"]
 mod tree_stream_tests;
 
-fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(), TreeStreamError> {
-    if cursor.encoding_version != TREE_ENCODING_VERSION {
+fn decode_block_frames(
+    raw: &[u8],
+    expected_entries: usize,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let mut frames = Vec::with_capacity(expected_entries);
+    let mut offset = 0usize;
+    for _ in 0..expected_entries {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid block frame length".into()))?,
+        ) as usize;
+        let frame_start = offset
+            .checked_add(4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_end =
+            frame_start
+                .checked_add(frame_len)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: offset as u64,
+                })?;
+        if frame_end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        frames.push((offset, frame_end));
+        offset = frame_end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(frames)
+}
+
+fn validate_cursor(
+    header: &TreeHeader,
+    layout: &TreeReaderLayout,
+    cursor: &TreeResumeCursor,
+) -> Result<(), TreeStreamError> {
+    if cursor.encoding_version != header.version {
         return Err(TreeStreamError::CursorMismatch(format!(
-            "encoding version {} is not {TREE_ENCODING_VERSION}",
-            cursor.encoding_version
+            "encoding version {} is not {}",
+            cursor.encoding_version, header.version
         )));
     }
     if cursor.tree_id != header.tree_id {
@@ -362,7 +667,10 @@ fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(),
             "cursor tree id does not match the opened object".into(),
         ));
     }
-    let payload_end = TREE_HEADER_LEN as u64 + header.payload_len;
+    let payload_end = match layout {
+        TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + header.payload_len,
+        TreeReaderLayout::Blocked { header, .. } => TREE_HEADER_LEN as u64 + header.raw_payload_len,
+    };
     if cursor.ordinal > header.entry_count {
         return Err(TreeStreamError::CursorMismatch(
             "cursor ordinal is past the declared entry count".into(),

--- a/crates/object-model/src/object/tree_stream_proptests.rs
+++ b/crates/object-model/src/object/tree_stream_proptests.rs
@@ -63,6 +63,7 @@ fn error_class(error: &TreeStreamError) -> &'static str {
         TreeStreamError::InvalidPageLimits => "limits",
         TreeStreamError::UnverifiedRange => "unverified",
         TreeStreamError::Malformed(_) => "malformed",
+        TreeStreamError::Compression(_) => "compression",
         TreeStreamError::Io(_) => "io",
         TreeStreamError::HashMismatch { .. } => "hash",
     }

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -32,6 +32,22 @@ fn sample_tree() -> Tree {
     ])
 }
 
+#[cfg(feature = "zstd")]
+fn compressible_tree(entries: usize) -> Tree {
+    Tree::from_entries(
+        (0..entries)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("crates__module_{index:04}__src__shared_component.rs"),
+                    ContentHash::compute(format!("real-blob-{index}").as_bytes()),
+                    index.is_multiple_of(17),
+                )
+                .expect("compressed fixture entry")
+            })
+            .collect(),
+    )
+}
+
 fn open_reader(tree: &Tree) -> (Vec<u8>, TreeEntryReader<BytesTreeSource>) {
     let bytes = tree.encode_canonical().expect("encode");
     let reader = TreeEntryReader::open(
@@ -53,6 +69,100 @@ fn canonical_round_trip_matches_eager_tree() {
         Tree::decode_canonical_streamed(&bytes).expect("streamed"),
         tree
     );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn block_compressed_round_trip_matches_eager_and_streamed_tree() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    assert_eq!(bytes[4], crate::object::TREE_BLOCK_ENCODING_VERSION);
+    assert_eq!(Tree::decode_canonical(&bytes).expect("eager"), tree);
+    assert_eq!(
+        Tree::decode_canonical_streamed(&bytes).expect("streamed"),
+        tree
+    );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_partial_read_and_resume_stay_block_local() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open blocked");
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("first page")
+        .expect("entry");
+    assert_eq!(first.entries, tree.entries()[..1]);
+    assert!(
+        reader.bytes_read() < 256,
+        "first block anchor should be a small ranged read"
+    );
+
+    let mut resumed = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes),
+        tree.hash(),
+        Some(&first.resume_cursor),
+    )
+    .expect("resume blocked");
+    let page = resumed
+        .next_page(TreePageLimits::new(100, usize::MAX).expect("limits"))
+        .expect("resumed page")
+        .expect("entries");
+    assert_eq!(page.entries, tree.entries()[1..101]);
+    assert!(
+        resumed.bytes_read() < tree.encode_canonical().expect("raw").len() as u64,
+        "resumed page should not read the whole tree"
+    );
+
+    let blocked = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut boundary_reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open boundary reader");
+    let before_boundary = boundary_reader
+        .next_page(TreePageLimits::new(256, usize::MAX).expect("limits"))
+        .expect("boundary page")
+        .expect("entries");
+    let mut at_boundary = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked),
+        tree.hash(),
+        Some(&before_boundary.resume_cursor),
+    )
+    .expect("resume at block boundary");
+    let anchor = at_boundary
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("anchor page")
+        .expect("entry");
+    assert_eq!(anchor.entries, tree.entries()[256..257]);
+    assert!(at_boundary.bytes_read() < 256);
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_hash_and_payload_corruption_fail_closed() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+
+    let mut bad_hash = bytes.clone();
+    bad_hash[5] ^= 1;
+    assert!(matches!(
+        Tree::decode_canonical(&bad_hash),
+        Err(TreeStreamError::HashMismatch { .. })
+    ));
+
+    let mut bad_payload = bytes;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    assert!(Tree::decode_canonical(&bad_payload).is_err());
 }
 
 #[test]

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -42,7 +42,12 @@ zstd = { workspace = true, optional = true }
 async-source = ["heddle-object-model/async-source"]
 bench = ["heddle-format/bench"]
 memory-backend = []
-zstd = ["dep:zstd", "heddle-format/zstd", "heddle-pack/zstd"]
+zstd = [
+    "dep:zstd",
+    "heddle-format/zstd",
+    "heddle-object-model/zstd",
+    "heddle-pack/zstd",
+]
 
 [dev-dependencies]
 criterion = "0.8"
@@ -90,6 +95,10 @@ required-features = ["bench"]
 
 [[example]]
 name = "train_tree_state_dictionary"
+required-features = ["zstd"]
+
+[[example]]
+name = "htr4_measure"
 required-features = ["zstd"]
 
 [[bench]]

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -1,0 +1,1542 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTR4 block-compression measurement and format-validation harness.
+//!
+//! Real-repository measurements exercise the production store codec and a
+//! file-backed `TreeEntryReader`. Synthetic measurements retain the original
+//! tunable prototype for comparison. Each block keeps its first complete HTR4
+//! frame raw as a restart anchor and compresses only the tail.
+
+use std::{
+    collections::BTreeSet,
+    env,
+    fs::File,
+    hint::black_box,
+    io::{BufRead, BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use bytes::Bytes;
+use heddle_format::compression::{
+    CompressionConfig, CompressionDictionary, compress_with_dictionary,
+};
+use objects::object::{
+    BytesTreeSource, ContentHash, EntryType, FileMode, FileTreeSource, SpoolId, StateId,
+    TREE_BLOCK_ENCODING_VERSION, TREE_HEADER_LEN, Tree, TreeEntry, TreeEntryReader, TreePageLimits,
+};
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+use tempfile::NamedTempFile;
+
+const SEED: u64 = 0x6874_7234_5f62_656e;
+const SIZES: [usize; 5] = [1, 10, 100, 1_000, 10_000];
+const SAMPLE_COUNT: usize = 15;
+const CALIBRATION_TIME: Duration = Duration::from_millis(25);
+const SAMPLE_TIME: Duration = Duration::from_millis(40);
+const DEFAULT_REAL_TREE_LIMIT: usize = 4_000;
+const REAL_FILE_SAMPLE_LIMIT: usize = 64;
+
+const BLOCK_MAGIC: &[u8; 4] = b"HTB1";
+const BLOCK_VERSION: u8 = 1;
+const BLOCK_CODEC_ZSTD: u8 = 1;
+const BLOCK_HEADER_LEN: usize = 72;
+const BLOCK_INDEX_LEN: usize = 24;
+const BLOCK_LEVEL: i32 = 3;
+const TRAINED_DICTIONARY_ID: u32 = 0x4854_4231;
+const LEGACY_DICTIONARY_ID: u32 = 1;
+const LEGACY_DICTIONARY: &[u8] =
+    include_bytes!("../../format/src/compression/dictionaries/tree-state-v1.zdict");
+
+#[derive(Clone, Copy)]
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn fill(&mut self, bytes: &mut [u8]) {
+        for chunk in bytes.chunks_mut(8) {
+            let random = self.next().to_le_bytes();
+            chunk.copy_from_slice(&random[..chunk.len()]);
+        }
+    }
+}
+
+fn content_hash(index: usize, salt: u64) -> ContentHash {
+    let mut random = SplitMix64::new(SEED ^ (index as u64).rotate_left(17) ^ salt);
+    let mut content = [0u8; 96];
+    random.fill(&mut content);
+    ContentHash::compute(&content)
+}
+
+fn oid(index: usize) -> GitObjectId {
+    let sha256 = (index / 20) % 2 == 1;
+    let len = if sha256 { 32 } else { 20 };
+    let format = if sha256 {
+        GitObjectFormat::Sha256
+    } else {
+        GitObjectFormat::Sha1
+    };
+    let mut bytes = [0u8; 32];
+    SplitMix64::new(SEED ^ index as u64 ^ 0x6f69_645f_7361_6c74).fill(&mut bytes[..len]);
+    GitObjectId::from_raw(format, &bytes[..len]).expect("valid deterministic git oid")
+}
+
+fn entry(index: usize) -> TreeEntry {
+    let stems = [
+        "README",
+        "src__object__tree",
+        "crates__cli__status",
+        "wire_protocol",
+        "integration_spec",
+        "config_local",
+        "snapshot_manifest",
+        "test_fixture",
+    ];
+    let mut name_rng = SplitMix64::new(SEED ^ index as u64);
+    let suffix = name_rng.next() as u32;
+    let residue = index % 20;
+    let extension = match residue {
+        2 => "dir",
+        3 => "link",
+        4 => "submodule",
+        5 => "spool",
+        _ => ["rs", "toml", "md", "json"][index % 4],
+    };
+    let name = format!(
+        "{index:05}_{}_{suffix:08x}.{extension}",
+        stems[index % stems.len()]
+    );
+
+    match residue {
+        1 => TreeEntry::file(name, content_hash(index, 1), true),
+        2 => TreeEntry::directory(name, content_hash(index, 2)),
+        3 => TreeEntry::symlink(name, content_hash(index, 3)),
+        4 => TreeEntry::gitlink(name, oid(index)),
+        5 => TreeEntry::spoollink(
+            name,
+            SpoolId::parse(format!("bench/child-{}", index % 64)).expect("valid spool id"),
+            StateId::from_bytes(*content_hash(index, 5).as_bytes()),
+        ),
+        _ => TreeEntry::file(name, content_hash(index, 0), false),
+    }
+    .expect("valid deterministic tree entry")
+}
+
+fn fixture(entries: usize) -> Tree {
+    Tree::from_entries((0..entries).map(entry).collect())
+}
+
+fn training_dictionary() -> Result<Vec<u8>> {
+    // A disjoint ordinal range prevents the measured objects from appearing in
+    // the training set while retaining the same mix of entry shapes.
+    let samples = (0..192)
+        .map(|sample| {
+            let start = 100_000 + sample * 64;
+            let tree = Tree::from_entries((start..start + 64).map(entry).collect());
+            let htr4 = tree.encode_canonical()?;
+            Ok(htr4[TREE_HEADER_LEN..].to_vec())
+        })
+        .collect::<Result<Vec<_>, objects::object::TreeStreamError>>()?;
+    zstd::dict::from_samples(&samples, 8 * 1024).context("train HTR4 block dictionary")
+}
+
+#[derive(Clone, Copy)]
+struct Dictionary<'a> {
+    name: &'static str,
+    id: u32,
+    bytes: &'a [u8],
+    encoder: Option<&'a zstd::dict::EncoderDictionary<'static>>,
+    decoder: Option<&'a zstd::dict::DecoderDictionary<'static>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockHeader {
+    block_entries: usize,
+    tree_id: ContentHash,
+    entry_count: usize,
+    raw_payload_len: usize,
+    logical_len: u64,
+    block_count: usize,
+    dictionary_id: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockIndex {
+    first_entry: usize,
+    offset: usize,
+    stored_len: usize,
+    raw_len: usize,
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16> {
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..offset + 2)
+            .context("truncated u16")?
+            .try_into()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .context("truncated u32")?
+            .try_into()?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .context("truncated u64")?
+            .try_into()?,
+    ))
+}
+
+fn usize_from(value: u64, field: &str) -> Result<usize> {
+    usize::try_from(value).with_context(|| format!("{field} exceeds usize"))
+}
+
+fn frame_ranges(htr4: &[u8]) -> Result<Vec<(usize, usize)>> {
+    let header = objects::object::decode_header(htr4)?;
+    let entry_count = usize_from(header.entry_count, "entry count")?;
+    let expected_len = TREE_HEADER_LEN
+        .checked_add(usize_from(header.payload_len, "payload length")?)
+        .context("HTR4 length overflow")?;
+    ensure!(htr4.len() == expected_len, "HTR4 length mismatch");
+    let mut ranges = Vec::with_capacity(entry_count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..entry_count {
+        let frame_len = read_u32(htr4, offset)? as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .context("frame end overflow")?;
+        ensure!(end <= htr4.len(), "truncated HTR4 entry frame");
+        ranges.push((offset, end));
+        offset = end;
+    }
+    ensure!(offset == htr4.len(), "trailing HTR4 payload bytes");
+    Ok(ranges)
+}
+
+fn encode_blocked(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    encode_blocked_htr4(&htr4, block_entries, dictionary)
+}
+
+fn encode_blocked_htr4(
+    htr4: &[u8],
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    ensure!(block_entries > 0 && block_entries <= u16::MAX as usize);
+    let htr4_header = objects::object::decode_header(htr4)?;
+    let ranges = frame_ranges(htr4)?;
+    let block_count = ranges.len().div_ceil(block_entries);
+    let mut compressor = if let Some(prepared) = dictionary.encoder {
+        zstd::bulk::Compressor::with_prepared_dictionary(prepared)?
+    } else {
+        zstd::bulk::Compressor::new(BLOCK_LEVEL)?
+    };
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(block_entries) {
+        let start = chunk.first().context("empty block")?.0;
+        let anchor_end = chunk.first().context("empty block")?.1;
+        let end = chunk.last().context("empty block")?.1;
+        let raw = &htr4[start..end];
+        let anchor = &htr4[start..anchor_end];
+        let compressed_tail = compressor.compress(&htr4[anchor_end..end])?;
+        blocks.push(if anchor.len() + compressed_tail.len() < raw.len() {
+            let mut stored = Vec::with_capacity(anchor.len() + compressed_tail.len());
+            stored.extend_from_slice(anchor);
+            stored.extend_from_slice(&compressed_tail);
+            stored
+        } else {
+            raw.to_vec()
+        });
+    }
+
+    let index_bytes = block_count
+        .checked_mul(BLOCK_INDEX_LEN)
+        .context("block index overflow")?;
+    let mut payload_offset = BLOCK_HEADER_LEN
+        .checked_add(index_bytes)
+        .context("block payload offset overflow")?;
+    let capacity = payload_offset
+        .checked_add(blocks.iter().map(Vec::len).sum::<usize>())
+        .context("blocked tree length overflow")?;
+    let mut out = Vec::with_capacity(capacity);
+    out.extend_from_slice(BLOCK_MAGIC);
+    out.push(BLOCK_VERSION);
+    out.push(BLOCK_CODEC_ZSTD);
+    out.extend_from_slice(&(block_entries as u16).to_le_bytes());
+    out.extend_from_slice(htr4_header.tree_id.as_bytes());
+    out.extend_from_slice(&htr4_header.entry_count.to_le_bytes());
+    out.extend_from_slice(&htr4_header.payload_len.to_le_bytes());
+    out.extend_from_slice(&htr4_header.logical_len.to_le_bytes());
+    out.extend_from_slice(&(block_count as u32).to_le_bytes());
+    out.extend_from_slice(&dictionary.id.to_le_bytes());
+    ensure!(out.len() == BLOCK_HEADER_LEN);
+
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * block_entries;
+        let chunk = &ranges[first_entry..(first_entry + block_entries).min(ranges.len())];
+        let raw_len = chunk.last().context("empty indexed block")?.1 - chunk[0].0;
+        out.extend_from_slice(&(first_entry as u64).to_le_bytes());
+        out.extend_from_slice(&(payload_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(raw_len as u32).to_le_bytes());
+        payload_offset += stored.len();
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    ensure!(out.len() == capacity);
+    Ok(out)
+}
+
+fn encode_adaptive(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+    Ok(if blocked.len() < htr4.len() {
+        blocked
+    } else {
+        htr4
+    })
+}
+
+fn parse_block_header(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<BlockHeader> {
+    parse_block_header_with_len(bytes, bytes.len(), dictionary)
+}
+
+fn parse_block_header_with_len(
+    bytes: &[u8],
+    stored_object_len: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<BlockHeader> {
+    ensure!(bytes.len() >= BLOCK_HEADER_LEN, "truncated HTB1 header");
+    ensure!(&bytes[..4] == BLOCK_MAGIC, "not an HTB1 tree");
+    ensure!(bytes[4] == BLOCK_VERSION, "unsupported HTB1 version");
+    ensure!(bytes[5] == BLOCK_CODEC_ZSTD, "unsupported HTB1 codec");
+    let block_entries = read_u16(bytes, 6)? as usize;
+    ensure!(block_entries > 0, "zero entries per block");
+    let mut tree_id = [0; 32];
+    tree_id.copy_from_slice(&bytes[8..40]);
+    let entry_count = usize_from(read_u64(bytes, 40)?, "entry count")?;
+    let raw_payload_len = usize_from(read_u64(bytes, 48)?, "raw payload length")?;
+    let logical_len = read_u64(bytes, 56)?;
+    let block_count = read_u32(bytes, 64)? as usize;
+    let dictionary_id = read_u32(bytes, 68)?;
+    ensure!(dictionary_id == dictionary.id, "HTB1 dictionary mismatch");
+    ensure!(block_count == entry_count.div_ceil(block_entries));
+    ensure!(
+        BLOCK_HEADER_LEN
+            .checked_add(block_count * BLOCK_INDEX_LEN)
+            .is_some_and(|index_end| index_end <= stored_object_len),
+        "truncated HTB1 index"
+    );
+    Ok(BlockHeader {
+        block_entries,
+        tree_id: ContentHash::from_bytes(tree_id),
+        entry_count,
+        raw_payload_len,
+        logical_len,
+        block_count,
+        dictionary_id,
+    })
+}
+
+fn parse_block_index_entry(
+    bytes: &[u8],
+    at: usize,
+    stored_object_len: usize,
+    header: BlockHeader,
+    block: usize,
+) -> Result<BlockIndex> {
+    let entry = BlockIndex {
+        first_entry: usize_from(read_u64(bytes, at)?, "first entry")?,
+        offset: usize_from(read_u64(bytes, at + 8)?, "block offset")?,
+        stored_len: read_u32(bytes, at + 16)? as usize,
+        raw_len: read_u32(bytes, at + 20)? as usize,
+    };
+    ensure!(entry.first_entry == block * header.block_entries);
+    let index_end = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    ensure!(entry.offset >= index_end, "block overlaps index");
+    ensure!(entry.stored_len > 0 && entry.raw_len > 0, "empty block");
+    ensure!(
+        entry
+            .offset
+            .checked_add(entry.stored_len)
+            .is_some_and(|end| end <= stored_object_len),
+        "truncated block payload"
+    );
+    Ok(entry)
+}
+
+fn parse_block_index(bytes: &[u8], header: BlockHeader, block: usize) -> Result<BlockIndex> {
+    ensure!(block < header.block_count, "block index out of bounds");
+    let at = BLOCK_HEADER_LEN + block * BLOCK_INDEX_LEN;
+    parse_block_index_entry(bytes, at, bytes.len(), header, block)
+}
+
+fn decompress_block(
+    bytes: &[u8],
+    index: BlockIndex,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let stored = &bytes[index.offset..index.offset + index.stored_len];
+    decompress_stored_block(stored, index.raw_len, decoder)
+}
+
+fn decompress_stored_block(
+    stored: &[u8],
+    raw_len: usize,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let raw = if stored.len() == raw_len {
+        stored.to_vec()
+    } else {
+        let anchor_end = raw_anchor_end(stored)?;
+        ensure!(anchor_end < raw_len, "compressed block has no tail");
+        let mut raw = Vec::with_capacity(raw_len);
+        raw.extend_from_slice(&stored[..anchor_end]);
+        raw.extend_from_slice(&decoder.decompress(&stored[anchor_end..], raw_len - anchor_end)?);
+        raw
+    };
+    ensure!(raw.len() == raw_len, "block decoded length mismatch");
+    Ok(raw)
+}
+
+fn raw_anchor_end(stored: &[u8]) -> Result<usize> {
+    let frame_len = read_u32(stored, 0)? as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .context("anchor frame length overflow")?;
+    ensure!(end <= stored.len(), "truncated raw block anchor");
+    Ok(end)
+}
+
+fn decode_entry_frame(frame: &[u8]) -> Result<TreeEntry> {
+    ensure!(frame.len() >= 4, "truncated entry frame");
+    let mode = FileMode::from_byte(frame[0]).context("invalid entry mode")?;
+    let kind = EntryType::from_byte(frame[1]).context("invalid entry kind")?;
+    let name_len = read_u16(frame, 2)? as usize;
+    let name_end = 4usize
+        .checked_add(name_len)
+        .context("name length overflow")?;
+    let name = std::str::from_utf8(frame.get(4..name_end).context("truncated entry name")?)?;
+    let payload = frame.get(name_end..).context("truncated entry payload")?;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            ensure!(payload.len() == 32, "invalid content hash length");
+            let hash = ContentHash::from_bytes(payload.try_into()?);
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let (&format, oid_bytes) = payload.split_first().context("missing gitlink format")?;
+            let format = match format {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid gitlink format"),
+            };
+            TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid_bytes)?)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = read_u16(payload, 0)? as usize;
+            let spool_end = 2usize
+                .checked_add(spool_len)
+                .context("spool length overflow")?;
+            let spool =
+                std::str::from_utf8(payload.get(2..spool_end).context("truncated spool id")?)?;
+            let state: [u8; 32] = payload
+                .get(spool_end..)
+                .context("missing spool state")?
+                .try_into()
+                .context("invalid spool state length")?;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, StateId::from_bytes(state))?
+        }
+    };
+    ensure!(entry.mode() == mode, "entry kind/mode mismatch");
+    Ok(entry)
+}
+
+fn decode_frames(raw: &[u8]) -> Result<(Vec<TreeEntry>, u64)> {
+    let mut entries = Vec::new();
+    let mut logical_len = 0u64;
+    let mut offset = 0usize;
+    while offset < raw.len() {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated entry frame")?;
+        let entry = decode_entry_frame(frame)?;
+        logical_len = logical_len
+            .checked_add(semantic_encoded_len(&entry) as u64)
+            .context("logical length overflow")?;
+        entries.push(entry);
+        offset = end;
+    }
+    ensure!(offset == raw.len());
+    Ok((entries, logical_len))
+}
+
+fn semantic_encoded_len(entry: &TreeEntry) -> usize {
+    let target_len = match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => 32,
+        EntryType::Gitlink => entry
+            .gitlink_target()
+            .expect("decoded gitlink has a target")
+            .as_bytes()
+            .len(),
+        EntryType::Spoollink => {
+            let (spool, state) = entry
+                .spoollink_target()
+                .expect("decoded spoollink has a target");
+            4 + spool.as_str().len() + state.as_bytes().len()
+        }
+    };
+    3 + entry.name().len() + target_len
+}
+
+fn block_decoder(dictionary: Dictionary<'_>) -> Result<zstd::bulk::Decompressor<'_>> {
+    if let Some(prepared) = dictionary.decoder {
+        Ok(zstd::bulk::Decompressor::with_prepared_dictionary(
+            prepared,
+        )?)
+    } else {
+        Ok(zstd::bulk::Decompressor::new()?)
+    }
+}
+
+fn decode_blocked(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    let header = parse_block_header(bytes, dictionary)?;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut entries = Vec::with_capacity(header.entry_count);
+    let mut raw_payload_len = 0usize;
+    let mut logical_len = 0u64;
+    let mut expected_offset = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    for block in 0..header.block_count {
+        let index = parse_block_index(bytes, header, block)?;
+        ensure!(
+            index.offset == expected_offset,
+            "non-contiguous block payload"
+        );
+        expected_offset += index.stored_len;
+        let raw = decompress_block(bytes, index, &mut decoder)?;
+        raw_payload_len += raw.len();
+        let (mut decoded, block_logical_len) = decode_frames(&raw)?;
+        let expected_entries = header
+            .block_entries
+            .min(header.entry_count - block * header.block_entries);
+        ensure!(
+            decoded.len() == expected_entries,
+            "block entry count mismatch"
+        );
+        logical_len += block_logical_len;
+        entries.append(&mut decoded);
+    }
+    ensure!(expected_offset == bytes.len(), "trailing HTB1 bytes");
+    ensure!(raw_payload_len == header.raw_payload_len);
+    ensure!(logical_len == header.logical_len);
+    ensure!(entries.len() == header.entry_count);
+    let tree = Tree::try_from_decoded_entries(entries)?;
+    ensure!(tree.hash() == header.tree_id, "HTB1 tree hash mismatch");
+    black_box(header.dictionary_id);
+    Ok(tree)
+}
+
+fn decode_adaptive(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        decode_blocked(bytes, dictionary)
+    } else {
+        Ok(Tree::decode_canonical(bytes)?)
+    }
+}
+
+struct PartialRead {
+    entries: Vec<TreeEntry>,
+    bytes_read: usize,
+}
+
+fn partial_blocked(
+    bytes: &[u8],
+    dictionary: Dictionary<'_>,
+    first: usize,
+    count: usize,
+) -> Result<PartialRead> {
+    let header = parse_block_header(bytes, dictionary)?;
+    ensure!(count > 0 && first + count <= header.entry_count);
+    let first_block = first / header.block_entries;
+    let last_block = (first + count - 1) / header.block_entries;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut selected = Vec::with_capacity(count);
+    let mut bytes_read = BLOCK_HEADER_LEN;
+    for block in first_block..=last_block {
+        let index = parse_block_index(bytes, header, block)?;
+        bytes_read += BLOCK_INDEX_LEN;
+        let stored = &bytes[index.offset..index.offset + index.stored_len];
+        let wanted_start = first.saturating_sub(index.first_entry);
+        let wanted_end = (first + count - index.first_entry)
+            .min(header.block_entries)
+            .min(header.entry_count - index.first_entry);
+        let only_anchor = wanted_start == 0 && wanted_end == 1;
+        let raw = if index.stored_len == index.raw_len {
+            let (entries, consumed) = decode_frame_range(stored, wanted_start, wanted_end)?;
+            bytes_read += consumed;
+            selected.extend(entries);
+            continue;
+        } else if only_anchor {
+            let anchor_end = raw_anchor_end(stored)?;
+            bytes_read += anchor_end;
+            let (entries, consumed) = decode_frame_range(stored, 0, 1)?;
+            ensure!(consumed == anchor_end);
+            selected.extend(entries);
+            continue;
+        } else {
+            bytes_read += index.stored_len;
+            decompress_block(bytes, index, &mut decoder)?
+        };
+        let (entries, _) = decode_frame_range(&raw, wanted_start, wanted_end)?;
+        selected.extend(entries);
+    }
+    ensure!(selected.len() == count);
+    Ok(PartialRead {
+        entries: selected,
+        bytes_read,
+    })
+}
+
+fn decode_frame_range(
+    raw: &[u8],
+    wanted_start: usize,
+    wanted_end: usize,
+) -> Result<(Vec<TreeEntry>, usize)> {
+    ensure!(wanted_start < wanted_end, "empty frame range");
+    let mut entries = Vec::with_capacity(wanted_end - wanted_start);
+    let mut offset = 0usize;
+    for ordinal in 0..wanted_end {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated ranged frame")?;
+        if ordinal >= wanted_start {
+            entries.push(decode_entry_frame(frame)?);
+        }
+        offset = end;
+    }
+    Ok((entries, offset))
+}
+
+fn partial_htr4(bytes: &Bytes, tree_id: ContentHash, count: usize) -> PartialRead {
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree_id,
+        None,
+    )
+    .expect("open HTR4 reader");
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX).expect("page limits"))
+        .expect("decode partial HTR4 page")
+        .expect("nonempty page");
+    let bytes_read = reader.bytes_read() as usize;
+    PartialRead {
+        entries: page.entries,
+        bytes_read,
+    }
+}
+
+fn partial_adaptive(
+    bytes: &Bytes,
+    dictionary: Dictionary<'_>,
+    tree_id: ContentHash,
+    count: usize,
+) -> PartialRead {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        partial_blocked(bytes, dictionary, 0, count).expect("partial HTB1")
+    } else {
+        partial_htr4(bytes, tree_id, count)
+    }
+}
+
+fn partial_whole_zstd(compressed: &[u8], tree_id: ContentHash, count: usize) -> PartialRead {
+    let htr4 = Bytes::from(zstd::decode_all(compressed).expect("decompress whole HTR4"));
+    let mut read = partial_htr4(&htr4, tree_id, count);
+    read.bytes_read = compressed.len();
+    read
+}
+
+fn partial_production_file(path: &Path, tree_id: ContentHash, count: usize) -> Result<PartialRead> {
+    let file = File::open(path)?;
+    let len = file.metadata()?.len();
+    let mut reader =
+        TreeEntryReader::open(FileTreeSource::sequential_verify(file, len), tree_id, None)?;
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX)?)?
+        .context("nonempty production tree page")?;
+    Ok(PartialRead {
+        entries: page.entries,
+        bytes_read: reader.bytes_read() as usize,
+    })
+}
+
+struct RealCorpus {
+    label: String,
+    path: PathBuf,
+    object_format: GitObjectFormat,
+    discovered_trees: usize,
+    skipped_trees: usize,
+    trees: Vec<Tree>,
+}
+
+fn git_output(repo: &Path, arguments: &[&str]) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(arguments)
+        .output()
+        .with_context(|| format!("run git in {}", repo.display()))?;
+    ensure!(
+        output.status.success(),
+        "git {} failed in {}: {}",
+        arguments.join(" "),
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(output.stdout)
+}
+
+fn real_object_format(repo: &Path) -> Result<GitObjectFormat> {
+    let output = git_output(repo, &["rev-parse", "--show-object-format"])?;
+    match std::str::from_utf8(&output)?.trim() {
+        "sha1" => Ok(GitObjectFormat::Sha1),
+        "sha256" => Ok(GitObjectFormat::Sha256),
+        format => bail!("unsupported Git object format {format}"),
+    }
+}
+
+fn sample_evenly<T: Clone>(values: &[T], limit: usize) -> Vec<T> {
+    if values.len() <= limit {
+        return values.to_vec();
+    }
+    if limit == 1 {
+        return vec![values[values.len() / 2].clone()];
+    }
+    (0..limit)
+        .map(|index| values[index * (values.len() - 1) / (limit - 1)].clone())
+        .collect()
+}
+
+fn discover_tree_ids(repo: &Path, limit: usize) -> Result<(usize, Vec<String>)> {
+    let output = git_output(
+        repo,
+        &[
+            "cat-file",
+            "--batch-all-objects",
+            "--batch-check=%(objectname) %(objecttype)",
+        ],
+    )?;
+    let mut tree_ids = BTreeSet::new();
+    for line in output.split(|byte| *byte == b'\n') {
+        let mut fields = line.split(|byte| *byte == b' ');
+        let Some(oid) = fields.next() else {
+            continue;
+        };
+        if fields.next() == Some(b"tree") {
+            tree_ids.insert(std::str::from_utf8(oid)?.to_string());
+        }
+    }
+    let discovered = tree_ids.len();
+    let tree_ids = sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit);
+    Ok((discovered, tree_ids))
+}
+
+fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> {
+    let oid_len = match format {
+        GitObjectFormat::Sha1 => 20,
+        GitObjectFormat::Sha256 => 32,
+    };
+    let mut entries = Vec::new();
+    let mut offset = 0usize;
+    while offset < body.len() {
+        let mode_end = body[offset..]
+            .iter()
+            .position(|byte| *byte == b' ')
+            .map(|relative| offset + relative)
+            .context("Git tree mode terminator")?;
+        let mode = u32::from_str_radix(std::str::from_utf8(&body[offset..mode_end])?, 8)?;
+        let name_start = mode_end + 1;
+        let name_end = body[name_start..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|relative| name_start + relative)
+            .context("Git tree name terminator")?;
+        let Some(name) = std::str::from_utf8(&body[name_start..name_end]).ok() else {
+            return Ok(None);
+        };
+        let oid_start = name_end + 1;
+        let oid_end = oid_start
+            .checked_add(oid_len)
+            .context("Git tree oid length overflow")?;
+        let oid = body
+            .get(oid_start..oid_end)
+            .context("truncated Git tree oid")?;
+        let mapped_hash = ContentHash::compute(oid);
+        let entry = match mode {
+            0o040000 => TreeEntry::directory(name, mapped_hash),
+            0o120000 => TreeEntry::symlink(name, mapped_hash),
+            0o160000 => TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid)?),
+            value if value & 0o170000 == 0o100000 => {
+                TreeEntry::file(name, mapped_hash, value & 0o111 != 0)
+            }
+            _ => return Ok(None),
+        };
+        let Ok(entry) = entry else {
+            return Ok(None);
+        };
+        entries.push(entry);
+        offset = oid_end;
+    }
+    Ok(Some(Tree::from_entries(entries)))
+}
+
+fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
+    let path = path.canonicalize()?;
+    let label = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("repository")
+        .to_string();
+    let object_format = real_object_format(&path)?;
+    let (discovered_trees, tree_ids) = discover_tree_ids(&path, limit)?;
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(&path)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdin = child.stdin.take().context("Git cat-file stdin")?;
+    let mut requests = BufWriter::new(stdin);
+    let stdout = child.stdout.take().context("Git cat-file stdout")?;
+    let mut reader = BufReader::new(stdout);
+    let mut trees = Vec::with_capacity(tree_ids.len());
+    let mut skipped_trees = 0usize;
+    for expected_oid in &tree_ids {
+        writeln!(requests, "{expected_oid}")?;
+        requests.flush()?;
+        let mut header = String::new();
+        reader.read_line(&mut header)?;
+        let mut fields = header.split_whitespace();
+        let oid = fields.next().context("Git batch object id")?;
+        let kind = fields.next().context("Git batch object type")?;
+        let size: usize = fields.next().context("Git batch object size")?.parse()?;
+        ensure!(
+            oid == expected_oid && kind == "tree",
+            "unexpected Git batch response"
+        );
+        let mut body = vec![0u8; size];
+        reader.read_exact(&mut body)?;
+        let mut delimiter = [0u8; 1];
+        reader.read_exact(&mut delimiter)?;
+        ensure!(delimiter == *b"\n", "missing Git batch delimiter");
+        if let Some(tree) = parse_git_tree(&body, object_format)? {
+            trees.push(tree);
+        } else {
+            skipped_trees += 1;
+        }
+    }
+    drop(requests);
+    let output = child.wait_with_output()?;
+    ensure!(
+        output.status.success(),
+        "Git tree batch failed in {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(RealCorpus {
+        label,
+        path,
+        object_format,
+        discovered_trees,
+        skipped_trees,
+        trees,
+    })
+}
+
+struct RealFileFixture {
+    raw: NamedTempFile,
+    adaptive: NamedTempFile,
+    tree_id: ContentHash,
+    entries: usize,
+}
+
+fn write_temp(bytes: &[u8]) -> Result<NamedTempFile> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(bytes)?;
+    file.as_file_mut().flush()?;
+    Ok(file)
+}
+
+fn percentile(sorted: &[usize], numerator: usize, denominator: usize) -> usize {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[(sorted.len() - 1) * numerator / denominator]
+}
+
+#[derive(Debug)]
+struct Timing {
+    median_ns: f64,
+    mean_ns: f64,
+    stddev_ns: f64,
+    cv_percent: f64,
+    iterations_per_sample: u64,
+}
+
+fn run_iterations<F, T>(operation: &mut F, iterations: u64) -> Duration
+where
+    F: FnMut() -> T,
+{
+    let started = Instant::now();
+    for _ in 0..iterations {
+        black_box(operation());
+    }
+    started.elapsed()
+}
+
+fn measure<F, T>(mut operation: F) -> Timing
+where
+    F: FnMut() -> T,
+{
+    let mut iterations = 1u64;
+    let elapsed = loop {
+        let elapsed = run_iterations(&mut operation, iterations);
+        if elapsed >= CALIBRATION_TIME || iterations >= (1 << 30) {
+            break elapsed;
+        }
+        iterations = iterations.saturating_mul(2);
+    };
+    let elapsed_ns = elapsed.as_nanos().max(1) as u64;
+    iterations = iterations
+        .saturating_mul(SAMPLE_TIME.as_nanos() as u64)
+        .div_ceil(elapsed_ns)
+        .max(1);
+
+    let mut samples = Vec::with_capacity(SAMPLE_COUNT);
+    for _ in 0..SAMPLE_COUNT {
+        let elapsed = run_iterations(&mut operation, iterations);
+        samples.push(elapsed.as_nanos() as f64 / iterations as f64);
+    }
+    samples.sort_by(f64::total_cmp);
+    let median_ns = samples[samples.len() / 2];
+    let mean_ns = samples.iter().sum::<f64>() / samples.len() as f64;
+    let variance = samples
+        .iter()
+        .map(|sample| (sample - mean_ns).powi(2))
+        .sum::<f64>()
+        / (samples.len() - 1) as f64;
+    let stddev_ns = variance.sqrt();
+    Timing {
+        median_ns,
+        mean_ns,
+        stddev_ns,
+        cv_percent: stddev_ns / mean_ns * 100.0,
+        iterations_per_sample: iterations,
+    }
+}
+
+fn print_timing(entries: usize, operation: &str, timing: &Timing) {
+    println!(
+        "TIMING,{entries},{operation},{:.3},{:.3},{:.3},{:.3},{}",
+        timing.median_ns,
+        timing.mean_ns,
+        timing.stddev_ns,
+        timing.cv_percent,
+        timing.iterations_per_sample
+    );
+}
+
+fn historical_loose(tree: &Tree) -> Vec<u8> {
+    let positional = rmp_serde::to_vec(tree).expect("encode positional MessagePack");
+    compress_with_dictionary(
+        &positional,
+        &CompressionConfig::default(),
+        CompressionDictionary::TreeStateV1,
+    )
+    .expect("compress historical loose-tree body")
+    .unwrap_or(positional)
+}
+
+fn measure_real_partial(
+    fixtures: &[&RealFileFixture],
+    count: usize,
+) -> Result<(Timing, Timing, f64, f64)> {
+    ensure!(
+        !fixtures.is_empty(),
+        "no real file fixtures for {count}-entry read"
+    );
+    let mut raw_index = 0usize;
+    let raw_timing = measure(|| {
+        let fixture = &fixtures[raw_index % fixtures.len()];
+        raw_index += 1;
+        let read = partial_production_file(fixture.raw.path(), fixture.tree_id, count)
+            .expect("file-backed raw read");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut adaptive_index = 0usize;
+    let adaptive_timing = measure(|| {
+        let fixture = &fixtures[adaptive_index % fixtures.len()];
+        adaptive_index += 1;
+        let read = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)
+            .expect("file-backed adaptive read");
+        black_box(read.entries[count - 1].name().len())
+    });
+
+    let mut raw_bytes = 0usize;
+    let mut adaptive_bytes = 0usize;
+    for fixture in fixtures {
+        let raw = partial_production_file(fixture.raw.path(), fixture.tree_id, count)?;
+        let adaptive = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)?;
+        ensure!(
+            raw.entries == adaptive.entries,
+            "file-backed partial mismatch"
+        );
+        raw_bytes += raw.bytes_read;
+        adaptive_bytes += adaptive.bytes_read;
+    }
+    Ok((
+        raw_timing,
+        adaptive_timing,
+        raw_bytes as f64 / fixtures.len() as f64,
+        adaptive_bytes as f64 / fixtures.len() as f64,
+    ))
+}
+
+fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
+    ensure!(!corpora.is_empty(), "no real repositories supplied");
+    println!(
+        "REAL_REPO,label,path,object_format,discovered_trees,sampled_trees,skipped_trees,min_entries,p50_entries,p95_entries,max_entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink"
+    );
+    println!(
+        "REAL_SIZE,label,trees,htr4_raw,historical_loose,adaptive,compressed_trees,raw_fallback_trees,vs_raw_percent,vs_historical_percent"
+    );
+
+    let mut aggregate_raw = 0usize;
+    let mut aggregate_historical = 0usize;
+    let mut aggregate_adaptive = 0usize;
+    let mut aggregate_trees = 0usize;
+    let mut aggregate_compressed = 0usize;
+    let mut file_candidates = Vec::new();
+    let config = CompressionConfig::default();
+
+    for corpus in corpora {
+        ensure!(
+            !corpus.trees.is_empty(),
+            "{} yielded no importable trees",
+            corpus.label
+        );
+        let mut entry_counts = corpus.trees.iter().map(Tree::len).collect::<Vec<_>>();
+        entry_counts.sort_unstable();
+        let mut name_lengths = Vec::new();
+        let mut variants = [0usize; 5];
+        let mut raw_total = 0usize;
+        let mut historical_total = 0usize;
+        let mut adaptive_total = 0usize;
+        let mut compressed_trees = 0usize;
+        let mut raw_fallback_trees = 0usize;
+        let mut eligible_files = Vec::new();
+
+        for tree in &corpus.trees {
+            for entry in tree.entries() {
+                name_lengths.push(entry.name().len());
+                let bucket = match (entry.entry_type(), entry.mode()) {
+                    (EntryType::Blob, FileMode::Normal) => 0,
+                    (EntryType::Blob, FileMode::Executable) => 1,
+                    (EntryType::Tree, _) => 2,
+                    (EntryType::Symlink, _) => 3,
+                    (EntryType::Gitlink, _) => 4,
+                    (EntryType::Spoollink, _) => continue,
+                    _ => continue,
+                };
+                variants[bucket] += 1;
+            }
+            let raw = tree.encode_canonical()?;
+            let historical = historical_loose(tree);
+            let (_, adaptive) = objects::store::codec::encode_tree(tree, &config)?;
+            raw_total += raw.len();
+            historical_total += historical.len();
+            adaptive_total += adaptive.len();
+            if adaptive.get(4) == Some(&TREE_BLOCK_ENCODING_VERSION) {
+                compressed_trees += 1;
+                if !tree.is_empty() {
+                    eligible_files.push((tree.len(), tree.hash(), raw, adaptive));
+                }
+            } else {
+                raw_fallback_trees += 1;
+            }
+        }
+
+        name_lengths.sort_unstable();
+        let mean_name = if name_lengths.is_empty() {
+            0.0
+        } else {
+            name_lengths.iter().sum::<usize>() as f64 / name_lengths.len() as f64
+        };
+        println!(
+            "REAL_REPO,{},{},{:?},{},{},{},{},{},{},{},{},{},{:.2},{},{},{},{},{}",
+            corpus.label,
+            corpus.path.display(),
+            corpus.object_format,
+            corpus.discovered_trees,
+            corpus.trees.len(),
+            corpus.skipped_trees,
+            entry_counts[0],
+            percentile(&entry_counts, 50, 100),
+            percentile(&entry_counts, 95, 100),
+            entry_counts[entry_counts.len() - 1],
+            name_lengths.first().copied().unwrap_or(0),
+            name_lengths.last().copied().unwrap_or(0),
+            mean_name,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+        );
+        println!(
+            "REAL_SIZE,{},{},{},{},{},{},{},{:.3},{:.3}",
+            corpus.label,
+            corpus.trees.len(),
+            raw_total,
+            historical_total,
+            adaptive_total,
+            compressed_trees,
+            raw_fallback_trees,
+            100.0 * (adaptive_total as f64 / raw_total as f64 - 1.0),
+            100.0 * (adaptive_total as f64 / historical_total as f64 - 1.0),
+        );
+        aggregate_raw += raw_total;
+        aggregate_historical += historical_total;
+        aggregate_adaptive += adaptive_total;
+        aggregate_trees += corpus.trees.len();
+        aggregate_compressed += compressed_trees;
+
+        eligible_files.sort_by_key(|candidate| candidate.0);
+        file_candidates.extend(sample_evenly(&eligible_files, REAL_FILE_SAMPLE_LIMIT));
+    }
+
+    println!(
+        "REAL_SIZE,ALL,{aggregate_trees},{aggregate_raw},{aggregate_historical},{aggregate_adaptive},{aggregate_compressed},{},{:.3},{:.3}",
+        aggregate_trees - aggregate_compressed,
+        100.0 * (aggregate_adaptive as f64 / aggregate_raw as f64 - 1.0),
+        100.0 * (aggregate_adaptive as f64 / aggregate_historical as f64 - 1.0),
+    );
+    ensure!(
+        aggregate_adaptive < aggregate_historical,
+        "real-tree adaptive size does not beat historical loose compression"
+    );
+
+    file_candidates.sort_by_key(|candidate| candidate.0);
+    let file_candidates = sample_evenly(&file_candidates, REAL_FILE_SAMPLE_LIMIT);
+    let mut file_fixtures = Vec::with_capacity(file_candidates.len());
+    for (entries, tree_id, raw, adaptive) in file_candidates {
+        file_fixtures.push(RealFileFixture {
+            raw: write_temp(&raw)?,
+            adaptive: write_temp(&adaptive)?,
+            tree_id,
+            entries,
+        });
+    }
+    println!(
+        "REAL_FILE_PARTIAL,count,trees,min_tree_entries,max_tree_entries,raw_mean_bytes,adaptive_mean_bytes,raw_median_ns,adaptive_median_ns,time_ratio"
+    );
+    for count in [1usize, 100] {
+        let eligible = file_fixtures
+            .iter()
+            .filter(|fixture| fixture.entries >= count)
+            .collect::<Vec<_>>();
+        ensure!(
+            !eligible.is_empty(),
+            "no compressed real trees with {count} entries"
+        );
+        let (raw_timing, adaptive_timing, raw_bytes, adaptive_bytes) =
+            measure_real_partial(&eligible, count)?;
+        let ratio = adaptive_timing.median_ns / raw_timing.median_ns;
+        println!(
+            "REAL_FILE_PARTIAL,{count},{},{},{},{raw_bytes:.2},{adaptive_bytes:.2},{:.3},{:.3},{ratio:.3}",
+            eligible.len(),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .min()
+                .unwrap_or(0),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .max()
+                .unwrap_or(0),
+            raw_timing.median_ns,
+            adaptive_timing.median_ns,
+        );
+        ensure!(
+            ratio <= 2.0,
+            "file-backed {count}-entry partial read is {ratio:.3}x raw HTR4"
+        );
+    }
+    println!("REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true");
+    Ok(())
+}
+
+fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
+    let tree = fixture(1_000);
+    let blocked = encode_blocked(&tree, block_entries, dictionary)?;
+    ensure!(decode_blocked(&blocked, dictionary)? == tree);
+    let range_start = block_entries.saturating_sub(20);
+    let partial = partial_blocked(&blocked, dictionary, range_start, 100)?;
+    ensure!(partial.entries == tree.entries()[range_start..range_start + 100]);
+    if block_entries < tree.len() {
+        let resumed = partial_blocked(&blocked, dictionary, block_entries, 1)?;
+        ensure!(resumed.entries == tree.entries()[block_entries..block_entries + 1]);
+    }
+
+    let mut bad_hash = blocked.clone();
+    bad_hash[8] ^= 1;
+    ensure!(decode_blocked(&bad_hash, dictionary).is_err());
+    let mut bad_payload = blocked;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    ensure!(decode_blocked(&bad_payload, dictionary).is_err());
+    Ok(())
+}
+
+fn tune(dictionaries: &[Dictionary<'_>]) -> Result<()> {
+    let tree = fixture(10_000);
+    let htr4 = tree.encode_canonical()?;
+    let historical = historical_loose(&tree);
+    println!(
+        "TUNE,block_entries,dictionary,encoded_bytes,vs_raw_percent,vs_historical_percent,first_1_bytes,first_100_bytes,first_1_median_ns,first_100_median_ns"
+    );
+    for dictionary in dictionaries {
+        for block_entries in [1, 8, 16, 32, 64, 128, 256, 512] {
+            let blocked = Bytes::from(encode_blocked(&tree, block_entries, *dictionary)?);
+            let first_1 = partial_blocked(&blocked, *dictionary, 0, 1)?;
+            let first_100 = partial_blocked(&blocked, *dictionary, 0, 100)?;
+            let first_1_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 1).expect("partial");
+                black_box(read.entries[0].name());
+            });
+            let first_100_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 100).expect("partial");
+                black_box(read.entries[99].name());
+            });
+            println!(
+                "TUNE,{block_entries},{},{},{:.3},{:.3},{},{},{:.3},{:.3}",
+                dictionary.name,
+                blocked.len(),
+                100.0 * (blocked.len() as f64 / htr4.len() as f64 - 1.0),
+                100.0 * (blocked.len() as f64 / historical.len() as f64 - 1.0),
+                first_1.bytes_read,
+                first_100.bytes_read,
+                first_1_timing.median_ns,
+                first_100_timing.median_ns,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn crossover(block_entries: usize, dictionary: Dictionary<'_>) -> Result<()> {
+    let mut first_raw_win = None;
+    let mut last_raw_loss = None;
+    let mut first_historical_win = None;
+    let mut last_historical_loss = None;
+    for entries in 1..=512 {
+        let tree = fixture(entries);
+        let htr4 = tree.encode_canonical()?;
+        let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+        let historical = historical_loose(&tree);
+        if blocked.len() < htr4.len() {
+            first_raw_win.get_or_insert(entries);
+        } else {
+            last_raw_loss = Some(entries);
+        }
+        if blocked.len() < historical.len() {
+            first_historical_win.get_or_insert(entries);
+        } else {
+            last_historical_loss = Some(entries);
+        }
+    }
+    println!(
+        "CROSSOVER,block_entries={},dictionary={},first_smaller_than_raw={},stable_smaller_than_raw_from={},first_smaller_than_historical={},stable_smaller_than_historical_from={},sweep_end=512",
+        block_entries,
+        dictionary.name,
+        first_raw_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_raw_loss.map_or(1, |value| value + 1),
+        first_historical_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_historical_loss.map_or(1, |value| value + 1),
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let trained = training_dictionary()?;
+    // A production decoder would retain these prepared dictionaries in a
+    // process-wide lazy cell. Preparation is outside all retained samples.
+    let legacy_encoder = zstd::dict::EncoderDictionary::copy(LEGACY_DICTIONARY, BLOCK_LEVEL);
+    let legacy_decoder = zstd::dict::DecoderDictionary::copy(LEGACY_DICTIONARY);
+    let trained_encoder = zstd::dict::EncoderDictionary::copy(&trained, BLOCK_LEVEL);
+    let trained_decoder = zstd::dict::DecoderDictionary::copy(&trained);
+    let dictionaries = [
+        Dictionary {
+            name: "none",
+            id: 0,
+            bytes: &[],
+            encoder: None,
+            decoder: None,
+        },
+        Dictionary {
+            name: "legacy",
+            id: LEGACY_DICTIONARY_ID,
+            bytes: LEGACY_DICTIONARY,
+            encoder: Some(&legacy_encoder),
+            decoder: Some(&legacy_decoder),
+        },
+        Dictionary {
+            name: "trained_htr4",
+            id: TRAINED_DICTIONARY_ID,
+            bytes: &trained,
+            encoder: Some(&trained_encoder),
+            decoder: Some(&trained_decoder),
+        },
+    ];
+    let dictionary_name = env::var("HTR4_DICTIONARY").unwrap_or_else(|_| "none".into());
+    let dictionary = *dictionaries
+        .iter()
+        .find(|dictionary| dictionary.name == dictionary_name)
+        .with_context(|| format!("unknown HTR4_DICTIONARY={dictionary_name}"))?;
+    let block_entries = env::var("HTR4_BLOCK_ENTRIES")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(256usize);
+    let real_tree_limit = env::var("HTR4_REAL_TREE_LIMIT")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(DEFAULT_REAL_TREE_LIMIT);
+    let real_paths = {
+        let supplied = env::args().skip(1).map(PathBuf::from).collect::<Vec<_>>();
+        if supplied.is_empty() {
+            vec![PathBuf::from(".")]
+        } else {
+            supplied
+        }
+    };
+    let real_corpora = real_paths
+        .iter()
+        .map(|path| load_real_corpus(path, real_tree_limit))
+        .collect::<Result<Vec<_>>>()?;
+
+    self_check(dictionary, block_entries)?;
+    println!("META,seed,0x{SEED:016x}");
+    println!("META,samples,{SAMPLE_COUNT}");
+    println!("META,target_sample_ms,{}", SAMPLE_TIME.as_millis());
+    println!("META,block_entries,{block_entries}");
+    println!("META,real_tree_limit_per_repo,{real_tree_limit}");
+    println!("META,dictionary,{}", dictionary.name);
+    println!("META,dictionary_bytes,{}", dictionary.bytes.len());
+    println!("META,dictionary_blake3,{}", blake3::hash(dictionary.bytes));
+    println!("META,self_check,roundtrip+range+hash_corruption+payload_corruption_ok");
+    validate_real_corpora(&real_corpora)?;
+    println!(
+        "FIXTURE,entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink,spoollink"
+    );
+    println!(
+        "SIZE,entries,htr4_raw,historical_loose,htr4_whole_zstd3,htb1_blocked,adaptive_size,adaptive_mode"
+    );
+    println!(
+        "TIMING,entries,operation,median_ns,mean_ns,stddev_ns,cv_percent,iterations_per_sample"
+    );
+
+    let fixtures: Vec<(usize, Tree)> = SIZES
+        .into_iter()
+        .map(|entries| (entries, fixture(entries)))
+        .collect();
+
+    for (entries, tree) in &fixtures {
+        let mut min_name = usize::MAX;
+        let mut max_name = 0usize;
+        let mut total_name = 0usize;
+        let mut variants = [0usize; 6];
+        for entry in tree.entries() {
+            min_name = min_name.min(entry.name().len());
+            max_name = max_name.max(entry.name().len());
+            total_name += entry.name().len();
+            let bucket = match (entry.entry_type(), entry.mode()) {
+                (EntryType::Blob, FileMode::Normal) => 0,
+                (EntryType::Blob, FileMode::Executable) => 1,
+                (EntryType::Tree, _) => 2,
+                (EntryType::Symlink, _) => 3,
+                (EntryType::Gitlink, _) => 4,
+                (EntryType::Spoollink, _) => 5,
+                _ => unreachable!("validated entry kind/mode"),
+            };
+            variants[bucket] += 1;
+        }
+        println!(
+            "FIXTURE,{entries},{min_name},{max_name},{:.2},{},{},{},{},{},{}",
+            total_name as f64 / *entries as f64,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+            variants[5]
+        );
+
+        let htr4 = tree.encode_canonical()?;
+        let historical = historical_loose(tree);
+        let whole_zstd = zstd::encode_all(htr4.as_slice(), BLOCK_LEVEL)?;
+        let blocked = encode_blocked(tree, block_entries, dictionary)?;
+        let adaptive = if blocked.len() < htr4.len() {
+            blocked.clone()
+        } else {
+            htr4.clone()
+        };
+        let mode = if adaptive.starts_with(BLOCK_MAGIC) {
+            "blocked"
+        } else {
+            "raw"
+        };
+        ensure!(Tree::decode_canonical(&htr4)? == *tree);
+        ensure!(decode_blocked(&blocked, dictionary)? == *tree);
+        ensure!(decode_adaptive(&adaptive, dictionary)? == *tree);
+        let whole_decoded = zstd::decode_all(whole_zstd.as_slice())?;
+        ensure!(Tree::decode_canonical(&whole_decoded)? == *tree);
+        println!(
+            "SIZE,{entries},{},{},{},{},{},{}",
+            htr4.len(),
+            historical.len(),
+            whole_zstd.len(),
+            blocked.len(),
+            adaptive.len(),
+            mode,
+        );
+
+        print_timing(
+            *entries,
+            "htr4_encode",
+            &measure(|| tree.encode_canonical().expect("encode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_encode",
+            &measure(|| {
+                let raw = tree.encode_canonical().expect("encode HTR4");
+                zstd::encode_all(raw.as_slice(), BLOCK_LEVEL).expect("compress whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_encode",
+            &measure(|| {
+                encode_adaptive(tree, block_entries, dictionary).expect("encode adaptive HTB1")
+            }),
+        );
+        print_timing(
+            *entries,
+            "htr4_decode",
+            &measure(|| Tree::decode_canonical(black_box(&htr4)).expect("decode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_decode",
+            &measure(|| {
+                let raw = zstd::decode_all(black_box(whole_zstd.as_slice()))
+                    .expect("decompress whole HTR4");
+                Tree::decode_canonical(&raw).expect("decode whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_decode",
+            &measure(|| {
+                decode_adaptive(black_box(&adaptive), dictionary).expect("decode adaptive HTB1")
+            }),
+        );
+    }
+
+    let (entries, tree) = fixtures.last().context("10k fixture")?;
+    let htr4 = Bytes::from(tree.encode_canonical()?);
+    let whole_zstd = zstd::encode_all(htr4.as_ref(), BLOCK_LEVEL)?;
+    let adaptive = Bytes::from(encode_adaptive(tree, block_entries, dictionary)?);
+    let tree_id = tree.hash();
+    println!("PARTIAL,entries,count,format,bytes_read,median_ns");
+    for count in [1usize, 100] {
+        let raw_read = partial_htr4(&htr4, tree_id, count);
+        let raw_timing = measure(|| {
+            let read = partial_htr4(&htr4, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},htr4_raw,{},{:.3}",
+            raw_read.bytes_read, raw_timing.median_ns
+        );
+
+        let block_read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+        let block_timing = measure(|| {
+            let read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},adaptive_block,{},{:.3}",
+            block_read.bytes_read, block_timing.median_ns
+        );
+
+        let whole_read = partial_whole_zstd(&whole_zstd, tree_id, count);
+        let whole_timing = measure(|| {
+            let read = partial_whole_zstd(&whole_zstd, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},whole_zstd,{},{:.3}",
+            whole_read.bytes_read, whole_timing.median_ns
+        );
+    }
+
+    crossover(block_entries, dictionary)?;
+    if env::var_os("HTR4_TUNE").is_some() {
+        tune(&dictionaries)?;
+    }
+    Ok(())
+}

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -823,7 +823,15 @@ fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> 
         entries.push(entry);
         offset = oid_end;
     }
-    Ok(Some(Tree::from_entries(entries)))
+    let tree = Tree::from_entries(entries);
+    if tree
+        .entries()
+        .windows(2)
+        .any(|pair| pair[0].name() == pair[1].name())
+    {
+        return Ok(None);
+    }
+    Ok(Some(tree))
 }
 
 fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -23,10 +23,13 @@ pub fn decode_blob_content(data: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
-pub fn encode_tree(tree: &Tree, _config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
-    // Canonical trees stay uncompressed so a resume cursor can seek to an
-    // entry frame without decompressing the prefix.
-    Ok((tree.hash(), tree.encode_canonical()?))
+pub fn encode_tree(tree: &Tree, config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
+    let encoded = if config.enabled && tree.len() >= crate::object::TREE_BLOCK_MIN_ENTRIES {
+        tree.encode_canonical_blocked(config.level, config.min_size)?
+    } else {
+        tree.encode_canonical()?
+    };
+    Ok((tree.hash(), encoded))
 }
 
 pub fn decode_tree(data: &[u8]) -> Result<Tree> {
@@ -135,16 +138,17 @@ mod tests {
         let (_, encoded_tree) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
         let encoded_state = encode_state(&state, &CompressionConfig::default()).unwrap();
 
-        assert!(
-            crate::object::is_canonical_tree(&encoded_tree),
-            "trees stay uncompressed HTR4 so resume can seek"
+        assert_eq!(
+            encoded_tree[4],
+            crate::object::TREE_BLOCK_ENCODING_VERSION,
+            "eligible trees use seekable block-compressed HTR4"
         );
         assert_eq!(&encoded_state[9..13], &1_u32.to_be_bytes());
     }
 
     #[test]
     #[cfg(feature = "zstd")]
-    fn tree_state_dictionary_corpus_roundtrips_byte_identically() {
+    fn tree_and_state_corpus_roundtrips() {
         let config = CompressionConfig::default();
 
         for revision in 0..64 {
@@ -162,9 +166,8 @@ mod tests {
                     })
                     .collect(),
             );
-            let serialized_tree = tree.encode_canonical().unwrap();
             let (_, encoded_tree) = encode_tree(&tree, &config).unwrap();
-            assert_eq!(decode_tree_body(&encoded_tree).unwrap(), serialized_tree);
+            assert_eq!(decode_tree_serialized(&encoded_tree).unwrap(), tree);
 
             let state = State::new(
                 tree.hash(),
@@ -182,6 +185,40 @@ mod tests {
                 serialized_state
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    fn small_tree_and_disabled_compression_use_raw_htr4() {
+        let tree = Tree::from_entries(
+            (0..crate::object::TREE_BLOCK_MIN_ENTRIES - 1)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:02}.rs"),
+                        ContentHash::compute(format!("blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let (_, small) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
+        assert_eq!(small[4], crate::object::TREE_ENCODING_VERSION);
+
+        let large = Tree::from_entries(
+            (0..64)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:02}.rs"),
+                        ContentHash::compute(format!("large-blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let (_, disabled) = encode_tree(&large, &CompressionConfig::disabled()).unwrap();
+        assert_eq!(disabled[4], crate::object::TREE_ENCODING_VERSION);
     }
 
     #[test]

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1072,6 +1072,49 @@ fn loose_htr4_open_is_sequential_and_hashes() {
 }
 
 #[test]
+#[cfg(feature = "zstd")]
+fn loose_block_compressed_htr4_reads_a_file_backed_page_and_verifies() {
+    use crate::object::{TREE_BLOCK_ENCODING_VERSION, TreePageLimits};
+
+    let (_temp, store) = create_test_store();
+    let tree = Tree::from_entries(
+        (0usize..600)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("blob-{index}").as_bytes()),
+                    index.is_multiple_of(19),
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let hash = store.put_tree(&tree).unwrap();
+    let path = hash_path(&trees_dir(store.root()), &hash);
+    let bytes = std::fs::read(&path).unwrap();
+    assert_eq!(bytes[4], TREE_BLOCK_ENCODING_VERSION);
+
+    let mut reader = store.open_tree(&hash, None).unwrap().unwrap();
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.entries, tree.entries()[..1]);
+    assert!(reader.bytes_read() < 256);
+    let next = reader
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(next.entries, tree.entries()[1..101]);
+    while reader
+        .next_page(TreePageLimits::new(256, usize::MAX).unwrap())
+        .unwrap()
+        .is_some()
+    {}
+    reader.finish_and_verify().unwrap();
+}
+
+#[test]
 fn test_state_roundtrip() {
     let (_temp, store) = create_test_store();
 


### PR DESCRIPTION
## Summary
- add HTR4 v5 block compression with 256-entry independent zstd-3 blocks and raw restart anchors
- preserve HTR4 v4 decoding, logical resume cursors, file-backed ranged reads, full layout validation, and tree-hash validation
- apply an 18-entry/min-size floor plus per-block and per-object raw fallbacks
- extend the measurement harness to materialize real Git trees and exercise the production codec through file-backed range I/O

## Real-tree validation
Measured 10,257 importable trees sampled from Heddle, ripgrep, Flask, and Git itself (one non-importable duplicate-name tree skipped at the same boundary as ingest).

- aggregate production size: 68,933,566 bytes
- raw HTR4: 86,411,215 bytes (20.226% larger)
- historical compressed loose: 76,053,315 bytes (9.362% larger)
- entry-count spread: 1 to 1,193; Git p50 339 and p95 1,017
- file-backed first-entry read: 1.230x raw (150.06 vs 110.06 mean bytes)
- file-backed 100-entry read: 0.622x raw across 14 trees (13,083.07 vs 5,428.86 mean bytes)

Per-corpus versus historical loose: Heddle -3.281%, ripgrep +0.403%, Flask -0.689%, Git -9.925%; aggregate -9.362%.

## Verification
- cargo test -p heddle-objects -p heddle-object-model: 259 + 2 + 32 object-model tests and 262 + 1 objects tests passed
- zstd-enabled package suites: 265 + 2 + 32 object-model tests and 267 + 1 objects tests passed
- cargo clippy for both crates, all targets, zstd enabled, with warnings denied: clean
- release-mode htr4_measure real + synthetic run: REAL_VALIDATION size_beats_historical=true,file_partial_within_2x=true

## Failing then passing proof
- the first zstd tree-stream run failed to compile because the corruption proptest classifier did not cover the new compression error; adding the explicit class made all 23 targeted tests pass
- the first compressed fixtures failed on path separators, proving model validation remained active; valid entry names then passed eager, streamed, partial-resume, and corruption tests
- the first file-backed store test failed on an ambiguous integer type; typing the fixture range made the test execute and pass
- the expanded Git corpus initially failed on a historical duplicate-name tree; the harness now counts and skips non-importable trees, then completed the full four-repository gate

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790407146&installation_model_id=21489&pr_number=1583&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1583&signature=e0b166d482e71a882e993ed38601109dbff62eaf4bed337e91f2890a47cacb7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->