### PR TITLE
spike(objects): prototype native packed trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.4+spec-1.1.0",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -26,9 +26,11 @@ sley.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 uuid.workspace = true
+zstd = { workspace = true, optional = true }
 
 [features]
 async-source = []
+zstd = ["dep:zstd"]
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -154,8 +154,8 @@ pub use tree::{
     validate_name as validate_tree_entry_name,
 };
 pub use tree_canonical::{
-    TREE_CANONICAL_MAGIC, TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header,
-    is_canonical_tree,
+    TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_MIN_ENTRIES, TREE_CANONICAL_MAGIC,
+    TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header, is_canonical_tree,
 };
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -1,23 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Streamable canonical Tree encoding (HTR4).
+//! Streamable canonical Tree encodings (HTR4).
 //!
 //! Each entry is a length-prefixed frame, so a reader can yield one entry or
-//! a caller-sized page and resume at a byte offset without decoding the prefix.
-//! Whole-object compression is not part of this encoding: a resume cursor must
-//! be able to seek without decompressing earlier frames.
+//! a caller-sized page and resume at a byte offset without decoding the whole
+//! tree. Version 4 stores frames raw. Version 5 groups frames into independently
+//! compressed blocks with raw restart anchors and a fixed-width range index.
 
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
-use super::tree::{git_format_from_tag, git_format_to_tag};
-use super::tree_stream::TreeStreamError;
-use super::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError};
+use super::{
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+    tree::{git_format_from_tag, git_format_to_tag},
+    tree_stream::TreeStreamError,
+};
 
 /// Durable encoding version stored in every HTR4 header and resume cursor.
 pub const TREE_ENCODING_VERSION: u8 = 4;
+/// Block-compressed HTR4 variant. Readers accept both v4 and v5.
+pub const TREE_BLOCK_ENCODING_VERSION: u8 = 5;
 /// Frame discriminator for a single canonical tree.
 pub const TREE_CANONICAL_MAGIC: &[u8; 4] = b"HTR4";
 /// Fixed header size: magic + version + tree id + counts.
 pub const TREE_HEADER_LEN: usize = 4 + 1 + 32 + 8 + 8 + 8;
+/// Small real trees do not repay block/index overhead.
+pub const TREE_BLOCK_MIN_ENTRIES: usize = 18;
+
+pub(crate) const TREE_BLOCK_ENTRIES: usize = 256;
+pub(crate) const TREE_BLOCK_PREAMBLE_LEN: usize = 16;
+pub(crate) const TREE_BLOCK_INDEX_LEN: usize = 24;
+const TREE_BLOCK_CODEC_ZSTD: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockHeader {
+    pub block_entries: usize,
+    pub block_count: usize,
+    pub raw_payload_len: u64,
+    pub index_end: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockIndex {
+    pub raw_offset: u64,
+    pub stored_offset: u64,
+    pub stored_len: usize,
+    pub raw_len: usize,
+}
 
 /// Parsed HTR4 header. Counts and payload length are known before any entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -66,6 +93,9 @@ impl Tree {
     /// Decode a complete HTR4 body, validating order incrementally.
     pub fn decode_canonical(data: &[u8]) -> Result<Self, TreeStreamError> {
         let header = decode_header(data)?;
+        if header.version == TREE_BLOCK_ENCODING_VERSION {
+            return Self::decode_canonical_streamed(data);
+        }
         let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
         if (data.len() as u64) < expected_len {
             return Err(TreeStreamError::TruncatedFrame {
@@ -111,6 +141,25 @@ impl Tree {
         }
         Ok(tree)
     }
+
+    /// Encode block-compressed HTR4, falling back to raw v4 when the complete
+    /// object would not be smaller. Callers apply the small-tree policy.
+    pub fn encode_canonical_blocked(
+        &self,
+        level: i32,
+        min_size: usize,
+    ) -> Result<Vec<u8>, TreeStreamError> {
+        let raw = self.encode_canonical()?;
+        if raw.len() < min_size {
+            return Ok(raw);
+        }
+        let blocked = encode_blocked_htr4(&raw, level)?;
+        if blocked.len() < raw.len() {
+            Ok(blocked)
+        } else {
+            Ok(raw)
+        }
+    }
 }
 
 /// Parse the fixed HTR4 header. Does not read entry frames.
@@ -124,7 +173,7 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         ));
     }
     let version = data[4];
-    if version != TREE_ENCODING_VERSION {
+    if version != TREE_ENCODING_VERSION && version != TREE_BLOCK_ENCODING_VERSION {
         return Err(TreeStreamError::UnsupportedVersion { found: version });
     }
     let tree_id = ContentHash::from_bytes(
@@ -152,6 +201,327 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         payload_len,
         logical_len,
     })
+}
+
+pub(crate) fn decode_block_header(
+    header: &TreeHeader,
+    preamble: &[u8],
+    object_len: u64,
+) -> Result<TreeBlockHeader, TreeStreamError> {
+    if header.version != TREE_BLOCK_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "tree does not use block compression".into(),
+        ));
+    }
+    if preamble.len() != TREE_BLOCK_PREAMBLE_LEN {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: TREE_HEADER_LEN as u64,
+        });
+    }
+    if preamble[0] != TREE_BLOCK_CODEC_ZSTD {
+        return Err(TreeStreamError::Malformed(format!(
+            "unsupported tree block codec {}",
+            preamble[0]
+        )));
+    }
+    if preamble[1] != 0 {
+        return Err(TreeStreamError::Malformed(
+            "unsupported tree block flags".into(),
+        ));
+    }
+    let block_entries = u16::from_le_bytes([preamble[2], preamble[3]]) as usize;
+    if block_entries == 0 {
+        return Err(TreeStreamError::Malformed(
+            "tree block size must be nonzero".into(),
+        ));
+    }
+    let block_count = u32::from_le_bytes(
+        preamble[4..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block count".into()))?,
+    ) as usize;
+    let raw_payload_len = u64::from_le_bytes(
+        preamble[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid raw tree payload length".into()))?,
+    );
+    let expected_blocks = header.entry_count.div_ceil(block_entries as u64);
+    if block_count as u64 != expected_blocks {
+        return Err(TreeStreamError::Malformed(
+            "tree block count does not match entry count".into(),
+        ));
+    }
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let index_end = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index end overflow".into()))?
+        as u64;
+    let expected_object_len = (TREE_HEADER_LEN as u64)
+        .checked_add(header.payload_len)
+        .ok_or_else(|| TreeStreamError::Malformed("tree object length overflow".into()))?;
+    if index_end > expected_object_len || expected_object_len != object_len {
+        return Err(TreeStreamError::TruncatedFrame { offset: object_len });
+    }
+    Ok(TreeBlockHeader {
+        block_entries,
+        block_count,
+        raw_payload_len,
+        index_end,
+    })
+}
+
+pub(crate) fn decode_block_index(
+    bytes: &[u8],
+    block: usize,
+    block_header: &TreeBlockHeader,
+    object_len: u64,
+) -> Result<TreeBlockIndex, TreeStreamError> {
+    if bytes.len() != TREE_BLOCK_INDEX_LEN || block >= block_header.block_count {
+        return Err(TreeStreamError::Malformed(
+            "invalid tree block index entry".into(),
+        ));
+    }
+    let raw_offset = u64::from_le_bytes(
+        bytes[0..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw offset".into()))?,
+    );
+    let stored_offset = u64::from_le_bytes(
+        bytes[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored offset".into()))?,
+    );
+    let stored_len = u32::from_le_bytes(
+        bytes[16..20]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored length".into()))?,
+    ) as usize;
+    let raw_len = u32::from_le_bytes(
+        bytes[20..24]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw length".into()))?,
+    ) as usize;
+    if stored_len == 0 || raw_len == 0 || stored_offset < block_header.index_end {
+        return Err(TreeStreamError::Malformed(
+            "invalid empty or overlapping tree block".into(),
+        ));
+    }
+    if stored_offset
+        .checked_add(stored_len as u64)
+        .is_none_or(|end| end > object_len)
+    {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: stored_offset,
+        });
+    }
+    Ok(TreeBlockIndex {
+        raw_offset,
+        stored_offset,
+        stored_len,
+        raw_len,
+    })
+}
+
+pub(crate) fn decode_block_payload(
+    stored: &[u8],
+    raw_len: usize,
+) -> Result<Vec<u8>, TreeStreamError> {
+    if stored.len() == raw_len {
+        return Ok(stored.to_vec());
+    }
+    let anchor_end = block_anchor_end(stored)?;
+    if anchor_end >= raw_len {
+        return Err(TreeStreamError::Malformed(
+            "compressed tree block has no tail".into(),
+        ));
+    }
+    let tail = decompress_block_tail(&stored[anchor_end..], raw_len - anchor_end)?;
+    let mut raw = Vec::with_capacity(raw_len);
+    raw.extend_from_slice(&stored[..anchor_end]);
+    raw.extend_from_slice(&tail);
+    if raw.len() != raw_len {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block length mismatch".into(),
+        ));
+    }
+    Ok(raw)
+}
+
+pub(crate) fn block_anchor_end(stored: &[u8]) -> Result<usize, TreeStreamError> {
+    let len_bytes = stored
+        .get(..4)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    let frame_len = u32::from_le_bytes(
+        len_bytes
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid anchor frame length".into()))?,
+    ) as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    if end > stored.len() {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    Ok(end)
+}
+
+fn encode_blocked_htr4(raw: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    let header = decode_header(raw)?;
+    if header.version != TREE_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "block encoder requires raw HTR4".into(),
+        ));
+    }
+    let ranges = entry_frame_ranges(raw, header.entry_count)?;
+    let block_count = ranges.len().div_ceil(TREE_BLOCK_ENTRIES);
+    let block_count_u32 = u32::try_from(block_count)
+        .map_err(|_| TreeStreamError::Malformed("tree has too many blocks".into()))?;
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(TREE_BLOCK_ENTRIES) {
+        let (start, anchor_end) = *chunk
+            .first()
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let end = chunk
+            .last()
+            .map(|range| range.1)
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let block = &raw[start..end];
+        let compressed_tail = compress_block_tail(&raw[anchor_end..end], level)?;
+        if anchor_end - start + compressed_tail.len() < block.len() {
+            let mut stored = Vec::with_capacity(anchor_end - start + compressed_tail.len());
+            stored.extend_from_slice(&raw[start..anchor_end]);
+            stored.extend_from_slice(&compressed_tail);
+            blocks.push(stored);
+        } else {
+            blocks.push(block.to_vec());
+        }
+    }
+
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let stored_payload_len = TREE_BLOCK_PREAMBLE_LEN
+        .checked_add(index_bytes)
+        .and_then(|len| {
+            blocks
+                .iter()
+                .try_fold(len, |total, block| total.checked_add(block.len()))
+        })
+        .ok_or_else(|| TreeStreamError::Malformed("blocked tree length overflow".into()))?;
+    let mut out = Vec::with_capacity(TREE_HEADER_LEN + stored_payload_len);
+    out.extend_from_slice(TREE_CANONICAL_MAGIC);
+    out.push(TREE_BLOCK_ENCODING_VERSION);
+    out.extend_from_slice(header.tree_id.as_bytes());
+    out.extend_from_slice(&header.entry_count.to_le_bytes());
+    out.extend_from_slice(&(stored_payload_len as u64).to_le_bytes());
+    out.extend_from_slice(&header.logical_len.to_le_bytes());
+    out.push(TREE_BLOCK_CODEC_ZSTD);
+    out.push(0);
+    out.extend_from_slice(&(TREE_BLOCK_ENTRIES as u16).to_le_bytes());
+    out.extend_from_slice(&block_count_u32.to_le_bytes());
+    out.extend_from_slice(&header.payload_len.to_le_bytes());
+
+    let mut stored_offset = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * TREE_BLOCK_ENTRIES;
+        let chunk = &ranges[first_entry..(first_entry + TREE_BLOCK_ENTRIES).min(ranges.len())];
+        let raw_offset = chunk[0].0 - TREE_HEADER_LEN;
+        let raw_len = chunk[chunk.len() - 1].1 - chunk[0].0;
+        let stored_len = u32::try_from(stored.len())
+            .map_err(|_| TreeStreamError::Malformed("stored tree block exceeds u32".into()))?;
+        let raw_len = u32::try_from(raw_len)
+            .map_err(|_| TreeStreamError::Malformed("raw tree block exceeds u32".into()))?;
+        out.extend_from_slice(&(raw_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored_offset as u64).to_le_bytes());
+        out.extend_from_slice(&stored_len.to_le_bytes());
+        out.extend_from_slice(&raw_len.to_le_bytes());
+        stored_offset = stored_offset
+            .checked_add(stored.len())
+            .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    Ok(out)
+}
+
+fn entry_frame_ranges(
+    raw: &[u8],
+    entry_count: u64,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let count = usize::try_from(entry_count)
+        .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?;
+    let mut ranges = Vec::with_capacity(count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..count {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid frame length".into()))?,
+        ) as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        if end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        ranges.push((offset, end));
+        offset = end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(ranges)
+}
+
+#[cfg(feature = "zstd")]
+fn compress_block_tail(data: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    zstd::bulk::compress(data, level)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))
+}
+
+#[cfg(not(feature = "zstd"))]
+fn compress_block_tail(_data: &[u8], _level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
+}
+
+#[cfg(feature = "zstd")]
+fn decompress_block_tail(data: &[u8], capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    let decoded = zstd::bulk::decompress(data, capacity)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))?;
+    if decoded.len() != capacity {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block tail length mismatch".into(),
+        ));
+    }
+    Ok(decoded)
+}
+
+#[cfg(not(feature = "zstd"))]
+fn decompress_block_tail(_data: &[u8], _capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
 }
 
 pub(crate) fn encode_entry_frame(entry: &TreeEntry) -> Result<Vec<u8>, TreeStreamError> {
@@ -323,4 +693,72 @@ fn decode_spoollink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStrea
             TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
         })?);
     TreeEntry::spoollink(name, spool_id, state).map_err(TreeStreamError::from)
+}
+
+#[cfg(all(test, feature = "zstd"))]
+mod block_tests {
+    use super::*;
+
+    fn fixture(entries: usize) -> Tree {
+        Tree::from_entries(
+            (0..entries)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:04}.rs"),
+                        ContentHash::compute(format!("blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .expect("fixture entry")
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn blocked_encoder_falls_back_for_the_complete_object() {
+        let tree = fixture(1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_ENCODING_VERSION);
+    }
+
+    #[test]
+    fn final_single_entry_block_is_stored_raw() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_BLOCK_ENCODING_VERSION);
+        let header = decode_header(&encoded).expect("header");
+        let preamble = &encoded[TREE_HEADER_LEN..TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN];
+        let block_header =
+            decode_block_header(&header, preamble, encoded.len() as u64).expect("block header");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let index = decode_block_index(
+            &encoded[second_index..second_index + TREE_BLOCK_INDEX_LEN],
+            1,
+            &block_header,
+            encoded.len() as u64,
+        )
+        .expect("second block");
+        assert_eq!(index.stored_len, index.raw_len);
+    }
+
+    #[test]
+    fn trailing_bytes_in_a_raw_block_are_rejected() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let mut encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let stored_len_offset = second_index + 16;
+        let stored_len = u32::from_le_bytes(
+            encoded[stored_len_offset..stored_len_offset + 4]
+                .try_into()
+                .expect("stored length"),
+        );
+        encoded[stored_len_offset..stored_len_offset + 4]
+            .copy_from_slice(&(stored_len + 1).to_le_bytes());
+        let payload_len =
+            u64::from_le_bytes(encoded[45..53].try_into().expect("stored payload length"));
+        encoded[45..53].copy_from_slice(&(payload_len + 1).to_le_bytes());
+        encoded.push(0);
+
+        assert!(Tree::decode_canonical(&encoded).is_err());
+    }
 }

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use super::{
     ContentHash, Tree, TreeEntry, TreeError,
     tree_canonical::{
-        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_entry_frame, decode_header,
+        TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_INDEX_LEN, TREE_BLOCK_PREAMBLE_LEN,
+        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeBlockHeader, TreeBlockIndex, TreeHeader,
+        decode_block_header, decode_block_index, decode_block_payload, decode_entry_frame,
+        decode_header,
     },
     tree_source::{TreeBodyIntegrity, TreeByteSource},
 };
@@ -17,7 +20,7 @@ pub enum TreeStreamError {
     #[error("invalid tree entry: {0}")]
     Invalid(#[from] TreeError),
     #[error(
-        "unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})"
+        "unsupported tree encoding version {found} (this binary supports {TREE_ENCODING_VERSION} and {TREE_BLOCK_ENCODING_VERSION})"
     )]
     UnsupportedVersion { found: u8 },
     #[error("tree resume cursor does not match this object: {0}")]
@@ -39,6 +42,8 @@ pub enum TreeStreamError {
     UnverifiedRange,
     #[error("malformed tree encoding: {0}")]
     Malformed(String),
+    #[error("tree compression failed: {0}")]
+    Compression(String),
     #[error("tree I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("decoded tree hash {found} does not match {expected}")]
@@ -89,9 +94,13 @@ pub struct TreeResumeCursor {
 
 impl TreeResumeCursor {
     pub fn start(tree_id: ContentHash) -> Self {
+        Self::start_for_version(tree_id, TREE_ENCODING_VERSION)
+    }
+
+    fn start_for_version(tree_id: ContentHash, encoding_version: u8) -> Self {
         Self {
             tree_id,
-            encoding_version: TREE_ENCODING_VERSION,
+            encoding_version,
             ordinal: 0,
             byte_offset: TREE_HEADER_LEN as u64,
             prev_name: None,
@@ -119,6 +128,23 @@ impl TreeResumeCursor {
     }
 }
 
+#[derive(Debug)]
+enum TreeReaderLayout {
+    Raw,
+    Blocked {
+        header: TreeBlockHeader,
+        cache: Option<DecodedBlock>,
+        validated_blocks: Vec<bool>,
+    },
+}
+
+#[derive(Debug)]
+struct DecodedBlock {
+    block: usize,
+    raw: Vec<u8>,
+    frames: Vec<(usize, usize)>,
+}
+
 /// One bounded page of decoded entries plus the cursor after the last entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TreePage {
@@ -131,9 +157,11 @@ pub struct TreePage {
 pub struct TreeEntryReader<S: TreeByteSource> {
     source: S,
     header: TreeHeader,
+    layout: TreeReaderLayout,
     cursor: TreeResumeCursor,
     hasher: Option<blake3::Hasher>,
     decoded_logical_len: u64,
+    started_at_zero: bool,
     pending: Option<(TreeEntry, usize)>,
     finished: bool,
 }
@@ -164,21 +192,36 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 extra: source.len() - expected_len,
             });
         }
+        let layout = if header.version == TREE_BLOCK_ENCODING_VERSION {
+            let mut preamble = [0u8; TREE_BLOCK_PREAMBLE_LEN];
+            source.read_exact_at(TREE_HEADER_LEN as u64, &mut preamble)?;
+            let block_header = decode_block_header(&header, &preamble, source.len())?;
+            TreeReaderLayout::Blocked {
+                header: block_header,
+                cache: None,
+                validated_blocks: vec![false; block_header.block_count],
+            }
+        } else {
+            TreeReaderLayout::Raw
+        };
         let cursor = resume
             .cloned()
-            .unwrap_or_else(|| TreeResumeCursor::start(expected_id));
-        validate_cursor(&header, &cursor)?;
+            .unwrap_or_else(|| TreeResumeCursor::start_for_version(expected_id, header.version));
+        validate_cursor(&header, &layout, &cursor)?;
         if cursor.ordinal > 0 && source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
         let hasher =
             (cursor.ordinal == 0).then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let started_at_zero = cursor.ordinal == 0;
         let mut reader = Self {
             source,
             header,
+            layout,
             cursor,
             hasher,
             decoded_logical_len: 0,
+            started_at_zero,
             pending: None,
             finished: false,
         };
@@ -249,7 +292,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 decoded: self.cursor.ordinal,
             });
         }
-        let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
+        let payload_end = self.logical_payload_end();
         if self.cursor.byte_offset != payload_end {
             return Err(TreeStreamError::TrailingBytes {
                 extra: payload_end.abs_diff(self.cursor.byte_offset),
@@ -271,6 +314,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         } else if self.source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
+        self.validate_complete_block_layout()?;
         self.finished = true;
         Ok(())
     }
@@ -283,6 +327,9 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
     }
 
     fn read_entry_at(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        if matches!(self.layout, TreeReaderLayout::Blocked { .. }) {
+            return self.read_blocked_entry();
+        }
         let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
         let mut len_buf = [0u8; 4];
         self.source.read_exact_at(offset, &mut len_buf)?;
@@ -302,6 +349,216 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         self.source.read_exact_at(frame_start, &mut frame)?;
         let entry = decode_entry_frame(&frame)?;
         Ok((entry, 4 + frame_len))
+    }
+
+    fn logical_payload_end(&self) -> u64 {
+        match &self.layout {
+            TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + self.header.payload_len,
+            TreeReaderLayout::Blocked { header, .. } => {
+                TREE_HEADER_LEN as u64 + header.raw_payload_len
+            }
+        }
+    }
+
+    fn read_blocked_entry(&mut self) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Blocked { header, .. } => *header,
+            TreeReaderLayout::Raw => {
+                return Err(TreeStreamError::Malformed(
+                    "raw tree entered blocked reader".into(),
+                ));
+            }
+        };
+        let ordinal = usize::try_from(self.cursor.ordinal)
+            .map_err(|_| TreeStreamError::Malformed("tree ordinal exceeds usize".into()))?;
+        let block = ordinal / block_header.block_entries;
+        let within_block = ordinal % block_header.block_entries;
+        let index = self.read_block_index(block, &block_header)?;
+        let block_logical_start = (TREE_HEADER_LEN as u64)
+            .checked_add(index.raw_offset)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block raw offset overflow".into()))?;
+
+        if within_block == 0 {
+            if self.cursor.byte_offset != block_logical_start {
+                return Err(TreeStreamError::CursorMismatch(
+                    "cursor byte offset is not the block restart boundary".into(),
+                ));
+            }
+            return self.read_block_anchor(index);
+        }
+
+        let needs_load = match &self.layout {
+            TreeReaderLayout::Blocked { cache, .. } => {
+                cache.as_ref().is_none_or(|cached| cached.block != block)
+            }
+            TreeReaderLayout::Raw => true,
+        };
+        if needs_load {
+            let decoded = self.load_block(index, block, &block_header)?;
+            if let TreeReaderLayout::Blocked {
+                cache,
+                validated_blocks,
+                ..
+            } = &mut self.layout
+            {
+                *cache = Some(decoded);
+                if let Some(validated) = validated_blocks.get_mut(block) {
+                    *validated = true;
+                }
+            }
+        }
+        let cached = match &self.layout {
+            TreeReaderLayout::Blocked {
+                cache: Some(cached),
+                ..
+            } => cached,
+            _ => {
+                return Err(TreeStreamError::Malformed(
+                    "tree block cache was not populated".into(),
+                ));
+            }
+        };
+        let (frame_start, frame_end) =
+            cached
+                .frames
+                .get(within_block)
+                .copied()
+                .ok_or(TreeStreamError::UnexpectedEof {
+                    expected: self.cursor.ordinal + 1,
+                    decoded: self.cursor.ordinal,
+                })?;
+        let frame =
+            cached
+                .raw
+                .get(frame_start + 4..frame_end)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: frame_start as u64,
+                })?;
+        let consumed = frame_end - frame_start;
+        let expected_offset = block_logical_start
+            .checked_add(frame_start as u64)
+            .ok_or_else(|| TreeStreamError::Malformed("tree cursor offset overflow".into()))?;
+        if self.cursor.byte_offset != expected_offset {
+            return Err(TreeStreamError::CursorMismatch(
+                "cursor byte offset is not an entry boundary".into(),
+            ));
+        }
+        Ok((decode_entry_frame(frame)?, consumed))
+    }
+
+    fn read_block_index(
+        &mut self,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<TreeBlockIndex, TreeStreamError> {
+        let relative = block
+            .checked_mul(TREE_BLOCK_INDEX_LEN)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index overflow".into()))?;
+        let offset = TREE_HEADER_LEN
+            .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+            .and_then(|start| start.checked_add(relative))
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index offset overflow".into()))?;
+        let mut bytes = [0u8; TREE_BLOCK_INDEX_LEN];
+        self.source.read_exact_at(offset as u64, &mut bytes)?;
+        decode_block_index(&bytes, block, block_header, self.source.len())
+    }
+
+    fn read_block_anchor(
+        &mut self,
+        index: TreeBlockIndex,
+    ) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let mut len_bytes = [0u8; 4];
+        self.source
+            .read_exact_at(index.stored_offset, &mut len_bytes)?;
+        let frame_len = u32::from_le_bytes(len_bytes) as usize;
+        let consumed = 4usize
+            .checked_add(frame_len)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            })?;
+        if consumed > index.stored_len || consumed > index.raw_len {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            });
+        }
+        let mut frame = vec![0u8; frame_len];
+        self.source
+            .read_exact_at(index.stored_offset + 4, &mut frame)?;
+        Ok((decode_entry_frame(&frame)?, consumed))
+    }
+
+    fn load_block(
+        &mut self,
+        index: TreeBlockIndex,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<DecodedBlock, TreeStreamError> {
+        let mut stored = vec![0u8; index.stored_len];
+        self.source
+            .read_exact_at(index.stored_offset, &mut stored)?;
+        let raw = decode_block_payload(&stored, index.raw_len)?;
+        let first_entry = block
+            .checked_mul(block_header.block_entries)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block ordinal overflow".into()))?;
+        let remaining = usize::try_from(self.header.entry_count)
+            .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?
+            .checked_sub(first_entry)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block starts past entries".into()))?;
+        let expected_entries = remaining.min(block_header.block_entries);
+        let frames = decode_block_frames(&raw, expected_entries)?;
+        Ok(DecodedBlock { block, raw, frames })
+    }
+
+    fn validate_complete_block_layout(&mut self) -> Result<(), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Raw => return Ok(()),
+            TreeReaderLayout::Blocked { header, .. } => *header,
+        };
+        let mut expected_raw_offset = 0u64;
+        let mut expected_stored_offset = block_header.index_end;
+        for block in 0..block_header.block_count {
+            let index = self.read_block_index(block, &block_header)?;
+            if index.raw_offset != expected_raw_offset
+                || index.stored_offset != expected_stored_offset
+            {
+                return Err(TreeStreamError::Malformed(
+                    "tree blocks are not contiguous".into(),
+                ));
+            }
+            expected_raw_offset = expected_raw_offset
+                .checked_add(index.raw_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("raw tree length overflow".into()))?;
+            expected_stored_offset = expected_stored_offset
+                .checked_add(index.stored_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("stored tree length overflow".into()))?;
+            let needs_payload_validation = self.started_at_zero
+                && match &self.layout {
+                    TreeReaderLayout::Blocked {
+                        validated_blocks, ..
+                    } => validated_blocks
+                        .get(block)
+                        .is_none_or(|validated| !validated),
+                    TreeReaderLayout::Raw => false,
+                };
+            if needs_payload_validation {
+                let _ = self.load_block(index, block, &block_header)?;
+                if let TreeReaderLayout::Blocked {
+                    validated_blocks, ..
+                } = &mut self.layout
+                    && let Some(validated) = validated_blocks.get_mut(block)
+                {
+                    *validated = true;
+                }
+            }
+        }
+        if expected_raw_offset != block_header.raw_payload_len
+            || expected_stored_offset != self.source.len()
+        {
+            return Err(TreeStreamError::Malformed(
+                "tree block lengths do not match the header".into(),
+            ));
+        }
+        Ok(())
     }
 
     fn commit_entry(&mut self, entry: &TreeEntry, consumed: usize) -> Result<(), TreeStreamError> {
@@ -350,11 +607,59 @@ mod tree_stream_proptests;
 #[path = "tree_stream_tests.rs"]
 mod tree_stream_tests;
 
-fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(), TreeStreamError> {
-    if cursor.encoding_version != TREE_ENCODING_VERSION {
+fn decode_block_frames(
+    raw: &[u8],
+    expected_entries: usize,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let mut frames = Vec::with_capacity(expected_entries);
+    let mut offset = 0usize;
+    for _ in 0..expected_entries {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid block frame length".into()))?,
+        ) as usize;
+        let frame_start = offset
+            .checked_add(4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_end =
+            frame_start
+                .checked_add(frame_len)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: offset as u64,
+                })?;
+        if frame_end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        frames.push((offset, frame_end));
+        offset = frame_end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(frames)
+}
+
+fn validate_cursor(
+    header: &TreeHeader,
+    layout: &TreeReaderLayout,
+    cursor: &TreeResumeCursor,
+) -> Result<(), TreeStreamError> {
+    if cursor.encoding_version != header.version {
         return Err(TreeStreamError::CursorMismatch(format!(
-            "encoding version {} is not {TREE_ENCODING_VERSION}",
-            cursor.encoding_version
+            "encoding version {} is not {}",
+            cursor.encoding_version, header.version
         )));
     }
     if cursor.tree_id != header.tree_id {
@@ -362,7 +667,10 @@ fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(),
             "cursor tree id does not match the opened object".into(),
         ));
     }
-    let payload_end = TREE_HEADER_LEN as u64 + header.payload_len;
+    let payload_end = match layout {
+        TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + header.payload_len,
+        TreeReaderLayout::Blocked { header, .. } => TREE_HEADER_LEN as u64 + header.raw_payload_len,
+    };
     if cursor.ordinal > header.entry_count {
         return Err(TreeStreamError::CursorMismatch(
             "cursor ordinal is past the declared entry count".into(),

--- a/crates/object-model/src/object/tree_stream_proptests.rs
+++ b/crates/object-model/src/object/tree_stream_proptests.rs
@@ -63,6 +63,7 @@ fn error_class(error: &TreeStreamError) -> &'static str {
         TreeStreamError::InvalidPageLimits => "limits",
         TreeStreamError::UnverifiedRange => "unverified",
         TreeStreamError::Malformed(_) => "malformed",
+        TreeStreamError::Compression(_) => "compression",
         TreeStreamError::Io(_) => "io",
         TreeStreamError::HashMismatch { .. } => "hash",
     }

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -32,6 +32,22 @@ fn sample_tree() -> Tree {
     ])
 }
 
+#[cfg(feature = "zstd")]
+fn compressible_tree(entries: usize) -> Tree {
+    Tree::from_entries(
+        (0..entries)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("crates__module_{index:04}__src__shared_component.rs"),
+                    ContentHash::compute(format!("real-blob-{index}").as_bytes()),
+                    index.is_multiple_of(17),
+                )
+                .expect("compressed fixture entry")
+            })
+            .collect(),
+    )
+}
+
 fn open_reader(tree: &Tree) -> (Vec<u8>, TreeEntryReader<BytesTreeSource>) {
     let bytes = tree.encode_canonical().expect("encode");
     let reader = TreeEntryReader::open(
@@ -53,6 +69,100 @@ fn canonical_round_trip_matches_eager_tree() {
         Tree::decode_canonical_streamed(&bytes).expect("streamed"),
         tree
     );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn block_compressed_round_trip_matches_eager_and_streamed_tree() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    assert_eq!(bytes[4], crate::object::TREE_BLOCK_ENCODING_VERSION);
+    assert_eq!(Tree::decode_canonical(&bytes).expect("eager"), tree);
+    assert_eq!(
+        Tree::decode_canonical_streamed(&bytes).expect("streamed"),
+        tree
+    );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_partial_read_and_resume_stay_block_local() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open blocked");
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("first page")
+        .expect("entry");
+    assert_eq!(first.entries, tree.entries()[..1]);
+    assert!(
+        reader.bytes_read() < 256,
+        "first block anchor should be a small ranged read"
+    );
+
+    let mut resumed = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes),
+        tree.hash(),
+        Some(&first.resume_cursor),
+    )
+    .expect("resume blocked");
+    let page = resumed
+        .next_page(TreePageLimits::new(100, usize::MAX).expect("limits"))
+        .expect("resumed page")
+        .expect("entries");
+    assert_eq!(page.entries, tree.entries()[1..101]);
+    assert!(
+        resumed.bytes_read() < tree.encode_canonical().expect("raw").len() as u64,
+        "resumed page should not read the whole tree"
+    );
+
+    let blocked = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut boundary_reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open boundary reader");
+    let before_boundary = boundary_reader
+        .next_page(TreePageLimits::new(256, usize::MAX).expect("limits"))
+        .expect("boundary page")
+        .expect("entries");
+    let mut at_boundary = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked),
+        tree.hash(),
+        Some(&before_boundary.resume_cursor),
+    )
+    .expect("resume at block boundary");
+    let anchor = at_boundary
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("anchor page")
+        .expect("entry");
+    assert_eq!(anchor.entries, tree.entries()[256..257]);
+    assert!(at_boundary.bytes_read() < 256);
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_hash_and_payload_corruption_fail_closed() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+
+    let mut bad_hash = bytes.clone();
+    bad_hash[5] ^= 1;
+    assert!(matches!(
+        Tree::decode_canonical(&bad_hash),
+        Err(TreeStreamError::HashMismatch { .. })
+    ));
+
+    let mut bad_payload = bytes;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    assert!(Tree::decode_canonical(&bad_payload).is_err());
 }
 
 #[test]

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -42,7 +42,12 @@ zstd = { workspace = true, optional = true }
 async-source = ["heddle-object-model/async-source"]
 bench = ["heddle-format/bench"]
 memory-backend = []
-zstd = ["dep:zstd", "heddle-format/zstd", "heddle-pack/zstd"]
+zstd = [
+    "dep:zstd",
+    "heddle-format/zstd",
+    "heddle-object-model/zstd",
+    "heddle-pack/zstd",
+]
 
 [dev-dependencies]
 criterion = "0.8"
@@ -90,6 +95,10 @@ required-features = ["bench"]
 
 [[example]]
 name = "train_tree_state_dictionary"
+required-features = ["zstd"]
+
+[[example]]
+name = "htr4_measure"
 required-features = ["zstd"]
 
 [[bench]]

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -29,6 +29,9 @@ use objects::object::{
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 use tempfile::{NamedTempFile, TempDir};
 
+#[path = "htr4_measure/native_pack.rs"]
+mod native_pack;
+
 const SEED: u64 = 0x6874_7234_5f62_656e;
 const SIZES: [usize; 5] = [1, 10, 100, 1_000, 10_000];
 const SAMPLE_COUNT: usize = 15;
@@ -1445,6 +1448,15 @@ struct RealCorpus {
     git_loose_bytes: usize,
     git_packed_bytes: usize,
     git_pack_files: usize,
+    git_pack_depths: Vec<usize>,
+    git_pack_chain_bytes: Vec<usize>,
+}
+
+struct GitPackedStats {
+    bytes: usize,
+    pack_files: usize,
+    depths: Vec<usize>,
+    chain_bytes: Vec<usize>,
 }
 
 fn git_output(repo: &Path, arguments: &[&str]) -> Result<Vec<u8>> {
@@ -1471,6 +1483,31 @@ fn real_object_format(repo: &Path) -> Result<GitObjectFormat> {
         "sha256" => Ok(GitObjectFormat::Sha256),
         format => bail!("unsupported Git object format {format}"),
     }
+}
+
+fn git_tree_only_pack_bytes(corpus: &RealCorpus) -> Result<usize> {
+    let hash_len = match corpus.object_format {
+        GitObjectFormat::Sha1 => 20usize,
+        GitObjectFormat::Sha256 => 32usize,
+    };
+    let pack_overhead = 12usize
+        .checked_add(hash_len)
+        .context("Git pack overhead overflow")?;
+    let index_overhead = (256usize * 4)
+        .checked_add(
+            corpus
+                .trees
+                .len()
+                .checked_mul(hash_len + 8)
+                .context("Git tree-only index entries overflow")?,
+        )
+        .and_then(|size| size.checked_add(hash_len * 2))
+        .context("Git tree-only index overhead overflow")?;
+    corpus
+        .git_packed_bytes
+        .checked_add(pack_overhead)
+        .and_then(|size| size.checked_add(index_overhead))
+        .context("Git tree-only pack total overflow")
 }
 
 fn sample_evenly<T: Clone>(values: &[T], limit: usize) -> Vec<T> {
@@ -1644,7 +1681,7 @@ fn git_loose_sizes(repo: &Path, tree_ids: &[String]) -> Result<usize> {
     Ok(total)
 }
 
-fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<(usize, usize)> {
+fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<GitPackedStats> {
     let git_dir = PathBuf::from(
         std::str::from_utf8(&git_output(repo, &["rev-parse", "--absolute-git-dir"])?)?.trim(),
     );
@@ -1662,8 +1699,7 @@ fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<(usize, usize)> 
         repo.display()
     );
 
-    let wanted = tree_ids.iter().map(String::as_str).collect::<HashSet<_>>();
-    let mut sizes = HashMap::with_capacity(wanted.len());
+    let mut records = HashMap::<String, (usize, usize, Option<String>)>::new();
     for index in &indexes {
         let output = Command::new("git")
             .args(["verify-pack", "-v"])
@@ -1685,26 +1721,69 @@ fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<(usize, usize)> 
                 continue;
             }
             let oid = std::str::from_utf8(fields[0])?;
-            if wanted.contains(oid) {
-                let packed_size = std::str::from_utf8(fields[3])?.parse::<usize>()?;
-                sizes.entry(oid.to_string()).or_insert(packed_size);
-            }
+            let packed_size = std::str::from_utf8(fields[3])?.parse::<usize>()?;
+            let depth = if let Some(field) = fields.get(5) {
+                std::str::from_utf8(field)?.parse::<usize>()?
+            } else {
+                0
+            };
+            let base = fields
+                .get(6)
+                .map(|field| std::str::from_utf8(field).map(str::to_string))
+                .transpose()?;
+            records
+                .entry(oid.to_string())
+                .or_insert((packed_size, depth, base));
         }
     }
     let missing = tree_ids
         .iter()
-        .filter(|oid| !sizes.contains_key(oid.as_str()))
+        .filter(|oid| !records.contains_key(oid.as_str()))
         .take(3)
         .cloned()
         .collect::<Vec<_>>();
     ensure!(
         missing.is_empty(),
         "{} selected tree objects are not packed (examples: {}); run `git -C {} gc --prune=now` first",
-        tree_ids.len() - sizes.len(),
+        tree_ids.len()
+            - tree_ids
+                .iter()
+                .filter(|oid| records.contains_key(oid.as_str()))
+                .count(),
         missing.join(","),
         repo.display()
     );
-    Ok((sizes.values().sum(), indexes.len()))
+    let mut depths = Vec::with_capacity(tree_ids.len());
+    let mut chain_bytes = Vec::with_capacity(tree_ids.len());
+    let mut bytes = 0usize;
+    for oid in tree_ids {
+        let (record_bytes, depth, _) = records
+            .get(oid)
+            .with_context(|| format!("missing packed Git tree {oid}"))?;
+        bytes += record_bytes;
+        depths.push(*depth);
+        let mut chain_total = 0usize;
+        let mut cursor = oid.as_str();
+        loop {
+            let (stored, _, base) = records
+                .get(cursor)
+                .with_context(|| format!("missing Git delta base {cursor}"))?;
+            chain_total = chain_total
+                .checked_add(*stored)
+                .context("Git packed chain byte overflow")?;
+            let Some(base) = base else {
+                break;
+            };
+            cursor = base;
+        }
+        chain_bytes.push(chain_total);
+    }
+    Ok(GitPackedStats {
+        bytes,
+        pack_files: indexes.len(),
+        depths,
+        chain_bytes,
+    })
 }
 
 fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> {
@@ -1823,7 +1902,7 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         String::from_utf8_lossy(&output.stderr)
     );
     let git_loose_bytes = git_loose_sizes(&path, &imported_tree_ids)?;
-    let (git_packed_bytes, git_pack_files) = git_packed_sizes(&path, &imported_tree_ids)?;
+    let git_packed = git_packed_sizes(&path, &imported_tree_ids)?;
     Ok(RealCorpus {
         label,
         path,
@@ -1834,8 +1913,10 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         trees,
         parent_tree_ids,
         git_loose_bytes,
-        git_packed_bytes,
-        git_pack_files,
+        git_packed_bytes: git_packed.bytes,
+        git_pack_files: git_packed.pack_files,
+        git_pack_depths: git_packed.depths,
+        git_pack_chain_bytes: git_packed.chain_bytes,
     })
 }
 
@@ -1867,6 +1948,86 @@ struct Timing {
     stddev_ns: f64,
     cv_percent: f64,
     iterations_per_sample: u64,
+}
+
+struct GitBatchReader {
+    child: std::process::Child,
+    requests: BufWriter<std::process::ChildStdin>,
+    responses: BufReader<std::process::ChildStdout>,
+}
+
+impl GitBatchReader {
+    fn open(repo: &Path) -> Result<Self> {
+        let mut child = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["cat-file", "--batch"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let requests = BufWriter::new(child.stdin.take().context("Git batch timing stdin")?);
+        let responses = BufReader::new(child.stdout.take().context("Git batch timing stdout")?);
+        Ok(Self {
+            child,
+            requests,
+            responses,
+        })
+    }
+
+    fn read_tree(&mut self, oid: &str) -> Result<usize> {
+        writeln!(self.requests, "{oid}")?;
+        self.requests.flush()?;
+        let mut header = String::new();
+        self.responses.read_line(&mut header)?;
+        let fields = header.split_ascii_whitespace().collect::<Vec<_>>();
+        ensure!(
+            fields.len() == 3 && fields[0] == oid && fields[1] == "tree",
+            "unexpected timed Git batch response {header:?}"
+        );
+        let size = fields[2].parse::<usize>()?;
+        let mut body = vec![0u8; size + 1];
+        self.responses.read_exact(&mut body)?;
+        ensure!(body.last() == Some(&b'\n'), "timed Git batch delimiter");
+        black_box(&body[..size]);
+        Ok(size)
+    }
+
+    fn finish(mut self) -> Result<()> {
+        self.requests.flush()?;
+        drop(self.requests);
+        let status = self.child.wait()?;
+        ensure!(status.success(), "timed Git batch process failed");
+        Ok(())
+    }
+}
+
+struct GitReadTiming {
+    samples: usize,
+    mean_tree_bytes: f64,
+    timing: Timing,
+}
+
+fn measure_git_pack_read(corpus: &RealCorpus) -> Result<GitReadTiming> {
+    let samples = sample_evenly(&corpus.tree_ids, 16);
+    ensure!(!samples.is_empty(), "Git packed read sample is empty");
+    let mut reader = GitBatchReader::open(&corpus.path)?;
+    let mut tree_bytes = 0usize;
+    for oid in &samples {
+        tree_bytes += reader.read_tree(oid)?;
+    }
+    let mut index = 0usize;
+    let timing = measure(|| {
+        let oid = &samples[index % samples.len()];
+        index += 1;
+        reader.read_tree(oid).expect("timed Git packed tree read")
+    });
+    reader.finish()?;
+    Ok(GitReadTiming {
+        samples: samples.len(),
+        mean_tree_bytes: tree_bytes as f64 / samples.len() as f64,
+        timing,
+    })
 }
 
 fn run_iterations<F, T>(operation: &mut F, iterations: u64) -> Duration
@@ -1999,6 +2160,23 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     println!(
         "RADICAL_SIZE,label,trees,parent_covered,bases,deltas,max_ops,lean_all,hot_bytes,settled_bytes,settled_over_git_loose,settled_over_git_packed,settled_over_raw,settled_over_v5"
     );
+    println!(
+        "NATIVE_PACK_SIZE,label,variant,trees,record_bytes,name_dictionary_bytes,target_dictionary_bytes,tree_index_bytes,total_bytes,anchors,deltas,cross_deltas,p50_depth,p95_depth,max_depth,total_over_git_loose,total_over_git_packed,total_over_radical"
+    );
+    println!(
+        "NATIVE_PACK_BUILD,label,trees,names,targets,candidate_pairs,winner_build_ms,exploration_build_ms,byte_delta_build_ms"
+    );
+    println!(
+        "NATIVE_PACK_READ,label,samples,mean_chain_record_bytes,p95_chain_record_bytes,mean_lookup_record_bytes,mean_lookup_records,mean_chain_ops,resolve_median_ns,lookup_median_ns"
+    );
+    println!(
+        "NATIVE_PACK_CHAIN,label,variant,trees,mean_chain_record_bytes,p95_chain_record_bytes,mean_chain_ops"
+    );
+    println!(
+        "GIT_PACK_CHAIN,label,trees,mean_chain_record_bytes,p95_chain_record_bytes,p50_depth,p95_depth,max_depth"
+    );
+    println!("GIT_PACK_TOTAL,label,trees,record_bytes,tree_only_pack_plus_index_bytes");
+    println!("GIT_PACK_READ,label,samples,mean_inflated_tree_bytes,cat_file_batch_median_ns");
 
     let mut aggregate_raw = 0usize;
     let mut aggregate_historical = 0usize;
@@ -2014,6 +2192,27 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     let mut aggregate_radical_deltas = 0usize;
     let mut aggregate_parent_coverage = 0usize;
     let mut aggregate_radical_max_ops = 0usize;
+    let mut aggregate_native_records = [0usize; 9];
+    let mut aggregate_native_totals = [0usize; 9];
+    let mut aggregate_native_anchors = [0usize; 9];
+    let mut aggregate_native_deltas = [0usize; 9];
+    let mut aggregate_native_cross_deltas = [0usize; 9];
+    let mut aggregate_native_max_depth = [0usize; 9];
+    let mut aggregate_native_names = 0usize;
+    let mut aggregate_native_targets = 0usize;
+    let mut aggregate_native_name_dictionary = 0usize;
+    let mut aggregate_native_target_dictionary = 0usize;
+    let mut aggregate_native_tree_index = 0usize;
+    let mut aggregate_native_candidate_pairs = 0usize;
+    let mut aggregate_native_build_ms = 0.0f64;
+    let mut aggregate_native_exploration_build_ms = 0.0f64;
+    let mut aggregate_native_byte_delta_build_ms = 0.0f64;
+    let mut aggregate_native_depths = vec![Vec::new(); 9];
+    let mut aggregate_native_chain_bytes = vec![Vec::new(); 9];
+    let mut aggregate_native_chain_ops = [0usize; 9];
+    let mut aggregate_git_depths = Vec::new();
+    let mut aggregate_git_chain_bytes = Vec::new();
+    let mut aggregate_git_tree_only_total = 0usize;
     let mut file_candidates = Vec::new();
     let mut radical_file_fixtures = Vec::new();
     let config = CompressionConfig::default();
@@ -2107,6 +2306,36 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             compressed_trees,
             raw_fallback_trees,
         );
+        let mut git_depths = corpus.git_pack_depths.clone();
+        let mut git_chain_bytes = corpus.git_pack_chain_bytes.clone();
+        git_depths.sort_unstable();
+        git_chain_bytes.sort_unstable();
+        println!(
+            "GIT_PACK_CHAIN,{},{},{:.2},{},{},{},{}",
+            corpus.label,
+            corpus.trees.len(),
+            git_chain_bytes.iter().sum::<usize>() as f64 / git_chain_bytes.len() as f64,
+            percentile(&git_chain_bytes, 95, 100),
+            percentile(&git_depths, 50, 100),
+            percentile(&git_depths, 95, 100),
+            git_depths.last().copied().unwrap_or(0),
+        );
+        let git_tree_only_total = git_tree_only_pack_bytes(corpus)?;
+        println!(
+            "GIT_PACK_TOTAL,{},{},{},{}",
+            corpus.label,
+            corpus.trees.len(),
+            corpus.git_packed_bytes,
+            git_tree_only_total,
+        );
+        aggregate_git_tree_only_total += git_tree_only_total;
+        let git_read = measure_git_pack_read(corpus)?;
+        println!(
+            "GIT_PACK_READ,{},{},{:.2},{:.3}",
+            corpus.label, git_read.samples, git_read.mean_tree_bytes, git_read.timing.median_ns,
+        );
+        aggregate_git_depths.extend(git_depths);
+        aggregate_git_chain_bytes.extend(git_chain_bytes);
         let radical = build_radical_corpus(corpus)?;
         println!(
             "RADICAL_SIZE,{},{},{},{},{},{},{},{},{},{:.6},{:.6},{:.6},{:.6}",
@@ -2124,6 +2353,83 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             radical.settled_total as f64 / raw_total as f64,
             radical.settled_total as f64 / adaptive_total as f64,
         );
+        let native = native_pack::build_native_pack(corpus)?;
+        for (variant_index, variant) in native.variants.iter().enumerate() {
+            println!(
+                "NATIVE_PACK_SIZE,{},{},{},{},{},{},{},{},{},{},{},{},{},{},{:.6},{:.6},{:.6}",
+                corpus.label,
+                variant.name,
+                corpus.trees.len(),
+                variant.record_bytes,
+                native.name_dictionary_bytes,
+                native.target_dictionary_bytes,
+                native.tree_index_bytes,
+                variant.total_bytes,
+                variant.anchors,
+                variant.deltas,
+                variant.cross_deltas,
+                variant.p50_depth,
+                variant.p95_depth,
+                variant.max_depth,
+                variant.total_bytes as f64 / corpus.git_loose_bytes as f64,
+                variant.total_bytes as f64 / corpus.git_packed_bytes as f64,
+                variant.total_bytes as f64 / radical.settled_total as f64,
+            );
+            println!(
+                "NATIVE_PACK_CHAIN,{},{},{},{:.2},{},{:.2}",
+                corpus.label,
+                variant.name,
+                corpus.trees.len(),
+                variant.chain_record_bytes.iter().sum::<usize>() as f64 / corpus.trees.len() as f64,
+                percentile(&variant.chain_record_bytes, 95, 100),
+                variant.total_chain_ops as f64 / corpus.trees.len() as f64,
+            );
+            aggregate_native_records[variant_index] += variant.record_bytes;
+            aggregate_native_totals[variant_index] += variant.total_bytes;
+            aggregate_native_anchors[variant_index] += variant.anchors;
+            aggregate_native_deltas[variant_index] += variant.deltas;
+            aggregate_native_cross_deltas[variant_index] += variant.cross_deltas;
+            aggregate_native_max_depth[variant_index] =
+                aggregate_native_max_depth[variant_index].max(variant.max_depth);
+            for (depth, count) in variant.depth_histogram.iter().copied().enumerate() {
+                aggregate_native_depths[variant_index].extend(std::iter::repeat_n(depth, count));
+            }
+            aggregate_native_chain_bytes[variant_index]
+                .extend(variant.chain_record_bytes.iter().copied());
+            aggregate_native_chain_ops[variant_index] += variant.total_chain_ops;
+        }
+        println!(
+            "NATIVE_PACK_BUILD,{},{},{},{},{},{:.3},{:.3},{:.3}",
+            corpus.label,
+            corpus.trees.len(),
+            native.names,
+            native.targets,
+            native.candidate_pairs,
+            native.build_ms,
+            native.exploration_build_ms,
+            native.byte_delta_build_ms,
+        );
+        println!(
+            "NATIVE_PACK_READ,{},{},{:.2},{},{:.2},{:.3},{:.2},{:.3},{:.3}",
+            corpus.label,
+            native.read.samples,
+            native.read.mean_chain_bytes,
+            native.read.p95_chain_bytes,
+            native.read.mean_lookup_bytes,
+            native.read.mean_lookup_records,
+            native.read.mean_chain_ops,
+            native.read.resolve_median_ns,
+            native.read.lookup_median_ns,
+        );
+        aggregate_native_names += native.names;
+        aggregate_native_targets += native.targets;
+        aggregate_native_name_dictionary += native.name_dictionary_bytes;
+        aggregate_native_target_dictionary += native.target_dictionary_bytes;
+        aggregate_native_tree_index += native.tree_index_bytes;
+        aggregate_native_candidate_pairs += native.candidate_pairs;
+        aggregate_native_build_ms += native.build_ms;
+        aggregate_native_exploration_build_ms += native.exploration_build_ms;
+        aggregate_native_byte_delta_build_ms += native.byte_delta_build_ms;
         let delta_candidates = radical
             .plans
             .iter()
@@ -2169,10 +2475,71 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
         aggregate_radical_settled as f64 / aggregate_raw as f64,
         aggregate_radical_settled as f64 / aggregate_adaptive as f64,
     );
+    aggregate_git_depths.sort_unstable();
+    aggregate_git_chain_bytes.sort_unstable();
+    println!(
+        "GIT_PACK_CHAIN,ALL,{aggregate_trees},{:.2},{},{},{},{}",
+        aggregate_git_chain_bytes.iter().sum::<usize>() as f64
+            / aggregate_git_chain_bytes.len() as f64,
+        percentile(&aggregate_git_chain_bytes, 95, 100),
+        percentile(&aggregate_git_depths, 50, 100),
+        percentile(&aggregate_git_depths, 95, 100),
+        aggregate_git_depths.last().copied().unwrap_or(0),
+    );
+    println!(
+        "GIT_PACK_TOTAL,ALL,{aggregate_trees},{aggregate_git_packed},{aggregate_git_tree_only_total}"
+    );
+    for (variant_index, name) in [
+        "interned-anchors",
+        "parent-d1",
+        "parent-d8",
+        "window-d1",
+        "window-d4",
+        "window-d8",
+        "window-d16",
+        "window-d8-raw",
+        "byte-window-d8",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut depths = std::mem::take(&mut aggregate_native_depths[variant_index]);
+        depths.sort_unstable();
+        println!(
+            "NATIVE_PACK_SIZE,ALL,{name},{aggregate_trees},{},{aggregate_native_name_dictionary},{aggregate_native_target_dictionary},{aggregate_native_tree_index},{},{},{},{},{},{},{},{:.6},{:.6},{:.6}",
+            aggregate_native_records[variant_index],
+            aggregate_native_totals[variant_index],
+            aggregate_native_anchors[variant_index],
+            aggregate_native_deltas[variant_index],
+            aggregate_native_cross_deltas[variant_index],
+            percentile(&depths, 50, 100),
+            percentile(&depths, 95, 100),
+            aggregate_native_max_depth[variant_index],
+            aggregate_native_totals[variant_index] as f64 / aggregate_git_loose as f64,
+            aggregate_native_totals[variant_index] as f64 / aggregate_git_packed as f64,
+            aggregate_native_totals[variant_index] as f64 / aggregate_radical_settled as f64,
+        );
+        aggregate_native_chain_bytes[variant_index].sort_unstable();
+        println!(
+            "NATIVE_PACK_CHAIN,ALL,{name},{aggregate_trees},{:.2},{},{:.2}",
+            aggregate_native_chain_bytes[variant_index]
+                .iter()
+                .sum::<usize>() as f64
+                / aggregate_trees as f64,
+            percentile(&aggregate_native_chain_bytes[variant_index], 95, 100),
+            aggregate_native_chain_ops[variant_index] as f64 / aggregate_trees as f64,
+        );
+    }
+    println!(
+        "NATIVE_PACK_BUILD,ALL,{aggregate_trees},{aggregate_native_names},{aggregate_native_targets},{aggregate_native_candidate_pairs},{aggregate_native_build_ms:.3},{aggregate_native_exploration_build_ms:.3},{aggregate_native_byte_delta_build_ms:.3}"
+    );
     ensure!(
         aggregate_adaptive < aggregate_historical,
         "real-tree adaptive size does not beat historical loose compression"
     );
+    if env::var_os("HTR4_PACK_ONLY").is_some() {
+        return Ok(());
+    }
 
     file_candidates.sort_by_key(|candidate| candidate.0);
     let file_candidates = sample_evenly(&file_candidates, REAL_FILE_SAMPLE_LIMIT);
@@ -2524,6 +2891,9 @@ fn main() -> Result<()> {
         "META,self_check,v5_roundtrip+range+hash_corruption+payload_corruption;radical_lean+delta_roundtrip+hash_mismatch_ok"
     );
     validate_real_corpora(&real_corpora)?;
+    if env::var_os("HTR4_VALIDATE_ONLY").is_some() || env::var_os("HTR4_PACK_ONLY").is_some() {
+        return Ok(());
+    }
     measure_radical_capture()?;
     println!(
         "FIXTURE,entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink,spoollink"

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -1,0 +1,1542 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTR4 block-compression measurement and format-validation harness.
+//!
+//! Real-repository measurements exercise the production store codec and a
+//! file-backed `TreeEntryReader`. Synthetic measurements retain the original
+//! tunable prototype for comparison. Each block keeps its first complete HTR4
+//! frame raw as a restart anchor and compresses only the tail.
+
+use std::{
+    collections::BTreeSet,
+    env,
+    fs::File,
+    hint::black_box,
+    io::{BufRead, BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use bytes::Bytes;
+use heddle_format::compression::{
+    CompressionConfig, CompressionDictionary, compress_with_dictionary,
+};
+use objects::object::{
+    BytesTreeSource, ContentHash, EntryType, FileMode, FileTreeSource, SpoolId, StateId,
+    TREE_BLOCK_ENCODING_VERSION, TREE_HEADER_LEN, Tree, TreeEntry, TreeEntryReader, TreePageLimits,
+};
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+use tempfile::NamedTempFile;
+
+const SEED: u64 = 0x6874_7234_5f62_656e;
+const SIZES: [usize; 5] = [1, 10, 100, 1_000, 10_000];
+const SAMPLE_COUNT: usize = 15;
+const CALIBRATION_TIME: Duration = Duration::from_millis(25);
+const SAMPLE_TIME: Duration = Duration::from_millis(40);
+const DEFAULT_REAL_TREE_LIMIT: usize = 4_000;
+const REAL_FILE_SAMPLE_LIMIT: usize = 64;
+
+const BLOCK_MAGIC: &[u8; 4] = b"HTB1";
+const BLOCK_VERSION: u8 = 1;
+const BLOCK_CODEC_ZSTD: u8 = 1;
+const BLOCK_HEADER_LEN: usize = 72;
+const BLOCK_INDEX_LEN: usize = 24;
+const BLOCK_LEVEL: i32 = 3;
+const TRAINED_DICTIONARY_ID: u32 = 0x4854_4231;
+const LEGACY_DICTIONARY_ID: u32 = 1;
+const LEGACY_DICTIONARY: &[u8] =
+    include_bytes!("../../format/src/compression/dictionaries/tree-state-v1.zdict");
+
+#[derive(Clone, Copy)]
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn fill(&mut self, bytes: &mut [u8]) {
+        for chunk in bytes.chunks_mut(8) {
+            let random = self.next().to_le_bytes();
+            chunk.copy_from_slice(&random[..chunk.len()]);
+        }
+    }
+}
+
+fn content_hash(index: usize, salt: u64) -> ContentHash {
+    let mut random = SplitMix64::new(SEED ^ (index as u64).rotate_left(17) ^ salt);
+    let mut content = [0u8; 96];
+    random.fill(&mut content);
+    ContentHash::compute(&content)
+}
+
+fn oid(index: usize) -> GitObjectId {
+    let sha256 = (index / 20) % 2 == 1;
+    let len = if sha256 { 32 } else { 20 };
+    let format = if sha256 {
+        GitObjectFormat::Sha256
+    } else {
+        GitObjectFormat::Sha1
+    };
+    let mut bytes = [0u8; 32];
+    SplitMix64::new(SEED ^ index as u64 ^ 0x6f69_645f_7361_6c74).fill(&mut bytes[..len]);
+    GitObjectId::from_raw(format, &bytes[..len]).expect("valid deterministic git oid")
+}
+
+fn entry(index: usize) -> TreeEntry {
+    let stems = [
+        "README",
+        "src__object__tree",
+        "crates__cli__status",
+        "wire_protocol",
+        "integration_spec",
+        "config_local",
+        "snapshot_manifest",
+        "test_fixture",
+    ];
+    let mut name_rng = SplitMix64::new(SEED ^ index as u64);
+    let suffix = name_rng.next() as u32;
+    let residue = index % 20;
+    let extension = match residue {
+        2 => "dir",
+        3 => "link",
+        4 => "submodule",
+        5 => "spool",
+        _ => ["rs", "toml", "md", "json"][index % 4],
+    };
+    let name = format!(
+        "{index:05}_{}_{suffix:08x}.{extension}",
+        stems[index % stems.len()]
+    );
+
+    match residue {
+        1 => TreeEntry::file(name, content_hash(index, 1), true),
+        2 => TreeEntry::directory(name, content_hash(index, 2)),
+        3 => TreeEntry::symlink(name, content_hash(index, 3)),
+        4 => TreeEntry::gitlink(name, oid(index)),
+        5 => TreeEntry::spoollink(
+            name,
+            SpoolId::parse(format!("bench/child-{}", index % 64)).expect("valid spool id"),
+            StateId::from_bytes(*content_hash(index, 5).as_bytes()),
+        ),
+        _ => TreeEntry::file(name, content_hash(index, 0), false),
+    }
+    .expect("valid deterministic tree entry")
+}
+
+fn fixture(entries: usize) -> Tree {
+    Tree::from_entries((0..entries).map(entry).collect())
+}
+
+fn training_dictionary() -> Result<Vec<u8>> {
+    // A disjoint ordinal range prevents the measured objects from appearing in
+    // the training set while retaining the same mix of entry shapes.
+    let samples = (0..192)
+        .map(|sample| {
+            let start = 100_000 + sample * 64;
+            let tree = Tree::from_entries((start..start + 64).map(entry).collect());
+            let htr4 = tree.encode_canonical()?;
+            Ok(htr4[TREE_HEADER_LEN..].to_vec())
+        })
+        .collect::<Result<Vec<_>, objects::object::TreeStreamError>>()?;
+    zstd::dict::from_samples(&samples, 8 * 1024).context("train HTR4 block dictionary")
+}
+
+#[derive(Clone, Copy)]
+struct Dictionary<'a> {
+    name: &'static str,
+    id: u32,
+    bytes: &'a [u8],
+    encoder: Option<&'a zstd::dict::EncoderDictionary<'static>>,
+    decoder: Option<&'a zstd::dict::DecoderDictionary<'static>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockHeader {
+    block_entries: usize,
+    tree_id: ContentHash,
+    entry_count: usize,
+    raw_payload_len: usize,
+    logical_len: u64,
+    block_count: usize,
+    dictionary_id: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockIndex {
+    first_entry: usize,
+    offset: usize,
+    stored_len: usize,
+    raw_len: usize,
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16> {
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..offset + 2)
+            .context("truncated u16")?
+            .try_into()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .context("truncated u32")?
+            .try_into()?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .context("truncated u64")?
+            .try_into()?,
+    ))
+}
+
+fn usize_from(value: u64, field: &str) -> Result<usize> {
+    usize::try_from(value).with_context(|| format!("{field} exceeds usize"))
+}
+
+fn frame_ranges(htr4: &[u8]) -> Result<Vec<(usize, usize)>> {
+    let header = objects::object::decode_header(htr4)?;
+    let entry_count = usize_from(header.entry_count, "entry count")?;
+    let expected_len = TREE_HEADER_LEN
+        .checked_add(usize_from(header.payload_len, "payload length")?)
+        .context("HTR4 length overflow")?;
+    ensure!(htr4.len() == expected_len, "HTR4 length mismatch");
+    let mut ranges = Vec::with_capacity(entry_count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..entry_count {
+        let frame_len = read_u32(htr4, offset)? as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .context("frame end overflow")?;
+        ensure!(end <= htr4.len(), "truncated HTR4 entry frame");
+        ranges.push((offset, end));
+        offset = end;
+    }
+    ensure!(offset == htr4.len(), "trailing HTR4 payload bytes");
+    Ok(ranges)
+}
+
+fn encode_blocked(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    encode_blocked_htr4(&htr4, block_entries, dictionary)
+}
+
+fn encode_blocked_htr4(
+    htr4: &[u8],
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    ensure!(block_entries > 0 && block_entries <= u16::MAX as usize);
+    let htr4_header = objects::object::decode_header(htr4)?;
+    let ranges = frame_ranges(htr4)?;
+    let block_count = ranges.len().div_ceil(block_entries);
+    let mut compressor = if let Some(prepared) = dictionary.encoder {
+        zstd::bulk::Compressor::with_prepared_dictionary(prepared)?
+    } else {
+        zstd::bulk::Compressor::new(BLOCK_LEVEL)?
+    };
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(block_entries) {
+        let start = chunk.first().context("empty block")?.0;
+        let anchor_end = chunk.first().context("empty block")?.1;
+        let end = chunk.last().context("empty block")?.1;
+        let raw = &htr4[start..end];
+        let anchor = &htr4[start..anchor_end];
+        let compressed_tail = compressor.compress(&htr4[anchor_end..end])?;
+        blocks.push(if anchor.len() + compressed_tail.len() < raw.len() {
+            let mut stored = Vec::with_capacity(anchor.len() + compressed_tail.len());
+            stored.extend_from_slice(anchor);
+            stored.extend_from_slice(&compressed_tail);
+            stored
+        } else {
+            raw.to_vec()
+        });
+    }
+
+    let index_bytes = block_count
+        .checked_mul(BLOCK_INDEX_LEN)
+        .context("block index overflow")?;
+    let mut payload_offset = BLOCK_HEADER_LEN
+        .checked_add(index_bytes)
+        .context("block payload offset overflow")?;
+    let capacity = payload_offset
+        .checked_add(blocks.iter().map(Vec::len).sum::<usize>())
+        .context("blocked tree length overflow")?;
+    let mut out = Vec::with_capacity(capacity);
+    out.extend_from_slice(BLOCK_MAGIC);
+    out.push(BLOCK_VERSION);
+    out.push(BLOCK_CODEC_ZSTD);
+    out.extend_from_slice(&(block_entries as u16).to_le_bytes());
+    out.extend_from_slice(htr4_header.tree_id.as_bytes());
+    out.extend_from_slice(&htr4_header.entry_count.to_le_bytes());
+    out.extend_from_slice(&htr4_header.payload_len.to_le_bytes());
+    out.extend_from_slice(&htr4_header.logical_len.to_le_bytes());
+    out.extend_from_slice(&(block_count as u32).to_le_bytes());
+    out.extend_from_slice(&dictionary.id.to_le_bytes());
+    ensure!(out.len() == BLOCK_HEADER_LEN);
+
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * block_entries;
+        let chunk = &ranges[first_entry..(first_entry + block_entries).min(ranges.len())];
+        let raw_len = chunk.last().context("empty indexed block")?.1 - chunk[0].0;
+        out.extend_from_slice(&(first_entry as u64).to_le_bytes());
+        out.extend_from_slice(&(payload_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(raw_len as u32).to_le_bytes());
+        payload_offset += stored.len();
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    ensure!(out.len() == capacity);
+    Ok(out)
+}
+
+fn encode_adaptive(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+    Ok(if blocked.len() < htr4.len() {
+        blocked
+    } else {
+        htr4
+    })
+}
+
+fn parse_block_header(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<BlockHeader> {
+    parse_block_header_with_len(bytes, bytes.len(), dictionary)
+}
+
+fn parse_block_header_with_len(
+    bytes: &[u8],
+    stored_object_len: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<BlockHeader> {
+    ensure!(bytes.len() >= BLOCK_HEADER_LEN, "truncated HTB1 header");
+    ensure!(&bytes[..4] == BLOCK_MAGIC, "not an HTB1 tree");
+    ensure!(bytes[4] == BLOCK_VERSION, "unsupported HTB1 version");
+    ensure!(bytes[5] == BLOCK_CODEC_ZSTD, "unsupported HTB1 codec");
+    let block_entries = read_u16(bytes, 6)? as usize;
+    ensure!(block_entries > 0, "zero entries per block");
+    let mut tree_id = [0; 32];
+    tree_id.copy_from_slice(&bytes[8..40]);
+    let entry_count = usize_from(read_u64(bytes, 40)?, "entry count")?;
+    let raw_payload_len = usize_from(read_u64(bytes, 48)?, "raw payload length")?;
+    let logical_len = read_u64(bytes, 56)?;
+    let block_count = read_u32(bytes, 64)? as usize;
+    let dictionary_id = read_u32(bytes, 68)?;
+    ensure!(dictionary_id == dictionary.id, "HTB1 dictionary mismatch");
+    ensure!(block_count == entry_count.div_ceil(block_entries));
+    ensure!(
+        BLOCK_HEADER_LEN
+            .checked_add(block_count * BLOCK_INDEX_LEN)
+            .is_some_and(|index_end| index_end <= stored_object_len),
+        "truncated HTB1 index"
+    );
+    Ok(BlockHeader {
+        block_entries,
+        tree_id: ContentHash::from_bytes(tree_id),
+        entry_count,
+        raw_payload_len,
+        logical_len,
+        block_count,
+        dictionary_id,
+    })
+}
+
+fn parse_block_index_entry(
+    bytes: &[u8],
+    at: usize,
+    stored_object_len: usize,
+    header: BlockHeader,
+    block: usize,
+) -> Result<BlockIndex> {
+    let entry = BlockIndex {
+        first_entry: usize_from(read_u64(bytes, at)?, "first entry")?,
+        offset: usize_from(read_u64(bytes, at + 8)?, "block offset")?,
+        stored_len: read_u32(bytes, at + 16)? as usize,
+        raw_len: read_u32(bytes, at + 20)? as usize,
+    };
+    ensure!(entry.first_entry == block * header.block_entries);
+    let index_end = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    ensure!(entry.offset >= index_end, "block overlaps index");
+    ensure!(entry.stored_len > 0 && entry.raw_len > 0, "empty block");
+    ensure!(
+        entry
+            .offset
+            .checked_add(entry.stored_len)
+            .is_some_and(|end| end <= stored_object_len),
+        "truncated block payload"
+    );
+    Ok(entry)
+}
+
+fn parse_block_index(bytes: &[u8], header: BlockHeader, block: usize) -> Result<BlockIndex> {
+    ensure!(block < header.block_count, "block index out of bounds");
+    let at = BLOCK_HEADER_LEN + block * BLOCK_INDEX_LEN;
+    parse_block_index_entry(bytes, at, bytes.len(), header, block)
+}
+
+fn decompress_block(
+    bytes: &[u8],
+    index: BlockIndex,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let stored = &bytes[index.offset..index.offset + index.stored_len];
+    decompress_stored_block(stored, index.raw_len, decoder)
+}
+
+fn decompress_stored_block(
+    stored: &[u8],
+    raw_len: usize,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let raw = if stored.len() == raw_len {
+        stored.to_vec()
+    } else {
+        let anchor_end = raw_anchor_end(stored)?;
+        ensure!(anchor_end < raw_len, "compressed block has no tail");
+        let mut raw = Vec::with_capacity(raw_len);
+        raw.extend_from_slice(&stored[..anchor_end]);
+        raw.extend_from_slice(&decoder.decompress(&stored[anchor_end..], raw_len - anchor_end)?);
+        raw
+    };
+    ensure!(raw.len() == raw_len, "block decoded length mismatch");
+    Ok(raw)
+}
+
+fn raw_anchor_end(stored: &[u8]) -> Result<usize> {
+    let frame_len = read_u32(stored, 0)? as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .context("anchor frame length overflow")?;
+    ensure!(end <= stored.len(), "truncated raw block anchor");
+    Ok(end)
+}
+
+fn decode_entry_frame(frame: &[u8]) -> Result<TreeEntry> {
+    ensure!(frame.len() >= 4, "truncated entry frame");
+    let mode = FileMode::from_byte(frame[0]).context("invalid entry mode")?;
+    let kind = EntryType::from_byte(frame[1]).context("invalid entry kind")?;
+    let name_len = read_u16(frame, 2)? as usize;
+    let name_end = 4usize
+        .checked_add(name_len)
+        .context("name length overflow")?;
+    let name = std::str::from_utf8(frame.get(4..name_end).context("truncated entry name")?)?;
+    let payload = frame.get(name_end..).context("truncated entry payload")?;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            ensure!(payload.len() == 32, "invalid content hash length");
+            let hash = ContentHash::from_bytes(payload.try_into()?);
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let (&format, oid_bytes) = payload.split_first().context("missing gitlink format")?;
+            let format = match format {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid gitlink format"),
+            };
+            TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid_bytes)?)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = read_u16(payload, 0)? as usize;
+            let spool_end = 2usize
+                .checked_add(spool_len)
+                .context("spool length overflow")?;
+            let spool =
+                std::str::from_utf8(payload.get(2..spool_end).context("truncated spool id")?)?;
+            let state: [u8; 32] = payload
+                .get(spool_end..)
+                .context("missing spool state")?
+                .try_into()
+                .context("invalid spool state length")?;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, StateId::from_bytes(state))?
+        }
+    };
+    ensure!(entry.mode() == mode, "entry kind/mode mismatch");
+    Ok(entry)
+}
+
+fn decode_frames(raw: &[u8]) -> Result<(Vec<TreeEntry>, u64)> {
+    let mut entries = Vec::new();
+    let mut logical_len = 0u64;
+    let mut offset = 0usize;
+    while offset < raw.len() {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated entry frame")?;
+        let entry = decode_entry_frame(frame)?;
+        logical_len = logical_len
+            .checked_add(semantic_encoded_len(&entry) as u64)
+            .context("logical length overflow")?;
+        entries.push(entry);
+        offset = end;
+    }
+    ensure!(offset == raw.len());
+    Ok((entries, logical_len))
+}
+
+fn semantic_encoded_len(entry: &TreeEntry) -> usize {
+    let target_len = match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => 32,
+        EntryType::Gitlink => entry
+            .gitlink_target()
+            .expect("decoded gitlink has a target")
+            .as_bytes()
+            .len(),
+        EntryType::Spoollink => {
+            let (spool, state) = entry
+                .spoollink_target()
+                .expect("decoded spoollink has a target");
+            4 + spool.as_str().len() + state.as_bytes().len()
+        }
+    };
+    3 + entry.name().len() + target_len
+}
+
+fn block_decoder(dictionary: Dictionary<'_>) -> Result<zstd::bulk::Decompressor<'_>> {
+    if let Some(prepared) = dictionary.decoder {
+        Ok(zstd::bulk::Decompressor::with_prepared_dictionary(
+            prepared,
+        )?)
+    } else {
+        Ok(zstd::bulk::Decompressor::new()?)
+    }
+}
+
+fn decode_blocked(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    let header = parse_block_header(bytes, dictionary)?;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut entries = Vec::with_capacity(header.entry_count);
+    let mut raw_payload_len = 0usize;
+    let mut logical_len = 0u64;
+    let mut expected_offset = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    for block in 0..header.block_count {
+        let index = parse_block_index(bytes, header, block)?;
+        ensure!(
+            index.offset == expected_offset,
+            "non-contiguous block payload"
+        );
+        expected_offset += index.stored_len;
+        let raw = decompress_block(bytes, index, &mut decoder)?;
+        raw_payload_len += raw.len();
+        let (mut decoded, block_logical_len) = decode_frames(&raw)?;
+        let expected_entries = header
+            .block_entries
+            .min(header.entry_count - block * header.block_entries);
+        ensure!(
+            decoded.len() == expected_entries,
+            "block entry count mismatch"
+        );
+        logical_len += block_logical_len;
+        entries.append(&mut decoded);
+    }
+    ensure!(expected_offset == bytes.len(), "trailing HTB1 bytes");
+    ensure!(raw_payload_len == header.raw_payload_len);
+    ensure!(logical_len == header.logical_len);
+    ensure!(entries.len() == header.entry_count);
+    let tree = Tree::try_from_decoded_entries(entries)?;
+    ensure!(tree.hash() == header.tree_id, "HTB1 tree hash mismatch");
+    black_box(header.dictionary_id);
+    Ok(tree)
+}
+
+fn decode_adaptive(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        decode_blocked(bytes, dictionary)
+    } else {
+        Ok(Tree::decode_canonical(bytes)?)
+    }
+}
+
+struct PartialRead {
+    entries: Vec<TreeEntry>,
+    bytes_read: usize,
+}
+
+fn partial_blocked(
+    bytes: &[u8],
+    dictionary: Dictionary<'_>,
+    first: usize,
+    count: usize,
+) -> Result<PartialRead> {
+    let header = parse_block_header(bytes, dictionary)?;
+    ensure!(count > 0 && first + count <= header.entry_count);
+    let first_block = first / header.block_entries;
+    let last_block = (first + count - 1) / header.block_entries;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut selected = Vec::with_capacity(count);
+    let mut bytes_read = BLOCK_HEADER_LEN;
+    for block in first_block..=last_block {
+        let index = parse_block_index(bytes, header, block)?;
+        bytes_read += BLOCK_INDEX_LEN;
+        let stored = &bytes[index.offset..index.offset + index.stored_len];
+        let wanted_start = first.saturating_sub(index.first_entry);
+        let wanted_end = (first + count - index.first_entry)
+            .min(header.block_entries)
+            .min(header.entry_count - index.first_entry);
+        let only_anchor = wanted_start == 0 && wanted_end == 1;
+        let raw = if index.stored_len == index.raw_len {
+            let (entries, consumed) = decode_frame_range(stored, wanted_start, wanted_end)?;
+            bytes_read += consumed;
+            selected.extend(entries);
+            continue;
+        } else if only_anchor {
+            let anchor_end = raw_anchor_end(stored)?;
+            bytes_read += anchor_end;
+            let (entries, consumed) = decode_frame_range(stored, 0, 1)?;
+            ensure!(consumed == anchor_end);
+            selected.extend(entries);
+            continue;
+        } else {
+            bytes_read += index.stored_len;
+            decompress_block(bytes, index, &mut decoder)?
+        };
+        let (entries, _) = decode_frame_range(&raw, wanted_start, wanted_end)?;
+        selected.extend(entries);
+    }
+    ensure!(selected.len() == count);
+    Ok(PartialRead {
+        entries: selected,
+        bytes_read,
+    })
+}
+
+fn decode_frame_range(
+    raw: &[u8],
+    wanted_start: usize,
+    wanted_end: usize,
+) -> Result<(Vec<TreeEntry>, usize)> {
+    ensure!(wanted_start < wanted_end, "empty frame range");
+    let mut entries = Vec::with_capacity(wanted_end - wanted_start);
+    let mut offset = 0usize;
+    for ordinal in 0..wanted_end {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated ranged frame")?;
+        if ordinal >= wanted_start {
+            entries.push(decode_entry_frame(frame)?);
+        }
+        offset = end;
+    }
+    Ok((entries, offset))
+}
+
+fn partial_htr4(bytes: &Bytes, tree_id: ContentHash, count: usize) -> PartialRead {
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree_id,
+        None,
+    )
+    .expect("open HTR4 reader");
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX).expect("page limits"))
+        .expect("decode partial HTR4 page")
+        .expect("nonempty page");
+    let bytes_read = reader.bytes_read() as usize;
+    PartialRead {
+        entries: page.entries,
+        bytes_read,
+    }
+}
+
+fn partial_adaptive(
+    bytes: &Bytes,
+    dictionary: Dictionary<'_>,
+    tree_id: ContentHash,
+    count: usize,
+) -> PartialRead {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        partial_blocked(bytes, dictionary, 0, count).expect("partial HTB1")
+    } else {
+        partial_htr4(bytes, tree_id, count)
+    }
+}
+
+fn partial_whole_zstd(compressed: &[u8], tree_id: ContentHash, count: usize) -> PartialRead {
+    let htr4 = Bytes::from(zstd::decode_all(compressed).expect("decompress whole HTR4"));
+    let mut read = partial_htr4(&htr4, tree_id, count);
+    read.bytes_read = compressed.len();
+    read
+}
+
+fn partial_production_file(path: &Path, tree_id: ContentHash, count: usize) -> Result<PartialRead> {
+    let file = File::open(path)?;
+    let len = file.metadata()?.len();
+    let mut reader =
+        TreeEntryReader::open(FileTreeSource::sequential_verify(file, len), tree_id, None)?;
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX)?)?
+        .context("nonempty production tree page")?;
+    Ok(PartialRead {
+        entries: page.entries,
+        bytes_read: reader.bytes_read() as usize,
+    })
+}
+
+struct RealCorpus {
+    label: String,
+    path: PathBuf,
+    object_format: GitObjectFormat,
+    discovered_trees: usize,
+    skipped_trees: usize,
+    trees: Vec<Tree>,
+}
+
+fn git_output(repo: &Path, arguments: &[&str]) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(arguments)
+        .output()
+        .with_context(|| format!("run git in {}", repo.display()))?;
+    ensure!(
+        output.status.success(),
+        "git {} failed in {}: {}",
+        arguments.join(" "),
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(output.stdout)
+}
+
+fn real_object_format(repo: &Path) -> Result<GitObjectFormat> {
+    let output = git_output(repo, &["rev-parse", "--show-object-format"])?;
+    match std::str::from_utf8(&output)?.trim() {
+        "sha1" => Ok(GitObjectFormat::Sha1),
+        "sha256" => Ok(GitObjectFormat::Sha256),
+        format => bail!("unsupported Git object format {format}"),
+    }
+}
+
+fn sample_evenly<T: Clone>(values: &[T], limit: usize) -> Vec<T> {
+    if values.len() <= limit {
+        return values.to_vec();
+    }
+    if limit == 1 {
+        return vec![values[values.len() / 2].clone()];
+    }
+    (0..limit)
+        .map(|index| values[index * (values.len() - 1) / (limit - 1)].clone())
+        .collect()
+}
+
+fn discover_tree_ids(repo: &Path, limit: usize) -> Result<(usize, Vec<String>)> {
+    let output = git_output(
+        repo,
+        &[
+            "cat-file",
+            "--batch-all-objects",
+            "--batch-check=%(objectname) %(objecttype)",
+        ],
+    )?;
+    let mut tree_ids = BTreeSet::new();
+    for line in output.split(|byte| *byte == b'\n') {
+        let mut fields = line.split(|byte| *byte == b' ');
+        let Some(oid) = fields.next() else {
+            continue;
+        };
+        if fields.next() == Some(b"tree") {
+            tree_ids.insert(std::str::from_utf8(oid)?.to_string());
+        }
+    }
+    let discovered = tree_ids.len();
+    let tree_ids = sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit);
+    Ok((discovered, tree_ids))
+}
+
+fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> {
+    let oid_len = match format {
+        GitObjectFormat::Sha1 => 20,
+        GitObjectFormat::Sha256 => 32,
+    };
+    let mut entries = Vec::new();
+    let mut offset = 0usize;
+    while offset < body.len() {
+        let mode_end = body[offset..]
+            .iter()
+            .position(|byte| *byte == b' ')
+            .map(|relative| offset + relative)
+            .context("Git tree mode terminator")?;
+        let mode = u32::from_str_radix(std::str::from_utf8(&body[offset..mode_end])?, 8)?;
+        let name_start = mode_end + 1;
+        let name_end = body[name_start..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|relative| name_start + relative)
+            .context("Git tree name terminator")?;
+        let Some(name) = std::str::from_utf8(&body[name_start..name_end]).ok() else {
+            return Ok(None);
+        };
+        let oid_start = name_end + 1;
+        let oid_end = oid_start
+            .checked_add(oid_len)
+            .context("Git tree oid length overflow")?;
+        let oid = body
+            .get(oid_start..oid_end)
+            .context("truncated Git tree oid")?;
+        let mapped_hash = ContentHash::compute(oid);
+        let entry = match mode {
+            0o040000 => TreeEntry::directory(name, mapped_hash),
+            0o120000 => TreeEntry::symlink(name, mapped_hash),
+            0o160000 => TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid)?),
+            value if value & 0o170000 == 0o100000 => {
+                TreeEntry::file(name, mapped_hash, value & 0o111 != 0)
+            }
+            _ => return Ok(None),
+        };
+        let Ok(entry) = entry else {
+            return Ok(None);
+        };
+        entries.push(entry);
+        offset = oid_end;
+    }
+    Ok(Some(Tree::from_entries(entries)))
+}
+
+fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
+    let path = path.canonicalize()?;
+    let label = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("repository")
+        .to_string();
+    let object_format = real_object_format(&path)?;
+    let (discovered_trees, tree_ids) = discover_tree_ids(&path, limit)?;
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(&path)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdin = child.stdin.take().context("Git cat-file stdin")?;
+    let mut requests = BufWriter::new(stdin);
+    let stdout = child.stdout.take().context("Git cat-file stdout")?;
+    let mut reader = BufReader::new(stdout);
+    let mut trees = Vec::with_capacity(tree_ids.len());
+    let mut skipped_trees = 0usize;
+    for expected_oid in &tree_ids {
+        writeln!(requests, "{expected_oid}")?;
+        requests.flush()?;
+        let mut header = String::new();
+        reader.read_line(&mut header)?;
+        let mut fields = header.split_whitespace();
+        let oid = fields.next().context("Git batch object id")?;
+        let kind = fields.next().context("Git batch object type")?;
+        let size: usize = fields.next().context("Git batch object size")?.parse()?;
+        ensure!(
+            oid == expected_oid && kind == "tree",
+            "unexpected Git batch response"
+        );
+        let mut body = vec![0u8; size];
+        reader.read_exact(&mut body)?;
+        let mut delimiter = [0u8; 1];
+        reader.read_exact(&mut delimiter)?;
+        ensure!(delimiter == *b"\n", "missing Git batch delimiter");
+        if let Some(tree) = parse_git_tree(&body, object_format)? {
+            trees.push(tree);
+        } else {
+            skipped_trees += 1;
+        }
+    }
+    drop(requests);
+    let output = child.wait_with_output()?;
+    ensure!(
+        output.status.success(),
+        "Git tree batch failed in {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(RealCorpus {
+        label,
+        path,
+        object_format,
+        discovered_trees,
+        skipped_trees,
+        trees,
+    })
+}
+
+struct RealFileFixture {
+    raw: NamedTempFile,
+    adaptive: NamedTempFile,
+    tree_id: ContentHash,
+    entries: usize,
+}
+
+fn write_temp(bytes: &[u8]) -> Result<NamedTempFile> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(bytes)?;
+    file.as_file_mut().flush()?;
+    Ok(file)
+}
+
+fn percentile(sorted: &[usize], numerator: usize, denominator: usize) -> usize {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[(sorted.len() - 1) * numerator / denominator]
+}
+
+#[derive(Debug)]
+struct Timing {
+    median_ns: f64,
+    mean_ns: f64,
+    stddev_ns: f64,
+    cv_percent: f64,
+    iterations_per_sample: u64,
+}
+
+fn run_iterations<F, T>(operation: &mut F, iterations: u64) -> Duration
+where
+    F: FnMut() -> T,
+{
+    let started = Instant::now();
+    for _ in 0..iterations {
+        black_box(operation());
+    }
+    started.elapsed()
+}
+
+fn measure<F, T>(mut operation: F) -> Timing
+where
+    F: FnMut() -> T,
+{
+    let mut iterations = 1u64;
+    let elapsed = loop {
+        let elapsed = run_iterations(&mut operation, iterations);
+        if elapsed >= CALIBRATION_TIME || iterations >= (1 << 30) {
+            break elapsed;
+        }
+        iterations = iterations.saturating_mul(2);
+    };
+    let elapsed_ns = elapsed.as_nanos().max(1) as u64;
+    iterations = iterations
+        .saturating_mul(SAMPLE_TIME.as_nanos() as u64)
+        .div_ceil(elapsed_ns)
+        .max(1);
+
+    let mut samples = Vec::with_capacity(SAMPLE_COUNT);
+    for _ in 0..SAMPLE_COUNT {
+        let elapsed = run_iterations(&mut operation, iterations);
+        samples.push(elapsed.as_nanos() as f64 / iterations as f64);
+    }
+    samples.sort_by(f64::total_cmp);
+    let median_ns = samples[samples.len() / 2];
+    let mean_ns = samples.iter().sum::<f64>() / samples.len() as f64;
+    let variance = samples
+        .iter()
+        .map(|sample| (sample - mean_ns).powi(2))
+        .sum::<f64>()
+        / (samples.len() - 1) as f64;
+    let stddev_ns = variance.sqrt();
+    Timing {
+        median_ns,
+        mean_ns,
+        stddev_ns,
+        cv_percent: stddev_ns / mean_ns * 100.0,
+        iterations_per_sample: iterations,
+    }
+}
+
+fn print_timing(entries: usize, operation: &str, timing: &Timing) {
+    println!(
+        "TIMING,{entries},{operation},{:.3},{:.3},{:.3},{:.3},{}",
+        timing.median_ns,
+        timing.mean_ns,
+        timing.stddev_ns,
+        timing.cv_percent,
+        timing.iterations_per_sample
+    );
+}
+
+fn historical_loose(tree: &Tree) -> Vec<u8> {
+    let positional = rmp_serde::to_vec(tree).expect("encode positional MessagePack");
+    compress_with_dictionary(
+        &positional,
+        &CompressionConfig::default(),
+        CompressionDictionary::TreeStateV1,
+    )
+    .expect("compress historical loose-tree body")
+    .unwrap_or(positional)
+}
+
+fn measure_real_partial(
+    fixtures: &[&RealFileFixture],
+    count: usize,
+) -> Result<(Timing, Timing, f64, f64)> {
+    ensure!(
+        !fixtures.is_empty(),
+        "no real file fixtures for {count}-entry read"
+    );
+    let mut raw_index = 0usize;
+    let raw_timing = measure(|| {
+        let fixture = &fixtures[raw_index % fixtures.len()];
+        raw_index += 1;
+        let read = partial_production_file(fixture.raw.path(), fixture.tree_id, count)
+            .expect("file-backed raw read");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut adaptive_index = 0usize;
+    let adaptive_timing = measure(|| {
+        let fixture = &fixtures[adaptive_index % fixtures.len()];
+        adaptive_index += 1;
+        let read = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)
+            .expect("file-backed adaptive read");
+        black_box(read.entries[count - 1].name().len())
+    });
+
+    let mut raw_bytes = 0usize;
+    let mut adaptive_bytes = 0usize;
+    for fixture in fixtures {
+        let raw = partial_production_file(fixture.raw.path(), fixture.tree_id, count)?;
+        let adaptive = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)?;
+        ensure!(
+            raw.entries == adaptive.entries,
+            "file-backed partial mismatch"
+        );
+        raw_bytes += raw.bytes_read;
+        adaptive_bytes += adaptive.bytes_read;
+    }
+    Ok((
+        raw_timing,
+        adaptive_timing,
+        raw_bytes as f64 / fixtures.len() as f64,
+        adaptive_bytes as f64 / fixtures.len() as f64,
+    ))
+}
+
+fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
+    ensure!(!corpora.is_empty(), "no real repositories supplied");
+    println!(
+        "REAL_REPO,label,path,object_format,discovered_trees,sampled_trees,skipped_trees,min_entries,p50_entries,p95_entries,max_entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink"
+    );
+    println!(
+        "REAL_SIZE,label,trees,htr4_raw,historical_loose,adaptive,compressed_trees,raw_fallback_trees,vs_raw_percent,vs_historical_percent"
+    );
+
+    let mut aggregate_raw = 0usize;
+    let mut aggregate_historical = 0usize;
+    let mut aggregate_adaptive = 0usize;
+    let mut aggregate_trees = 0usize;
+    let mut aggregate_compressed = 0usize;
+    let mut file_candidates = Vec::new();
+    let config = CompressionConfig::default();
+
+    for corpus in corpora {
+        ensure!(
+            !corpus.trees.is_empty(),
+            "{} yielded no importable trees",
+            corpus.label
+        );
+        let mut entry_counts = corpus.trees.iter().map(Tree::len).collect::<Vec<_>>();
+        entry_counts.sort_unstable();
+        let mut name_lengths = Vec::new();
+        let mut variants = [0usize; 5];
+        let mut raw_total = 0usize;
+        let mut historical_total = 0usize;
+        let mut adaptive_total = 0usize;
+        let mut compressed_trees = 0usize;
+        let mut raw_fallback_trees = 0usize;
+        let mut eligible_files = Vec::new();
+
+        for tree in &corpus.trees {
+            for entry in tree.entries() {
+                name_lengths.push(entry.name().len());
+                let bucket = match (entry.entry_type(), entry.mode()) {
+                    (EntryType::Blob, FileMode::Normal) => 0,
+                    (EntryType::Blob, FileMode::Executable) => 1,
+                    (EntryType::Tree, _) => 2,
+                    (EntryType::Symlink, _) => 3,
+                    (EntryType::Gitlink, _) => 4,
+                    (EntryType::Spoollink, _) => continue,
+                    _ => continue,
+                };
+                variants[bucket] += 1;
+            }
+            let raw = tree.encode_canonical()?;
+            let historical = historical_loose(tree);
+            let (_, adaptive) = objects::store::codec::encode_tree(tree, &config)?;
+            raw_total += raw.len();
+            historical_total += historical.len();
+            adaptive_total += adaptive.len();
+            if adaptive.get(4) == Some(&TREE_BLOCK_ENCODING_VERSION) {
+                compressed_trees += 1;
+                if !tree.is_empty() {
+                    eligible_files.push((tree.len(), tree.hash(), raw, adaptive));
+                }
+            } else {
+                raw_fallback_trees += 1;
+            }
+        }
+
+        name_lengths.sort_unstable();
+        let mean_name = if name_lengths.is_empty() {
+            0.0
+        } else {
+            name_lengths.iter().sum::<usize>() as f64 / name_lengths.len() as f64
+        };
+        println!(
+            "REAL_REPO,{},{},{:?},{},{},{},{},{},{},{},{},{},{:.2},{},{},{},{},{}",
+            corpus.label,
+            corpus.path.display(),
+            corpus.object_format,
+            corpus.discovered_trees,
+            corpus.trees.len(),
+            corpus.skipped_trees,
+            entry_counts[0],
+            percentile(&entry_counts, 50, 100),
+            percentile(&entry_counts, 95, 100),
+            entry_counts[entry_counts.len() - 1],
+            name_lengths.first().copied().unwrap_or(0),
+            name_lengths.last().copied().unwrap_or(0),
+            mean_name,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+        );
+        println!(
+            "REAL_SIZE,{},{},{},{},{},{},{},{:.3},{:.3}",
+            corpus.label,
+            corpus.trees.len(),
+            raw_total,
+            historical_total,
+            adaptive_total,
+            compressed_trees,
+            raw_fallback_trees,
+            100.0 * (adaptive_total as f64 / raw_total as f64 - 1.0),
+            100.0 * (adaptive_total as f64 / historical_total as f64 - 1.0),
+        );
+        aggregate_raw += raw_total;
+        aggregate_historical += historical_total;
+        aggregate_adaptive += adaptive_total;
+        aggregate_trees += corpus.trees.len();
+        aggregate_compressed += compressed_trees;
+
+        eligible_files.sort_by_key(|candidate| candidate.0);
+        file_candidates.extend(sample_evenly(&eligible_files, REAL_FILE_SAMPLE_LIMIT));
+    }
+
+    println!(
+        "REAL_SIZE,ALL,{aggregate_trees},{aggregate_raw},{aggregate_historical},{aggregate_adaptive},{aggregate_compressed},{},{:.3},{:.3}",
+        aggregate_trees - aggregate_compressed,
+        100.0 * (aggregate_adaptive as f64 / aggregate_raw as f64 - 1.0),
+        100.0 * (aggregate_adaptive as f64 / aggregate_historical as f64 - 1.0),
+    );
+    ensure!(
+        aggregate_adaptive < aggregate_historical,
+        "real-tree adaptive size does not beat historical loose compression"
+    );
+
+    file_candidates.sort_by_key(|candidate| candidate.0);
+    let file_candidates = sample_evenly(&file_candidates, REAL_FILE_SAMPLE_LIMIT);
+    let mut file_fixtures = Vec::with_capacity(file_candidates.len());
+    for (entries, tree_id, raw, adaptive) in file_candidates {
+        file_fixtures.push(RealFileFixture {
+            raw: write_temp(&raw)?,
+            adaptive: write_temp(&adaptive)?,
+            tree_id,
+            entries,
+        });
+    }
+    println!(
+        "REAL_FILE_PARTIAL,count,trees,min_tree_entries,max_tree_entries,raw_mean_bytes,adaptive_mean_bytes,raw_median_ns,adaptive_median_ns,time_ratio"
+    );
+    for count in [1usize, 100] {
+        let eligible = file_fixtures
+            .iter()
+            .filter(|fixture| fixture.entries >= count)
+            .collect::<Vec<_>>();
+        ensure!(
+            !eligible.is_empty(),
+            "no compressed real trees with {count} entries"
+        );
+        let (raw_timing, adaptive_timing, raw_bytes, adaptive_bytes) =
+            measure_real_partial(&eligible, count)?;
+        let ratio = adaptive_timing.median_ns / raw_timing.median_ns;
+        println!(
+            "REAL_FILE_PARTIAL,{count},{},{},{},{raw_bytes:.2},{adaptive_bytes:.2},{:.3},{:.3},{ratio:.3}",
+            eligible.len(),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .min()
+                .unwrap_or(0),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .max()
+                .unwrap_or(0),
+            raw_timing.median_ns,
+            adaptive_timing.median_ns,
+        );
+        ensure!(
+            ratio <= 2.0,
+            "file-backed {count}-entry partial read is {ratio:.3}x raw HTR4"
+        );
+    }
+    println!("REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true");
+    Ok(())
+}
+
+fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
+    let tree = fixture(1_000);
+    let blocked = encode_blocked(&tree, block_entries, dictionary)?;
+    ensure!(decode_blocked(&blocked, dictionary)? == tree);
+    let range_start = block_entries.saturating_sub(20);
+    let partial = partial_blocked(&blocked, dictionary, range_start, 100)?;
+    ensure!(partial.entries == tree.entries()[range_start..range_start + 100]);
+    if block_entries < tree.len() {
+        let resumed = partial_blocked(&blocked, dictionary, block_entries, 1)?;
+        ensure!(resumed.entries == tree.entries()[block_entries..block_entries + 1]);
+    }
+
+    let mut bad_hash = blocked.clone();
+    bad_hash[8] ^= 1;
+    ensure!(decode_blocked(&bad_hash, dictionary).is_err());
+    let mut bad_payload = blocked;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    ensure!(decode_blocked(&bad_payload, dictionary).is_err());
+    Ok(())
+}
+
+fn tune(dictionaries: &[Dictionary<'_>]) -> Result<()> {
+    let tree = fixture(10_000);
+    let htr4 = tree.encode_canonical()?;
+    let historical = historical_loose(&tree);
+    println!(
+        "TUNE,block_entries,dictionary,encoded_bytes,vs_raw_percent,vs_historical_percent,first_1_bytes,first_100_bytes,first_1_median_ns,first_100_median_ns"
+    );
+    for dictionary in dictionaries {
+        for block_entries in [1, 8, 16, 32, 64, 128, 256, 512] {
+            let blocked = Bytes::from(encode_blocked(&tree, block_entries, *dictionary)?);
+            let first_1 = partial_blocked(&blocked, *dictionary, 0, 1)?;
+            let first_100 = partial_blocked(&blocked, *dictionary, 0, 100)?;
+            let first_1_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 1).expect("partial");
+                black_box(read.entries[0].name());
+            });
+            let first_100_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 100).expect("partial");
+                black_box(read.entries[99].name());
+            });
+            println!(
+                "TUNE,{block_entries},{},{},{:.3},{:.3},{},{},{:.3},{:.3}",
+                dictionary.name,
+                blocked.len(),
+                100.0 * (blocked.len() as f64 / htr4.len() as f64 - 1.0),
+                100.0 * (blocked.len() as f64 / historical.len() as f64 - 1.0),
+                first_1.bytes_read,
+                first_100.bytes_read,
+                first_1_timing.median_ns,
+                first_100_timing.median_ns,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn crossover(block_entries: usize, dictionary: Dictionary<'_>) -> Result<()> {
+    let mut first_raw_win = None;
+    let mut last_raw_loss = None;
+    let mut first_historical_win = None;
+    let mut last_historical_loss = None;
+    for entries in 1..=512 {
+        let tree = fixture(entries);
+        let htr4 = tree.encode_canonical()?;
+        let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+        let historical = historical_loose(&tree);
+        if blocked.len() < htr4.len() {
+            first_raw_win.get_or_insert(entries);
+        } else {
+            last_raw_loss = Some(entries);
+        }
+        if blocked.len() < historical.len() {
+            first_historical_win.get_or_insert(entries);
+        } else {
+            last_historical_loss = Some(entries);
+        }
+    }
+    println!(
+        "CROSSOVER,block_entries={},dictionary={},first_smaller_than_raw={},stable_smaller_than_raw_from={},first_smaller_than_historical={},stable_smaller_than_historical_from={},sweep_end=512",
+        block_entries,
+        dictionary.name,
+        first_raw_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_raw_loss.map_or(1, |value| value + 1),
+        first_historical_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_historical_loss.map_or(1, |value| value + 1),
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let trained = training_dictionary()?;
+    // A production decoder would retain these prepared dictionaries in a
+    // process-wide lazy cell. Preparation is outside all retained samples.
+    let legacy_encoder = zstd::dict::EncoderDictionary::copy(LEGACY_DICTIONARY, BLOCK_LEVEL);
+    let legacy_decoder = zstd::dict::DecoderDictionary::copy(LEGACY_DICTIONARY);
+    let trained_encoder = zstd::dict::EncoderDictionary::copy(&trained, BLOCK_LEVEL);
+    let trained_decoder = zstd::dict::DecoderDictionary::copy(&trained);
+    let dictionaries = [
+        Dictionary {
+            name: "none",
+            id: 0,
+            bytes: &[],
+            encoder: None,
+            decoder: None,
+        },
+        Dictionary {
+            name: "legacy",
+            id: LEGACY_DICTIONARY_ID,
+            bytes: LEGACY_DICTIONARY,
+            encoder: Some(&legacy_encoder),
+            decoder: Some(&legacy_decoder),
+        },
+        Dictionary {
+            name: "trained_htr4",
+            id: TRAINED_DICTIONARY_ID,
+            bytes: &trained,
+            encoder: Some(&trained_encoder),
+            decoder: Some(&trained_decoder),
+        },
+    ];
+    let dictionary_name = env::var("HTR4_DICTIONARY").unwrap_or_else(|_| "none".into());
+    let dictionary = *dictionaries
+        .iter()
+        .find(|dictionary| dictionary.name == dictionary_name)
+        .with_context(|| format!("unknown HTR4_DICTIONARY={dictionary_name}"))?;
+    let block_entries = env::var("HTR4_BLOCK_ENTRIES")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(256usize);
+    let real_tree_limit = env::var("HTR4_REAL_TREE_LIMIT")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(DEFAULT_REAL_TREE_LIMIT);
+    let real_paths = {
+        let supplied = env::args().skip(1).map(PathBuf::from).collect::<Vec<_>>();
+        if supplied.is_empty() {
+            vec![PathBuf::from(".")]
+        } else {
+            supplied
+        }
+    };
+    let real_corpora = real_paths
+        .iter()
+        .map(|path| load_real_corpus(path, real_tree_limit))
+        .collect::<Result<Vec<_>>>()?;
+
+    self_check(dictionary, block_entries)?;
+    println!("META,seed,0x{SEED:016x}");
+    println!("META,samples,{SAMPLE_COUNT}");
+    println!("META,target_sample_ms,{}", SAMPLE_TIME.as_millis());
+    println!("META,block_entries,{block_entries}");
+    println!("META,real_tree_limit_per_repo,{real_tree_limit}");
+    println!("META,dictionary,{}", dictionary.name);
+    println!("META,dictionary_bytes,{}", dictionary.bytes.len());
+    println!("META,dictionary_blake3,{}", blake3::hash(dictionary.bytes));
+    println!("META,self_check,roundtrip+range+hash_corruption+payload_corruption_ok");
+    validate_real_corpora(&real_corpora)?;
+    println!(
+        "FIXTURE,entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink,spoollink"
+    );
+    println!(
+        "SIZE,entries,htr4_raw,historical_loose,htr4_whole_zstd3,htb1_blocked,adaptive_size,adaptive_mode"
+    );
+    println!(
+        "TIMING,entries,operation,median_ns,mean_ns,stddev_ns,cv_percent,iterations_per_sample"
+    );
+
+    let fixtures: Vec<(usize, Tree)> = SIZES
+        .into_iter()
+        .map(|entries| (entries, fixture(entries)))
+        .collect();
+
+    for (entries, tree) in &fixtures {
+        let mut min_name = usize::MAX;
+        let mut max_name = 0usize;
+        let mut total_name = 0usize;
+        let mut variants = [0usize; 6];
+        for entry in tree.entries() {
+            min_name = min_name.min(entry.name().len());
+            max_name = max_name.max(entry.name().len());
+            total_name += entry.name().len();
+            let bucket = match (entry.entry_type(), entry.mode()) {
+                (EntryType::Blob, FileMode::Normal) => 0,
+                (EntryType::Blob, FileMode::Executable) => 1,
+                (EntryType::Tree, _) => 2,
+                (EntryType::Symlink, _) => 3,
+                (EntryType::Gitlink, _) => 4,
+                (EntryType::Spoollink, _) => 5,
+                _ => unreachable!("validated entry kind/mode"),
+            };
+            variants[bucket] += 1;
+        }
+        println!(
+            "FIXTURE,{entries},{min_name},{max_name},{:.2},{},{},{},{},{},{}",
+            total_name as f64 / *entries as f64,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+            variants[5]
+        );
+
+        let htr4 = tree.encode_canonical()?;
+        let historical = historical_loose(tree);
+        let whole_zstd = zstd::encode_all(htr4.as_slice(), BLOCK_LEVEL)?;
+        let blocked = encode_blocked(tree, block_entries, dictionary)?;
+        let adaptive = if blocked.len() < htr4.len() {
+            blocked.clone()
+        } else {
+            htr4.clone()
+        };
+        let mode = if adaptive.starts_with(BLOCK_MAGIC) {
+            "blocked"
+        } else {
+            "raw"
+        };
+        ensure!(Tree::decode_canonical(&htr4)? == *tree);
+        ensure!(decode_blocked(&blocked, dictionary)? == *tree);
+        ensure!(decode_adaptive(&adaptive, dictionary)? == *tree);
+        let whole_decoded = zstd::decode_all(whole_zstd.as_slice())?;
+        ensure!(Tree::decode_canonical(&whole_decoded)? == *tree);
+        println!(
+            "SIZE,{entries},{},{},{},{},{},{}",
+            htr4.len(),
+            historical.len(),
+            whole_zstd.len(),
+            blocked.len(),
+            adaptive.len(),
+            mode,
+        );
+
+        print_timing(
+            *entries,
+            "htr4_encode",
+            &measure(|| tree.encode_canonical().expect("encode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_encode",
+            &measure(|| {
+                let raw = tree.encode_canonical().expect("encode HTR4");
+                zstd::encode_all(raw.as_slice(), BLOCK_LEVEL).expect("compress whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_encode",
+            &measure(|| {
+                encode_adaptive(tree, block_entries, dictionary).expect("encode adaptive HTB1")
+            }),
+        );
+        print_timing(
+            *entries,
+            "htr4_decode",
+            &measure(|| Tree::decode_canonical(black_box(&htr4)).expect("decode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_decode",
+            &measure(|| {
+                let raw = zstd::decode_all(black_box(whole_zstd.as_slice()))
+                    .expect("decompress whole HTR4");
+                Tree::decode_canonical(&raw).expect("decode whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_decode",
+            &measure(|| {
+                decode_adaptive(black_box(&adaptive), dictionary).expect("decode adaptive HTB1")
+            }),
+        );
+    }
+
+    let (entries, tree) = fixtures.last().context("10k fixture")?;
+    let htr4 = Bytes::from(tree.encode_canonical()?);
+    let whole_zstd = zstd::encode_all(htr4.as_ref(), BLOCK_LEVEL)?;
+    let adaptive = Bytes::from(encode_adaptive(tree, block_entries, dictionary)?);
+    let tree_id = tree.hash();
+    println!("PARTIAL,entries,count,format,bytes_read,median_ns");
+    for count in [1usize, 100] {
+        let raw_read = partial_htr4(&htr4, tree_id, count);
+        let raw_timing = measure(|| {
+            let read = partial_htr4(&htr4, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},htr4_raw,{},{:.3}",
+            raw_read.bytes_read, raw_timing.median_ns
+        );
+
+        let block_read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+        let block_timing = measure(|| {
+            let read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},adaptive_block,{},{:.3}",
+            block_read.bytes_read, block_timing.median_ns
+        );
+
+        let whole_read = partial_whole_zstd(&whole_zstd, tree_id, count);
+        let whole_timing = measure(|| {
+            let read = partial_whole_zstd(&whole_zstd, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},whole_zstd,{},{:.3}",
+            whole_read.bytes_read, whole_timing.median_ns
+        );
+    }
+
+    crossover(block_entries, dictionary)?;
+    if env::var_os("HTR4_TUNE").is_some() {
+        tune(&dictionaries)?;
+    }
+    Ok(())
+}

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -823,7 +823,15 @@ fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> 
         entries.push(entry);
         offset = oid_end;
     }
-    Ok(Some(Tree::from_entries(entries)))
+    let tree = Tree::from_entries(entries);
+    if tree
+        .entries()
+        .windows(2)
+        .any(|pair| pair[0].name() == pair[1].name())
+    {
+        return Ok(None);
+    }
+    Ok(Some(tree))
 }
 
 fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -7,7 +7,7 @@
 //! frame raw as a restart anchor and compresses only the tail.
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap, HashSet},
     env,
     fs::File,
     hint::black_box,
@@ -27,7 +27,7 @@ use objects::object::{
     TREE_BLOCK_ENCODING_VERSION, TREE_HEADER_LEN, Tree, TreeEntry, TreeEntryReader, TreePageLimits,
 };
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 const SEED: u64 = 0x6874_7234_5f62_656e;
 const SIZES: [usize; 5] = [1, 10, 100, 1_000, 10_000];
@@ -713,6 +713,9 @@ struct RealCorpus {
     discovered_trees: usize,
     skipped_trees: usize,
     trees: Vec<Tree>,
+    git_loose_bytes: usize,
+    git_packed_bytes: usize,
+    git_pack_files: usize,
 }
 
 fn git_output(repo: &Path, arguments: &[&str]) -> Result<Vec<u8>> {
@@ -773,8 +776,137 @@ fn discover_tree_ids(repo: &Path, limit: usize) -> Result<(usize, Vec<String>)> 
         }
     }
     let discovered = tree_ids.len();
-    let tree_ids = sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit);
+    let tree_ids = if limit == 0 {
+        tree_ids.into_iter().collect()
+    } else {
+        sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit)
+    };
     Ok((discovered, tree_ids))
+}
+
+fn git_loose_sizes(repo: &Path, tree_ids: &[String]) -> Result<usize> {
+    let temp = TempDir::new()?;
+    let object_dir = temp.path().join("objects");
+    std::fs::create_dir(&object_dir)?;
+    let mut pack = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "pack-objects",
+            "--stdout",
+            "--compression=1",
+            "--no-reuse-delta",
+            "--no-reuse-object",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let pack_stdout = pack.stdout.take().context("Git pack-objects stdout")?;
+    let unpack = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["unpack-objects", "-r"])
+        .env("GIT_OBJECT_DIRECTORY", &object_dir)
+        .stdin(Stdio::from(pack_stdout))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut requests = BufWriter::new(pack.stdin.take().context("Git pack-objects stdin")?);
+    for oid in tree_ids {
+        writeln!(requests, "{oid}")?;
+    }
+    drop(requests);
+    let unpack_output = unpack.wait_with_output()?;
+    let pack_output = pack.wait_with_output()?;
+    ensure!(
+        pack_output.status.success(),
+        "git pack-objects failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&pack_output.stderr)
+    );
+    ensure!(
+        unpack_output.status.success(),
+        "git unpack-objects failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&unpack_output.stderr)
+    );
+
+    let mut total = 0usize;
+    for oid in tree_ids {
+        ensure!(oid.len() > 2, "invalid Git object id {oid}");
+        let path = object_dir.join(&oid[..2]).join(&oid[2..]);
+        total = total
+            .checked_add(usize_from(
+                std::fs::metadata(&path)?.len(),
+                "Git loose size",
+            )?)
+            .context("Git loose total overflow")?;
+    }
+    Ok(total)
+}
+
+fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<(usize, usize)> {
+    let git_dir = PathBuf::from(
+        std::str::from_utf8(&git_output(repo, &["rev-parse", "--absolute-git-dir"])?)?.trim(),
+    );
+    let pack_dir = git_dir.join("objects/pack");
+    let mut indexes = std::fs::read_dir(&pack_dir)
+        .with_context(|| format!("read Git pack directory {}", pack_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|extension| extension == "idx"))
+        .collect::<Vec<_>>();
+    indexes.sort();
+    ensure!(
+        !indexes.is_empty(),
+        "{} has no pack indexes; run `git -C {} gc --prune=now` first",
+        repo.display(),
+        repo.display()
+    );
+
+    let wanted = tree_ids.iter().map(String::as_str).collect::<HashSet<_>>();
+    let mut sizes = HashMap::with_capacity(wanted.len());
+    for index in &indexes {
+        let output = Command::new("git")
+            .args(["verify-pack", "-v"])
+            .arg(index)
+            .output()
+            .with_context(|| format!("verify Git pack {}", index.display()))?;
+        ensure!(
+            output.status.success(),
+            "git verify-pack failed for {}: {}",
+            index.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in output.stdout.split(|byte| *byte == b'\n') {
+            let fields = line
+                .split(|byte| byte.is_ascii_whitespace())
+                .filter(|field| !field.is_empty())
+                .collect::<Vec<_>>();
+            if fields.len() < 5 || fields[1] != b"tree" {
+                continue;
+            }
+            let oid = std::str::from_utf8(fields[0])?;
+            if wanted.contains(oid) {
+                let packed_size = std::str::from_utf8(fields[3])?.parse::<usize>()?;
+                sizes.entry(oid.to_string()).or_insert(packed_size);
+            }
+        }
+    }
+    let missing = tree_ids
+        .iter()
+        .filter(|oid| !sizes.contains_key(oid.as_str()))
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>();
+    ensure!(
+        missing.is_empty(),
+        "{} selected tree objects are not packed (examples: {}); run `git -C {} gc --prune=now` first",
+        tree_ids.len() - sizes.len(),
+        missing.join(","),
+        repo.display()
+    );
+    Ok((sizes.values().sum(), indexes.len()))
 }
 
 fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> {
@@ -856,6 +988,7 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
     let stdout = child.stdout.take().context("Git cat-file stdout")?;
     let mut reader = BufReader::new(stdout);
     let mut trees = Vec::with_capacity(tree_ids.len());
+    let mut imported_tree_ids = Vec::with_capacity(tree_ids.len());
     let mut skipped_trees = 0usize;
     for expected_oid in &tree_ids {
         writeln!(requests, "{expected_oid}")?;
@@ -876,6 +1009,7 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         reader.read_exact(&mut delimiter)?;
         ensure!(delimiter == *b"\n", "missing Git batch delimiter");
         if let Some(tree) = parse_git_tree(&body, object_format)? {
+            imported_tree_ids.push(expected_oid.clone());
             trees.push(tree);
         } else {
             skipped_trees += 1;
@@ -889,6 +1023,8 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         path.display(),
         String::from_utf8_lossy(&output.stderr)
     );
+    let git_loose_bytes = git_loose_sizes(&path, &imported_tree_ids)?;
+    let (git_packed_bytes, git_pack_files) = git_packed_sizes(&path, &imported_tree_ids)?;
     Ok(RealCorpus {
         label,
         path,
@@ -896,6 +1032,9 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         discovered_trees,
         skipped_trees,
         trees,
+        git_loose_bytes,
+        git_packed_bytes,
+        git_pack_files,
     })
 }
 
@@ -1051,15 +1190,17 @@ fn measure_real_partial(
 fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     ensure!(!corpora.is_empty(), "no real repositories supplied");
     println!(
-        "REAL_REPO,label,path,object_format,discovered_trees,sampled_trees,skipped_trees,min_entries,p50_entries,p95_entries,max_entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink"
+        "REAL_REPO,label,path,object_format,discovered_trees,measured_trees,skipped_trees,pack_files,min_entries,p50_entries,p95_entries,max_entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink"
     );
     println!(
-        "REAL_SIZE,label,trees,htr4_raw,historical_loose,adaptive,compressed_trees,raw_fallback_trees,vs_raw_percent,vs_historical_percent"
+        "REAL_SIZE,label,trees,htr4_v5,htr4_raw,git_loose,git_packed,historical_loose,v5_over_git_loose,v5_over_git_packed,compressed_trees,raw_fallback_trees"
     );
 
     let mut aggregate_raw = 0usize;
     let mut aggregate_historical = 0usize;
     let mut aggregate_adaptive = 0usize;
+    let mut aggregate_git_loose = 0usize;
+    let mut aggregate_git_packed = 0usize;
     let mut aggregate_trees = 0usize;
     let mut aggregate_compressed = 0usize;
     let mut file_candidates = Vec::new();
@@ -1119,13 +1260,14 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             name_lengths.iter().sum::<usize>() as f64 / name_lengths.len() as f64
         };
         println!(
-            "REAL_REPO,{},{},{:?},{},{},{},{},{},{},{},{},{},{:.2},{},{},{},{},{}",
+            "REAL_REPO,{},{},{:?},{},{},{},{},{},{},{},{},{},{},{:.2},{},{},{},{},{}",
             corpus.label,
             corpus.path.display(),
             corpus.object_format,
             corpus.discovered_trees,
             corpus.trees.len(),
             corpus.skipped_trees,
+            corpus.git_pack_files,
             entry_counts[0],
             percentile(&entry_counts, 50, 100),
             percentile(&entry_counts, 95, 100),
@@ -1140,20 +1282,24 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             variants[4],
         );
         println!(
-            "REAL_SIZE,{},{},{},{},{},{},{},{:.3},{:.3}",
+            "REAL_SIZE,{},{},{},{},{},{},{},{:.6},{:.6},{},{}",
             corpus.label,
             corpus.trees.len(),
-            raw_total,
-            historical_total,
             adaptive_total,
+            raw_total,
+            corpus.git_loose_bytes,
+            corpus.git_packed_bytes,
+            historical_total,
+            adaptive_total as f64 / corpus.git_loose_bytes as f64,
+            adaptive_total as f64 / corpus.git_packed_bytes as f64,
             compressed_trees,
             raw_fallback_trees,
-            100.0 * (adaptive_total as f64 / raw_total as f64 - 1.0),
-            100.0 * (adaptive_total as f64 / historical_total as f64 - 1.0),
         );
         aggregate_raw += raw_total;
         aggregate_historical += historical_total;
         aggregate_adaptive += adaptive_total;
+        aggregate_git_loose += corpus.git_loose_bytes;
+        aggregate_git_packed += corpus.git_packed_bytes;
         aggregate_trees += corpus.trees.len();
         aggregate_compressed += compressed_trees;
 
@@ -1162,10 +1308,10 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     }
 
     println!(
-        "REAL_SIZE,ALL,{aggregate_trees},{aggregate_raw},{aggregate_historical},{aggregate_adaptive},{aggregate_compressed},{},{:.3},{:.3}",
+        "REAL_SIZE,ALL,{aggregate_trees},{aggregate_adaptive},{aggregate_raw},{aggregate_git_loose},{aggregate_git_packed},{aggregate_historical},{:.6},{:.6},{aggregate_compressed},{}",
+        aggregate_adaptive as f64 / aggregate_git_loose as f64,
+        aggregate_adaptive as f64 / aggregate_git_packed as f64,
         aggregate_trees - aggregate_compressed,
-        100.0 * (aggregate_adaptive as f64 / aggregate_raw as f64 - 1.0),
-        100.0 * (aggregate_adaptive as f64 / aggregate_historical as f64 - 1.0),
     );
     ensure!(
         aggregate_adaptive < aggregate_historical,
@@ -1381,6 +1527,10 @@ fn main() -> Result<()> {
     println!("META,target_sample_ms,{}", SAMPLE_TIME.as_millis());
     println!("META,block_entries,{block_entries}");
     println!("META,real_tree_limit_per_repo,{real_tree_limit}");
+    println!("META,git_loose,actual_git_loose_object_file_bytes(tree_header+body)");
+    println!(
+        "META,git_packed,sum_verify_pack_object_record_bytes_excluding_pack_and_index_fixed_overhead"
+    );
     println!("META,dictionary,{}", dictionary.name);
     println!("META,dictionary_bytes,{}", dictionary.bytes.len());
     println!("META,dictionary_blake3,{}", blake3::hash(dictionary.bytes));

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -36,6 +36,11 @@ const CALIBRATION_TIME: Duration = Duration::from_millis(25);
 const SAMPLE_TIME: Duration = Duration::from_millis(40);
 const DEFAULT_REAL_TREE_LIMIT: usize = 4_000;
 const REAL_FILE_SAMPLE_LIMIT: usize = 64;
+const RADICAL_ANCHOR_INTERVAL: usize = 128;
+const RADICAL_MAX_OPS: usize = 512;
+const RADICAL_HEADER_LEN: usize = 59;
+const RADICAL_MAGIC: &[u8; 4] = b"HDC1";
+const LEAN_MAGIC: &[u8; 4] = b"HLR1";
 
 const BLOCK_MAGIC: &[u8; 4] = b"HTB1";
 const BLOCK_VERSION: u8 = 1;
@@ -525,6 +530,417 @@ fn semantic_encoded_len(entry: &TreeEntry) -> usize {
     3 + entry.name().len() + target_len
 }
 
+fn put_varint(mut value: usize, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+fn take_varint(bytes: &[u8], offset: &mut usize) -> Result<usize> {
+    let mut value = 0usize;
+    for shift in (0..usize::BITS).step_by(7) {
+        let byte = *bytes.get(*offset).context("truncated varint")?;
+        *offset += 1;
+        value |= ((byte & 0x7f) as usize)
+            .checked_shl(shift)
+            .context("varint overflow")?;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    bail!("varint overflow")
+}
+
+fn shared_prefix(left: &str, right: &str) -> usize {
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn encode_compact_entry(entry: &TreeEntry, previous_name: &str, out: &mut Vec<u8>) {
+    out.push((entry.mode().to_byte() << 3) | entry.entry_type().to_byte());
+    let prefix = shared_prefix(previous_name, entry.name());
+    put_varint(prefix, out);
+    put_varint(entry.name().len() - prefix, out);
+    out.extend_from_slice(&entry.name().as_bytes()[prefix..]);
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => out.extend_from_slice(
+            entry
+                .content_hash()
+                .expect("content-addressed compact entry")
+                .as_bytes(),
+        ),
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().expect("compact gitlink target");
+            out.push(match target.format() {
+                GitObjectFormat::Sha1 => 1,
+                GitObjectFormat::Sha256 => 2,
+            });
+            out.extend_from_slice(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().expect("compact spoollink target");
+            put_varint(spool.as_str().len(), out);
+            out.extend_from_slice(spool.as_str().as_bytes());
+            out.extend_from_slice(state.as_bytes());
+        }
+    }
+}
+
+fn decode_compact_entry(
+    bytes: &[u8],
+    offset: &mut usize,
+    previous_name: &str,
+) -> Result<TreeEntry> {
+    let tag = *bytes.get(*offset).context("truncated compact entry tag")?;
+    *offset += 1;
+    let mode = FileMode::from_byte(tag >> 3).context("invalid compact entry mode")?;
+    let kind = EntryType::from_byte(tag & 0x07).context("invalid compact entry kind")?;
+    let prefix = take_varint(bytes, offset)?;
+    let suffix_len = take_varint(bytes, offset)?;
+    ensure!(
+        prefix <= previous_name.len(),
+        "compact name prefix exceeds predecessor"
+    );
+    let suffix_end = offset
+        .checked_add(suffix_len)
+        .context("compact name length overflow")?;
+    let suffix = bytes
+        .get(*offset..suffix_end)
+        .context("truncated compact name suffix")?;
+    let mut name = previous_name.as_bytes()[..prefix].to_vec();
+    name.extend_from_slice(suffix);
+    let name = String::from_utf8(name)?;
+    *offset = suffix_end;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let end = offset.checked_add(32).context("compact hash overflow")?;
+            let hash = ContentHash::from_bytes(
+                bytes
+                    .get(*offset..end)
+                    .context("truncated compact content hash")?
+                    .try_into()?,
+            );
+            *offset = end;
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let format = match *bytes
+                .get(*offset)
+                .context("missing compact gitlink format")?
+            {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid compact gitlink format"),
+            };
+            *offset += 1;
+            let oid_len = match format {
+                GitObjectFormat::Sha1 => 20,
+                GitObjectFormat::Sha256 => 32,
+            };
+            let end = offset
+                .checked_add(oid_len)
+                .context("compact gitlink length overflow")?;
+            let target = GitObjectId::from_raw(
+                format,
+                bytes
+                    .get(*offset..end)
+                    .context("truncated compact gitlink")?,
+            )?;
+            *offset = end;
+            TreeEntry::gitlink(name, target)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = take_varint(bytes, offset)?;
+            let spool_end = offset
+                .checked_add(spool_len)
+                .context("compact spool length overflow")?;
+            let spool = std::str::from_utf8(
+                bytes
+                    .get(*offset..spool_end)
+                    .context("truncated compact spool id")?,
+            )?;
+            *offset = spool_end;
+            let state_end = offset.checked_add(32).context("compact state overflow")?;
+            let state = StateId::from_bytes(
+                bytes
+                    .get(*offset..state_end)
+                    .context("truncated compact spool state")?
+                    .try_into()?,
+            );
+            *offset = state_end;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, state)?
+        }
+    };
+    ensure!(entry.mode() == mode, "compact entry kind/mode mismatch");
+    Ok(entry)
+}
+
+fn encode_lean(tree: &Tree) -> Vec<u8> {
+    encode_lean_entries(tree.entries())
+}
+
+fn encode_lean_prefix(tree: &Tree, count: usize) -> Vec<u8> {
+    encode_lean_entries(&tree.entries()[..count.min(tree.len())])
+}
+
+fn encode_lean_entries(entries: &[TreeEntry]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(LEAN_MAGIC);
+    put_varint(entries.len(), &mut out);
+    let mut previous = "";
+    for entry in entries {
+        encode_compact_entry(entry, previous, &mut out);
+        previous = entry.name();
+    }
+    out
+}
+
+fn decode_lean(bytes: &[u8], expected: ContentHash) -> Result<Tree> {
+    ensure!(bytes.starts_with(LEAN_MAGIC), "not a lean tree anchor");
+    let mut offset = LEAN_MAGIC.len();
+    let count = take_varint(bytes, &mut offset)?;
+    let mut entries = Vec::with_capacity(count);
+    let mut previous = String::new();
+    for _ in 0..count {
+        let entry = decode_compact_entry(bytes, &mut offset, &previous)?;
+        previous = entry.name().to_string();
+        entries.push(entry);
+    }
+    ensure!(offset == bytes.len(), "trailing lean tree bytes");
+    let tree = Tree::try_from_decoded_entries(entries)?;
+    ensure!(tree.hash() == expected, "lean tree hash mismatch");
+    Ok(tree)
+}
+
+#[derive(Clone, Debug)]
+enum DeltaOp {
+    Remove(String),
+    Upsert(TreeEntry),
+}
+
+impl DeltaOp {
+    fn name(&self) -> &str {
+        match self {
+            Self::Remove(name) => name,
+            Self::Upsert(entry) => entry.name(),
+        }
+    }
+}
+
+fn tree_delta(anchor: &Tree, current: &Tree) -> Vec<DeltaOp> {
+    let mut ops = Vec::new();
+    let mut anchor_index = 0usize;
+    let mut current_index = 0usize;
+    while anchor_index < anchor.len() || current_index < current.len() {
+        match (
+            anchor.entries().get(anchor_index),
+            current.entries().get(current_index),
+        ) {
+            (Some(anchor_entry), Some(current_entry)) => {
+                match anchor_entry.name().cmp(current_entry.name()) {
+                    std::cmp::Ordering::Less => {
+                        ops.push(DeltaOp::Remove(anchor_entry.name().to_string()));
+                        anchor_index += 1;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        ops.push(DeltaOp::Upsert(current_entry.clone()));
+                        current_index += 1;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if anchor_entry != current_entry {
+                            ops.push(DeltaOp::Upsert(current_entry.clone()));
+                        }
+                        anchor_index += 1;
+                        current_index += 1;
+                    }
+                }
+            }
+            (Some(anchor_entry), None) => {
+                ops.push(DeltaOp::Remove(anchor_entry.name().to_string()));
+                anchor_index += 1;
+            }
+            (None, Some(current_entry)) => {
+                ops.push(DeltaOp::Upsert(current_entry.clone()));
+                current_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    ops
+}
+
+fn apply_delta(anchor: &Tree, ops: &[DeltaOp]) -> Result<Tree> {
+    let mut entries = Vec::with_capacity(anchor.len() + ops.len());
+    let mut anchor_index = 0usize;
+    let mut op_index = 0usize;
+    while anchor_index < anchor.len() || op_index < ops.len() {
+        match (anchor.entries().get(anchor_index), ops.get(op_index)) {
+            (Some(anchor_entry), Some(op)) => match anchor_entry.name().cmp(op.name()) {
+                std::cmp::Ordering::Less => {
+                    entries.push(anchor_entry.clone());
+                    anchor_index += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    if let DeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    op_index += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if let DeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    anchor_index += 1;
+                    op_index += 1;
+                }
+            },
+            (Some(anchor_entry), None) => {
+                entries.push(anchor_entry.clone());
+                anchor_index += 1;
+            }
+            (None, Some(op)) => {
+                if let DeltaOp::Upsert(entry) = op {
+                    entries.push(entry.clone());
+                }
+                op_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    Ok(Tree::try_from_decoded_entries(entries)?)
+}
+
+fn delta_prefix_counts(anchor: &Tree, current: &Tree, ops: &[DeltaOp], count: usize) -> (u16, u16) {
+    if current.is_empty() {
+        return (0, 0);
+    }
+    let boundary = current.entries()[count.min(current.len()) - 1].name();
+    let op_count = ops.partition_point(|op| op.name() <= boundary);
+    let base_count = anchor
+        .entries()
+        .partition_point(|entry| entry.name() <= boundary);
+    (
+        u16::try_from(op_count).expect("radical op bound fits u16"),
+        u16::try_from(base_count).expect("prefix base count fits u16"),
+    )
+}
+
+fn encode_delta(anchor_id: ContentHash, anchor: &Tree, current: &Tree, ops: &[DeltaOp]) -> Vec<u8> {
+    let (first_ops, first_base) = delta_prefix_counts(anchor, current, ops, 1);
+    let (hundred_ops, hundred_base) = delta_prefix_counts(anchor, current, ops, 100);
+    let mut body = Vec::new();
+    let mut ends = Vec::with_capacity(ops.len());
+    let mut previous = "";
+    for op in ops {
+        match op {
+            DeltaOp::Remove(name) => {
+                body.push(0);
+                let prefix = shared_prefix(previous, name);
+                put_varint(prefix, &mut body);
+                put_varint(name.len() - prefix, &mut body);
+                body.extend_from_slice(&name.as_bytes()[prefix..]);
+            }
+            DeltaOp::Upsert(entry) => {
+                body.push(1);
+                encode_compact_entry(entry, previous, &mut body);
+            }
+        }
+        previous = op.name();
+        ends.push(body.len());
+    }
+    let end_for = |count: u16| {
+        if count == 0 {
+            RADICAL_HEADER_LEN
+        } else {
+            RADICAL_HEADER_LEN + ends[count as usize - 1]
+        }
+    };
+    let mut out = Vec::with_capacity(RADICAL_HEADER_LEN + body.len());
+    out.extend_from_slice(RADICAL_MAGIC);
+    out.push(1);
+    out.extend_from_slice(anchor_id.as_bytes());
+    out.extend_from_slice(&(current.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(ops.len() as u16).to_le_bytes());
+    out.extend_from_slice(&first_ops.to_le_bytes());
+    out.extend_from_slice(&first_base.to_le_bytes());
+    out.extend_from_slice(&(end_for(first_ops) as u32).to_le_bytes());
+    out.extend_from_slice(&hundred_ops.to_le_bytes());
+    out.extend_from_slice(&hundred_base.to_le_bytes());
+    out.extend_from_slice(&(end_for(hundred_ops) as u32).to_le_bytes());
+    debug_assert_eq!(out.len(), RADICAL_HEADER_LEN);
+    out.extend_from_slice(&body);
+    out
+}
+
+fn decode_delta_ops(
+    bytes: &[u8],
+    wanted: usize,
+) -> Result<(ContentHash, usize, Vec<DeltaOp>, usize)> {
+    ensure!(
+        bytes.len() >= RADICAL_HEADER_LEN,
+        "truncated radical delta header"
+    );
+    ensure!(bytes.starts_with(RADICAL_MAGIC), "not a radical tree delta");
+    ensure!(bytes[4] == 1, "unsupported radical delta version");
+    let anchor = ContentHash::from_bytes(bytes[5..37].try_into()?);
+    let result_count = read_u32(bytes, 37)? as usize;
+    let op_count = read_u16(bytes, 41)? as usize;
+    ensure!(wanted <= op_count, "partial delta op count exceeds object");
+    let mut offset = RADICAL_HEADER_LEN;
+    let mut previous = String::new();
+    let mut ops = Vec::with_capacity(wanted);
+    for _ in 0..wanted {
+        let opcode = *bytes.get(offset).context("truncated radical delta op")?;
+        offset += 1;
+        let op = match opcode {
+            0 => {
+                let prefix = take_varint(bytes, &mut offset)?;
+                let suffix_len = take_varint(bytes, &mut offset)?;
+                ensure!(
+                    prefix <= previous.len(),
+                    "delta name prefix exceeds predecessor"
+                );
+                let end = offset
+                    .checked_add(suffix_len)
+                    .context("delta name overflow")?;
+                let mut name = previous.as_bytes()[..prefix].to_vec();
+                name.extend_from_slice(bytes.get(offset..end).context("truncated delta name")?);
+                offset = end;
+                DeltaOp::Remove(String::from_utf8(name)?)
+            }
+            1 => DeltaOp::Upsert(decode_compact_entry(bytes, &mut offset, &previous)?),
+            _ => bail!("invalid radical delta opcode"),
+        };
+        previous = op.name().to_string();
+        ops.push(op);
+    }
+    Ok((anchor, result_count, ops, offset))
+}
+
+fn decode_delta(bytes: &[u8], anchor: &Tree, expected: ContentHash) -> Result<Tree> {
+    let op_count = read_u16(bytes, 41)? as usize;
+    let (anchor_id, result_count, ops, consumed) = decode_delta_ops(bytes, op_count)?;
+    ensure!(consumed == bytes.len(), "trailing radical delta bytes");
+    ensure!(anchor.hash() == anchor_id, "radical delta anchor mismatch");
+    let tree = apply_delta(anchor, &ops)?;
+    ensure!(
+        tree.len() == result_count,
+        "radical delta entry count mismatch"
+    );
+    ensure!(tree.hash() == expected, "radical delta tree hash mismatch");
+    Ok(tree)
+}
+
 fn block_decoder(dictionary: Dictionary<'_>) -> Result<zstd::bulk::Decompressor<'_>> {
     if let Some(prepared) = dictionary.decoder {
         Ok(zstd::bulk::Decompressor::with_prepared_dictionary(
@@ -706,13 +1122,326 @@ fn partial_production_file(path: &Path, tree_id: ContentHash, count: usize) -> R
     })
 }
 
+fn partial_lean_bytes(bytes: &[u8], count: usize) -> Result<PartialRead> {
+    ensure!(bytes.starts_with(LEAN_MAGIC), "not a lean tree anchor");
+    let mut offset = LEAN_MAGIC.len();
+    let entries = take_varint(bytes, &mut offset)?;
+    let wanted = count.min(entries);
+    let mut decoded = Vec::with_capacity(wanted);
+    let mut previous = String::new();
+    for _ in 0..wanted {
+        let entry = decode_compact_entry(bytes, &mut offset, &previous)?;
+        previous = entry.name().to_string();
+        decoded.push(entry);
+    }
+    Ok(PartialRead {
+        entries: decoded,
+        bytes_read: offset,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RadicalMode {
+    LeanAnchor,
+    Htr4Anchor,
+    Delta,
+}
+
+#[derive(Clone, Debug)]
+struct RadicalPlan {
+    mode: RadicalMode,
+    anchor: usize,
+    epoch_depth: usize,
+    settled_len: usize,
+    hot_len: usize,
+    op_count: usize,
+}
+
+struct RadicalCorpus {
+    plans: Vec<RadicalPlan>,
+    lean_total: usize,
+    settled_total: usize,
+    hot_total: usize,
+    bases: usize,
+    deltas: usize,
+    parent_coverage: usize,
+    max_ops: usize,
+}
+
+fn build_radical_corpus(corpus: &RealCorpus) -> Result<RadicalCorpus> {
+    let config = CompressionConfig::default();
+    let indexes = corpus
+        .tree_ids
+        .iter()
+        .enumerate()
+        .map(|(index, oid)| (oid.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let parent_indexes = corpus
+        .tree_ids
+        .iter()
+        .map(|oid| {
+            corpus
+                .parent_tree_ids
+                .get(oid)
+                .and_then(|parent| indexes.get(parent.as_str()).copied())
+        })
+        .collect::<Vec<_>>();
+    let parent_coverage = parent_indexes
+        .iter()
+        .filter(|parent| parent.is_some())
+        .count();
+    let tree_hashes = corpus.trees.iter().map(Tree::hash).collect::<Vec<_>>();
+    let mut lean_sizes = Vec::with_capacity(corpus.trees.len());
+    let mut adaptive_sizes = Vec::with_capacity(corpus.trees.len());
+    let mut lean_total = 0usize;
+    for tree in &corpus.trees {
+        let lean = encode_lean(tree);
+        let (_, adaptive) = objects::store::codec::encode_tree(tree, &config)?;
+        lean_total += lean.len();
+        lean_sizes.push(lean.len());
+        adaptive_sizes.push(adaptive.len());
+    }
+    let mut plans: Vec<Option<RadicalPlan>> = vec![None; corpus.trees.len()];
+    for start in 0..corpus.trees.len() {
+        if plans[start].is_some() {
+            continue;
+        }
+        let mut chain = Vec::new();
+        let mut cursor = start;
+        let mut seen = HashSet::new();
+        while plans[cursor].is_none() && seen.insert(cursor) {
+            chain.push(cursor);
+            let Some(parent) = parent_indexes[cursor] else {
+                break;
+            };
+            cursor = parent;
+        }
+        while let Some(index) = chain.pop() {
+            let lean_len = lean_sizes[index];
+            let htr4_with_porch = adaptive_sizes[index]
+                .checked_add(encode_lean_prefix(&corpus.trees[index], 100).len())
+                .context("radical anchor size overflow")?;
+            let (base_mode, base_len) = if lean_len <= htr4_with_porch {
+                (RadicalMode::LeanAnchor, lean_len)
+            } else {
+                (RadicalMode::Htr4Anchor, htr4_with_porch)
+            };
+            let mut plan = RadicalPlan {
+                mode: base_mode,
+                anchor: index,
+                epoch_depth: 0,
+                settled_len: base_len,
+                hot_len: lean_len,
+                op_count: 0,
+            };
+            if let Some(parent) = parent_indexes[index]
+                && let Some(parent_plan) = plans[parent].as_ref()
+                && parent_plan.epoch_depth + 1 < RADICAL_ANCHOR_INTERVAL
+            {
+                let anchor = parent_plan.anchor;
+                let ops = tree_delta(&corpus.trees[anchor], &corpus.trees[index]);
+                if ops.len() <= RADICAL_MAX_OPS {
+                    let encoded = encode_delta(
+                        tree_hashes[anchor],
+                        &corpus.trees[anchor],
+                        &corpus.trees[index],
+                        &ops,
+                    );
+                    let prefix_is_bounded =
+                        read_u16(&encoded, 45)? <= 1 && read_u16(&encoded, 53)? <= 100;
+                    if prefix_is_bounded && encoded.len() < base_len {
+                        plan = RadicalPlan {
+                            mode: RadicalMode::Delta,
+                            anchor,
+                            epoch_depth: parent_plan.epoch_depth + 1,
+                            settled_len: encoded.len(),
+                            hot_len: encoded.len(),
+                            op_count: ops.len(),
+                        };
+                    }
+                }
+            }
+            plans[index] = Some(plan);
+        }
+    }
+    let plans = plans
+        .into_iter()
+        .enumerate()
+        .map(|(index, plan)| plan.with_context(|| format!("unplanned tree {index}")))
+        .collect::<Result<Vec<_>>>()?;
+    let settled_total = plans.iter().map(|plan| plan.settled_len).sum();
+    let hot_total = plans.iter().map(|plan| plan.hot_len).sum();
+    let bases = plans
+        .iter()
+        .filter(|plan| plan.mode != RadicalMode::Delta)
+        .count();
+    let deltas = plans.len() - bases;
+    let max_ops = plans.iter().map(|plan| plan.op_count).max().unwrap_or(0);
+    Ok(RadicalCorpus {
+        plans,
+        lean_total,
+        settled_total,
+        hot_total,
+        bases,
+        deltas,
+        parent_coverage,
+        max_ops,
+    })
+}
+
+struct RadicalFileFixture {
+    raw: NamedTempFile,
+    delta: NamedTempFile,
+    anchor: NamedTempFile,
+    anchor_lean: bool,
+    anchor_id: ContentHash,
+    expected: ContentHash,
+    entries: usize,
+}
+
+fn radical_file_fixture(
+    corpus: &RealCorpus,
+    radical: &RadicalCorpus,
+    index: usize,
+) -> Result<RadicalFileFixture> {
+    let plan = &radical.plans[index];
+    ensure!(
+        plan.mode == RadicalMode::Delta,
+        "radical fixture must be a delta"
+    );
+    let anchor_plan = &radical.plans[plan.anchor];
+    ensure!(
+        anchor_plan.mode != RadicalMode::Delta,
+        "radical anchor must be materialized"
+    );
+    let anchor_tree = &corpus.trees[plan.anchor];
+    let current = &corpus.trees[index];
+    let ops = tree_delta(anchor_tree, current);
+    let delta = encode_delta(anchor_tree.hash(), anchor_tree, current, &ops);
+    let (anchor_lean, anchor) = if anchor_plan.mode == RadicalMode::LeanAnchor {
+        (true, encode_lean(anchor_tree))
+    } else {
+        (true, encode_lean_prefix(anchor_tree, 100))
+    };
+    ensure!(decode_delta(&delta, anchor_tree, current.hash())? == *current);
+    Ok(RadicalFileFixture {
+        raw: write_temp(&current.encode_canonical()?)?,
+        delta: write_temp(&delta)?,
+        anchor: write_temp(&anchor)?,
+        anchor_lean,
+        anchor_id: anchor_tree.hash(),
+        expected: current.hash(),
+        entries: current.len(),
+    })
+}
+
+fn measure_radical_partial(
+    fixtures: &[&RadicalFileFixture],
+    count: usize,
+) -> Result<(Timing, Timing, f64, f64)> {
+    ensure!(
+        !fixtures.is_empty(),
+        "no radical fixtures for {count}-entry read"
+    );
+    let mut raw_index = 0usize;
+    let raw_timing = measure(|| {
+        let fixture = &fixtures[raw_index % fixtures.len()];
+        raw_index += 1;
+        let read = partial_production_file(fixture.raw.path(), fixture.expected, count)
+            .expect("file-backed raw radical comparison");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut radical_index = 0usize;
+    let radical_timing = measure(|| {
+        let fixture = &fixtures[radical_index % fixtures.len()];
+        radical_index += 1;
+        let read = partial_radical_file(fixture, count).expect("file-backed radical partial");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut raw_bytes = 0usize;
+    let mut radical_bytes = 0usize;
+    for fixture in fixtures {
+        let raw = partial_production_file(fixture.raw.path(), fixture.expected, count)?;
+        let radical = partial_radical_file(fixture, count)?;
+        ensure!(
+            raw.entries == radical.entries,
+            "radical file partial mismatch"
+        );
+        raw_bytes += raw.bytes_read;
+        radical_bytes += radical.bytes_read;
+    }
+    Ok((
+        raw_timing,
+        radical_timing,
+        raw_bytes as f64 / fixtures.len() as f64,
+        radical_bytes as f64 / fixtures.len() as f64,
+    ))
+}
+
+fn partial_radical_file(fixture: &RadicalFileFixture, count: usize) -> Result<PartialRead> {
+    let mut delta_file = File::open(fixture.delta.path())?;
+    let mut header = [0u8; RADICAL_HEADER_LEN];
+    delta_file.read_exact(&mut header)?;
+    let (op_count, base_count, end) = if count == 1 {
+        (
+            read_u16(&header, 43)? as usize,
+            read_u16(&header, 45)? as usize,
+            read_u32(&header, 47)? as usize,
+        )
+    } else {
+        (
+            read_u16(&header, 51)? as usize,
+            read_u16(&header, 53)? as usize,
+            read_u32(&header, 55)? as usize,
+        )
+    };
+    ensure!(end >= RADICAL_HEADER_LEN, "invalid radical partial end");
+    let mut prefix = Vec::with_capacity(end);
+    prefix.extend_from_slice(&header);
+    prefix.resize(end, 0);
+    delta_file.read_exact(&mut prefix[RADICAL_HEADER_LEN..])?;
+    let (anchor_id, result_count, ops, consumed) = decode_delta_ops(&prefix, op_count)?;
+    ensure!(consumed == end, "radical partial index mismatch");
+    ensure!(
+        anchor_id == fixture.anchor_id,
+        "radical partial anchor mismatch"
+    );
+    let base = if base_count == 0 {
+        PartialRead {
+            entries: Vec::new(),
+            bytes_read: 0,
+        }
+    } else if fixture.anchor_lean {
+        let bytes = std::fs::read(fixture.anchor.path())?;
+        partial_lean_bytes(&bytes, base_count)?
+    } else {
+        partial_production_file(fixture.anchor.path(), fixture.anchor_id, base_count)?
+    };
+    let tree = apply_delta(&Tree::from_entries(base.entries), &ops)?;
+    let wanted = count.min(result_count);
+    ensure!(
+        tree.len() >= wanted,
+        "radical partial reconstruction is short"
+    );
+    let entries = tree.entries()[..wanted].to_vec();
+    if wanted == result_count {
+        ensure!(Tree::from_entries(entries.clone()).hash() == fixture.expected);
+    }
+    Ok(PartialRead {
+        entries,
+        bytes_read: end + base.bytes_read,
+    })
+}
+
 struct RealCorpus {
     label: String,
     path: PathBuf,
     object_format: GitObjectFormat,
     discovered_trees: usize,
     skipped_trees: usize,
+    tree_ids: Vec<String>,
     trees: Vec<Tree>,
+    parent_tree_ids: HashMap<String, String>,
     git_loose_bytes: usize,
     git_packed_bytes: usize,
     git_pack_files: usize,
@@ -782,6 +1511,75 @@ fn discover_tree_ids(repo: &Path, limit: usize) -> Result<(usize, Vec<String>)> 
         sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit)
     };
     Ok((discovered, tree_ids))
+}
+
+fn discover_parent_tree_ids(repo: &Path, selected: &[String]) -> Result<HashMap<String, String>> {
+    let wanted = selected.iter().map(String::as_str).collect::<HashSet<_>>();
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "log",
+            "--all",
+            "--topo-order",
+            "--reverse",
+            "--raw",
+            "-r",
+            "-t",
+            "--root",
+            "--no-abbrev",
+            "--diff-merges=first-parent",
+            "--format=COMMIT %H %T %P",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("walk Git tree history in {}", repo.display()))?;
+    let stdout = child.stdout.take().context("Git log stdout")?;
+    let mut roots = HashMap::<String, String>::new();
+    let mut parents = HashMap::new();
+    for line in BufReader::new(stdout).lines() {
+        let line = line?;
+        if let Some(rest) = line.strip_prefix("COMMIT ") {
+            let fields = rest.split_ascii_whitespace().collect::<Vec<_>>();
+            ensure!(fields.len() >= 2, "malformed Git commit/tree record");
+            let commit = fields[0];
+            let root = fields[1];
+            if let Some(parent_commit) = fields.get(2)
+                && let Some(parent_root) = roots.get(*parent_commit)
+                && wanted.contains(root)
+                && root != parent_root
+            {
+                parents
+                    .entry(root.to_string())
+                    .or_insert_with(|| parent_root.clone());
+            }
+            roots.insert(commit.to_string(), root.to_string());
+            continue;
+        }
+        if !line.starts_with(':') {
+            continue;
+        }
+        let fields = line.split_ascii_whitespace().collect::<Vec<_>>();
+        if fields.len() < 5 || fields[0] != ":040000" || fields[1] != "040000" {
+            continue;
+        }
+        let old = fields[2];
+        let new = fields[3];
+        if wanted.contains(new) && old != new && !old.bytes().all(|byte| byte == b'0') {
+            parents
+                .entry(new.to_string())
+                .or_insert_with(|| old.to_string());
+        }
+    }
+    let output = child.wait_with_output()?;
+    ensure!(
+        output.status.success(),
+        "git log tree-history walk failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(parents)
 }
 
 fn git_loose_sizes(repo: &Path, tree_ids: &[String]) -> Result<usize> {
@@ -975,6 +1773,7 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         .to_string();
     let object_format = real_object_format(&path)?;
     let (discovered_trees, tree_ids) = discover_tree_ids(&path, limit)?;
+    let parent_tree_ids = discover_parent_tree_ids(&path, &tree_ids)?;
     let mut child = Command::new("git")
         .arg("-C")
         .arg(&path)
@@ -1031,7 +1830,9 @@ fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
         object_format,
         discovered_trees,
         skipped_trees,
+        tree_ids: imported_tree_ids,
         trees,
+        parent_tree_ids,
         git_loose_bytes,
         git_packed_bytes,
         git_pack_files,
@@ -1195,6 +1996,9 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     println!(
         "REAL_SIZE,label,trees,htr4_v5,htr4_raw,git_loose,git_packed,historical_loose,v5_over_git_loose,v5_over_git_packed,compressed_trees,raw_fallback_trees"
     );
+    println!(
+        "RADICAL_SIZE,label,trees,parent_covered,bases,deltas,max_ops,lean_all,hot_bytes,settled_bytes,settled_over_git_loose,settled_over_git_packed,settled_over_raw,settled_over_v5"
+    );
 
     let mut aggregate_raw = 0usize;
     let mut aggregate_historical = 0usize;
@@ -1203,7 +2007,15 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
     let mut aggregate_git_packed = 0usize;
     let mut aggregate_trees = 0usize;
     let mut aggregate_compressed = 0usize;
+    let mut aggregate_lean = 0usize;
+    let mut aggregate_radical_hot = 0usize;
+    let mut aggregate_radical_settled = 0usize;
+    let mut aggregate_radical_bases = 0usize;
+    let mut aggregate_radical_deltas = 0usize;
+    let mut aggregate_parent_coverage = 0usize;
+    let mut aggregate_radical_max_ops = 0usize;
     let mut file_candidates = Vec::new();
+    let mut radical_file_fixtures = Vec::new();
     let config = CompressionConfig::default();
 
     for corpus in corpora {
@@ -1295,6 +2107,36 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             compressed_trees,
             raw_fallback_trees,
         );
+        let radical = build_radical_corpus(corpus)?;
+        println!(
+            "RADICAL_SIZE,{},{},{},{},{},{},{},{},{},{:.6},{:.6},{:.6},{:.6}",
+            corpus.label,
+            corpus.trees.len(),
+            radical.parent_coverage,
+            radical.bases,
+            radical.deltas,
+            radical.max_ops,
+            radical.lean_total,
+            radical.hot_total,
+            radical.settled_total,
+            radical.settled_total as f64 / corpus.git_loose_bytes as f64,
+            radical.settled_total as f64 / corpus.git_packed_bytes as f64,
+            radical.settled_total as f64 / raw_total as f64,
+            radical.settled_total as f64 / adaptive_total as f64,
+        );
+        let delta_candidates = radical
+            .plans
+            .iter()
+            .enumerate()
+            .filter(|(index, plan)| {
+                plan.mode == RadicalMode::Delta && !corpus.trees[*index].is_empty()
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        let per_corpus = (REAL_FILE_SAMPLE_LIMIT / corpora.len()).max(1);
+        for index in sample_evenly(&delta_candidates, per_corpus) {
+            radical_file_fixtures.push(radical_file_fixture(corpus, &radical, index)?);
+        }
         aggregate_raw += raw_total;
         aggregate_historical += historical_total;
         aggregate_adaptive += adaptive_total;
@@ -1302,6 +2144,13 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
         aggregate_git_packed += corpus.git_packed_bytes;
         aggregate_trees += corpus.trees.len();
         aggregate_compressed += compressed_trees;
+        aggregate_lean += radical.lean_total;
+        aggregate_radical_hot += radical.hot_total;
+        aggregate_radical_settled += radical.settled_total;
+        aggregate_radical_bases += radical.bases;
+        aggregate_radical_deltas += radical.deltas;
+        aggregate_parent_coverage += radical.parent_coverage;
+        aggregate_radical_max_ops = aggregate_radical_max_ops.max(radical.max_ops);
 
         eligible_files.sort_by_key(|candidate| candidate.0);
         file_candidates.extend(sample_evenly(&eligible_files, REAL_FILE_SAMPLE_LIMIT));
@@ -1312,6 +2161,13 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
         aggregate_adaptive as f64 / aggregate_git_loose as f64,
         aggregate_adaptive as f64 / aggregate_git_packed as f64,
         aggregate_trees - aggregate_compressed,
+    );
+    println!(
+        "RADICAL_SIZE,ALL,{aggregate_trees},{aggregate_parent_coverage},{aggregate_radical_bases},{aggregate_radical_deltas},{aggregate_radical_max_ops},{aggregate_lean},{aggregate_radical_hot},{aggregate_radical_settled},{:.6},{:.6},{:.6},{:.6}",
+        aggregate_radical_settled as f64 / aggregate_git_loose as f64,
+        aggregate_radical_settled as f64 / aggregate_git_packed as f64,
+        aggregate_radical_settled as f64 / aggregate_raw as f64,
+        aggregate_radical_settled as f64 / aggregate_adaptive as f64,
     );
     ensure!(
         aggregate_adaptive < aggregate_historical,
@@ -1365,12 +2221,60 @@ fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
             "file-backed {count}-entry partial read is {ratio:.3}x raw HTR4"
         );
     }
-    println!("REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true");
+    println!(
+        "RADICAL_FILE_PARTIAL,count,trees,min_tree_entries,max_tree_entries,raw_mean_bytes,radical_mean_bytes,byte_ratio,raw_median_ns,radical_median_ns,time_ratio"
+    );
+    let mut radical_partial_within_2x = true;
+    for count in [1usize, 100] {
+        let eligible = radical_file_fixtures
+            .iter()
+            .filter(|fixture| fixture.entries >= count)
+            .collect::<Vec<_>>();
+        ensure!(
+            !eligible.is_empty(),
+            "no radical trees with {count} entries"
+        );
+        let (raw_timing, radical_timing, raw_bytes, radical_bytes) =
+            measure_radical_partial(&eligible, count)?;
+        let byte_ratio = radical_bytes / raw_bytes;
+        let time_ratio = radical_timing.median_ns / raw_timing.median_ns;
+        radical_partial_within_2x &= byte_ratio <= 2.0 && time_ratio <= 2.0;
+        println!(
+            "RADICAL_FILE_PARTIAL,{count},{},{},{},{raw_bytes:.2},{radical_bytes:.2},{byte_ratio:.3},{:.3},{:.3},{time_ratio:.3}",
+            eligible.len(),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .min()
+                .unwrap_or(0),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .max()
+                .unwrap_or(0),
+            raw_timing.median_ns,
+            radical_timing.median_ns,
+        );
+    }
+    println!(
+        "REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true,radical_smaller_than_git_loose={},radical_partial_within_2x={radical_partial_within_2x}",
+        aggregate_radical_settled < aggregate_git_loose,
+    );
     Ok(())
 }
 
 fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
     let tree = fixture(1_000);
+    let lean = encode_lean(&tree);
+    ensure!(decode_lean(&lean, tree.hash())? == tree);
+    let mut changed = tree.clone();
+    let changed_name = tree.entries()[500].name().to_string();
+    changed.insert(TreeEntry::file(changed_name, content_hash(500, 99), false)?);
+    let ops = tree_delta(&tree, &changed);
+    ensure!(ops.len() == 1, "one-entry radical self-check delta");
+    let delta = encode_delta(tree.hash(), &tree, &changed, &ops);
+    ensure!(decode_delta(&delta, &tree, changed.hash())? == changed);
+    ensure!(decode_delta(&delta, &tree, tree.hash()).is_err());
     let blocked = encode_blocked(&tree, block_entries, dictionary)?;
     ensure!(decode_blocked(&blocked, dictionary)? == tree);
     let range_start = block_entries.saturating_sub(20);
@@ -1388,6 +2292,88 @@ fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
     let last = bad_payload.len() - 1;
     bad_payload[last] ^= 1;
     ensure!(decode_blocked(&bad_payload, dictionary).is_err());
+    Ok(())
+}
+
+fn measure_radical_capture() -> Result<()> {
+    let anchor = fixture(100_000);
+    let mut current = anchor.clone();
+    let changed_name = anchor.entries()[50_000].name().to_string();
+    current.insert(TreeEntry::file(
+        changed_name,
+        content_hash(50_000, 0xfeed),
+        false,
+    )?);
+    let ops = tree_delta(&anchor, &current);
+    ensure!(
+        ops.len() == 1,
+        "100k radical capture fixture must change one entry"
+    );
+    let raw = current.encode_canonical()?;
+    let v5 = objects::store::codec::encode_tree(&current, &CompressionConfig::default())?.1;
+    let lean = encode_lean(&current);
+    let anchor_id = anchor.hash();
+    let delta = encode_delta(anchor_id, &anchor, &current, &ops);
+    ensure!(decode_lean(&lean, current.hash())? == current);
+    ensure!(decode_delta(&delta, &anchor, current.hash())? == current);
+    println!(
+        "RADICAL_CAPTURE,entries,changes,htr4_raw_bytes,htr4_v5_bytes,lean_bytes,delta_bytes,operation,median_ns,mean_ns,stddev_ns,cv_percent,iterations_per_sample"
+    );
+    for (operation, timing) in [
+        ("lean_anchor_encode", measure(|| encode_lean(&current))),
+        (
+            "htr4_raw_encode",
+            measure(|| current.encode_canonical().expect("100k raw encode")),
+        ),
+        (
+            "htr4_v5_encode",
+            measure(|| {
+                objects::store::codec::encode_tree(&current, &CompressionConfig::default())
+                    .expect("100k v5 encode")
+                    .1
+            }),
+        ),
+        (
+            "htr4_raw_decode",
+            measure(|| Tree::decode_canonical(&raw).expect("100k raw decode")),
+        ),
+        (
+            "htr4_v5_decode",
+            measure(|| Tree::decode_canonical(&v5).expect("100k v5 decode")),
+        ),
+        (
+            "known_delta_encode",
+            measure(|| encode_delta(anchor_id, &anchor, &current, &ops)),
+        ),
+        (
+            "diff_and_delta_encode",
+            measure(|| {
+                let measured_ops = tree_delta(&anchor, &current);
+                encode_delta(anchor_id, &anchor, &current, &measured_ops)
+            }),
+        ),
+        (
+            "lean_anchor_decode",
+            measure(|| decode_lean(&lean, current.hash()).expect("100k lean decode")),
+        ),
+        (
+            "delta_decode",
+            measure(|| decode_delta(&delta, &anchor, current.hash()).expect("100k delta decode")),
+        ),
+    ] {
+        println!(
+            "RADICAL_CAPTURE,100000,1,{},{},{},{},{operation},{:.3},{:.3},{:.3},{:.3},{}",
+            raw.len(),
+            v5.len(),
+            lean.len(),
+            delta.len(),
+            timing.median_ns,
+            timing.mean_ns,
+            timing.stddev_ns,
+            timing.cv_percent,
+            timing.iterations_per_sample,
+        );
+    }
     Ok(())
 }
 
@@ -1534,8 +2520,11 @@ fn main() -> Result<()> {
     println!("META,dictionary,{}", dictionary.name);
     println!("META,dictionary_bytes,{}", dictionary.bytes.len());
     println!("META,dictionary_blake3,{}", blake3::hash(dictionary.bytes));
-    println!("META,self_check,roundtrip+range+hash_corruption+payload_corruption_ok");
+    println!(
+        "META,self_check,v5_roundtrip+range+hash_corruption+payload_corruption;radical_lean+delta_roundtrip+hash_mismatch_ok"
+    );
     validate_real_corpora(&real_corpora)?;
+    measure_radical_capture()?;
     println!(
         "FIXTURE,entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink,spoollink"
     );

--- a/crates/objects/examples/htr4_measure/native_pack.rs
+++ b/crates/objects/examples/htr4_measure/native_pack.rs
@@ -1,0 +1,1582 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Native packed-tree research prototype.
+//!
+//! This is deliberately a measurement format, not a production codec. It
+//! nevertheless accounts every byte needed by the directly-served layout:
+//! pack header, global dictionaries, object records, and hash-to-offset index.
+
+use super::*;
+use std::collections::VecDeque;
+
+const NAME_RESTART: usize = 128;
+const RECORD_BLOCK_ENTRIES: usize = 128;
+const WINDOW_BUCKET_LIMIT: usize = 64;
+const EXACT_CANDIDATES: usize = 16;
+const PACK_HEADER_LEN: usize = 64;
+const PACK_INDEX_HEADER_LEN: usize = 4 + 256 * 4;
+// The hash-sorted table maps each content hash to a 32-bit pack ordinal. A
+// second ordinal-sorted table maps ordinals to record offsets, so base-distance
+// references and record lengths need no hidden in-memory side structure. A
+// production writer adds an 8-byte large-offset escape table beyond 2 GiB;
+// none of the measured packs cross that boundary.
+const PACK_INDEX_ENTRY_LEN: usize = 32 + 4;
+const PACK_ORDINAL_OFFSET_LEN: usize = 4;
+const PACK_INDEX_TRAILER_LEN: usize = 32;
+const RECORD_LEVEL: i32 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CandidateScope {
+    None,
+    Parent,
+    Window,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeltaKind {
+    Structural,
+    Byte,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct NativeConfig {
+    name: &'static str,
+    scope: CandidateScope,
+    max_depth: usize,
+    compressed_blocks: bool,
+    delta_kind: DeltaKind,
+}
+
+const NATIVE_CONFIGS: [NativeConfig; 9] = [
+    NativeConfig {
+        name: "interned-anchors",
+        scope: CandidateScope::None,
+        max_depth: 0,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "parent-d1",
+        scope: CandidateScope::Parent,
+        max_depth: 1,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "parent-d8",
+        scope: CandidateScope::Parent,
+        max_depth: 8,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "window-d1",
+        scope: CandidateScope::Window,
+        max_depth: 1,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "window-d4",
+        scope: CandidateScope::Window,
+        max_depth: 4,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "window-d8",
+        scope: CandidateScope::Window,
+        max_depth: 8,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "window-d16",
+        scope: CandidateScope::Window,
+        max_depth: 16,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "window-d8-raw",
+        scope: CandidateScope::Window,
+        max_depth: 8,
+        compressed_blocks: false,
+        delta_kind: DeltaKind::Structural,
+    },
+    NativeConfig {
+        name: "byte-window-d8",
+        scope: CandidateScope::Window,
+        max_depth: 8,
+        compressed_blocks: true,
+        delta_kind: DeltaKind::Byte,
+    },
+];
+
+const WINNER_CONFIG: usize = 6;
+
+#[derive(Debug)]
+struct NativeDictionary {
+    names: Vec<String>,
+    name_ids: HashMap<String, u32>,
+    targets: Vec<[u8; 32]>,
+    target_ids: HashMap<[u8; 32], u32>,
+    encoded_name_bytes: usize,
+    encoded_target_bytes: usize,
+}
+
+impl NativeDictionary {
+    fn build(corpus: &RealCorpus) -> Result<Self> {
+        let mut names = HashSet::new();
+        let mut target_counts = HashMap::<[u8; 32], usize>::new();
+        for tree in &corpus.trees {
+            for entry in tree.entries() {
+                names.insert(entry.name().to_string());
+                if let Some(target) = native_content_target(entry) {
+                    *target_counts.entry(target).or_default() += 1;
+                }
+            }
+        }
+        let mut names = names.into_iter().collect::<Vec<_>>();
+        names.sort();
+        ensure!(
+            names.len() <= u32::MAX as usize,
+            "native name dictionary overflow"
+        );
+        let name_ids = names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| (name.clone(), index as u32))
+            .collect();
+
+        // Frequent targets receive the shortest varints. The 32-byte table is
+        // fixed-width, so frequency ordering does not cost another index.
+        // A one-use target is cheaper inline (32 bytes) than as a 32-byte
+        // dictionary row plus a reference. Interning begins at the first
+        // actual cross-tree reuse.
+        let mut counted_targets = target_counts
+            .into_iter()
+            .filter(|(_, count)| *count >= 2)
+            .collect::<Vec<_>>();
+        counted_targets.sort_by(|(left_hash, left_count), (right_hash, right_count)| {
+            right_count
+                .cmp(left_count)
+                .then_with(|| left_hash.cmp(right_hash))
+        });
+        ensure!(
+            counted_targets.len() <= u32::MAX as usize,
+            "native target dictionary overflow"
+        );
+        let targets = counted_targets
+            .into_iter()
+            .map(|(target, _)| target)
+            .collect::<Vec<_>>();
+        let target_ids = targets
+            .iter()
+            .enumerate()
+            .map(|(index, target)| (*target, index as u32))
+            .collect();
+        let encoded_name_bytes = encoded_name_dictionary_len(&names)?;
+        let encoded_target_bytes = 4usize
+            .checked_add(varint_len(targets.len()))
+            .and_then(|size| size.checked_add(targets.len().checked_mul(32)?))
+            .context("native target dictionary size overflow")?;
+        Ok(Self {
+            names,
+            name_ids,
+            targets,
+            target_ids,
+            encoded_name_bytes,
+            encoded_target_bytes,
+        })
+    }
+
+    fn name_id(&self, name: &str) -> u32 {
+        self.name_ids[name]
+    }
+
+    fn target_id(&self, target: [u8; 32]) -> Option<u32> {
+        self.target_ids.get(&target).copied()
+    }
+}
+
+fn native_content_target(entry: &TreeEntry) -> Option<[u8; 32]> {
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            entry.content_hash().map(|hash| *hash.as_bytes())
+        }
+        EntryType::Gitlink | EntryType::Spoollink => None,
+    }
+}
+
+fn varint_len(value: usize) -> usize {
+    let mut bytes = Vec::new();
+    put_varint(value, &mut bytes);
+    bytes.len()
+}
+
+fn encoded_name_dictionary_len(names: &[String]) -> Result<usize> {
+    let blocks = names.len().div_ceil(NAME_RESTART);
+    let mut size = 4usize
+        .checked_add(varint_len(names.len()))
+        .and_then(|value| value.checked_add(varint_len(NAME_RESTART)))
+        .and_then(|value| value.checked_add(varint_len(blocks)))
+        .and_then(|value| value.checked_add(blocks.checked_mul(4)?))
+        .context("native name dictionary header overflow")?;
+    for block in names.chunks(NAME_RESTART) {
+        let mut previous = "";
+        for name in block {
+            let prefix = shared_prefix(previous, name);
+            let suffix = name.len() - prefix;
+            size = size
+                .checked_add(varint_len(prefix))
+                .and_then(|value| value.checked_add(varint_len(suffix)))
+                .and_then(|value| value.checked_add(suffix))
+                .context("native name dictionary overflow")?;
+            previous = name;
+        }
+    }
+    Ok(size)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TreeSketch {
+    entries: usize,
+    shape: u64,
+    minima: [u64; 4],
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn name_hash(name: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in name.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+fn tree_sketch(tree: &Tree) -> TreeSketch {
+    let mut shape = 0x6e70_6b31_7368_6170u64;
+    let salts = [
+        0x243f_6a88_85a3_08d3,
+        0x1319_8a2e_0370_7344,
+        0xa409_3822_299f_31d0,
+        0x082e_fa98_ec4e_6c89,
+    ];
+    let mut minima = [u64::MAX; 4];
+    for entry in tree.entries() {
+        let hash = name_hash(entry.name()) ^ (entry.entry_type().to_byte() as u64);
+        shape = mix64(shape ^ hash.rotate_left(17));
+        for (minimum, salt) in minima.iter_mut().zip(salts) {
+            *minimum = (*minimum).min(mix64(hash ^ salt));
+        }
+    }
+    if tree.is_empty() {
+        minima = salts;
+    }
+    TreeSketch {
+        entries: tree.len(),
+        shape,
+        minima,
+    }
+}
+
+fn size_bucket(entries: usize) -> usize {
+    if entries == 0 {
+        0
+    } else {
+        (usize::BITS - entries.leading_zeros()) as usize
+    }
+}
+
+#[derive(Default)]
+struct CandidateWindow {
+    shapes: HashMap<(usize, u64), VecDeque<usize>>,
+    minima: HashMap<(usize, usize, u64), VecDeque<usize>>,
+    sizes: HashMap<usize, VecDeque<usize>>,
+}
+
+fn retain_recent(bucket: &mut VecDeque<usize>, index: usize) {
+    bucket.push_back(index);
+    if bucket.len() > WINDOW_BUCKET_LIMIT {
+        bucket.pop_front();
+    }
+}
+
+impl CandidateWindow {
+    fn insert(&mut self, index: usize, sketch: TreeSketch) {
+        retain_recent(
+            self.shapes
+                .entry((sketch.entries, sketch.shape))
+                .or_default(),
+            index,
+        );
+        let size = size_bucket(sketch.entries);
+        for (band, minimum) in sketch.minima.into_iter().enumerate() {
+            retain_recent(self.minima.entry((size, band, minimum)).or_default(), index);
+        }
+        retain_recent(self.sizes.entry(size).or_default(), index);
+    }
+
+    fn candidates(
+        &self,
+        sketch: TreeSketch,
+        sketches: &[TreeSketch],
+        parent: Option<usize>,
+    ) -> Vec<(usize, bool)> {
+        let mut candidates = HashSet::new();
+        if let Some(parent) = parent {
+            candidates.insert(parent);
+        }
+        if let Some(bucket) = self.shapes.get(&(sketch.entries, sketch.shape)) {
+            candidates.extend(bucket.iter().copied());
+        }
+        let size = size_bucket(sketch.entries);
+        for (band, minimum) in sketch.minima.into_iter().enumerate() {
+            if let Some(bucket) = self.minima.get(&(size, band, minimum)) {
+                candidates.extend(bucket.iter().copied());
+            }
+        }
+        for neighboring_size in size.saturating_sub(1)..=size.saturating_add(1) {
+            if let Some(bucket) = self.sizes.get(&neighboring_size) {
+                candidates.extend(bucket.iter().copied());
+            }
+        }
+        let mut ranked = candidates
+            .into_iter()
+            .filter(|candidate| {
+                let base_entries = sketches[*candidate].entries;
+                let difference = base_entries.abs_diff(sketch.entries);
+                difference <= sketch.entries.max(base_entries).div_ceil(2).max(64)
+                    || Some(*candidate) == parent
+            })
+            .map(|candidate| {
+                let base = sketches[candidate];
+                let exact_shape = base.entries == sketch.entries && base.shape == sketch.shape;
+                let matching_minima = base
+                    .minima
+                    .iter()
+                    .zip(sketch.minima)
+                    .filter(|(left, right)| **left == *right)
+                    .count();
+                let size_difference = base.entries.abs_diff(sketch.entries);
+                let score = (exact_shape as u64) << 63
+                    | (matching_minima as u64) << 56
+                    | (u32::MAX as usize - size_difference.min(u32::MAX as usize)) as u64;
+                (candidate, Some(candidate) == parent, score)
+            })
+            .collect::<Vec<_>>();
+        ranked.sort_by_key(|(candidate, is_parent, score)| {
+            (
+                std::cmp::Reverse(*is_parent),
+                std::cmp::Reverse(*score),
+                std::cmp::Reverse(*candidate),
+            )
+        });
+        ranked.truncate(EXACT_CANDIDATES);
+        ranked
+            .into_iter()
+            .map(|(candidate, is_parent, _)| (candidate, is_parent))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct NativePlan {
+    base: Option<usize>,
+    depth: usize,
+    record_len: usize,
+    op_count: usize,
+    cross_object: bool,
+}
+
+struct VariantBuild {
+    config: NativeConfig,
+    plans: Vec<Option<NativePlan>>,
+    record_bytes: usize,
+}
+
+struct CandidateRecord {
+    base: usize,
+    is_parent: bool,
+    op_count: usize,
+    raw: Vec<u8>,
+    blocked: Vec<u8>,
+    byte: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug)]
+struct BlockDescriptor {
+    first_name: u32,
+    raw_len: usize,
+    stored_len: usize,
+    payload_offset: usize,
+}
+
+fn encode_native_entry(entry: &TreeEntry, dictionary: &NativeDictionary, out: &mut Vec<u8>) {
+    out.push((entry.mode().to_byte() << 3) | entry.entry_type().to_byte());
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let target = native_content_target(entry).expect("native content target");
+            if let Some(target_id) = dictionary.target_id(target) {
+                put_varint(target_id as usize + 1, out);
+            } else {
+                put_varint(0, out);
+                out.extend_from_slice(&target);
+            }
+        }
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().expect("native gitlink target");
+            out.push(match target.format() {
+                GitObjectFormat::Sha1 => 1,
+                GitObjectFormat::Sha256 => 2,
+            });
+            out.extend_from_slice(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().expect("native spoollink target");
+            put_varint(spool.as_str().len(), out);
+            out.extend_from_slice(spool.as_str().as_bytes());
+            out.extend_from_slice(state.as_bytes());
+        }
+    }
+}
+
+fn finish_native_record(
+    tag: u8,
+    prefix: &[usize],
+    raw_blocks: Vec<(u32, Vec<u8>)>,
+    compressed: bool,
+) -> Result<Vec<u8>> {
+    let mut stored_blocks = Vec::with_capacity(raw_blocks.len());
+    for (first_name, raw) in raw_blocks {
+        let encoded = if compressed && !raw.is_empty() {
+            let candidate = zstd::bulk::compress(&raw, RECORD_LEVEL)?;
+            if candidate.len() < raw.len() {
+                candidate
+            } else {
+                raw.clone()
+            }
+        } else {
+            raw.clone()
+        };
+        stored_blocks.push((first_name, raw.len(), encoded));
+    }
+    let mut out = Vec::new();
+    out.push(tag);
+    for value in prefix {
+        put_varint(*value, &mut out);
+    }
+    put_varint(stored_blocks.len(), &mut out);
+    for (first_name, raw_len, stored) in &stored_blocks {
+        put_varint(*first_name as usize, &mut out);
+        put_varint(*raw_len, &mut out);
+        put_varint(stored.len(), &mut out);
+    }
+    for (_, _, stored) in stored_blocks {
+        out.extend_from_slice(&stored);
+    }
+    Ok(out)
+}
+
+fn encode_native_anchor(
+    tree: &Tree,
+    dictionary: &NativeDictionary,
+    compressed: bool,
+) -> Result<Vec<u8>> {
+    let mut blocks = Vec::new();
+    for entries in tree.entries().chunks(RECORD_BLOCK_ENTRIES) {
+        let first_name = entries
+            .first()
+            .map(|entry| dictionary.name_id(entry.name()))
+            .unwrap_or(0);
+        let mut previous = 0u32;
+        let mut raw = Vec::new();
+        for (ordinal, entry) in entries.iter().enumerate() {
+            let name = dictionary.name_id(entry.name());
+            let encoded_name = if ordinal == 0 { name } else { name - previous };
+            put_varint(encoded_name as usize, &mut raw);
+            encode_native_entry(entry, dictionary, &mut raw);
+            previous = name;
+        }
+        blocks.push((first_name, raw));
+    }
+    finish_native_record(b'A', &[tree.len()], blocks, compressed)
+}
+
+fn encode_native_delta(
+    base_distance: usize,
+    current: &Tree,
+    ops: &[DeltaOp],
+    dictionary: &NativeDictionary,
+    compressed: bool,
+) -> Result<Vec<u8>> {
+    let mut blocks = Vec::new();
+    for operations in ops.chunks(RECORD_BLOCK_ENTRIES) {
+        let first_name = operations
+            .first()
+            .map(|op| dictionary.name_id(op.name()))
+            .unwrap_or(0);
+        let mut previous = 0u32;
+        let mut raw = Vec::new();
+        for (ordinal, op) in operations.iter().enumerate() {
+            let name = dictionary.name_id(op.name());
+            let encoded_name = if ordinal == 0 { name } else { name - previous };
+            put_varint(encoded_name as usize, &mut raw);
+            match op {
+                DeltaOp::Remove(_) => raw.push(0),
+                DeltaOp::Upsert(entry) => {
+                    raw.push(1);
+                    encode_native_entry(entry, dictionary, &mut raw);
+                }
+            }
+            previous = name;
+        }
+        blocks.push((first_name, raw));
+    }
+    finish_native_record(
+        b'D',
+        &[base_distance, current.len(), ops.len()],
+        blocks,
+        compressed,
+    )
+}
+
+fn flush_byte_insert(insert: &mut Vec<u8>, commands: &mut Vec<u8>) {
+    if insert.is_empty() {
+        return;
+    }
+    commands.push(0);
+    put_varint(insert.len(), commands);
+    commands.append(insert);
+}
+
+fn byte_match_key(bytes: &[u8], offset: usize) -> Option<u64> {
+    let key: [u8; 8] = bytes.get(offset..offset + 8)?.try_into().ok()?;
+    Some(u64::from_le_bytes(key))
+}
+
+fn encode_byte_delta(base_distance: usize, base: &[u8], target: &[u8]) -> Result<Vec<u8>> {
+    let mut matches = HashMap::<u64, Vec<usize>>::new();
+    for offset in (0..base.len().saturating_sub(7)).step_by(4) {
+        let key = byte_match_key(base, offset).context("byte delta base key")?;
+        let positions = matches.entry(key).or_default();
+        if positions.len() < 4 {
+            positions.push(offset);
+        }
+    }
+    let mut commands = Vec::new();
+    let mut insert = Vec::new();
+    let mut target_offset = 0usize;
+    while target_offset < target.len() {
+        let mut best = None;
+        if let Some(key) = byte_match_key(target, target_offset)
+            && let Some(positions) = matches.get(&key)
+        {
+            for base_offset in positions {
+                let mut length = 8usize;
+                while base_offset + length < base.len()
+                    && target_offset + length < target.len()
+                    && base[base_offset + length] == target[target_offset + length]
+                {
+                    length += 1;
+                }
+                if best.is_none_or(|(_, best_length)| length > best_length) {
+                    best = Some((*base_offset, length));
+                }
+            }
+        }
+        if let Some((base_offset, length)) = best {
+            flush_byte_insert(&mut insert, &mut commands);
+            commands.push(1);
+            put_varint(base_offset, &mut commands);
+            put_varint(length, &mut commands);
+            target_offset += length;
+        } else {
+            insert.push(target[target_offset]);
+            target_offset += 1;
+        }
+    }
+    flush_byte_insert(&mut insert, &mut commands);
+    let compressed = zstd::bulk::compress(&commands, RECORD_LEVEL)?;
+    let stored = if compressed.len() < commands.len() {
+        compressed
+    } else {
+        commands.clone()
+    };
+    let mut out = Vec::new();
+    out.push(b'B');
+    put_varint(base_distance, &mut out);
+    put_varint(target.len(), &mut out);
+    put_varint(commands.len(), &mut out);
+    put_varint(stored.len(), &mut out);
+    out.extend_from_slice(&stored);
+    Ok(out)
+}
+
+fn apply_byte_delta(bytes: &[u8], base: &[u8]) -> Result<Vec<u8>> {
+    ensure!(bytes.first() == Some(&b'B'), "not a native byte delta");
+    let mut offset = 1usize;
+    black_box(take_varint(bytes, &mut offset)?);
+    let target_len = take_varint(bytes, &mut offset)?;
+    let command_len = take_varint(bytes, &mut offset)?;
+    let stored_len = take_varint(bytes, &mut offset)?;
+    ensure!(
+        offset + stored_len == bytes.len(),
+        "native byte delta length"
+    );
+    let commands = if stored_len == command_len {
+        bytes[offset..].to_vec()
+    } else {
+        zstd::bulk::decompress(&bytes[offset..], command_len)?
+    };
+    let mut command_offset = 0usize;
+    let mut target = Vec::with_capacity(target_len);
+    while command_offset < commands.len() {
+        let opcode = commands[command_offset];
+        command_offset += 1;
+        match opcode {
+            0 => {
+                let length = take_varint(&commands, &mut command_offset)?;
+                let end = command_offset
+                    .checked_add(length)
+                    .context("native byte insert overflow")?;
+                target.extend_from_slice(
+                    commands
+                        .get(command_offset..end)
+                        .context("truncated native byte insert")?,
+                );
+                command_offset = end;
+            }
+            1 => {
+                let base_offset = take_varint(&commands, &mut command_offset)?;
+                let length = take_varint(&commands, &mut command_offset)?;
+                let end = base_offset
+                    .checked_add(length)
+                    .context("native byte copy overflow")?;
+                target.extend_from_slice(
+                    base.get(base_offset..end)
+                        .context("native byte copy out of bounds")?,
+                );
+            }
+            _ => bail!("invalid native byte delta opcode"),
+        }
+    }
+    ensure!(
+        target.len() == target_len,
+        "native byte delta target length"
+    );
+    Ok(target)
+}
+
+fn decode_native_entry(
+    bytes: &[u8],
+    offset: &mut usize,
+    name: &str,
+    dictionary: &NativeDictionary,
+) -> Result<TreeEntry> {
+    let tag = *bytes.get(*offset).context("truncated native entry tag")?;
+    *offset += 1;
+    let mode = FileMode::from_byte(tag >> 3).context("invalid native entry mode")?;
+    let kind = EntryType::from_byte(tag & 0x07).context("invalid native entry kind")?;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let encoded_target = take_varint(bytes, offset)?;
+            let target = if encoded_target == 0 {
+                let end = offset
+                    .checked_add(32)
+                    .context("native inline target overflow")?;
+                let target = ContentHash::from_bytes(
+                    bytes
+                        .get(*offset..end)
+                        .context("truncated native inline target")?
+                        .try_into()?,
+                );
+                *offset = end;
+                target
+            } else {
+                ContentHash::from_bytes(
+                    *dictionary
+                        .targets
+                        .get(encoded_target - 1)
+                        .context("native target id out of bounds")?,
+                )
+            };
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, target, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, target)?,
+                EntryType::Symlink => TreeEntry::symlink(name, target)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let format = match *bytes
+                .get(*offset)
+                .context("missing native gitlink format")?
+            {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid native gitlink format"),
+            };
+            *offset += 1;
+            let target_len = match format {
+                GitObjectFormat::Sha1 => 20,
+                GitObjectFormat::Sha256 => 32,
+            };
+            let end = offset
+                .checked_add(target_len)
+                .context("native gitlink overflow")?;
+            let target = GitObjectId::from_raw(
+                format,
+                bytes
+                    .get(*offset..end)
+                    .context("truncated native gitlink")?,
+            )?;
+            *offset = end;
+            TreeEntry::gitlink(name, target)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = take_varint(bytes, offset)?;
+            let spool_end = offset
+                .checked_add(spool_len)
+                .context("native spoollink overflow")?;
+            let spool = std::str::from_utf8(
+                bytes
+                    .get(*offset..spool_end)
+                    .context("truncated native spool id")?,
+            )?;
+            *offset = spool_end;
+            let state_end = offset.checked_add(32).context("native state overflow")?;
+            let state = StateId::from_bytes(
+                bytes
+                    .get(*offset..state_end)
+                    .context("truncated native spool state")?
+                    .try_into()?,
+            );
+            *offset = state_end;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, state)?
+        }
+    };
+    ensure!(entry.mode() == mode, "native entry mode mismatch");
+    Ok(entry)
+}
+
+fn parse_record_header(bytes: &[u8]) -> Result<(u8, Vec<usize>, Vec<BlockDescriptor>, usize)> {
+    let tag = *bytes.first().context("empty native record")?;
+    ensure!(tag == b'A' || tag == b'D', "unknown native record tag");
+    let mut offset = 1usize;
+    let prefix_fields = if tag == b'A' { 1 } else { 3 };
+    let mut prefix = Vec::with_capacity(prefix_fields);
+    for _ in 0..prefix_fields {
+        prefix.push(take_varint(bytes, &mut offset)?);
+    }
+    let block_count = take_varint(bytes, &mut offset)?;
+    let mut blocks = Vec::with_capacity(block_count);
+    for _ in 0..block_count {
+        let first_name = u32::try_from(take_varint(bytes, &mut offset)?)
+            .context("native first name id overflow")?;
+        let raw_len = take_varint(bytes, &mut offset)?;
+        let stored_len = take_varint(bytes, &mut offset)?;
+        blocks.push(BlockDescriptor {
+            first_name,
+            raw_len,
+            stored_len,
+            payload_offset: 0,
+        });
+    }
+    let header_len = offset;
+    for block in &mut blocks {
+        block.payload_offset = offset;
+        offset = offset
+            .checked_add(block.stored_len)
+            .context("native record length overflow")?;
+    }
+    ensure!(offset == bytes.len(), "native record length mismatch");
+    Ok((tag, prefix, blocks, header_len))
+}
+
+fn decode_native_block(bytes: &[u8], block: &BlockDescriptor) -> Result<Vec<u8>> {
+    let stored = bytes
+        .get(block.payload_offset..block.payload_offset + block.stored_len)
+        .context("truncated native record block")?;
+    if block.stored_len == block.raw_len {
+        Ok(stored.to_vec())
+    } else {
+        Ok(zstd::bulk::decompress(stored, block.raw_len)?)
+    }
+}
+
+fn decode_anchor_record(bytes: &[u8], dictionary: &NativeDictionary) -> Result<Tree> {
+    let (tag, prefix, blocks, _) = parse_record_header(bytes)?;
+    ensure!(tag == b'A', "native anchor expected");
+    let expected_entries = prefix[0];
+    let mut entries = Vec::with_capacity(expected_entries);
+    for block in &blocks {
+        let raw = decode_native_block(bytes, block)?;
+        let mut offset = 0usize;
+        let mut name_id = 0u32;
+        let mut ordinal = 0usize;
+        while offset < raw.len() {
+            let encoded_name = u32::try_from(take_varint(&raw, &mut offset)?)?;
+            name_id = if ordinal == 0 {
+                encoded_name
+            } else {
+                name_id
+                    .checked_add(encoded_name)
+                    .context("native name id overflow")?
+            };
+            let name = dictionary
+                .names
+                .get(name_id as usize)
+                .context("native name id out of bounds")?;
+            entries.push(decode_native_entry(&raw, &mut offset, name, dictionary)?);
+            ordinal += 1;
+        }
+    }
+    ensure!(
+        entries.len() == expected_entries,
+        "native anchor entry mismatch"
+    );
+    Ok(Tree::try_from_decoded_entries(entries)?)
+}
+
+fn decode_delta_record(bytes: &[u8], base: &Tree, dictionary: &NativeDictionary) -> Result<Tree> {
+    let (tag, prefix, blocks, _) = parse_record_header(bytes)?;
+    ensure!(tag == b'D', "native delta expected");
+    let result_entries = prefix[1];
+    let expected_ops = prefix[2];
+    let mut ops = Vec::with_capacity(expected_ops);
+    for block in &blocks {
+        let raw = decode_native_block(bytes, block)?;
+        let mut offset = 0usize;
+        let mut name_id = 0u32;
+        let mut ordinal = 0usize;
+        while offset < raw.len() {
+            let encoded_name = u32::try_from(take_varint(&raw, &mut offset)?)?;
+            name_id = if ordinal == 0 {
+                encoded_name
+            } else {
+                name_id
+                    .checked_add(encoded_name)
+                    .context("native delta name id overflow")?
+            };
+            let name = dictionary
+                .names
+                .get(name_id as usize)
+                .context("native delta name id out of bounds")?;
+            let opcode = *raw.get(offset).context("truncated native delta opcode")?;
+            offset += 1;
+            ops.push(match opcode {
+                0 => DeltaOp::Remove(name.clone()),
+                1 => DeltaOp::Upsert(decode_native_entry(&raw, &mut offset, name, dictionary)?),
+                _ => bail!("invalid native delta opcode"),
+            });
+            ordinal += 1;
+        }
+    }
+    ensure!(ops.len() == expected_ops, "native delta op count mismatch");
+    let tree = apply_delta(base, &ops)?;
+    ensure!(
+        tree.len() == result_entries,
+        "native delta result count mismatch"
+    );
+    Ok(tree)
+}
+
+fn record_base_distance(bytes: &[u8]) -> Result<Option<usize>> {
+    match bytes.first() {
+        Some(b'A') => Ok(None),
+        Some(b'D') => {
+            let mut offset = 1usize;
+            Ok(Some(take_varint(bytes, &mut offset)?))
+        }
+        _ => bail!("invalid native record"),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LookupState {
+    Missing,
+    Removed,
+    Found,
+}
+
+fn lookup_record(
+    bytes: &[u8],
+    dictionary: &NativeDictionary,
+    wanted_name: u32,
+) -> Result<(LookupState, Option<TreeEntry>, usize)> {
+    let (tag, _, blocks, header_len) = parse_record_header(bytes)?;
+    let Some(block_index) = blocks
+        .partition_point(|block| block.first_name <= wanted_name)
+        .checked_sub(1)
+    else {
+        return Ok((LookupState::Missing, None, header_len));
+    };
+    let block = &blocks[block_index];
+    let raw = decode_native_block(bytes, block)?;
+    let mut offset = 0usize;
+    let mut name_id = 0u32;
+    let mut ordinal = 0usize;
+    while offset < raw.len() {
+        let encoded_name = u32::try_from(take_varint(&raw, &mut offset)?)?;
+        name_id = if ordinal == 0 {
+            encoded_name
+        } else {
+            name_id
+                .checked_add(encoded_name)
+                .context("native lookup name overflow")?
+        };
+        let name = dictionary
+            .names
+            .get(name_id as usize)
+            .context("native lookup name id out of bounds")?;
+        if tag == b'D' {
+            let opcode = *raw.get(offset).context("truncated native lookup opcode")?;
+            offset += 1;
+            match opcode {
+                0 => {
+                    if name_id == wanted_name {
+                        return Ok((LookupState::Removed, None, header_len + block.stored_len));
+                    }
+                }
+                1 => {
+                    let entry = decode_native_entry(&raw, &mut offset, name, dictionary)?;
+                    if name_id == wanted_name {
+                        return Ok((
+                            LookupState::Found,
+                            Some(entry),
+                            header_len + block.stored_len,
+                        ));
+                    }
+                }
+                _ => bail!("invalid native lookup opcode"),
+            }
+        } else {
+            let entry = decode_native_entry(&raw, &mut offset, name, dictionary)?;
+            if name_id == wanted_name {
+                return Ok((
+                    LookupState::Found,
+                    Some(entry),
+                    header_len + block.stored_len,
+                ));
+            }
+        }
+        if name_id > wanted_name {
+            break;
+        }
+        ordinal += 1;
+    }
+    Ok((LookupState::Missing, None, header_len + block.stored_len))
+}
+
+struct NativePackedCorpus {
+    dictionary: NativeDictionary,
+    record_bytes: Vec<u8>,
+    record_offsets: Vec<(usize, usize)>,
+    object_index: Vec<([u8; 32], usize)>,
+}
+
+impl NativePackedCorpus {
+    fn record(&self, ordinal: usize) -> Result<&[u8]> {
+        let (offset, length) = *self
+            .record_offsets
+            .get(ordinal)
+            .context("native record ordinal out of bounds")?;
+        self.record_bytes
+            .get(offset..offset + length)
+            .context("native record offset out of bounds")
+    }
+
+    fn object_ordinal(&self, expected: ContentHash) -> Result<usize> {
+        let key = *expected.as_bytes();
+        let index = self
+            .object_index
+            .binary_search_by_key(&key, |(hash, _)| *hash)
+            .map_err(|_| anyhow::anyhow!("native pack object index miss"))?;
+        Ok(self.object_index[index].1)
+    }
+
+    fn resolve(&self, expected: ContentHash) -> Result<Tree> {
+        let mut ordinal = self.object_ordinal(expected)?;
+        let mut chain = Vec::new();
+        loop {
+            chain.push(ordinal);
+            let record = self.record(ordinal)?;
+            let Some(distance) = record_base_distance(record)? else {
+                break;
+            };
+            ensure!(
+                distance > 0 && distance <= ordinal,
+                "invalid native base distance"
+            );
+            ordinal -= distance;
+        }
+        let anchor = chain.pop().context("empty native chain")?;
+        let mut tree = decode_anchor_record(self.record(anchor)?, &self.dictionary)?;
+        while let Some(delta) = chain.pop() {
+            tree = decode_delta_record(self.record(delta)?, &tree, &self.dictionary)?;
+        }
+        ensure!(
+            tree.hash() == expected,
+            "native resolved tree hash mismatch"
+        );
+        Ok(tree)
+    }
+
+    fn lookup(
+        &self,
+        expected: ContentHash,
+        name: &str,
+    ) -> Result<(Option<TreeEntry>, usize, usize)> {
+        let wanted_name = self.dictionary.name_id(name);
+        let mut ordinal = self.object_ordinal(expected)?;
+        let mut bytes_read = 0usize;
+        let mut records_read = 0usize;
+        loop {
+            let record = self.record(ordinal)?;
+            let (state, entry, read) = lookup_record(record, &self.dictionary, wanted_name)?;
+            bytes_read += read;
+            records_read += 1;
+            match state {
+                LookupState::Found => return Ok((entry, bytes_read, records_read)),
+                LookupState::Removed => return Ok((None, bytes_read, records_read)),
+                LookupState::Missing => {}
+            }
+            let Some(distance) = record_base_distance(record)? else {
+                return Ok((None, bytes_read, records_read));
+            };
+            ensure!(
+                distance > 0 && distance <= ordinal,
+                "invalid native lookup base"
+            );
+            ordinal -= distance;
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct NativeVariantResult {
+    pub name: &'static str,
+    pub record_bytes: usize,
+    pub total_bytes: usize,
+    pub anchors: usize,
+    pub deltas: usize,
+    pub cross_deltas: usize,
+    pub max_depth: usize,
+    pub p50_depth: usize,
+    pub p95_depth: usize,
+    pub depth_histogram: Vec<usize>,
+    pub chain_record_bytes: Vec<usize>,
+    pub total_chain_ops: usize,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct NativeReadResult {
+    pub samples: usize,
+    pub mean_chain_bytes: f64,
+    pub p95_chain_bytes: usize,
+    pub mean_lookup_bytes: f64,
+    pub mean_lookup_records: f64,
+    pub mean_chain_ops: f64,
+    pub resolve_median_ns: f64,
+    pub lookup_median_ns: f64,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct NativePackResult {
+    pub variants: Vec<NativeVariantResult>,
+    pub names: usize,
+    pub targets: usize,
+    pub name_dictionary_bytes: usize,
+    pub target_dictionary_bytes: usize,
+    pub tree_index_bytes: usize,
+    pub build_ms: f64,
+    pub exploration_build_ms: f64,
+    pub byte_delta_build_ms: f64,
+    pub candidate_pairs: usize,
+    pub read: NativeReadResult,
+}
+
+fn pack_index_bytes(trees: usize) -> Result<usize> {
+    PACK_INDEX_HEADER_LEN
+        .checked_add(
+            trees
+                .checked_mul(PACK_INDEX_ENTRY_LEN)
+                .context("native pack index entries overflow")?,
+        )
+        .and_then(|size| {
+            size.checked_add(trees.checked_add(1)?.checked_mul(PACK_ORDINAL_OFFSET_LEN)?)
+        })
+        .and_then(|size| size.checked_add(PACK_INDEX_TRAILER_LEN))
+        .context("native pack index overflow")
+}
+
+fn chain_record_bytes(plans: &[NativePlan], start: usize) -> usize {
+    let mut total = 0usize;
+    let mut cursor = start;
+    loop {
+        let plan = &plans[cursor];
+        total += plan.record_len;
+        let Some(base) = plan.base else {
+            break;
+        };
+        cursor = base;
+    }
+    total
+}
+
+fn chain_ops(plans: &[NativePlan], start: usize) -> usize {
+    let mut total = 0usize;
+    let mut cursor = start;
+    loop {
+        let plan = &plans[cursor];
+        total += plan.op_count;
+        let Some(base) = plan.base else {
+            break;
+        };
+        cursor = base;
+    }
+    total
+}
+
+fn measure_reads(
+    corpus: &RealCorpus,
+    pack: &NativePackedCorpus,
+    plans: &[NativePlan],
+) -> Result<NativeReadResult> {
+    let candidates = corpus
+        .trees
+        .iter()
+        .enumerate()
+        .filter(|(_, tree)| !tree.is_empty())
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let samples = sample_evenly(&candidates, 16);
+    ensure!(!samples.is_empty(), "native read sample is empty");
+    for index in &samples {
+        let resolved = pack.resolve(corpus.trees[*index].hash())?;
+        ensure!(
+            resolved == corpus.trees[*index],
+            "native pack roundtrip mismatch"
+        );
+        let wanted = &corpus.trees[*index].entries()[corpus.trees[*index].len() / 2];
+        let (found, _, _) = pack.lookup(corpus.trees[*index].hash(), wanted.name())?;
+        ensure!(
+            found.as_ref() == Some(wanted),
+            "native pack lookup mismatch"
+        );
+    }
+
+    let mut resolve_index = 0usize;
+    let resolve_timing = measure(|| {
+        let index = samples[resolve_index % samples.len()];
+        resolve_index += 1;
+        let tree = pack
+            .resolve(corpus.trees[index].hash())
+            .expect("native measured resolve");
+        black_box(tree.len())
+    });
+    let mut lookup_index = 0usize;
+    let lookup_timing = measure(|| {
+        let index = samples[lookup_index % samples.len()];
+        lookup_index += 1;
+        let wanted = &corpus.trees[index].entries()[corpus.trees[index].len() / 2];
+        let (entry, _, _) = pack
+            .lookup(corpus.trees[index].hash(), wanted.name())
+            .expect("native measured lookup");
+        black_box(entry.expect("native measured entry").name().len())
+    });
+    let mut chain_bytes = samples
+        .iter()
+        .map(|index| chain_record_bytes(plans, *index))
+        .collect::<Vec<_>>();
+    chain_bytes.sort_unstable();
+    let mut lookup_bytes = 0usize;
+    let mut lookup_records = 0usize;
+    let mut applied_ops = 0usize;
+    for index in &samples {
+        let wanted = &corpus.trees[*index].entries()[corpus.trees[*index].len() / 2];
+        let (_, bytes, records) = pack.lookup(corpus.trees[*index].hash(), wanted.name())?;
+        lookup_bytes += bytes;
+        lookup_records += records;
+        applied_ops += chain_ops(plans, *index);
+    }
+    Ok(NativeReadResult {
+        samples: samples.len(),
+        mean_chain_bytes: chain_bytes.iter().sum::<usize>() as f64 / samples.len() as f64,
+        p95_chain_bytes: percentile(&chain_bytes, 95, 100),
+        mean_lookup_bytes: lookup_bytes as f64 / samples.len() as f64,
+        mean_lookup_records: lookup_records as f64 / samples.len() as f64,
+        mean_chain_ops: applied_ops as f64 / samples.len() as f64,
+        resolve_median_ns: resolve_timing.median_ns,
+        lookup_median_ns: lookup_timing.median_ns,
+    })
+}
+
+pub(super) fn build_native_pack(corpus: &RealCorpus) -> Result<NativePackResult> {
+    let started = Instant::now();
+    let dictionary = NativeDictionary::build(corpus)?;
+    let sketches = corpus.trees.iter().map(tree_sketch).collect::<Vec<_>>();
+    let indexes = corpus
+        .tree_ids
+        .iter()
+        .enumerate()
+        .map(|(index, oid)| (oid.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let parent_indexes = corpus
+        .tree_ids
+        .iter()
+        .map(|oid| {
+            corpus
+                .parent_tree_ids
+                .get(oid)
+                .and_then(|parent| indexes.get(parent.as_str()).copied())
+        })
+        .collect::<Vec<_>>();
+    let mut variants = NATIVE_CONFIGS
+        .iter()
+        .map(|config| VariantBuild {
+            config: *config,
+            plans: vec![None; corpus.trees.len()],
+            record_bytes: 0,
+        })
+        .collect::<Vec<_>>();
+    let mut window = CandidateWindow::default();
+    let mut order = Vec::with_capacity(corpus.trees.len());
+    let mut ordinals = vec![usize::MAX; corpus.trees.len()];
+    let mut records = vec![Vec::new(); corpus.trees.len()];
+    let mut candidate_pairs = 0usize;
+    let mut byte_delta_checked = false;
+    let mut byte_delta_build_time = Duration::ZERO;
+
+    for start in 0..corpus.trees.len() {
+        if variants[0].plans[start].is_some() {
+            continue;
+        }
+        let mut lineage = Vec::new();
+        let mut cursor = start;
+        let mut seen = HashSet::new();
+        while variants[0].plans[cursor].is_none() && seen.insert(cursor) {
+            lineage.push(cursor);
+            let Some(parent) = parent_indexes[cursor] else {
+                break;
+            };
+            cursor = parent;
+        }
+        while let Some(index) = lineage.pop() {
+            let ordinal = order.len();
+            ordinals[index] = ordinal;
+            let anchor_raw = encode_native_anchor(&corpus.trees[index], &dictionary, false)?;
+            let anchor_blocked = encode_native_anchor(&corpus.trees[index], &dictionary, true)?;
+            let candidate_indexes =
+                window.candidates(sketches[index], &sketches, parent_indexes[index]);
+            let mut candidates = Vec::with_capacity(candidate_indexes.len());
+            for (base, is_parent) in candidate_indexes {
+                if ordinals[base] == usize::MAX || ordinals[base] >= ordinal {
+                    continue;
+                }
+                let ops = tree_delta(&corpus.trees[base], &corpus.trees[index]);
+                let distance = ordinal - ordinals[base];
+                let raw =
+                    encode_native_delta(distance, &corpus.trees[index], &ops, &dictionary, false)?;
+                let blocked =
+                    encode_native_delta(distance, &corpus.trees[index], &ops, &dictionary, true)?;
+                candidates.push(CandidateRecord {
+                    base,
+                    is_parent,
+                    op_count: ops.len(),
+                    raw,
+                    blocked,
+                    byte: None,
+                });
+            }
+            candidate_pairs += candidates.len();
+            let byte_started = Instant::now();
+            let mut byte_candidates = (0..candidates.len()).collect::<Vec<_>>();
+            byte_candidates.sort_by_key(|candidate| candidates[*candidate].blocked.len());
+            byte_candidates.truncate(4);
+            if let Some(parent_candidate) =
+                candidates.iter().position(|candidate| candidate.is_parent)
+                && !byte_candidates.contains(&parent_candidate)
+            {
+                byte_candidates.push(parent_candidate);
+            }
+            for candidate_index in byte_candidates {
+                let base = candidates[candidate_index].base;
+                let base_anchor = encode_native_anchor(&corpus.trees[base], &dictionary, false)?;
+                let byte = encode_byte_delta(ordinal - ordinals[base], &base_anchor, &anchor_raw)?;
+                if !byte_delta_checked {
+                    ensure!(
+                        apply_byte_delta(&byte, &base_anchor)? == anchor_raw,
+                        "native byte delta roundtrip mismatch"
+                    );
+                    byte_delta_checked = true;
+                }
+                candidates[candidate_index].byte = Some(byte);
+            }
+            byte_delta_build_time += byte_started.elapsed();
+
+            for variant in &mut variants {
+                let anchor_len = if variant.config.compressed_blocks {
+                    anchor_blocked.len()
+                } else {
+                    anchor_raw.len()
+                };
+                let mut selected = NativePlan {
+                    base: None,
+                    depth: 0,
+                    record_len: anchor_len,
+                    op_count: 0,
+                    cross_object: false,
+                };
+                if variant.config.scope != CandidateScope::None {
+                    for candidate in &candidates {
+                        if variant.config.scope == CandidateScope::Parent && !candidate.is_parent {
+                            continue;
+                        }
+                        let Some(base_plan) = variant.plans[candidate.base].as_ref() else {
+                            continue;
+                        };
+                        let depth = base_plan.depth + 1;
+                        if depth > variant.config.max_depth {
+                            continue;
+                        }
+                        let record_len = match variant.config.delta_kind {
+                            DeltaKind::Structural if variant.config.compressed_blocks => {
+                                candidate.blocked.len()
+                            }
+                            DeltaKind::Structural => candidate.raw.len(),
+                            DeltaKind::Byte => {
+                                let Some(byte) = candidate.byte.as_ref() else {
+                                    continue;
+                                };
+                                byte.len()
+                            }
+                        };
+                        if record_len < selected.record_len {
+                            selected = NativePlan {
+                                base: Some(candidate.base),
+                                depth,
+                                record_len,
+                                op_count: candidate.op_count,
+                                cross_object: !candidate.is_parent,
+                            };
+                        }
+                    }
+                }
+                variant.record_bytes = variant
+                    .record_bytes
+                    .checked_add(selected.record_len)
+                    .context("native record total overflow")?;
+                variant.plans[index] = Some(selected);
+            }
+
+            let winner = variants[WINNER_CONFIG].plans[index]
+                .as_ref()
+                .context("native winner plan missing")?;
+            records[index] = if let Some(base) = winner.base {
+                let candidate = candidates
+                    .iter_mut()
+                    .find(|candidate| candidate.base == base)
+                    .context("native winner candidate missing")?;
+                std::mem::take(&mut candidate.blocked)
+            } else {
+                anchor_blocked
+            };
+            order.push(index);
+            window.insert(index, sketches[index]);
+        }
+    }
+
+    let tree_index_bytes = pack_index_bytes(corpus.trees.len())?;
+    let common_bytes = PACK_HEADER_LEN
+        .checked_add(dictionary.encoded_name_bytes)
+        .and_then(|size| size.checked_add(dictionary.encoded_target_bytes))
+        .and_then(|size| size.checked_add(tree_index_bytes))
+        .context("native common pack bytes overflow")?;
+    let mut results = Vec::with_capacity(variants.len());
+    let mut winner_plans = None;
+    for (variant_index, variant) in variants.into_iter().enumerate() {
+        let plans = variant
+            .plans
+            .into_iter()
+            .enumerate()
+            .map(|(index, plan)| plan.with_context(|| format!("native unplanned tree {index}")))
+            .collect::<Result<Vec<_>>>()?;
+        let mut depths = plans.iter().map(|plan| plan.depth).collect::<Vec<_>>();
+        depths.sort_unstable();
+        let anchors = plans.iter().filter(|plan| plan.base.is_none()).count();
+        let cross_deltas = plans.iter().filter(|plan| plan.cross_object).count();
+        let mut depth_histogram = vec![0usize; depths.last().copied().unwrap_or(0) + 1];
+        for plan in &plans {
+            depth_histogram[plan.depth] += 1;
+        }
+        let mut chain_record_bytes = (0..plans.len())
+            .map(|index| chain_record_bytes(&plans, index))
+            .collect::<Vec<_>>();
+        chain_record_bytes.sort_unstable();
+        let total_chain_ops = (0..plans.len()).map(|index| chain_ops(&plans, index)).sum();
+        results.push(NativeVariantResult {
+            name: variant.config.name,
+            record_bytes: variant.record_bytes,
+            total_bytes: common_bytes
+                .checked_add(variant.record_bytes)
+                .context("native total pack bytes overflow")?,
+            anchors,
+            deltas: plans.len() - anchors,
+            cross_deltas,
+            max_depth: depths.last().copied().unwrap_or(0),
+            p50_depth: percentile(&depths, 50, 100),
+            p95_depth: percentile(&depths, 95, 100),
+            depth_histogram,
+            chain_record_bytes,
+            total_chain_ops,
+        });
+        if variant_index == WINNER_CONFIG {
+            winner_plans = Some(plans);
+        }
+    }
+    let winner_plans = winner_plans.context("native winner plans absent")?;
+    let mut record_bytes = Vec::with_capacity(results[WINNER_CONFIG].record_bytes);
+    let mut record_offsets = Vec::with_capacity(order.len());
+    for source_index in &order {
+        let offset = record_bytes.len();
+        record_bytes.extend_from_slice(&records[*source_index]);
+        record_offsets.push((offset, records[*source_index].len()));
+    }
+    ensure!(
+        record_bytes.len() == results[WINNER_CONFIG].record_bytes,
+        "native concatenated record byte mismatch"
+    );
+    let mut object_index = order
+        .iter()
+        .enumerate()
+        .map(|(ordinal, source_index)| (*corpus.trees[*source_index].hash().as_bytes(), ordinal))
+        .collect::<Vec<_>>();
+    object_index.sort_by_key(|(hash, _)| *hash);
+    let pack = NativePackedCorpus {
+        dictionary,
+        record_bytes,
+        record_offsets,
+        object_index,
+    };
+    let exploration_build_time = started.elapsed();
+    let build_ms = exploration_build_time
+        .saturating_sub(byte_delta_build_time)
+        .as_secs_f64()
+        * 1_000.0;
+    let read = measure_reads(corpus, &pack, &winner_plans)?;
+    Ok(NativePackResult {
+        variants: results,
+        names: pack.dictionary.names.len(),
+        targets: pack.dictionary.targets.len(),
+        name_dictionary_bytes: pack.dictionary.encoded_name_bytes,
+        target_dictionary_bytes: pack.dictionary.encoded_target_bytes,
+        tree_index_bytes,
+        build_ms,
+        exploration_build_ms: exploration_build_time.as_secs_f64() * 1_000.0,
+        byte_delta_build_ms: byte_delta_build_time.as_secs_f64() * 1_000.0,
+        candidate_pairs,
+        read,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dictionary_corpus(trees: Vec<Tree>) -> RealCorpus {
+        RealCorpus {
+            label: "native-pack-test".into(),
+            path: PathBuf::from("."),
+            object_format: GitObjectFormat::Sha1,
+            discovered_trees: trees.len(),
+            skipped_trees: 0,
+            tree_ids: (0..trees.len())
+                .map(|index| format!("{index:040x}"))
+                .collect(),
+            trees,
+            parent_tree_ids: HashMap::new(),
+            git_loose_bytes: 0,
+            git_packed_bytes: 0,
+            git_pack_files: 0,
+            git_pack_depths: Vec::new(),
+            git_pack_chain_bytes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn concatenated_pack_resolves_and_seeks_through_hash_index() {
+        let anchor = fixture(32);
+        let mut current = anchor.clone();
+        let changed_name = anchor.entries()[17].name().to_string();
+        current.insert(
+            TreeEntry::file(changed_name.clone(), content_hash(17, 0xbeef), false)
+                .expect("changed native test entry"),
+        );
+        let corpus = dictionary_corpus(vec![anchor.clone(), current.clone()]);
+        let dictionary = NativeDictionary::build(&corpus).expect("native test dictionary");
+        let anchor_record =
+            encode_native_anchor(&anchor, &dictionary, true).expect("native anchor record");
+        let delta_record = encode_native_delta(
+            1,
+            &current,
+            &tree_delta(&anchor, &current),
+            &dictionary,
+            true,
+        )
+        .expect("native delta record");
+        let mut record_bytes = anchor_record.clone();
+        record_bytes.extend_from_slice(&delta_record);
+        let mut object_index = vec![
+            (*anchor.hash().as_bytes(), 0),
+            (*current.hash().as_bytes(), 1),
+        ];
+        object_index.sort_by_key(|(hash, _)| *hash);
+        let pack = NativePackedCorpus {
+            dictionary,
+            record_bytes,
+            record_offsets: vec![
+                (0, anchor_record.len()),
+                (anchor_record.len(), delta_record.len()),
+            ],
+            object_index,
+        };
+
+        assert_eq!(
+            pack.resolve(current.hash())
+                .expect("resolve native test tree"),
+            current
+        );
+        let expected = current
+            .entries()
+            .iter()
+            .find(|entry| entry.name() == changed_name)
+            .expect("changed entry");
+        let (found, bytes_read, records_read) = pack
+            .lookup(current.hash(), &changed_name)
+            .expect("seek native test entry");
+        assert_eq!(found.as_ref(), Some(expected));
+        assert!(bytes_read > 0);
+        assert_eq!(records_read, 1);
+    }
+
+    #[test]
+    fn byte_delta_roundtrips_copy_and_insert_commands() {
+        let base = b"header:alpha-alpha-alpha;body:0123456789;tail";
+        let target = b"header:alpha-alpha-alpha;body:0123-CHANGED-6789;tail";
+        let delta = encode_byte_delta(1, base, target).expect("encode native byte delta");
+        assert_eq!(
+            apply_byte_delta(&delta, base).expect("apply native byte delta"),
+            target
+        );
+    }
+}

--- a/crates/objects/examples/htr4_measure_corpus.sh
+++ b/crates/objects/examples/htr4_measure_corpus.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+root=${1:?usage: htr4_measure_corpus.sh OUTPUT_DIRECTORY}
+mkdir -p "$root"
+
+emit_data() {
+    local value=$1
+    printf 'data %d\n%s' "${#value}" "$value"
+}
+
+tiny="$root/many-tiny-trees.git"
+git init --bare "$tiny"
+{
+    printf 'commit refs/heads/main\n'
+    printf 'committer HTR4 Measurement <measure@example.com> 1700000000 +0000\n'
+    emit_data '12,000 unique one-file subtrees'
+    printf '\n'
+    for ((entry = 0; entry < 12000; entry++)); do
+        printf -v content 'tiny-%05d' "$entry"
+        printf 'M 100644 inline dir-%05d/index.js\n' "$entry"
+        emit_data "$content"
+        printf '\n'
+    done
+    printf 'done\n'
+} | git -C "$tiny" fast-import --quiet
+git -C "$tiny" gc --prune=now
+
+fanout="$root/huge-fanout.git"
+git init --bare "$fanout"
+{
+    for ((revision = 0; revision < 64; revision++)); do
+        printf 'commit refs/heads/main\n'
+        printf 'committer HTR4 Measurement <measure@example.com> %d +0000\n' "$((1700100000 + revision))"
+        printf -v message '10,000-sibling root revision %d' "$revision"
+        emit_data "$message"
+        printf '\n'
+        if ((revision == 0)); then
+            for ((entry = 0; entry < 10000; entry++)); do
+                printf -v content 'fanout-%05d-r00' "$entry"
+                printf 'M 100644 inline file-%05d.txt\n' "$entry"
+                emit_data "$content"
+                printf '\n'
+            done
+        else
+            entry=$(((revision * 157) % 10000))
+            printf -v content 'fanout-%05d-r%02d' "$entry" "$revision"
+            printf 'M 100644 inline file-%05d.txt\n' "$entry"
+            emit_data "$content"
+            printf '\n'
+        fi
+    done
+    printf 'done\n'
+} | git -C "$fanout" fast-import --quiet
+git -C "$fanout" gc --prune=now
+
+deep="$root/deep-vendored.git"
+git init --bare "$deep"
+{
+    printf 'commit refs/heads/main\n'
+    printf 'committer HTR4 Measurement <measure@example.com> 1700200000 +0000\n'
+    emit_data '32 vendored dependency chains, each 32 packages deep'
+    printf '\n'
+    for ((chain = 0; chain < 32; chain++)); do
+        path="vendor/chain-$(printf '%02d' "$chain")"
+        for ((depth = 0; depth < 32; depth++)); do
+            path="$path/node_modules/pkg-$(printf '%02d' "$depth")"
+        done
+        printf -v content 'chain-%02d-leaf' "$chain"
+        printf 'M 100644 inline %s/index.js\n' "$path"
+        emit_data "$content"
+        printf '\n'
+    done
+    printf 'done\n'
+} | git -C "$deep" fast-import --quiet
+git -C "$deep" gc --prune=now
+
+printf '%s\n' "$tiny" "$fanout" "$deep"

--- a/crates/objects/examples/htr4_measure_corpus.sh
+++ b/crates/objects/examples/htr4_measure_corpus.sh
@@ -10,6 +10,37 @@ emit_data() {
     printf 'data %d\n%s' "${#value}" "$value"
 }
 
+monorepo="$root/monorepo.git"
+git init --bare "$monorepo"
+{
+    for ((revision = 0; revision < 128; revision++)); do
+        printf 'commit refs/heads/main\n'
+        printf 'committer HTR4 Measurement <measure@example.com> %d +0000\n' "$((1699900000 + revision))"
+        printf -v message '10,000-file hierarchical monorepo revision %d' "$revision"
+        emit_data "$message"
+        printf '\n'
+        if ((revision == 0)); then
+            for ((package = 0; package < 200; package++)); do
+                for ((entry = 0; entry < 50; entry++)); do
+                    printf -v content 'package-%03d-file-%02d-r000' "$package" "$entry"
+                    printf 'M 100644 inline packages/pkg-%03d/src/file-%02d.ts\n' "$package" "$entry"
+                    emit_data "$content"
+                    printf '\n'
+                done
+            done
+        else
+            package=$(((revision * 37) % 200))
+            entry=$(((revision * 17) % 50))
+            printf -v content 'package-%03d-file-%02d-r%03d' "$package" "$entry" "$revision"
+            printf 'M 100644 inline packages/pkg-%03d/src/file-%02d.ts\n' "$package" "$entry"
+            emit_data "$content"
+            printf '\n'
+        fi
+    done
+    printf 'done\n'
+} | git -C "$monorepo" fast-import --quiet
+git -C "$monorepo" gc --prune=now
+
 tiny="$root/many-tiny-trees.git"
 git init --bare "$tiny"
 {
@@ -76,4 +107,4 @@ git init --bare "$deep"
 } | git -C "$deep" fast-import --quiet
 git -C "$deep" gc --prune=now
 
-printf '%s\n' "$tiny" "$fanout" "$deep"
+printf '%s\n' "$monorepo" "$tiny" "$fanout" "$deep"

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -23,10 +23,13 @@ pub fn decode_blob_content(data: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
-pub fn encode_tree(tree: &Tree, _config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
-    // Canonical trees stay uncompressed so a resume cursor can seek to an
-    // entry frame without decompressing the prefix.
-    Ok((tree.hash(), tree.encode_canonical()?))
+pub fn encode_tree(tree: &Tree, config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
+    let encoded = if config.enabled && tree.len() >= crate::object::TREE_BLOCK_MIN_ENTRIES {
+        tree.encode_canonical_blocked(config.level, config.min_size)?
+    } else {
+        tree.encode_canonical()?
+    };
+    Ok((tree.hash(), encoded))
 }
 
 pub fn decode_tree(data: &[u8]) -> Result<Tree> {
@@ -135,16 +138,17 @@ mod tests {
         let (_, encoded_tree) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
         let encoded_state = encode_state(&state, &CompressionConfig::default()).unwrap();
 
-        assert!(
-            crate::object::is_canonical_tree(&encoded_tree),
-            "trees stay uncompressed HTR4 so resume can seek"
+        assert_eq!(
+            encoded_tree[4],
+            crate::object::TREE_BLOCK_ENCODING_VERSION,
+            "eligible trees use seekable block-compressed HTR4"
         );
         assert_eq!(&encoded_state[9..13], &1_u32.to_be_bytes());
     }
 
     #[test]
     #[cfg(feature = "zstd")]
-    fn tree_state_dictionary_corpus_roundtrips_byte_identically() {
+    fn tree_and_state_corpus_roundtrips() {
         let config = CompressionConfig::default();
 
         for revision in 0..64 {
@@ -162,9 +166,8 @@ mod tests {
                     })
                     .collect(),
             );
-            let serialized_tree = tree.encode_canonical().unwrap();
             let (_, encoded_tree) = encode_tree(&tree, &config).unwrap();
-            assert_eq!(decode_tree_body(&encoded_tree).unwrap(), serialized_tree);
+            assert_eq!(decode_tree_serialized(&encoded_tree).unwrap(), tree);
 
             let state = State::new(
                 tree.hash(),
@@ -182,6 +185,40 @@ mod tests {
                 serialized_state
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    fn small_tree_and_disabled_compression_use_raw_htr4() {
+        let tree = Tree::from_entries(
+            (0..crate::object::TREE_BLOCK_MIN_ENTRIES - 1)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:02}.rs"),
+                        ContentHash::compute(format!("blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let (_, small) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
+        assert_eq!(small[4], crate::object::TREE_ENCODING_VERSION);
+
+        let large = Tree::from_entries(
+            (0..64)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:02}.rs"),
+                        ContentHash::compute(format!("large-blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let (_, disabled) = encode_tree(&large, &CompressionConfig::disabled()).unwrap();
+        assert_eq!(disabled[4], crate::object::TREE_ENCODING_VERSION);
     }
 
     #[test]

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1072,6 +1072,49 @@ fn loose_htr4_open_is_sequential_and_hashes() {
 }
 
 #[test]
+#[cfg(feature = "zstd")]
+fn loose_block_compressed_htr4_reads_a_file_backed_page_and_verifies() {
+    use crate::object::{TREE_BLOCK_ENCODING_VERSION, TreePageLimits};
+
+    let (_temp, store) = create_test_store();
+    let tree = Tree::from_entries(
+        (0usize..600)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("blob-{index}").as_bytes()),
+                    index.is_multiple_of(19),
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let hash = store.put_tree(&tree).unwrap();
+    let path = hash_path(&trees_dir(store.root()), &hash);
+    let bytes = std::fs::read(&path).unwrap();
+    assert_eq!(bytes[4], TREE_BLOCK_ENCODING_VERSION);
+
+    let mut reader = store.open_tree(&hash, None).unwrap().unwrap();
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.entries, tree.entries()[..1]);
+    assert!(reader.bytes_read() < 256);
+    let next = reader
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(next.entries, tree.entries()[1..101]);
+    while reader
+        .next_page(TreePageLimits::new(256, usize::MAX).unwrap())
+        .unwrap()
+        .is_some()
+    {}
+    reader.finish_and_verify().unwrap();
+}
+
+#[test]
 fn test_state_roundtrip() {
     let (_temp, store) = create_test_store();
 

--- a/docs/spikes/htr4-native-pack.md
+++ b/docs/spikes/htr4-native-pack.md
@@ -1,0 +1,220 @@
+# HTR4 native packed-tree spike
+
+Date: 2026-08-27
+Branch: `spike/htr4-native-pack`
+Base: `0e43f845` (`spike/htr4-radical`)
+
+## Verdict
+
+Yes. A native structural tree pack can be smaller than Git packed while one
+tree or entry remains directly addressable from the pack. The depth-16
+prototype stores all 212,832 trees in **35,842,671 bytes**, including its pack
+header, dictionaries, content-hash index, and ordinal-to-record-offset table.
+That is **0.430x** the inherited strict Git-packed baseline (83,413,546 object
+record bytes), **0.401x** a dedicated Git tree-only pack plus index
+(89,381,610 bytes), **0.070x** HLR1/HDC1, and **0.020x** Git loose.
+
+This is a pack winner, not a replacement for the hot object format. It buys
+the result by reintroducing a global pack/repack lifecycle, a similarity search,
+shared dictionaries, and chains which are commonly at the configured depth
+limit. HLR1/HDC1 remains the simpler independent-object form for capture and
+unsettled objects. The native pack is credible as a settlement/GC format.
+
+## NPK1 prototype
+
+### Pack-wide dictionaries
+
+- Names receive lexicographic pack ordinals. The dictionary is front-coded in
+  128-name restart blocks, so a name remains individually resolvable.
+- A 32-byte target hash is interned only when it occurs at least twice. Single-
+  use hashes stay inline; this avoids making history-free tiny trees worse just
+  to claim interning.
+- Frequent target hashes receive the shortest varints.
+- Gitlinks and spoollinks remain typed inline values.
+
+Across all eight packs the name dictionaries cost 223,947 bytes and the
+194,705 repeated-target rows cost 6,230,607 bytes.
+
+### Structural anchors and deltas
+
+An anchor is a sorted stream of `(name ordinal, mode/type, target)` rows. A
+delta is a sorted stream of remove/upsert operations against another packed
+tree. Both use 128-row restart blocks; each block independently keeps the
+smaller of raw or zstd level 3. A full resolve reads one anchor and applies at
+most 16 deltas. A named-entry lookup walks the chain newest-to-oldest, reads
+only the candidate block in each record, and stops at the first upsert/remove.
+
+The winning aggregate has 22,061 anchors and 190,771 deltas. Of those deltas,
+104,042 select a non-parent base. Chain depth is p50 15, p95 16, max 16: the
+bound is real and frequently active.
+
+### Cross-object candidate window
+
+Each tree has a name/type shape hash and four MinHash values. The builder
+collects candidates from exact-shape, MinHash, and neighboring-size buckets,
+retains the most recent 64 members of each bucket, ranks the union, and exactly
+encodes at most 16 candidates. Historical parent is included when it is a
+valid backward record. Equal similarity scores prefer the most recent candidate,
+making the sliding-window result deterministic. A reused tree ID can make the
+inferred tree-parent map cyclic; such a hint is rejected because pack bases
+must point backward.
+
+### Direct pack serving and accounted index
+
+Records are concatenated in pack order. A hash-sorted index maps each 32-byte
+Heddle tree ID to a 32-bit pack ordinal; an ordinal-sorted 32-bit offset table
+locates the record and its predecessor boundary. Delta records carry a backward
+ordinal distance. The index includes fanout and checksum bytes and costs
+8,521,792 bytes aggregate. Packs over 2 GiB would need Git-style 64-bit escape
+offsets; no measured pack crosses that boundary.
+
+The prototype resolves sampled objects by binary-searching this content-hash
+index, slicing records from a single concatenated pack buffer, walking backward
+base references, decoding, and validating the final semantic tree hash. It is
+not wired into the production filesystem store.
+
+## Complete-corpus storage
+
+Git loose is the actual loose object file size at zlib level 1. `Git packed`
+is the inherited harness's sum of `verify-pack` object record sizes and excludes
+pack/index fixed overhead. Native totals include all of their index and shared
+metadata, making `native / Git packed` the deliberately stricter comparison.
+
+| Corpus | Trees | Raw HTR4 | v5 | Git loose | Git packed | HLR1/HDC1 | NPK1 d16 | NPK1 / Git packed |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Heddle | 12,022 | 11,859,145 | 10,879,700 | 6,960,113 | 1,374,333 | 6,606,810 | 1,598,304 | 1.163x |
+| ripgrep | 6,351 | 4,609,691 | 4,537,923 | 2,841,433 | 558,782 | 2,526,717 | 718,113 | 1.285x |
+| Flask | 11,414 | 11,828,380 | 11,330,371 | 7,211,630 | 1,438,405 | 6,584,613 | 1,335,288 | 0.928x |
+| Git | 167,988 | 3,301,664,847 | 2,600,180,873 | 1,769,314,788 | 78,319,496 | 493,722,880 | 29,698,182 | 0.379x |
+| hierarchical monorepo | 910 | 2,096,415 | 1,552,791 | 1,059,260 | 299,367 | 745,089 | 433,913 | 1.449x |
+| many tiny trees | 12,001 | 1,896,061 | 1,716,905 | 926,183 | 845,658 | 988,527 | 1,455,385 | 1.721x |
+| huge fanout/history | 64 | 34,563,904 | 22,282,909 | 15,828,447 | 482,567 | 443,324 | 432,370 | 0.896x |
+| deep vendored | 2,082 | 230,472 | 230,152 | 107,431 | 94,938 | 103,101 | 171,116 | 1.802x |
+| **All** | **212,832** | **3,368,748,915** | **2,652,711,624** | **1,804,249,285** | **83,413,546** | **511,721,061** | **35,842,671** | **0.430x** |
+
+NPK1 wins the strict Git baseline on Flask, Git history, huge fanout/history,
+and the aggregate. It loses on Heddle, ripgrep, hierarchical monorepo, tiny
+trees, and deep vendored. Against a like-for-like dedicated Git tree pack plus
+index it additionally wins Heddle and ripgrep; it still loses the three
+history-poor synthetic shapes.
+
+The tiny/deep loss is structural: there is no history to delta, Heddle retains
+32-byte hashes where this Git corpus uses SHA-1, and the directly-served native
+index costs 40 bytes per tree plus fixed tables. HLR1/HDC1 is the better format
+for those shapes.
+
+## What closed the gap
+
+All rows include the revised full native index described above.
+
+| Variant | Total bytes | vs Git packed | p50/p95/max depth |
+|---|---:|---:|---:|
+| Interned anchors only | 241,896,576 | 2.900x | 0 / 0 / 0 |
+| Parent only, depth 1 | 132,564,564 | 1.589x | 0 / 1 / 1 |
+| Parent only, depth 8 | 48,119,266 | 0.577x | 3 / 8 / 8 |
+| Cross-object window, depth 1 | 61,960,010 | 0.743x | 1 / 1 / 1 |
+| Cross-object window, depth 4 | 44,708,429 | 0.536x | 4 / 4 / 4 |
+| Cross-object window, depth 8 | 39,757,673 | 0.477x | 8 / 8 / 8 |
+| **Cross-object window, depth 16** | **35,842,671** | **0.430x** | **15 / 16 / 16** |
+| Cross-object depth 8, no block zstd | 41,017,749 | 0.492x | 8 / 8 / 8 |
+| Byte-delta control, depth 8 | 39,518,077 | 0.474x | 6 / 8 / 8 |
+
+The window cuts depth-1 parent storage from 1.589x to 0.743x. Increasing the
+window scheme from depth 1 to 4, 8, and 16 supplies the rest. Structural depth
+8 is 17.4% smaller than parent-only depth 8. It is 0.6% larger than the byte-
+delta control at equal depth, so this experiment does **not** show structural
+deltas intrinsically beating byte deltas. Per-block zstd saves 3.1% at depth 8;
+the deeper bounded chain is what makes the structural variant the tested winner.
+
+The byte control uses fixed/rolling 8-byte matches, copy/insert commands, and
+zstd. It is a useful same-native-representation control, not a reimplementation
+of Git's heavily tuned delta search. Git packed remains the authoritative byte-
+delta baseline.
+
+## Read and serve cost
+
+Across every object, NPK1 depth 16 reads a mean 1,669 record bytes per full
+chain (p95 3,909) and applies a mean 61 structural operations. Git reads a mean
+13,893 compressed record bytes (p95 44,199), with depth p50 4, p95 38, max 50.
+NPK1 trades more consistently deep chains for much smaller records.
+
+On the dominant 167,988-tree Git corpus, 16 evenly selected hot samples measured:
+
+| Operation | Bytes/records | Median |
+|---|---:|---:|
+| NPK1 full semantic resolve + final hash validation | 2,212 mean chain bytes; 90.1 ops | 372.4 us |
+| NPK1 one named entry, dictionary resident | 907 mean record bytes; 9.9 records | 32.0 us |
+| Git `cat-file --batch`, raw inflated tree | 18,144 mean output bytes | 12.9 us |
+
+The Git timing is a warm persistent subprocess and returns raw Git bytes; it
+does not parse a Heddle tree or validate the Heddle semantic hash. Treat it as a
+lower bound, not an apples-to-apples codec benchmark. NPK1 full resolve is 29x
+slower on that sample. Direct NPK1 entry lookup is 2.5x that Git lower bound,
+but avoids inflating and parsing the whole tree; its byte count excludes cold
+reads of the shared dictionaries.
+
+The pathological 10,000-entry history makes the distinction clear: full NPK1
+resolve is 7.66 ms, while one entry is 0.638 ms and about 1,149 record bytes.
+The pack is directly servable, but callers that repeatedly materialize whole
+large trees should cache resolved anchors/trees.
+
+The per-corpus measurements below use 16 evenly selected objects each. Native
+times include the content-hash index lookup; dictionaries and the concatenated
+pack buffer are memory-resident. The last column is the warm Git lower bound
+described above.
+
+| Corpus | NPK1 build | Full tree median | Entry median | Entry record bytes / records | Git tree median |
+|---|---:|---:|---:|---:|---:|
+| Heddle | 0.726 s | 11.7 us | 1.88 us | 220 / 5.2 | 6.08 us |
+| ripgrep | 0.311 s | 6.67 us | 1.56 us | 210 / 8.2 | 6.68 us |
+| Flask | 0.700 s | 13.1 us | 1.92 us | 169 / 4.4 | 6.16 us |
+| Git | 48.916 s | 372.4 us | 32.0 us | 907 / 9.9 | 12.9 us |
+| hierarchical monorepo | 0.077 s | 49.2 us | 7.31 us | 196 / 3.2 | 6.59 us |
+| many tiny trees | 0.261 s | 0.406 us | 0.291 us | 43 / 1.0 | 8.21 us |
+| huge fanout/history | 0.222 s | 7.66 ms | 0.638 ms | 1,149 / 14.8 | 0.156 ms |
+| deep vendored | 0.058 s | 0.373 us | 0.261 us | 41 / 1.0 | 7.37 us |
+
+## Build and lifecycle cost
+
+The winning pack plans/builds in **51.3 s** after corpus ingestion. The full
+multi-variant exploration takes 79.5 s, of which the byte-delta controls take
+28.2 s. The exhaustive pack harness, including Git accounting, decoding all
+trees, HLR1/HDC1, read measurements, and native variants, takes 5m07s and peaks
+at 13,874,972 KiB RSS. Git packs were pre-existing, so this run does not supply
+an apples-to-apples Git repack time. The prototype is intentionally in-memory;
+a production builder must stream sketches/dictionaries and cap memory.
+
+This reintroduces the lifecycle HLR1/HDC1 avoided:
+
+- captures should write independent hot objects first;
+- settlement must build dictionaries, choose bases, and atomically publish a
+  pack plus index;
+- append-only additions can tolerate suboptimal compression, but optimal
+  dictionaries/base choices require repack;
+- deletion and retention must preserve every live base until GC rewrites its
+  dependants;
+- dictionary/index corruption affects the pack, not one object, so checksums
+  and atomic generation swaps are mandatory;
+- serve caches are important because full resolution commonly walks 16 records.
+
+The recommendation is therefore **HLR1/HDC1 hot, NPK1 settled**, with adaptive
+fallback to HLR1/HDC1 for history-poor/tiny packs. It is worth pursuing as a
+pack/GC layer because the aggregate saving is 57.0% versus Git packed and 93.0%
+versus HLR1/HDC1. It is not worth replacing the simple capture-time object path.
+
+## Reproduction
+
+Use the mirrors and synthetic repositories recorded by the predecessor spike:
+
+```bash
+HTR4_REAL_TREE_LIMIT=0 HTR4_VALIDATE_ONLY=1 \
+cargo run --release -p heddle-objects --features zstd \
+  --example htr4_measure -- \
+  /path/to/heddle.git /path/to/ripgrep.git /path/to/flask.git /path/to/git.git \
+  /path/to/monorepo.git /path/to/many-tiny-trees.git \
+  /path/to/huge-fanout.git /path/to/deep-vendored.git
+```
+
+The harness self-checks structural and byte-delta round trips, resolves sampled
+objects through the hash index from the concatenated pack buffer, verifies the
+final tree hash, and compares direct entry lookup with the source tree.

--- a/docs/spikes/htr4-radical-tree-storage.md
+++ b/docs/spikes/htr4-radical-tree-storage.md
@@ -1,0 +1,208 @@
+# HTR4 radical tree-storage spike
+
+Date: 2026-08-27  
+Branch: `spike/htr4-radical`  
+Base: `bd2f083c` (`measure/htr4-vs-git`)
+
+## Verdict
+
+There is a credible storage format beyond v5, but this spike did **not** find a
+complete magic path that clears every invariant.
+
+The best prototype—lean materialized anchors plus anchor-relative coalesced
+deltas—stores the complete 212,832-tree corpus in 511,721,061 bytes. That is
+0.284x Git loose, 6.135x Git packed, 0.193x v5, and 0.152x raw HTR4. Its
+file-backed first-entry read is 1.062x raw bytes and 1.248x raw latency; its
+first-100 read is 0.932x raw bytes and 0.134x raw latency. A known one-entry
+delta at 100,000 entries encodes in 294 ns.
+
+The end-to-end capture gate remains red. Production v5 measures 224.177 ms p95
+at 100,000 paths. A controlled raw-tree-write build measures 223.449 ms, proving
+that merely deferring zstd does not recover the budget. Both runs decode 1,008
+objects for a one-file capture. Capture must consume parent/tree-index changes
+incrementally before this storage primitive can matter end to end.
+
+Therefore:
+
+- **smaller than Git loose + seekable:** yes, on the aggregate and on every
+  corpus except the deliberately history-free many-tiny-trees case;
+- **close to Git packed:** no in general (6.135x aggregate), although the
+  one-file huge-fanout history is 0.919x Git packed;
+- **under the 100 ms capture gate:** no; measured at 224.177 ms, with raw
+  encoding as a negative control at 223.449 ms;
+- **winner/PR:** no. Keep this as a design/prototype commit, not a production
+  format PR.
+
+## Prototype: HLR1 anchors + HDC1 coalesced deltas
+
+### Lean restartable anchors (HLR1)
+
+HLR1 is the cheap hot/base form:
+
+- the content-addressed store key supplies the expected tree ID, so the body
+  does not repeat the 32-byte tree hash;
+- counts, name-prefix lengths, and suffix lengths use varints;
+- sorted names use predecessor-prefix compression;
+- entry mode/type and the complete 32-byte target hash remain in the body;
+- full decode recomputes the normal Heddle semantic tree hash and compares it
+  with the external expected ID.
+
+HLR1 is restartable by retaining the predecessor name in a resume cursor. A
+production format would add sparse restart records for arbitrary ordinal seeks;
+the prototype exercises the required first-entry and first-100 paths.
+
+### One-hop coalesced parent deltas (HDC1)
+
+Each HDC1 object stores sorted upsert/remove operations relative to a
+materialized ancestor, not relative to the immediately previous delta. The
+capture path can update the parent's coalesced operation map with its known
+changed entries. Full reconstruction always needs one anchor plus one delta;
+there is no read-time delta chain.
+
+The prototype refreshes an anchor after 127 descendants, rejects deltas over
+512 coalesced operations, and falls back to an anchor whenever a delta is not
+smaller. These are local object dependencies: retaining a delta and its named
+anchor is sufficient; no global pack or GC lifecycle is mandatory.
+
+### Seek front porch
+
+An HDC1 header carries byte offsets and anchor-entry counts for entry 1 and
+entry 100. The reader fetches only the relevant leading delta operations. A
+block-compressed anchor additionally stores a compact HLR1 copy of its first
+100 entries. The porch is paid once per anchor and shared by up to 127 delta
+objects.
+
+The encoder falls back to a new anchor if deletes would require more than one
+anchor entry for the first-entry read or more than 100 for the first-100 read.
+This makes the byte bound structural rather than corpus luck.
+
+### Deferred settlement
+
+The hot form is HLR1 for an anchor or HDC1 for a delta. In the settled form, an
+anchor uses the smaller of HLR1 and v5 plus its HLR1 front porch. Delta bodies
+remain uncompressed because they are already small and prefix-indexed. The
+prototype measures the hot and settled totals separately; it does not wire a
+background sweeper into the production store.
+
+## Complete-corpus storage results
+
+All reachable, importable tree objects were measured (`HTR4_REAL_TREE_LIMIT=0`).
+Git loose is the actual loose-object file size after unpacking with zlib level 1.
+Git packed is the sum of `verify-pack` object-record sizes and excludes fixed
+pack/index overhead, matching the inherited harness definition. Radical sizes
+include every anchor body, delta body, and compressed-anchor seek porch.
+
+| Corpus | Trees | Raw HTR4 | v5 | Git loose | Git packed | Radical settled | vs loose | vs packed |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Heddle | 12,022 | 11,859,145 | 10,879,700 | 6,960,113 | 1,374,333 | 6,606,810 | 0.949x | 4.807x |
+| ripgrep | 6,351 | 4,609,691 | 4,537,923 | 2,841,433 | 558,782 | 2,526,717 | 0.889x | 4.522x |
+| Flask | 11,414 | 11,828,380 | 11,330,371 | 7,211,630 | 1,438,405 | 6,584,613 | 0.913x | 4.578x |
+| Git | 167,988 | 3,301,664,847 | 2,600,180,873 | 1,769,314,788 | 78,319,496 | 493,722,880 | 0.279x | 6.304x |
+| hierarchical monorepo | 910 | 2,096,415 | 1,552,791 | 1,059,260 | 299,367 | 745,089 | 0.703x | 2.489x |
+| many tiny trees | 12,001 | 1,896,061 | 1,716,905 | 926,183 | 845,658 | 988,527 | 1.067x | 1.169x |
+| huge fanout/history | 64 | 34,563,904 | 22,282,909 | 15,828,447 | 482,567 | 443,324 | 0.028x | 0.919x |
+| deep vendored | 2,082 | 230,472 | 230,152 | 107,431 | 94,938 | 103,101 | 0.960x | 1.086x |
+| **All** | **212,832** | **3,368,748,915** | **2,652,711,624** | **1,804,249,285** | **83,413,546** | **511,721,061** | **0.284x** | **6.135x** |
+
+The hot total is 512,144,438 bytes; settlement saves only another 423,377
+bytes because most retained anchors prefer the cheap lean form. Of 212,832
+objects, 187,877 are deltas and 24,955 are materialized anchors. The history
+walk found a capture-realistic parent for 197,412 objects; the remainder are
+roots or objects introduced without a same-path first-parent tree.
+
+The many-tiny-trees loss is the irreducible self-contained-object corner of this
+prototype: there is one commit, no parent reuse, and Heddle retains 32-byte
+targets against Git SHA-1's 20 bytes. A repo-local short-reference table could
+close it, but would add lookup latency and a retention side structure; this
+spike did not pretend that complexity was free.
+
+## Encode/decode and partial access
+
+The 100,000-entry capture fixture changes one known entry. Times are medians of
+15 calibrated samples on an AMD Ryzen 7 7700, Rust 1.98.0. Git timings are not
+reported: the inherited harness accounts real Git storage but does not provide
+an in-process Git tree codec, and process-level `git mktree`/`cat-file` timing
+would not be comparable.
+
+| Format/operation | Bytes | Encode | Full decode |
+|---|---:|---:|---:|
+| raw HTR4 | 7,399,123 | 16.750 ms | 16.703 ms |
+| v5 block-zstd | 4,537,894 | 41.816 ms | 34.925 ms |
+| HLR1 lean anchor | 6,505,179 | 0.797 ms | 26.665 ms |
+| HDC1 known one-entry delta | 119 | 0.000294 ms | 27.424 ms including anchor merge + full hash validation |
+| HDC1 with full anchor/current diff | 119 | 0.713 ms | same as above |
+
+The HLR1 encode advantage partly comes from emitting the already validated tree
+without recomputing its content hash. HDC1 receives the already-known anchor
+ID, as the store would. Every full-decode path above validates the resulting
+semantic tree hash.
+
+| File-backed partial read | Raw bytes | Radical bytes | Byte ratio | Raw median | Radical median | Time ratio |
+|---|---:|---:|---:|---:|---:|---:|
+| first entry | 111.33 | 118.21 | 1.062x | 6.464 us | 8.066 us | 1.248x |
+| first 100 | 5,309.24 | 4,947.43 | 0.932x | 169.595 us | 22.763 us | 0.134x |
+
+These samples cover 48 delta trees for entry 1 and 21 trees with at least 100
+entries, evenly selected across the eight corpora. The prototype self-checks
+lean and delta round trips and expected-hash mismatches; the inherited v5 checks
+cover range reconstruction plus header/payload corruption.
+
+## Capture gate and the actual wall
+
+Exact current CI command, 20 samples:
+
+| Build | `capture_one @ 100000` p95 | Budget | Object decodes | Result |
+|---|---:|---:|---:|---|
+| production v5 | 224.177 ms | 100 ms | 1,008 | red |
+| temporary raw-tree-write control | 223.449 ms | 100 ms | 1,008 | red |
+
+The raw control changed only `encode_tree` to emit raw HTR4 and was reverted
+after measurement. It refutes the narrow deferred-zstd explanation. The next
+prototype must change snapshot construction so the fsmonitor/tree index passes
+the changed leaf-to-root path and parent tree objects directly to the writer.
+Only then can HDC1's 294 ns known-delta encode replace the 1,008-object decode
+walk. Until that integration clears the real gate, an end-to-end speed claim is
+not supported.
+
+## Reproduction
+
+The real mirror heads used for this run were:
+
+- Heddle `82a11acf0c3a39cf591835cc717892a25764d232`
+- ripgrep `3fce3b5bb0236da2df6d99672afb8a719642eca7`
+- Flask `d318b683471101618febed18996405ad26462110`
+- Git `f78ce2f7b6df702f93d40b85d6bda92a3f65da79`
+
+Generate the deterministic synthetic repositories:
+
+```bash
+corpus=$(mktemp -d /home/scratch/htr4-radical-corpus.XXXXXX)
+bash crates/objects/examples/htr4_measure_corpus.sh "$corpus"
+```
+
+Run the complete measurement (replace the four real mirror paths):
+
+```bash
+HTR4_REAL_TREE_LIMIT=0 \
+cargo run --release -p heddle-objects --features zstd \
+  --example htr4_measure -- \
+  /path/to/heddle.git /path/to/ripgrep.git /path/to/flask.git /path/to/git.git \
+  "$corpus/monorepo.git" "$corpus/many-tiny-trees.git" \
+  "$corpus/huge-fanout.git" "$corpus/deep-vendored.git"
+```
+
+The exhaustive run took 591.22 seconds and peaked at 13,772,248 KiB RSS. Keep
+the default `HTR4_REAL_TREE_LIMIT=4000` for ordinary iteration; use zero only
+when dependency-complete totals are required.
+
+Run the production capture contract:
+
+```bash
+TMPDIR=/home/scratch \
+cargo test --locked --release -p heddle-cli --test cli_basics \
+  perf_core_loop::core_loop_release_contract -- --ignored --nocapture
+```
+
+The `AGENTS.md` ignore message still names the retired `cli_integration` test
+binary; the command above is the current command from
+`.github/workflows/perf-core-loop.yml`.


### PR DESCRIPTION
## Result

Research spike only; no production store integration.

NPK1 combines pack-wide name/hash dictionaries, structural cross-object deltas, bounded depth-16 chains, independently compressed 128-row blocks, and a directly addressable hash/offset index.

Across 212,832 trees:

- NPK1: 35,842,671 bytes including dictionaries and full serving index
- Git packed tree records: 83,413,546 bytes (0.430x)
- dedicated Git tree pack plus index: 89,381,610 bytes (0.401x)
- HLR1/HDC1: 511,721,061 bytes (0.070x)

It wins Flask, Git history, huge-fanout/history, and aggregate; it loses Heddle, ripgrep, monorepo, tiny-tree, and deep-vendored shapes against the strict Git record baseline. Direct reads remain bounded at 16 records, but full resolution is materially slower than warm git cat-file on the dominant corpus.

The design note includes the full corpus/ablation/read/build tables and recommends HLR1/HDC1 for hot objects with NPK1 only as a settled pack/GC format.

## Proof

- cargo test --release -p heddle-objects --features zstd --example htr4_measure -- --nocapture
- cargo clippy -p heddle-objects --features zstd --example htr4_measure -- -D warnings
- exhaustive eight-corpus release harness: exit 0, 5m07s, 13,874,972 KiB peak RSS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439112&installation_model_id=21489&pr_number=1586&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1586&signature=d8f6f7dd61ef091e33c07b183605db9fc48d277aa5f1c8feb48338e487ebf3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->