### PR TITLE
feat: productionize incremental HLR1/HDC1 tree storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.4+spec-1.1.0",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -94,6 +94,7 @@ pub(crate) fn create_git_checkpoint(
         require_clean_worktree: true,
         require_worktree_change: false,
         worktree_status_options: status_options,
+        known_worktree_changes: None,
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -589,6 +589,7 @@ pub(crate) fn create_snapshot_profiled(
         require_worktree_change: repo.capability() == RepositoryCapability::NativeHeddle
             && repo.merge_state_manager().load()?.is_none(),
         worktree_status_options: worktree_status_options(Some(repo.config())),
+        known_worktree_changes: None,
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,
@@ -643,6 +644,7 @@ pub(crate) fn create_snapshot_from_tree_profiled(
         require_clean_worktree: false,
         require_worktree_change: false,
         worktree_status_options: worktree_status_options(Some(repo.config())),
+        known_worktree_changes: None,
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,

--- a/crates/cli/tests/cli_integration/hooks.rs
+++ b/crates/cli/tests/cli_integration/hooks.rs
@@ -5,6 +5,118 @@ use tempfile::TempDir;
 
 use super::*;
 
+fn warm_native_monitor(root: &std::path::Path) {
+    let envs = [("HEDDLE_FSMONITOR", "native")];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(6);
+    let mut last_monitor = Value::Null;
+
+    while std::time::Instant::now() < deadline {
+        heddle_env(&["status", "--short"], Some(root), &envs).unwrap();
+        let inspect = heddle_env(
+            &["maintenance", "inspect", "--output", "json"],
+            Some(root),
+            &envs,
+        )
+        .unwrap();
+        let report: Value = serde_json::from_str(&inspect).unwrap();
+        last_monitor = report["change_monitor"].clone();
+        if last_monitor["backend"] == "native-helper" && last_monitor["status"] == "usable" {
+            heddle_env(&["status", "--short"], Some(root), &envs).unwrap();
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    panic!("native monitor did not become usable; last monitor: {last_monitor}");
+}
+
+#[cfg(unix)]
+#[test]
+#[serial_test::serial(fsmonitor)]
+fn pre_snapshot_hook_changes_are_captured_with_native_and_off_fsmonitor() {
+    for mode in ["native", "off"] {
+        let temp = TempDir::new().unwrap();
+        heddle(&["init"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("a.txt"), "baseline a\n").unwrap();
+        fs::write(temp.path().join("b.txt"), "baseline b\n").unwrap();
+        heddle(
+            &["capture", "-m", "baseline before pre-snapshot hook"],
+            Some(temp.path()),
+        )
+        .unwrap();
+
+        let repo = Repository::open(temp.path()).unwrap();
+        let mut config = repo.config().clone();
+        config.worktree.fsmonitor.mode = match mode {
+            "native" => repo::FsMonitorMode::Native,
+            "off" => repo::FsMonitorMode::Off,
+            _ => unreachable!(),
+        };
+        config.save(&repo.heddle_dir().join("config.toml")).unwrap();
+        drop(repo);
+
+        if mode == "native" {
+            warm_native_monitor(temp.path());
+        }
+
+        fs::write(temp.path().join("a.txt"), "user change\n").unwrap();
+        if mode == "native" {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        let hook_script = "#!/bin/sh\nif [ -z \"$HEDDLE_HOOK_PROTOCOL\" ]; then\n  printf 'hook change\\n' > b.txt\nfi\n";
+        let install = heddle_output_with_stdin(
+            &["hook", "install", "pre-snapshot", "--from-stdin"],
+            temp.path(),
+            hook_script,
+        )
+        .unwrap();
+        assert!(
+            install.status.success(),
+            "install hook for {mode}: {}",
+            String::from_utf8_lossy(&install.stderr)
+        );
+
+        let envs = [("HEDDLE_FSMONITOR", mode)];
+        let capture = heddle_output_env(
+            &[
+                "--output",
+                "json",
+                "capture",
+                "-m",
+                "capture user and hook changes",
+            ],
+            Some(temp.path()),
+            &envs,
+        )
+        .unwrap();
+        assert!(
+            capture.status.success(),
+            "capture with {mode}: {}",
+            String::from_utf8_lossy(&capture.stderr)
+        );
+        let report: Value = serde_json::from_slice(&capture.stdout).unwrap();
+        assert_eq!(
+            report["captured_path_count"], 2,
+            "capture with {mode} must include the path changed by the hook: {report}"
+        );
+
+        let authoritative = heddle_env(
+            &["--output", "json", "status"],
+            Some(temp.path()),
+            &[("HEDDLE_FSMONITOR", "off")],
+        )
+        .unwrap();
+        let authoritative: Value = serde_json::from_str(&authoritative).unwrap();
+        for kind in ["added", "modified", "deleted"] {
+            assert_eq!(
+                authoritative["changes"][kind],
+                serde_json::json!([]),
+                "authoritative fsmonitor-off status after {mode} capture must be clean: {authoritative}"
+            );
+        }
+    }
+}
+
 #[test]
 fn hook_install_reads_script_from_file() {
     let temp = TempDir::new().unwrap();

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -26,9 +26,11 @@ sley.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 uuid.workspace = true
+zstd = { workspace = true, optional = true }
 
 [features]
 async-source = []
+zstd = ["dep:zstd"]
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -55,6 +55,7 @@ pub use action_id::ActionId;
 pub use action_operation::Operation;
 pub use action_struct::Action;
 pub use annotated_tag::{AnnotatedTag, AnnotatedTagError, AnnotatedTagMarker};
+pub use audience_tier::{AudienceParseError, AudienceTier, visible};
 pub use blob::Blob;
 pub use collaboration::*;
 pub use diff::{DiffKind, FileChange, FileChangeSet};
@@ -154,8 +155,14 @@ pub use tree::{
     validate_name as validate_tree_entry_name,
 };
 pub use tree_canonical::{
-    TREE_CANONICAL_MAGIC, TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header,
-    is_canonical_tree,
+    TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_MIN_ENTRIES, TREE_CANONICAL_MAGIC,
+    TREE_DELTA_ANCHOR_INTERVAL, TREE_DELTA_ENCODING_VERSION, TREE_DELTA_HEADER_LEN,
+    TREE_DELTA_MAGIC, TREE_DELTA_MAX_OPS, TREE_ENCODING_VERSION, TREE_HEADER_LEN,
+    TREE_LEAN_ENCODING_VERSION, TREE_LEAN_MAGIC, TreeDeltaHeader, TreeDeltaOp, TreeHeader,
+    apply_tree_delta, decode_header, decode_lean_prefix, decode_tree_delta,
+    decode_tree_delta_header, decode_tree_delta_header_prefix, decode_tree_delta_ops,
+    decode_tree_delta_ops_prefix, encode_lean_entry, encode_tree_delta, is_canonical_tree,
+    is_delta_tree, is_lean_tree, is_streamable_tree, tree_delta,
 };
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;
@@ -172,5 +179,4 @@ pub use tree_stream::{
     TreeEntryReader, TreePage, TreePageLimits, TreeResumeCursor, TreeStreamError,
 };
 pub use tree_walk::{TreeIntegrityEvent, walk_tree_integrity};
-pub use audience_tier::{AudienceParseError, AudienceTier, visible};
 pub use visibility_tier::VisibilityTier;

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -1,23 +1,64 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Streamable canonical Tree encoding (HTR4).
+//! Streamable canonical Tree encodings (HTR4).
 //!
 //! Each entry is a length-prefixed frame, so a reader can yield one entry or
-//! a caller-sized page and resume at a byte offset without decoding the prefix.
-//! Whole-object compression is not part of this encoding: a resume cursor must
-//! be able to seek without decompressing earlier frames.
+//! a caller-sized page and resume at a byte offset without decoding the whole
+//! tree. Version 4 stores frames raw. Version 5 groups frames into independently
+//! compressed blocks with raw restart anchors and a fixed-width range index.
 
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
-use super::tree::{git_format_from_tag, git_format_to_tag};
-use super::tree_stream::TreeStreamError;
-use super::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError};
+use super::{
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+    tree::{git_format_from_tag, git_format_to_tag},
+    tree_stream::TreeStreamError,
+};
 
 /// Durable encoding version stored in every HTR4 header and resume cursor.
 pub const TREE_ENCODING_VERSION: u8 = 4;
+/// Block-compressed HTR4 variant. Readers accept both v4 and v5.
+pub const TREE_BLOCK_ENCODING_VERSION: u8 = 5;
 /// Frame discriminator for a single canonical tree.
 pub const TREE_CANONICAL_MAGIC: &[u8; 4] = b"HTR4";
+/// Lean hot-path tree anchor. The object key supplies the omitted tree hash.
+pub const TREE_LEAN_MAGIC: &[u8; 4] = b"HLR1";
+/// One-hop cumulative delta against a materialized tree anchor.
+pub const TREE_DELTA_MAGIC: &[u8; 4] = b"HDC1";
+/// Cursor version used by the HLR1 streaming reader.
+pub const TREE_LEAN_ENCODING_VERSION: u8 = 6;
+/// Current HDC1 body version.
+pub const TREE_DELTA_ENCODING_VERSION: u8 = 1;
+/// Fixed HDC1 header from the HTR4 radical spike.
+pub const TREE_DELTA_HEADER_LEN: usize = 59;
+/// A lineage is refreshed after 127 delta descendants.
+pub const TREE_DELTA_ANCHOR_INTERVAL: u8 = 128;
+/// Cumulative deltas above this operation count become anchors.
+pub const TREE_DELTA_MAX_OPS: usize = 512;
 /// Fixed header size: magic + version + tree id + counts.
 pub const TREE_HEADER_LEN: usize = 4 + 1 + 32 + 8 + 8 + 8;
+/// Small real trees do not repay block/index overhead.
+pub const TREE_BLOCK_MIN_ENTRIES: usize = 18;
+
+pub(crate) const TREE_BLOCK_ENTRIES: usize = 256;
+pub(crate) const TREE_BLOCK_PREAMBLE_LEN: usize = 16;
+pub(crate) const TREE_BLOCK_INDEX_LEN: usize = 24;
+const TREE_BLOCK_CODEC_ZSTD: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockHeader {
+    pub block_entries: usize,
+    pub block_count: usize,
+    pub raw_payload_len: u64,
+    pub index_end: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TreeBlockIndex {
+    pub raw_offset: u64,
+    pub stored_offset: u64,
+    pub stored_len: usize,
+    pub raw_len: usize,
+}
 
 /// Parsed HTR4 header. Counts and payload length are known before any entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -32,6 +73,21 @@ pub struct TreeHeader {
 /// True when `bytes` begin with the canonical tree discriminator.
 pub fn is_canonical_tree(bytes: &[u8]) -> bool {
     bytes.starts_with(TREE_CANONICAL_MAGIC)
+}
+
+/// True when `bytes` contain a lean materialized anchor.
+pub fn is_lean_tree(bytes: &[u8]) -> bool {
+    bytes.starts_with(TREE_LEAN_MAGIC)
+}
+
+/// True when `bytes` contain an anchor-relative delta.
+pub fn is_delta_tree(bytes: &[u8]) -> bool {
+    bytes.starts_with(TREE_DELTA_MAGIC)
+}
+
+/// True when the body can be paged directly without reconstruction.
+pub fn is_streamable_tree(bytes: &[u8]) -> bool {
+    is_canonical_tree(bytes) || is_lean_tree(bytes)
 }
 
 impl Tree {
@@ -66,6 +122,9 @@ impl Tree {
     /// Decode a complete HTR4 body, validating order incrementally.
     pub fn decode_canonical(data: &[u8]) -> Result<Self, TreeStreamError> {
         let header = decode_header(data)?;
+        if header.version == TREE_BLOCK_ENCODING_VERSION {
+            return Self::decode_canonical_streamed(data);
+        }
         let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
         if (data.len() as u64) < expected_len {
             return Err(TreeStreamError::TruncatedFrame {
@@ -111,6 +170,25 @@ impl Tree {
         }
         Ok(tree)
     }
+
+    /// Encode block-compressed HTR4, falling back to raw v4 when the complete
+    /// object would not be smaller. Callers apply the small-tree policy.
+    pub fn encode_canonical_blocked(
+        &self,
+        level: i32,
+        min_size: usize,
+    ) -> Result<Vec<u8>, TreeStreamError> {
+        let raw = self.encode_canonical()?;
+        if raw.len() < min_size {
+            return Ok(raw);
+        }
+        let blocked = encode_blocked_htr4(&raw, level)?;
+        if blocked.len() < raw.len() {
+            Ok(blocked)
+        } else {
+            Ok(raw)
+        }
+    }
 }
 
 /// Parse the fixed HTR4 header. Does not read entry frames.
@@ -124,7 +202,7 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         ));
     }
     let version = data[4];
-    if version != TREE_ENCODING_VERSION {
+    if version != TREE_ENCODING_VERSION && version != TREE_BLOCK_ENCODING_VERSION {
         return Err(TreeStreamError::UnsupportedVersion { found: version });
     }
     let tree_id = ContentHash::from_bytes(
@@ -152,6 +230,1025 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
         payload_len,
         logical_len,
     })
+}
+
+pub(crate) fn decode_block_header(
+    header: &TreeHeader,
+    preamble: &[u8],
+    object_len: u64,
+) -> Result<TreeBlockHeader, TreeStreamError> {
+    if header.version != TREE_BLOCK_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "tree does not use block compression".into(),
+        ));
+    }
+    if preamble.len() != TREE_BLOCK_PREAMBLE_LEN {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: TREE_HEADER_LEN as u64,
+        });
+    }
+    if preamble[0] != TREE_BLOCK_CODEC_ZSTD {
+        return Err(TreeStreamError::Malformed(format!(
+            "unsupported tree block codec {}",
+            preamble[0]
+        )));
+    }
+    if preamble[1] != 0 {
+        return Err(TreeStreamError::Malformed(
+            "unsupported tree block flags".into(),
+        ));
+    }
+    let block_entries = u16::from_le_bytes([preamble[2], preamble[3]]) as usize;
+    if block_entries == 0 {
+        return Err(TreeStreamError::Malformed(
+            "tree block size must be nonzero".into(),
+        ));
+    }
+    let block_count = u32::from_le_bytes(
+        preamble[4..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block count".into()))?,
+    ) as usize;
+    let raw_payload_len = u64::from_le_bytes(
+        preamble[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid raw tree payload length".into()))?,
+    );
+    let expected_blocks = header.entry_count.div_ceil(block_entries as u64);
+    if block_count as u64 != expected_blocks {
+        return Err(TreeStreamError::Malformed(
+            "tree block count does not match entry count".into(),
+        ));
+    }
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let index_end = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index end overflow".into()))?
+        as u64;
+    let expected_object_len = (TREE_HEADER_LEN as u64)
+        .checked_add(header.payload_len)
+        .ok_or_else(|| TreeStreamError::Malformed("tree object length overflow".into()))?;
+    if index_end > expected_object_len || expected_object_len != object_len {
+        return Err(TreeStreamError::TruncatedFrame { offset: object_len });
+    }
+    Ok(TreeBlockHeader {
+        block_entries,
+        block_count,
+        raw_payload_len,
+        index_end,
+    })
+}
+
+pub(crate) fn decode_block_index(
+    bytes: &[u8],
+    block: usize,
+    block_header: &TreeBlockHeader,
+    object_len: u64,
+) -> Result<TreeBlockIndex, TreeStreamError> {
+    if bytes.len() != TREE_BLOCK_INDEX_LEN || block >= block_header.block_count {
+        return Err(TreeStreamError::Malformed(
+            "invalid tree block index entry".into(),
+        ));
+    }
+    let raw_offset = u64::from_le_bytes(
+        bytes[0..8]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw offset".into()))?,
+    );
+    let stored_offset = u64::from_le_bytes(
+        bytes[8..16]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored offset".into()))?,
+    );
+    let stored_len = u32::from_le_bytes(
+        bytes[16..20]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block stored length".into()))?,
+    ) as usize;
+    let raw_len = u32::from_le_bytes(
+        bytes[20..24]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid tree block raw length".into()))?,
+    ) as usize;
+    if stored_len == 0 || raw_len == 0 || stored_offset < block_header.index_end {
+        return Err(TreeStreamError::Malformed(
+            "invalid empty or overlapping tree block".into(),
+        ));
+    }
+    if stored_offset
+        .checked_add(stored_len as u64)
+        .is_none_or(|end| end > object_len)
+    {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: stored_offset,
+        });
+    }
+    Ok(TreeBlockIndex {
+        raw_offset,
+        stored_offset,
+        stored_len,
+        raw_len,
+    })
+}
+
+pub(crate) fn decode_block_payload(
+    stored: &[u8],
+    raw_len: usize,
+) -> Result<Vec<u8>, TreeStreamError> {
+    if stored.len() == raw_len {
+        return Ok(stored.to_vec());
+    }
+    let anchor_end = block_anchor_end(stored)?;
+    if anchor_end >= raw_len {
+        return Err(TreeStreamError::Malformed(
+            "compressed tree block has no tail".into(),
+        ));
+    }
+    let tail = decompress_block_tail(&stored[anchor_end..], raw_len - anchor_end)?;
+    let mut raw = Vec::with_capacity(raw_len);
+    raw.extend_from_slice(&stored[..anchor_end]);
+    raw.extend_from_slice(&tail);
+    if raw.len() != raw_len {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block length mismatch".into(),
+        ));
+    }
+    Ok(raw)
+}
+
+pub(crate) fn block_anchor_end(stored: &[u8]) -> Result<usize, TreeStreamError> {
+    let len_bytes = stored
+        .get(..4)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    let frame_len = u32::from_le_bytes(
+        len_bytes
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid anchor frame length".into()))?,
+    ) as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .ok_or(TreeStreamError::TruncatedFrame { offset: 0 })?;
+    if end > stored.len() {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    Ok(end)
+}
+
+fn encode_blocked_htr4(raw: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    let header = decode_header(raw)?;
+    if header.version != TREE_ENCODING_VERSION {
+        return Err(TreeStreamError::Malformed(
+            "block encoder requires raw HTR4".into(),
+        ));
+    }
+    let ranges = entry_frame_ranges(raw, header.entry_count)?;
+    let block_count = ranges.len().div_ceil(TREE_BLOCK_ENTRIES);
+    let block_count_u32 = u32::try_from(block_count)
+        .map_err(|_| TreeStreamError::Malformed("tree has too many blocks".into()))?;
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(TREE_BLOCK_ENTRIES) {
+        let (start, anchor_end) = *chunk
+            .first()
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let end = chunk
+            .last()
+            .map(|range| range.1)
+            .ok_or_else(|| TreeStreamError::Malformed("empty tree block".into()))?;
+        let block = &raw[start..end];
+        let compressed_tail = compress_block_tail(&raw[anchor_end..end], level)?;
+        if anchor_end - start + compressed_tail.len() < block.len() {
+            let mut stored = Vec::with_capacity(anchor_end - start + compressed_tail.len());
+            stored.extend_from_slice(&raw[start..anchor_end]);
+            stored.extend_from_slice(&compressed_tail);
+            blocks.push(stored);
+        } else {
+            blocks.push(block.to_vec());
+        }
+    }
+
+    let index_bytes = block_count
+        .checked_mul(TREE_BLOCK_INDEX_LEN)
+        .ok_or_else(|| TreeStreamError::Malformed("tree block index length overflow".into()))?;
+    let stored_payload_len = TREE_BLOCK_PREAMBLE_LEN
+        .checked_add(index_bytes)
+        .and_then(|len| {
+            blocks
+                .iter()
+                .try_fold(len, |total, block| total.checked_add(block.len()))
+        })
+        .ok_or_else(|| TreeStreamError::Malformed("blocked tree length overflow".into()))?;
+    let mut out = Vec::with_capacity(TREE_HEADER_LEN + stored_payload_len);
+    out.extend_from_slice(TREE_CANONICAL_MAGIC);
+    out.push(TREE_BLOCK_ENCODING_VERSION);
+    out.extend_from_slice(header.tree_id.as_bytes());
+    out.extend_from_slice(&header.entry_count.to_le_bytes());
+    out.extend_from_slice(&(stored_payload_len as u64).to_le_bytes());
+    out.extend_from_slice(&header.logical_len.to_le_bytes());
+    out.push(TREE_BLOCK_CODEC_ZSTD);
+    out.push(0);
+    out.extend_from_slice(&(TREE_BLOCK_ENTRIES as u16).to_le_bytes());
+    out.extend_from_slice(&block_count_u32.to_le_bytes());
+    out.extend_from_slice(&header.payload_len.to_le_bytes());
+
+    let mut stored_offset = TREE_HEADER_LEN
+        .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+        .and_then(|len| len.checked_add(index_bytes))
+        .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * TREE_BLOCK_ENTRIES;
+        let chunk = &ranges[first_entry..(first_entry + TREE_BLOCK_ENTRIES).min(ranges.len())];
+        let raw_offset = chunk[0].0 - TREE_HEADER_LEN;
+        let raw_len = chunk[chunk.len() - 1].1 - chunk[0].0;
+        let stored_len = u32::try_from(stored.len())
+            .map_err(|_| TreeStreamError::Malformed("stored tree block exceeds u32".into()))?;
+        let raw_len = u32::try_from(raw_len)
+            .map_err(|_| TreeStreamError::Malformed("raw tree block exceeds u32".into()))?;
+        out.extend_from_slice(&(raw_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored_offset as u64).to_le_bytes());
+        out.extend_from_slice(&stored_len.to_le_bytes());
+        out.extend_from_slice(&raw_len.to_le_bytes());
+        stored_offset = stored_offset
+            .checked_add(stored.len())
+            .ok_or_else(|| TreeStreamError::Malformed("tree block offset overflow".into()))?;
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    Ok(out)
+}
+
+fn entry_frame_ranges(
+    raw: &[u8],
+    entry_count: u64,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let count = usize::try_from(entry_count)
+        .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?;
+    let mut ranges = Vec::with_capacity(count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..count {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid frame length".into()))?,
+        ) as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        if end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        ranges.push((offset, end));
+        offset = end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(ranges)
+}
+
+#[cfg(feature = "zstd")]
+fn compress_block_tail(data: &[u8], level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    zstd::bulk::compress(data, level)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))
+}
+
+#[cfg(not(feature = "zstd"))]
+fn compress_block_tail(_data: &[u8], _level: i32) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
+}
+
+#[cfg(feature = "zstd")]
+fn decompress_block_tail(data: &[u8], capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    let decoded = zstd::bulk::decompress(data, capacity)
+        .map_err(|error| TreeStreamError::Compression(error.to_string()))?;
+    if decoded.len() != capacity {
+        return Err(TreeStreamError::Malformed(
+            "decoded tree block tail length mismatch".into(),
+        ));
+    }
+    Ok(decoded)
+}
+
+#[cfg(not(feature = "zstd"))]
+fn decompress_block_tail(_data: &[u8], _capacity: usize) -> Result<Vec<u8>, TreeStreamError> {
+    Err(TreeStreamError::Compression(
+        "zstd support is not compiled into this build".into(),
+    ))
+}
+
+/// A cumulative HDC1 operation against a materialized anchor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TreeDeltaOp {
+    Remove(String),
+    Upsert(TreeEntry),
+}
+
+impl TreeDeltaOp {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Remove(name) => name,
+            Self::Upsert(entry) => entry.name(),
+        }
+    }
+}
+
+/// Parsed HDC1 header, including its bounded first-entry and first-100 porch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TreeDeltaHeader {
+    pub anchor: ContentHash,
+    pub result_count: usize,
+    pub op_count: usize,
+    pub first_op_count: usize,
+    pub first_base_count: usize,
+    pub first_end: usize,
+    pub hundred_op_count: usize,
+    pub hundred_base_count: usize,
+    pub hundred_end: usize,
+}
+
+impl Tree {
+    /// Encode a cheap HLR1 materialized anchor. The content hash deliberately
+    /// stays outside the body and must be supplied by the object store while
+    /// decoding.
+    pub fn encode_lean(&self) -> Result<Vec<u8>, TreeStreamError> {
+        self.validate()?;
+        encode_lean_entries(self.entries())
+    }
+
+    /// Decode a complete HLR1 anchor and validate it against its object key.
+    pub fn decode_lean(data: &[u8], expected: ContentHash) -> Result<Self, TreeStreamError> {
+        let (entries, consumed) = decode_lean_entries(data, usize::MAX)?;
+        if consumed != data.len() {
+            return Err(TreeStreamError::TrailingBytes {
+                extra: data.len().abs_diff(consumed) as u64,
+            });
+        }
+        let tree = Tree::try_from_decoded_entries(entries)?;
+        let found = tree.hash();
+        if found != expected {
+            return Err(TreeStreamError::HashMismatch { expected, found });
+        }
+        Ok(tree)
+    }
+}
+
+/// Decode at most `wanted` entries from the compact HLR1 porch. The returned
+/// byte count is the exact prefix a file-backed reader had to consume.
+pub fn decode_lean_prefix(
+    data: &[u8],
+    wanted: usize,
+) -> Result<(Vec<TreeEntry>, usize), TreeStreamError> {
+    decode_lean_entries(data, wanted)
+}
+
+fn encode_lean_entries(entries: &[TreeEntry]) -> Result<Vec<u8>, TreeStreamError> {
+    let mut out = Vec::new();
+    out.extend_from_slice(TREE_LEAN_MAGIC);
+    put_varint(entries.len(), &mut out);
+    let mut previous = "";
+    for entry in entries {
+        encode_lean_entry(entry, previous, &mut out)?;
+        previous = entry.name();
+    }
+    Ok(out)
+}
+
+fn decode_lean_entries(
+    data: &[u8],
+    wanted: usize,
+) -> Result<(Vec<TreeEntry>, usize), TreeStreamError> {
+    if !is_lean_tree(data) {
+        return Err(TreeStreamError::Malformed(
+            "bytes are not an HLR1 tree anchor".into(),
+        ));
+    }
+    let mut offset = TREE_LEAN_MAGIC.len();
+    let count = take_varint(data, &mut offset)?;
+    let wanted = wanted.min(count);
+    let mut entries = Vec::with_capacity(wanted);
+    let mut previous = String::new();
+    for _ in 0..wanted {
+        let entry = decode_compact_entry(data, &mut offset, &previous)?;
+        if !previous.is_empty() && previous.as_str() >= entry.name() {
+            return Err(TreeError::InvalidStructure(
+                "entries must be strictly sorted by name".into(),
+            )
+            .into());
+        }
+        previous = entry.name().to_string();
+        entries.push(entry);
+    }
+    if wanted == count && offset != data.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: data.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok((entries, offset))
+}
+
+fn put_varint(mut value: usize, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+pub(crate) fn take_varint(bytes: &[u8], offset: &mut usize) -> Result<usize, TreeStreamError> {
+    let mut value = 0usize;
+    for shift in (0..usize::BITS).step_by(7) {
+        let byte = *bytes.get(*offset).ok_or(TreeStreamError::TruncatedFrame {
+            offset: *offset as u64,
+        })?;
+        *offset += 1;
+        value |= ((byte & 0x7f) as usize)
+            .checked_shl(shift)
+            .ok_or_else(|| TreeStreamError::Malformed("varint overflow".into()))?;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(TreeStreamError::Malformed("varint overflow".into()))
+}
+
+fn shared_prefix(left: &str, right: &str) -> usize {
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+/// Append one HLR1 entry using `previous_name` as its prefix-compression base.
+/// Store readers use this to expose a lazily merged HDC1 body as HLR1 bytes.
+pub fn encode_lean_entry(
+    entry: &TreeEntry,
+    previous_name: &str,
+    out: &mut Vec<u8>,
+) -> Result<(), TreeStreamError> {
+    out.push((entry.mode().to_byte() << 3) | entry.entry_type().to_byte());
+    let prefix = shared_prefix(previous_name, entry.name());
+    put_varint(prefix, out);
+    put_varint(entry.name().len() - prefix, out);
+    out.extend_from_slice(&entry.name().as_bytes()[prefix..]);
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let hash = entry.content_hash().ok_or_else(|| {
+                TreeStreamError::Malformed("compact entry is missing its content hash".into())
+            })?;
+            out.extend_from_slice(hash.as_bytes());
+        }
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().ok_or_else(|| {
+                TreeStreamError::Malformed("compact gitlink is missing its target".into())
+            })?;
+            out.push(git_format_to_tag(target.format()));
+            out.extend_from_slice(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().ok_or_else(|| {
+                TreeStreamError::Malformed("compact spoollink is missing its target".into())
+            })?;
+            put_varint(spool.as_str().len(), out);
+            out.extend_from_slice(spool.as_str().as_bytes());
+            out.extend_from_slice(state.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn decode_compact_entry(
+    bytes: &[u8],
+    offset: &mut usize,
+    previous_name: &str,
+) -> Result<TreeEntry, TreeStreamError> {
+    let tag = *bytes.get(*offset).ok_or(TreeStreamError::TruncatedFrame {
+        offset: *offset as u64,
+    })?;
+    *offset += 1;
+    let mode = FileMode::from_byte(tag >> 3).ok_or_else(|| {
+        TreeStreamError::Malformed(format!("invalid compact entry mode {}", tag >> 3))
+    })?;
+    let kind = EntryType::from_byte(tag & 0x07).ok_or_else(|| {
+        TreeStreamError::Malformed(format!("invalid compact entry kind {}", tag & 0x07))
+    })?;
+    let prefix = take_varint(bytes, offset)?;
+    let suffix_len = take_varint(bytes, offset)?;
+    if prefix > previous_name.len() {
+        return Err(TreeStreamError::Malformed(
+            "compact name prefix exceeds predecessor".into(),
+        ));
+    }
+    let suffix_end = offset
+        .checked_add(suffix_len)
+        .ok_or_else(|| TreeStreamError::Malformed("compact name length overflow".into()))?;
+    let suffix = bytes
+        .get(*offset..suffix_end)
+        .ok_or(TreeStreamError::TruncatedFrame {
+            offset: *offset as u64,
+        })?;
+    let mut name = previous_name.as_bytes()[..prefix].to_vec();
+    name.extend_from_slice(suffix);
+    let name = String::from_utf8(name)
+        .map_err(|_| TreeStreamError::Malformed("compact entry name is not UTF-8".into()))?;
+    *offset = suffix_end;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let end = offset
+                .checked_add(32)
+                .ok_or_else(|| TreeStreamError::Malformed("compact hash overflow".into()))?;
+            let hash = ContentHash::from_bytes(
+                bytes
+                    .get(*offset..end)
+                    .ok_or(TreeStreamError::TruncatedFrame {
+                        offset: *offset as u64,
+                    })?
+                    .try_into()
+                    .map_err(|_| {
+                        TreeStreamError::Malformed("compact hash is not 32 bytes".into())
+                    })?,
+            );
+            *offset = end;
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                EntryType::Gitlink | EntryType::Spoollink => {
+                    return Err(TreeStreamError::Malformed(
+                        "invalid compact content-addressed kind".into(),
+                    ));
+                }
+            }
+        }
+        EntryType::Gitlink => {
+            let format_tag = *bytes.get(*offset).ok_or(TreeStreamError::TruncatedFrame {
+                offset: *offset as u64,
+            })?;
+            *offset += 1;
+            let format = git_format_from_tag(format_tag)?;
+            let oid_len = match format {
+                GitObjectFormat::Sha1 => 20,
+                GitObjectFormat::Sha256 => 32,
+            };
+            let end = offset.checked_add(oid_len).ok_or_else(|| {
+                TreeStreamError::Malformed("compact gitlink length overflow".into())
+            })?;
+            let target = GitObjectId::from_raw(
+                format,
+                bytes
+                    .get(*offset..end)
+                    .ok_or(TreeStreamError::TruncatedFrame {
+                        offset: *offset as u64,
+                    })?,
+            )
+            .map_err(|error| {
+                TreeStreamError::Malformed(format!("invalid compact gitlink: {error}"))
+            })?;
+            *offset = end;
+            TreeEntry::gitlink(name, target)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = take_varint(bytes, offset)?;
+            let spool_end = offset.checked_add(spool_len).ok_or_else(|| {
+                TreeStreamError::Malformed("compact spool length overflow".into())
+            })?;
+            let spool = std::str::from_utf8(bytes.get(*offset..spool_end).ok_or(
+                TreeStreamError::TruncatedFrame {
+                    offset: *offset as u64,
+                },
+            )?)
+            .map_err(|_| TreeStreamError::Malformed("compact spool id is not UTF-8".into()))?;
+            *offset = spool_end;
+            let state_end = offset
+                .checked_add(32)
+                .ok_or_else(|| TreeStreamError::Malformed("compact state overflow".into()))?;
+            let state = StateId::from_bytes(
+                bytes
+                    .get(*offset..state_end)
+                    .ok_or(TreeStreamError::TruncatedFrame {
+                        offset: *offset as u64,
+                    })?
+                    .try_into()
+                    .map_err(|_| {
+                        TreeStreamError::Malformed("compact state is not 32 bytes".into())
+                    })?,
+            );
+            *offset = state_end;
+            let spool_id = SpoolId::parse(spool).map_err(|error| {
+                TreeStreamError::Malformed(format!("invalid compact spool id: {error}"))
+            })?;
+            TreeEntry::spoollink(name, spool_id, state)?
+        }
+    };
+    if entry.mode() != mode {
+        return Err(TreeStreamError::Malformed(format!(
+            "compact entry kind/mode mismatch for {}: {kind:?}/{mode:?}",
+            entry.name()
+        )));
+    }
+    Ok(entry)
+}
+
+/// Compute the sorted cumulative edit from `anchor` to `current`.
+pub fn tree_delta(anchor: &Tree, current: &Tree) -> Vec<TreeDeltaOp> {
+    let mut ops = Vec::new();
+    let mut anchor_index = 0usize;
+    let mut current_index = 0usize;
+    while anchor_index < anchor.len() || current_index < current.len() {
+        match (
+            anchor.entries().get(anchor_index),
+            current.entries().get(current_index),
+        ) {
+            (Some(anchor_entry), Some(current_entry)) => {
+                match anchor_entry.name().cmp(current_entry.name()) {
+                    std::cmp::Ordering::Less => {
+                        ops.push(TreeDeltaOp::Remove(anchor_entry.name().to_string()));
+                        anchor_index += 1;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        ops.push(TreeDeltaOp::Upsert(current_entry.clone()));
+                        current_index += 1;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if anchor_entry != current_entry {
+                            ops.push(TreeDeltaOp::Upsert(current_entry.clone()));
+                        }
+                        anchor_index += 1;
+                        current_index += 1;
+                    }
+                }
+            }
+            (Some(anchor_entry), None) => {
+                ops.push(TreeDeltaOp::Remove(anchor_entry.name().to_string()));
+                anchor_index += 1;
+            }
+            (None, Some(current_entry)) => {
+                ops.push(TreeDeltaOp::Upsert(current_entry.clone()));
+                current_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    ops
+}
+
+/// Apply a sorted cumulative delta to its materialized anchor.
+pub fn apply_tree_delta(anchor: &Tree, ops: &[TreeDeltaOp]) -> Result<Tree, TreeStreamError> {
+    let mut entries = Vec::with_capacity(anchor.len().saturating_add(ops.len()));
+    let mut anchor_index = 0usize;
+    let mut op_index = 0usize;
+    while anchor_index < anchor.len() || op_index < ops.len() {
+        match (anchor.entries().get(anchor_index), ops.get(op_index)) {
+            (Some(anchor_entry), Some(op)) => match anchor_entry.name().cmp(op.name()) {
+                std::cmp::Ordering::Less => {
+                    entries.push(anchor_entry.clone());
+                    anchor_index += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    if let TreeDeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    op_index += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if let TreeDeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    anchor_index += 1;
+                    op_index += 1;
+                }
+            },
+            (Some(anchor_entry), None) => {
+                entries.push(anchor_entry.clone());
+                anchor_index += 1;
+            }
+            (None, Some(op)) => {
+                if let TreeDeltaOp::Upsert(entry) = op {
+                    entries.push(entry.clone());
+                }
+                op_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    Tree::try_from_decoded_entries(entries).map_err(TreeStreamError::from)
+}
+
+fn delta_prefix_counts(
+    anchor: &Tree,
+    current: &Tree,
+    ops: &[TreeDeltaOp],
+    count: usize,
+) -> Result<(u16, u16), TreeStreamError> {
+    if current.is_empty() {
+        return Ok((0, 0));
+    }
+    let boundary = current.entries()[count.min(current.len()) - 1].name();
+    let op_count = ops.partition_point(|op| op.name() <= boundary);
+    let base_count = anchor
+        .entries()
+        .partition_point(|entry| entry.name() <= boundary);
+    Ok((
+        u16::try_from(op_count)
+            .map_err(|_| TreeStreamError::Malformed("delta porch op count exceeds u16".into()))?,
+        u16::try_from(base_count).map_err(|_| {
+            TreeStreamError::Malformed("delta porch anchor count exceeds u16".into())
+        })?,
+    ))
+}
+
+/// Encode a one-hop HDC1 body against `anchor`.
+pub fn encode_tree_delta(
+    anchor_id: ContentHash,
+    anchor: &Tree,
+    current: &Tree,
+    ops: &[TreeDeltaOp],
+) -> Result<Vec<u8>, TreeStreamError> {
+    anchor.validate()?;
+    current.validate()?;
+    if anchor.hash() != anchor_id {
+        return Err(TreeStreamError::HashMismatch {
+            expected: anchor_id,
+            found: anchor.hash(),
+        });
+    }
+    if ops.len() > TREE_DELTA_MAX_OPS {
+        return Err(TreeStreamError::Malformed(format!(
+            "tree delta has {} operations; maximum is {TREE_DELTA_MAX_OPS}",
+            ops.len()
+        )));
+    }
+    if apply_tree_delta(anchor, ops)? != *current {
+        return Err(TreeStreamError::Malformed(
+            "tree delta operations do not reconstruct the result".into(),
+        ));
+    }
+    let result_count = u32::try_from(current.len())
+        .map_err(|_| TreeStreamError::Malformed("delta result count exceeds u32".into()))?;
+    let op_count = u16::try_from(ops.len())
+        .map_err(|_| TreeStreamError::Malformed("delta operation count exceeds u16".into()))?;
+    let (first_ops, first_base) = delta_prefix_counts(anchor, current, ops, 1)?;
+    let (hundred_ops, hundred_base) = delta_prefix_counts(anchor, current, ops, 100)?;
+    let mut body = Vec::new();
+    let mut ends = Vec::with_capacity(ops.len());
+    let mut previous = "";
+    for op in ops {
+        match op {
+            TreeDeltaOp::Remove(name) => {
+                body.push(0);
+                let prefix = shared_prefix(previous, name);
+                put_varint(prefix, &mut body);
+                put_varint(name.len() - prefix, &mut body);
+                body.extend_from_slice(&name.as_bytes()[prefix..]);
+            }
+            TreeDeltaOp::Upsert(entry) => {
+                body.push(1);
+                encode_lean_entry(entry, previous, &mut body)?;
+            }
+        }
+        if !previous.is_empty() && previous >= op.name() {
+            return Err(TreeStreamError::Malformed(
+                "tree delta operations must be strictly sorted".into(),
+            ));
+        }
+        previous = op.name();
+        ends.push(body.len());
+    }
+    let end_for = |count: u16| -> Result<u32, TreeStreamError> {
+        let end = if count == 0 {
+            TREE_DELTA_HEADER_LEN
+        } else {
+            TREE_DELTA_HEADER_LEN
+                .checked_add(*ends.get(count as usize - 1).ok_or_else(|| {
+                    TreeStreamError::Malformed("delta porch exceeds operation count".into())
+                })?)
+                .ok_or_else(|| TreeStreamError::Malformed("delta porch offset overflow".into()))?
+        };
+        u32::try_from(end)
+            .map_err(|_| TreeStreamError::Malformed("delta porch offset exceeds u32".into()))
+    };
+    let mut out = Vec::with_capacity(TREE_DELTA_HEADER_LEN + body.len());
+    out.extend_from_slice(TREE_DELTA_MAGIC);
+    out.push(TREE_DELTA_ENCODING_VERSION);
+    out.extend_from_slice(anchor_id.as_bytes());
+    out.extend_from_slice(&result_count.to_le_bytes());
+    out.extend_from_slice(&op_count.to_le_bytes());
+    out.extend_from_slice(&first_ops.to_le_bytes());
+    out.extend_from_slice(&first_base.to_le_bytes());
+    out.extend_from_slice(&end_for(first_ops)?.to_le_bytes());
+    out.extend_from_slice(&hundred_ops.to_le_bytes());
+    out.extend_from_slice(&hundred_base.to_le_bytes());
+    out.extend_from_slice(&end_for(hundred_ops)?.to_le_bytes());
+    if out.len() != TREE_DELTA_HEADER_LEN {
+        return Err(TreeStreamError::Malformed(
+            "internal HDC1 header length mismatch".into(),
+        ));
+    }
+    out.extend_from_slice(&body);
+    Ok(out)
+}
+
+/// Parse and validate the fixed HDC1 header without reading its operations.
+pub fn decode_tree_delta_header(data: &[u8]) -> Result<TreeDeltaHeader, TreeStreamError> {
+    decode_tree_delta_header_prefix(data, data.len())
+}
+
+/// Parse an HDC1 header from a bounded prefix while validating its offsets
+/// against the complete file length.
+pub fn decode_tree_delta_header_prefix(
+    data: &[u8],
+    object_len: usize,
+) -> Result<TreeDeltaHeader, TreeStreamError> {
+    if data.len() < TREE_DELTA_HEADER_LEN {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    if !is_delta_tree(data) {
+        return Err(TreeStreamError::Malformed(
+            "bytes are not an HDC1 tree delta".into(),
+        ));
+    }
+    if data[4] != TREE_DELTA_ENCODING_VERSION {
+        return Err(TreeStreamError::UnsupportedVersion { found: data[4] });
+    }
+    let anchor = ContentHash::from_bytes(
+        data[5..37]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("delta anchor hash is not 32 bytes".into()))?,
+    );
+    let header = TreeDeltaHeader {
+        anchor,
+        result_count: read_u32_at(data, 37)? as usize,
+        op_count: read_u16_at(data, 41)? as usize,
+        first_op_count: read_u16_at(data, 43)? as usize,
+        first_base_count: read_u16_at(data, 45)? as usize,
+        first_end: read_u32_at(data, 47)? as usize,
+        hundred_op_count: read_u16_at(data, 51)? as usize,
+        hundred_base_count: read_u16_at(data, 53)? as usize,
+        hundred_end: read_u32_at(data, 55)? as usize,
+    };
+    if header.op_count > TREE_DELTA_MAX_OPS
+        || header.first_op_count > header.op_count
+        || header.hundred_op_count > header.op_count
+        || header.first_end < TREE_DELTA_HEADER_LEN
+        || header.hundred_end < header.first_end
+        || header.hundred_end > object_len
+    {
+        return Err(TreeStreamError::Malformed(
+            "invalid HDC1 porch or operation bounds".into(),
+        ));
+    }
+    Ok(header)
+}
+
+/// Decode `wanted` HDC1 operations. Used by bounded porch reads as well as
+/// full reconstruction.
+pub fn decode_tree_delta_ops(
+    data: &[u8],
+    wanted: usize,
+) -> Result<(TreeDeltaHeader, Vec<TreeDeltaOp>, usize), TreeStreamError> {
+    decode_tree_delta_ops_prefix(data, data.len(), wanted)
+}
+
+/// Decode an HDC1 operation porch without transferring the rest of the body.
+pub fn decode_tree_delta_ops_prefix(
+    data: &[u8],
+    object_len: usize,
+    wanted: usize,
+) -> Result<(TreeDeltaHeader, Vec<TreeDeltaOp>, usize), TreeStreamError> {
+    let header = decode_tree_delta_header_prefix(data, object_len)?;
+    if wanted > header.op_count {
+        return Err(TreeStreamError::Malformed(
+            "partial delta operation count exceeds object".into(),
+        ));
+    }
+    let mut offset = TREE_DELTA_HEADER_LEN;
+    let mut previous = String::new();
+    let mut ops = Vec::with_capacity(wanted);
+    for _ in 0..wanted {
+        let opcode = *data.get(offset).ok_or(TreeStreamError::TruncatedFrame {
+            offset: offset as u64,
+        })?;
+        offset += 1;
+        let op =
+            match opcode {
+                0 => {
+                    let prefix = take_varint(data, &mut offset)?;
+                    let suffix_len = take_varint(data, &mut offset)?;
+                    if prefix > previous.len() {
+                        return Err(TreeStreamError::Malformed(
+                            "delta name prefix exceeds predecessor".into(),
+                        ));
+                    }
+                    let end = offset.checked_add(suffix_len).ok_or_else(|| {
+                        TreeStreamError::Malformed("delta name length overflow".into())
+                    })?;
+                    let mut name = previous.as_bytes()[..prefix].to_vec();
+                    name.extend_from_slice(data.get(offset..end).ok_or(
+                        TreeStreamError::TruncatedFrame {
+                            offset: offset as u64,
+                        },
+                    )?);
+                    offset = end;
+                    TreeDeltaOp::Remove(String::from_utf8(name).map_err(|_| {
+                        TreeStreamError::Malformed("delta name is not UTF-8".into())
+                    })?)
+                }
+                1 => TreeDeltaOp::Upsert(decode_compact_entry(data, &mut offset, &previous)?),
+                _ => {
+                    return Err(TreeStreamError::Malformed(format!(
+                        "invalid tree delta opcode {opcode}"
+                    )));
+                }
+            };
+        if !previous.is_empty() && previous.as_str() >= op.name() {
+            return Err(TreeStreamError::Malformed(
+                "tree delta operations must be strictly sorted".into(),
+            ));
+        }
+        previous = op.name().to_string();
+        ops.push(op);
+    }
+    if (wanted == header.first_op_count && offset != header.first_end)
+        || (wanted == header.hundred_op_count && offset != header.hundred_end)
+    {
+        return Err(TreeStreamError::Malformed(
+            "HDC1 porch offset does not match decoded operations".into(),
+        ));
+    }
+    Ok((header, ops, offset))
+}
+
+/// Reconstruct an HDC1 tree from exactly one materialized anchor and validate
+/// the result against its external object key.
+pub fn decode_tree_delta(
+    data: &[u8],
+    anchor: &Tree,
+    expected: ContentHash,
+) -> Result<Tree, TreeStreamError> {
+    let header = decode_tree_delta_header(data)?;
+    let (decoded_header, ops, consumed) = decode_tree_delta_ops(data, header.op_count)?;
+    if consumed != data.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: data.len().abs_diff(consumed) as u64,
+        });
+    }
+    let anchor_found = anchor.hash();
+    if anchor_found != decoded_header.anchor {
+        return Err(TreeStreamError::HashMismatch {
+            expected: decoded_header.anchor,
+            found: anchor_found,
+        });
+    }
+    let tree = apply_tree_delta(anchor, &ops)?;
+    if tree.len() != decoded_header.result_count {
+        return Err(TreeStreamError::Malformed(
+            "delta result count does not match reconstructed tree".into(),
+        ));
+    }
+    let found = tree.hash();
+    if found != expected {
+        return Err(TreeStreamError::HashMismatch { expected, found });
+    }
+    Ok(tree)
+}
+
+fn read_u16_at(data: &[u8], offset: usize) -> Result<u16, TreeStreamError> {
+    Ok(u16::from_le_bytes(
+        data.get(offset..offset + 2)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid u16 field".into()))?,
+    ))
+}
+
+fn read_u32_at(data: &[u8], offset: usize) -> Result<u32, TreeStreamError> {
+    Ok(u32::from_le_bytes(
+        data.get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("invalid u32 field".into()))?,
+    ))
 }
 
 pub(crate) fn encode_entry_frame(entry: &TreeEntry) -> Result<Vec<u8>, TreeStreamError> {
@@ -323,4 +1420,72 @@ fn decode_spoollink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStrea
             TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
         })?);
     TreeEntry::spoollink(name, spool_id, state).map_err(TreeStreamError::from)
+}
+
+#[cfg(all(test, feature = "zstd"))]
+mod block_tests {
+    use super::*;
+
+    fn fixture(entries: usize) -> Tree {
+        Tree::from_entries(
+            (0..entries)
+                .map(|index| {
+                    TreeEntry::file(
+                        format!("module_{index:04}.rs"),
+                        ContentHash::compute(format!("blob-{index}").as_bytes()),
+                        false,
+                    )
+                    .expect("fixture entry")
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn blocked_encoder_falls_back_for_the_complete_object() {
+        let tree = fixture(1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_ENCODING_VERSION);
+    }
+
+    #[test]
+    fn final_single_entry_block_is_stored_raw() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        assert_eq!(encoded[4], TREE_BLOCK_ENCODING_VERSION);
+        let header = decode_header(&encoded).expect("header");
+        let preamble = &encoded[TREE_HEADER_LEN..TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN];
+        let block_header =
+            decode_block_header(&header, preamble, encoded.len() as u64).expect("block header");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let index = decode_block_index(
+            &encoded[second_index..second_index + TREE_BLOCK_INDEX_LEN],
+            1,
+            &block_header,
+            encoded.len() as u64,
+        )
+        .expect("second block");
+        assert_eq!(index.stored_len, index.raw_len);
+    }
+
+    #[test]
+    fn trailing_bytes_in_a_raw_block_are_rejected() {
+        let tree = fixture(TREE_BLOCK_ENTRIES + 1);
+        let mut encoded = tree.encode_canonical_blocked(3, 0).expect("encode");
+        let second_index = TREE_HEADER_LEN + TREE_BLOCK_PREAMBLE_LEN + TREE_BLOCK_INDEX_LEN;
+        let stored_len_offset = second_index + 16;
+        let stored_len = u32::from_le_bytes(
+            encoded[stored_len_offset..stored_len_offset + 4]
+                .try_into()
+                .expect("stored length"),
+        );
+        encoded[stored_len_offset..stored_len_offset + 4]
+            .copy_from_slice(&(stored_len + 1).to_le_bytes());
+        let payload_len =
+            u64::from_le_bytes(encoded[45..53].try_into().expect("stored payload length"));
+        encoded[45..53].copy_from_slice(&(payload_len + 1).to_le_bytes());
+        encoded.push(0);
+
+        assert!(Tree::decode_canonical(&encoded).is_err());
+    }
 }

--- a/crates/object-model/src/object/tree_source.rs
+++ b/crates/object-model/src/object/tree_source.rs
@@ -139,11 +139,21 @@ impl TreeByteSource for FileTreeSource {
     }
 }
 
-/// Store-facing handle: either in-memory bytes or a seekable loose file.
-#[derive(Debug)]
+/// Store-facing handle for a seekable or lazily generated tree body.
 pub enum OpenedTreeBody {
     Bytes(BytesTreeSource),
     File(FileTreeSource),
+    Dynamic(Box<dyn TreeByteSource + Send>),
+}
+
+impl std::fmt::Debug for OpenedTreeBody {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bytes(source) => formatter.debug_tuple("Bytes").field(source).finish(),
+            Self::File(source) => formatter.debug_tuple("File").field(source).finish(),
+            Self::Dynamic(_) => formatter.write_str("Dynamic(..)"),
+        }
+    }
 }
 
 impl TreeByteSource for OpenedTreeBody {
@@ -151,6 +161,7 @@ impl TreeByteSource for OpenedTreeBody {
         match self {
             Self::Bytes(source) => source.read_exact_at(offset, buf),
             Self::File(source) => source.read_exact_at(offset, buf),
+            Self::Dynamic(source) => source.read_exact_at(offset, buf),
         }
     }
 
@@ -158,6 +169,7 @@ impl TreeByteSource for OpenedTreeBody {
         match self {
             Self::Bytes(source) => source.len(),
             Self::File(source) => source.len(),
+            Self::Dynamic(source) => source.len(),
         }
     }
 
@@ -165,6 +177,7 @@ impl TreeByteSource for OpenedTreeBody {
         match self {
             Self::Bytes(source) => source.integrity(),
             Self::File(source) => source.integrity(),
+            Self::Dynamic(source) => source.integrity(),
         }
     }
 
@@ -172,6 +185,7 @@ impl TreeByteSource for OpenedTreeBody {
         match self {
             Self::Bytes(source) => source.bytes_read(),
             Self::File(source) => source.bytes_read(),
+            Self::Dynamic(source) => source.bytes_read(),
         }
     }
 }

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -2,11 +2,16 @@
 //! Streaming Tree entry reader with persistable resume cursors.
 
 use serde::{Deserialize, Serialize};
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
-    ContentHash, Tree, TreeEntry, TreeError,
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+    tree::git_format_from_tag,
     tree_canonical::{
-        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_entry_frame, decode_header,
+        TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_INDEX_LEN, TREE_BLOCK_PREAMBLE_LEN,
+        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TREE_LEAN_ENCODING_VERSION, TREE_LEAN_MAGIC,
+        TreeBlockHeader, TreeBlockIndex, TreeHeader, decode_block_header, decode_block_index,
+        decode_block_payload, decode_entry_frame, decode_header,
     },
     tree_source::{TreeBodyIntegrity, TreeByteSource},
 };
@@ -17,7 +22,7 @@ pub enum TreeStreamError {
     #[error("invalid tree entry: {0}")]
     Invalid(#[from] TreeError),
     #[error(
-        "unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})"
+        "unsupported tree encoding version {found} (this binary supports {TREE_ENCODING_VERSION}, {TREE_BLOCK_ENCODING_VERSION}, and {TREE_LEAN_ENCODING_VERSION})"
     )]
     UnsupportedVersion { found: u8 },
     #[error("tree resume cursor does not match this object: {0}")]
@@ -39,6 +44,8 @@ pub enum TreeStreamError {
     UnverifiedRange,
     #[error("malformed tree encoding: {0}")]
     Malformed(String),
+    #[error("tree compression failed: {0}")]
+    Compression(String),
     #[error("tree I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("decoded tree hash {found} does not match {expected}")]
@@ -89,9 +96,13 @@ pub struct TreeResumeCursor {
 
 impl TreeResumeCursor {
     pub fn start(tree_id: ContentHash) -> Self {
+        Self::start_for_version(tree_id, TREE_ENCODING_VERSION)
+    }
+
+    fn start_for_version(tree_id: ContentHash, encoding_version: u8) -> Self {
         Self {
             tree_id,
-            encoding_version: TREE_ENCODING_VERSION,
+            encoding_version,
             ordinal: 0,
             byte_offset: TREE_HEADER_LEN as u64,
             prev_name: None,
@@ -119,6 +130,26 @@ impl TreeResumeCursor {
     }
 }
 
+#[derive(Debug)]
+enum TreeReaderLayout {
+    Raw,
+    Lean {
+        body_start: u64,
+    },
+    Blocked {
+        header: TreeBlockHeader,
+        cache: Option<DecodedBlock>,
+        validated_blocks: Vec<bool>,
+    },
+}
+
+#[derive(Debug)]
+struct DecodedBlock {
+    block: usize,
+    raw: Vec<u8>,
+    frames: Vec<(usize, usize)>,
+}
+
 /// One bounded page of decoded entries plus the cursor after the last entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TreePage {
@@ -131,9 +162,12 @@ pub struct TreePage {
 pub struct TreeEntryReader<S: TreeByteSource> {
     source: S,
     header: TreeHeader,
+    layout: TreeReaderLayout,
     cursor: TreeResumeCursor,
     hasher: Option<blake3::Hasher>,
+    lean_hash_entries: Option<Vec<TreeEntry>>,
     decoded_logical_len: u64,
+    started_at_zero: bool,
     pending: Option<(TreeEntry, usize)>,
     finished: bool,
 }
@@ -144,41 +178,87 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         expected_id: ContentHash,
         resume: Option<&TreeResumeCursor>,
     ) -> Result<Self, TreeStreamError> {
-        let mut header_buf = [0u8; TREE_HEADER_LEN];
-        source.read_exact_at(0, &mut header_buf)?;
-        let header = decode_header(&header_buf)?;
-        if header.tree_id != expected_id {
-            return Err(TreeStreamError::HashMismatch {
-                expected: expected_id,
-                found: header.tree_id,
-            });
-        }
-        let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
-        if source.len() < expected_len {
-            return Err(TreeStreamError::TruncatedFrame {
-                offset: source.len(),
-            });
-        }
-        if source.len() > expected_len {
-            return Err(TreeStreamError::TrailingBytes {
-                extra: source.len() - expected_len,
-            });
-        }
-        let cursor = resume
+        let mut magic = [0u8; 4];
+        source.read_exact_at(0, &mut magic)?;
+        let (header, layout) = if &magic == TREE_LEAN_MAGIC {
+            let (entry_count, body_start) = read_source_varint(&mut source, 4)?;
+            let entry_count = u64::try_from(entry_count)
+                .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds u64".into()))?;
+            let payload_len = source
+                .len()
+                .checked_sub(body_start)
+                .ok_or(TreeStreamError::TruncatedFrame { offset: body_start })?;
+            (
+                TreeHeader {
+                    version: TREE_LEAN_ENCODING_VERSION,
+                    tree_id: expected_id,
+                    entry_count,
+                    payload_len,
+                    logical_len: 0,
+                },
+                TreeReaderLayout::Lean { body_start },
+            )
+        } else {
+            let mut header_buf = [0u8; TREE_HEADER_LEN];
+            source.read_exact_at(0, &mut header_buf)?;
+            let header = decode_header(&header_buf)?;
+            if header.tree_id != expected_id {
+                return Err(TreeStreamError::HashMismatch {
+                    expected: expected_id,
+                    found: header.tree_id,
+                });
+            }
+            let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
+            if source.len() < expected_len {
+                return Err(TreeStreamError::TruncatedFrame {
+                    offset: source.len(),
+                });
+            }
+            if source.len() > expected_len {
+                return Err(TreeStreamError::TrailingBytes {
+                    extra: source.len() - expected_len,
+                });
+            }
+            let layout = if header.version == TREE_BLOCK_ENCODING_VERSION {
+                let mut preamble = [0u8; TREE_BLOCK_PREAMBLE_LEN];
+                source.read_exact_at(TREE_HEADER_LEN as u64, &mut preamble)?;
+                let block_header = decode_block_header(&header, &preamble, source.len())?;
+                TreeReaderLayout::Blocked {
+                    header: block_header,
+                    cache: None,
+                    validated_blocks: vec![false; block_header.block_count],
+                }
+            } else {
+                TreeReaderLayout::Raw
+            };
+            (header, layout)
+        };
+        let mut cursor = resume
             .cloned()
-            .unwrap_or_else(|| TreeResumeCursor::start(expected_id));
-        validate_cursor(&header, &cursor)?;
+            .unwrap_or_else(|| TreeResumeCursor::start_for_version(expected_id, header.version));
+        if resume.is_none()
+            && let TreeReaderLayout::Lean { body_start } = &layout
+        {
+            cursor.byte_offset = *body_start;
+        }
+        validate_cursor(&header, &layout, &cursor)?;
         if cursor.ordinal > 0 && source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
-        let hasher =
-            (cursor.ordinal == 0).then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let is_lean = matches!(layout, TreeReaderLayout::Lean { .. });
+        let hasher = (cursor.ordinal == 0 && !is_lean)
+            .then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let lean_hash_entries = (cursor.ordinal == 0 && is_lean).then(Vec::new);
+        let started_at_zero = cursor.ordinal == 0;
         let mut reader = Self {
             source,
             header,
+            layout,
             cursor,
             hasher,
+            lean_hash_entries,
             decoded_logical_len: 0,
+            started_at_zero,
             pending: None,
             finished: false,
         };
@@ -249,7 +329,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 decoded: self.cursor.ordinal,
             });
         }
-        let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
+        let payload_end = self.logical_payload_end();
         if self.cursor.byte_offset != payload_end {
             return Err(TreeStreamError::TrailingBytes {
                 extra: payload_end.abs_diff(self.cursor.byte_offset),
@@ -268,9 +348,19 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                     found,
                 });
             }
+        } else if let Some(entries) = self.lean_hash_entries.take() {
+            let tree = Tree::try_from_decoded_entries(entries)?;
+            let found = tree.hash();
+            if found != self.header.tree_id {
+                return Err(TreeStreamError::HashMismatch {
+                    expected: self.header.tree_id,
+                    found,
+                });
+            }
         } else if self.source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
+        self.validate_complete_block_layout()?;
         self.finished = true;
         Ok(())
     }
@@ -283,6 +373,12 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
     }
 
     fn read_entry_at(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        if matches!(self.layout, TreeReaderLayout::Lean { .. }) {
+            return self.read_lean_entry(offset);
+        }
+        if matches!(self.layout, TreeReaderLayout::Blocked { .. }) {
+            return self.read_blocked_entry();
+        }
         let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
         let mut len_buf = [0u8; 4];
         self.source.read_exact_at(offset, &mut len_buf)?;
@@ -304,6 +400,310 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         Ok((entry, 4 + frame_len))
     }
 
+    fn logical_payload_end(&self) -> u64 {
+        match &self.layout {
+            TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + self.header.payload_len,
+            TreeReaderLayout::Lean { .. } => self.source.len(),
+            TreeReaderLayout::Blocked { header, .. } => {
+                TREE_HEADER_LEN as u64 + header.raw_payload_len
+            }
+        }
+    }
+
+    fn read_lean_entry(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let mut cursor = offset;
+        let tag = read_source_byte(&mut self.source, &mut cursor)?;
+        let mode = FileMode::from_byte(tag >> 3).ok_or_else(|| {
+            TreeStreamError::Malformed(format!("invalid compact entry mode {}", tag >> 3))
+        })?;
+        let kind = EntryType::from_byte(tag & 0x07).ok_or_else(|| {
+            TreeStreamError::Malformed(format!("invalid compact entry kind {}", tag & 0x07))
+        })?;
+        let prefix = read_source_varint_at(&mut self.source, &mut cursor)?;
+        let suffix_len = read_source_varint_at(&mut self.source, &mut cursor)?;
+        let previous = self.cursor.prev_name.as_deref().unwrap_or("");
+        if prefix > previous.len() {
+            return Err(TreeStreamError::Malformed(
+                "compact name prefix exceeds predecessor".into(),
+            ));
+        }
+        let mut suffix = vec![0u8; suffix_len];
+        self.source.read_exact_at(cursor, &mut suffix)?;
+        cursor = cursor
+            .checked_add(suffix_len as u64)
+            .ok_or_else(|| TreeStreamError::Malformed("compact name offset overflow".into()))?;
+        let mut name = previous.as_bytes()[..prefix].to_vec();
+        name.extend_from_slice(&suffix);
+        let name = String::from_utf8(name)
+            .map_err(|_| TreeStreamError::Malformed("compact entry name is not UTF-8".into()))?;
+        let entry = match kind {
+            EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+                let mut bytes = [0u8; 32];
+                self.source.read_exact_at(cursor, &mut bytes)?;
+                cursor = cursor.checked_add(32).ok_or_else(|| {
+                    TreeStreamError::Malformed("compact hash offset overflow".into())
+                })?;
+                let hash = ContentHash::from_bytes(bytes);
+                match kind {
+                    EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                    EntryType::Tree => TreeEntry::directory(name, hash)?,
+                    EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                    EntryType::Gitlink | EntryType::Spoollink => {
+                        return Err(TreeStreamError::Malformed(
+                            "invalid compact content-addressed kind".into(),
+                        ));
+                    }
+                }
+            }
+            EntryType::Gitlink => {
+                let format = git_format_from_tag(read_source_byte(&mut self.source, &mut cursor)?)?;
+                let oid_len = match format {
+                    GitObjectFormat::Sha1 => 20,
+                    GitObjectFormat::Sha256 => 32,
+                };
+                let mut oid = vec![0u8; oid_len];
+                self.source.read_exact_at(cursor, &mut oid)?;
+                cursor = cursor.checked_add(oid_len as u64).ok_or_else(|| {
+                    TreeStreamError::Malformed("compact gitlink offset overflow".into())
+                })?;
+                let target = GitObjectId::from_raw(format, &oid).map_err(|error| {
+                    TreeStreamError::Malformed(format!("invalid compact gitlink: {error}"))
+                })?;
+                TreeEntry::gitlink(name, target)?
+            }
+            EntryType::Spoollink => {
+                let spool_len = read_source_varint_at(&mut self.source, &mut cursor)?;
+                let mut spool = vec![0u8; spool_len];
+                self.source.read_exact_at(cursor, &mut spool)?;
+                cursor = cursor.checked_add(spool_len as u64).ok_or_else(|| {
+                    TreeStreamError::Malformed("compact spool offset overflow".into())
+                })?;
+                let spool = std::str::from_utf8(&spool).map_err(|_| {
+                    TreeStreamError::Malformed("compact spool id is not UTF-8".into())
+                })?;
+                let spool_id = SpoolId::parse(spool).map_err(|error| {
+                    TreeStreamError::Malformed(format!("invalid compact spool id: {error}"))
+                })?;
+                let mut state = [0u8; 32];
+                self.source.read_exact_at(cursor, &mut state)?;
+                cursor = cursor.checked_add(32).ok_or_else(|| {
+                    TreeStreamError::Malformed("compact state offset overflow".into())
+                })?;
+                TreeEntry::spoollink(name, spool_id, StateId::from_bytes(state))?
+            }
+        };
+        if entry.mode() != mode {
+            return Err(TreeStreamError::Malformed(format!(
+                "compact entry kind/mode mismatch for {}: {kind:?}/{mode:?}",
+                entry.name()
+            )));
+        }
+        let consumed = usize::try_from(cursor - offset)
+            .map_err(|_| TreeStreamError::Malformed("compact entry length exceeds usize".into()))?;
+        Ok((entry, consumed))
+    }
+
+    fn read_blocked_entry(&mut self) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Blocked { header, .. } => *header,
+            TreeReaderLayout::Raw | TreeReaderLayout::Lean { .. } => {
+                return Err(TreeStreamError::Malformed(
+                    "raw tree entered blocked reader".into(),
+                ));
+            }
+        };
+        let ordinal = usize::try_from(self.cursor.ordinal)
+            .map_err(|_| TreeStreamError::Malformed("tree ordinal exceeds usize".into()))?;
+        let block = ordinal / block_header.block_entries;
+        let within_block = ordinal % block_header.block_entries;
+        let index = self.read_block_index(block, &block_header)?;
+        let block_logical_start = (TREE_HEADER_LEN as u64)
+            .checked_add(index.raw_offset)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block raw offset overflow".into()))?;
+
+        if within_block == 0 {
+            if self.cursor.byte_offset != block_logical_start {
+                return Err(TreeStreamError::CursorMismatch(
+                    "cursor byte offset is not the block restart boundary".into(),
+                ));
+            }
+            return self.read_block_anchor(index);
+        }
+
+        let needs_load = match &self.layout {
+            TreeReaderLayout::Blocked { cache, .. } => {
+                cache.as_ref().is_none_or(|cached| cached.block != block)
+            }
+            TreeReaderLayout::Raw | TreeReaderLayout::Lean { .. } => true,
+        };
+        if needs_load {
+            let decoded = self.load_block(index, block, &block_header)?;
+            if let TreeReaderLayout::Blocked {
+                cache,
+                validated_blocks,
+                ..
+            } = &mut self.layout
+            {
+                *cache = Some(decoded);
+                if let Some(validated) = validated_blocks.get_mut(block) {
+                    *validated = true;
+                }
+            }
+        }
+        let cached = match &self.layout {
+            TreeReaderLayout::Blocked {
+                cache: Some(cached),
+                ..
+            } => cached,
+            _ => {
+                return Err(TreeStreamError::Malformed(
+                    "tree block cache was not populated".into(),
+                ));
+            }
+        };
+        let (frame_start, frame_end) =
+            cached
+                .frames
+                .get(within_block)
+                .copied()
+                .ok_or(TreeStreamError::UnexpectedEof {
+                    expected: self.cursor.ordinal + 1,
+                    decoded: self.cursor.ordinal,
+                })?;
+        let frame =
+            cached
+                .raw
+                .get(frame_start + 4..frame_end)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: frame_start as u64,
+                })?;
+        let consumed = frame_end - frame_start;
+        let expected_offset = block_logical_start
+            .checked_add(frame_start as u64)
+            .ok_or_else(|| TreeStreamError::Malformed("tree cursor offset overflow".into()))?;
+        if self.cursor.byte_offset != expected_offset {
+            return Err(TreeStreamError::CursorMismatch(
+                "cursor byte offset is not an entry boundary".into(),
+            ));
+        }
+        Ok((decode_entry_frame(frame)?, consumed))
+    }
+
+    fn read_block_index(
+        &mut self,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<TreeBlockIndex, TreeStreamError> {
+        let relative = block
+            .checked_mul(TREE_BLOCK_INDEX_LEN)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index overflow".into()))?;
+        let offset = TREE_HEADER_LEN
+            .checked_add(TREE_BLOCK_PREAMBLE_LEN)
+            .and_then(|start| start.checked_add(relative))
+            .ok_or_else(|| TreeStreamError::Malformed("tree block index offset overflow".into()))?;
+        let mut bytes = [0u8; TREE_BLOCK_INDEX_LEN];
+        self.source.read_exact_at(offset as u64, &mut bytes)?;
+        decode_block_index(&bytes, block, block_header, self.source.len())
+    }
+
+    fn read_block_anchor(
+        &mut self,
+        index: TreeBlockIndex,
+    ) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let mut len_bytes = [0u8; 4];
+        self.source
+            .read_exact_at(index.stored_offset, &mut len_bytes)?;
+        let frame_len = u32::from_le_bytes(len_bytes) as usize;
+        let consumed = 4usize
+            .checked_add(frame_len)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            })?;
+        if consumed > index.stored_len || consumed > index.raw_len {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: index.stored_offset,
+            });
+        }
+        let mut frame = vec![0u8; frame_len];
+        self.source
+            .read_exact_at(index.stored_offset + 4, &mut frame)?;
+        Ok((decode_entry_frame(&frame)?, consumed))
+    }
+
+    fn load_block(
+        &mut self,
+        index: TreeBlockIndex,
+        block: usize,
+        block_header: &TreeBlockHeader,
+    ) -> Result<DecodedBlock, TreeStreamError> {
+        let mut stored = vec![0u8; index.stored_len];
+        self.source
+            .read_exact_at(index.stored_offset, &mut stored)?;
+        let raw = decode_block_payload(&stored, index.raw_len)?;
+        let first_entry = block
+            .checked_mul(block_header.block_entries)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block ordinal overflow".into()))?;
+        let remaining = usize::try_from(self.header.entry_count)
+            .map_err(|_| TreeStreamError::Malformed("tree entry count exceeds usize".into()))?
+            .checked_sub(first_entry)
+            .ok_or_else(|| TreeStreamError::Malformed("tree block starts past entries".into()))?;
+        let expected_entries = remaining.min(block_header.block_entries);
+        let frames = decode_block_frames(&raw, expected_entries)?;
+        Ok(DecodedBlock { block, raw, frames })
+    }
+
+    fn validate_complete_block_layout(&mut self) -> Result<(), TreeStreamError> {
+        let block_header = match &self.layout {
+            TreeReaderLayout::Raw | TreeReaderLayout::Lean { .. } => return Ok(()),
+            TreeReaderLayout::Blocked { header, .. } => *header,
+        };
+        let mut expected_raw_offset = 0u64;
+        let mut expected_stored_offset = block_header.index_end;
+        for block in 0..block_header.block_count {
+            let index = self.read_block_index(block, &block_header)?;
+            if index.raw_offset != expected_raw_offset
+                || index.stored_offset != expected_stored_offset
+            {
+                return Err(TreeStreamError::Malformed(
+                    "tree blocks are not contiguous".into(),
+                ));
+            }
+            expected_raw_offset = expected_raw_offset
+                .checked_add(index.raw_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("raw tree length overflow".into()))?;
+            expected_stored_offset = expected_stored_offset
+                .checked_add(index.stored_len as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("stored tree length overflow".into()))?;
+            let needs_payload_validation = self.started_at_zero
+                && match &self.layout {
+                    TreeReaderLayout::Blocked {
+                        validated_blocks, ..
+                    } => validated_blocks
+                        .get(block)
+                        .is_none_or(|validated| !validated),
+                    TreeReaderLayout::Raw | TreeReaderLayout::Lean { .. } => false,
+                };
+            if needs_payload_validation {
+                let _ = self.load_block(index, block, &block_header)?;
+                if let TreeReaderLayout::Blocked {
+                    validated_blocks, ..
+                } = &mut self.layout
+                    && let Some(validated) = validated_blocks.get_mut(block)
+                {
+                    *validated = true;
+                }
+            }
+        }
+        if expected_raw_offset != block_header.raw_payload_len
+            || expected_stored_offset != self.source.len()
+        {
+            return Err(TreeStreamError::Malformed(
+                "tree block lengths do not match the header".into(),
+            ));
+        }
+        Ok(())
+    }
+
     fn commit_entry(&mut self, entry: &TreeEntry, consumed: usize) -> Result<(), TreeStreamError> {
         if let Some(previous) = self.cursor.prev_name.as_deref()
             && previous >= entry.name()
@@ -315,6 +715,9 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         }
         if let Some(hasher) = &mut self.hasher {
             entry.update_hasher(hasher);
+        }
+        if let Some(entries) = &mut self.lean_hash_entries {
+            entries.push(entry.clone());
         }
         self.decoded_logical_len = self
             .decoded_logical_len
@@ -350,11 +753,59 @@ mod tree_stream_proptests;
 #[path = "tree_stream_tests.rs"]
 mod tree_stream_tests;
 
-fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(), TreeStreamError> {
-    if cursor.encoding_version != TREE_ENCODING_VERSION {
+fn decode_block_frames(
+    raw: &[u8],
+    expected_entries: usize,
+) -> Result<Vec<(usize, usize)>, TreeStreamError> {
+    let mut frames = Vec::with_capacity(expected_entries);
+    let mut offset = 0usize;
+    for _ in 0..expected_entries {
+        let len_bytes = raw
+            .get(offset..offset + 4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_len = u32::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| TreeStreamError::Malformed("invalid block frame length".into()))?,
+        ) as usize;
+        let frame_start = offset
+            .checked_add(4)
+            .ok_or(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
+        let frame_end =
+            frame_start
+                .checked_add(frame_len)
+                .ok_or(TreeStreamError::TruncatedFrame {
+                    offset: offset as u64,
+                })?;
+        if frame_end > raw.len() {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            });
+        }
+        frames.push((offset, frame_end));
+        offset = frame_end;
+    }
+    if offset != raw.len() {
+        return Err(TreeStreamError::TrailingBytes {
+            extra: raw.len().abs_diff(offset) as u64,
+        });
+    }
+    Ok(frames)
+}
+
+fn validate_cursor(
+    header: &TreeHeader,
+    layout: &TreeReaderLayout,
+    cursor: &TreeResumeCursor,
+) -> Result<(), TreeStreamError> {
+    if cursor.encoding_version != header.version {
         return Err(TreeStreamError::CursorMismatch(format!(
-            "encoding version {} is not {TREE_ENCODING_VERSION}",
-            cursor.encoding_version
+            "encoding version {} is not {}",
+            cursor.encoding_version, header.version
         )));
     }
     if cursor.tree_id != header.tree_id {
@@ -362,14 +813,22 @@ fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(),
             "cursor tree id does not match the opened object".into(),
         ));
     }
-    let payload_end = TREE_HEADER_LEN as u64 + header.payload_len;
+    let payload_end = match layout {
+        TreeReaderLayout::Raw => TREE_HEADER_LEN as u64 + header.payload_len,
+        TreeReaderLayout::Lean { body_start } => body_start + header.payload_len,
+        TreeReaderLayout::Blocked { header, .. } => TREE_HEADER_LEN as u64 + header.raw_payload_len,
+    };
+    let payload_start = match layout {
+        TreeReaderLayout::Raw | TreeReaderLayout::Blocked { .. } => TREE_HEADER_LEN as u64,
+        TreeReaderLayout::Lean { body_start } => *body_start,
+    };
     if cursor.ordinal > header.entry_count {
         return Err(TreeStreamError::CursorMismatch(
             "cursor ordinal is past the declared entry count".into(),
         ));
     }
     if cursor.ordinal == 0 {
-        if cursor.byte_offset != TREE_HEADER_LEN as u64 || cursor.prev_name.is_some() {
+        if cursor.byte_offset != payload_start || cursor.prev_name.is_some() {
             return Err(TreeStreamError::CursorMismatch(
                 "start cursor must be the first entry boundary".into(),
             ));
@@ -384,12 +843,50 @@ fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(),
         }
         return Ok(());
     }
-    if cursor.byte_offset < TREE_HEADER_LEN as u64 || cursor.byte_offset >= payload_end {
+    if cursor.byte_offset < payload_start || cursor.byte_offset >= payload_end {
         return Err(TreeStreamError::CursorMismatch(
             "cursor byte offset is not inside the payload".into(),
         ));
     }
     Ok(())
+}
+
+fn read_source_byte<S: TreeByteSource>(
+    source: &mut S,
+    offset: &mut u64,
+) -> Result<u8, TreeStreamError> {
+    let mut byte = [0u8; 1];
+    source.read_exact_at(*offset, &mut byte)?;
+    *offset = offset
+        .checked_add(1)
+        .ok_or_else(|| TreeStreamError::Malformed("tree byte offset overflow".into()))?;
+    Ok(byte[0])
+}
+
+fn read_source_varint<S: TreeByteSource>(
+    source: &mut S,
+    offset: u64,
+) -> Result<(usize, u64), TreeStreamError> {
+    let mut cursor = offset;
+    let value = read_source_varint_at(source, &mut cursor)?;
+    Ok((value, cursor))
+}
+
+fn read_source_varint_at<S: TreeByteSource>(
+    source: &mut S,
+    offset: &mut u64,
+) -> Result<usize, TreeStreamError> {
+    let mut value = 0usize;
+    for shift in (0..usize::BITS).step_by(7) {
+        let byte = read_source_byte(source, offset)?;
+        value |= ((byte & 0x7f) as usize)
+            .checked_shl(shift)
+            .ok_or_else(|| TreeStreamError::Malformed("varint overflow".into()))?;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(TreeStreamError::Malformed("varint overflow".into()))
 }
 
 impl Tree {

--- a/crates/object-model/src/object/tree_stream_proptests.rs
+++ b/crates/object-model/src/object/tree_stream_proptests.rs
@@ -63,6 +63,7 @@ fn error_class(error: &TreeStreamError) -> &'static str {
         TreeStreamError::InvalidPageLimits => "limits",
         TreeStreamError::UnverifiedRange => "unverified",
         TreeStreamError::Malformed(_) => "malformed",
+        TreeStreamError::Compression(_) => "compression",
         TreeStreamError::Io(_) => "io",
         TreeStreamError::HashMismatch { .. } => "hash",
     }

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -32,6 +32,22 @@ fn sample_tree() -> Tree {
     ])
 }
 
+#[cfg(feature = "zstd")]
+fn compressible_tree(entries: usize) -> Tree {
+    Tree::from_entries(
+        (0..entries)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("crates__module_{index:04}__src__shared_component.rs"),
+                    ContentHash::compute(format!("real-blob-{index}").as_bytes()),
+                    index.is_multiple_of(17),
+                )
+                .expect("compressed fixture entry")
+            })
+            .collect(),
+    )
+}
+
 fn open_reader(tree: &Tree) -> (Vec<u8>, TreeEntryReader<BytesTreeSource>) {
     let bytes = tree.encode_canonical().expect("encode");
     let reader = TreeEntryReader::open(
@@ -53,6 +69,100 @@ fn canonical_round_trip_matches_eager_tree() {
         Tree::decode_canonical_streamed(&bytes).expect("streamed"),
         tree
     );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn block_compressed_round_trip_matches_eager_and_streamed_tree() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    assert_eq!(bytes[4], crate::object::TREE_BLOCK_ENCODING_VERSION);
+    assert_eq!(Tree::decode_canonical(&bytes).expect("eager"), tree);
+    assert_eq!(
+        Tree::decode_canonical_streamed(&bytes).expect("streamed"),
+        tree
+    );
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_partial_read_and_resume_stay_block_local() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open blocked");
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("first page")
+        .expect("entry");
+    assert_eq!(first.entries, tree.entries()[..1]);
+    assert!(
+        reader.bytes_read() < 256,
+        "first block anchor should be a small ranged read"
+    );
+
+    let mut resumed = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes),
+        tree.hash(),
+        Some(&first.resume_cursor),
+    )
+    .expect("resume blocked");
+    let page = resumed
+        .next_page(TreePageLimits::new(100, usize::MAX).expect("limits"))
+        .expect("resumed page")
+        .expect("entries");
+    assert_eq!(page.entries, tree.entries()[1..101]);
+    assert!(
+        resumed.bytes_read() < tree.encode_canonical().expect("raw").len() as u64,
+        "resumed page should not read the whole tree"
+    );
+
+    let blocked = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+    let mut boundary_reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open boundary reader");
+    let before_boundary = boundary_reader
+        .next_page(TreePageLimits::new(256, usize::MAX).expect("limits"))
+        .expect("boundary page")
+        .expect("entries");
+    let mut at_boundary = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(blocked),
+        tree.hash(),
+        Some(&before_boundary.resume_cursor),
+    )
+    .expect("resume at block boundary");
+    let anchor = at_boundary
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("anchor page")
+        .expect("entry");
+    assert_eq!(anchor.entries, tree.entries()[256..257]);
+    assert!(at_boundary.bytes_read() < 256);
+}
+
+#[test]
+#[cfg(feature = "zstd")]
+fn compressed_tree_hash_and_payload_corruption_fail_closed() {
+    let tree = compressible_tree(600);
+    let bytes = tree.encode_canonical_blocked(3, 0).expect("encode blocked");
+
+    let mut bad_hash = bytes.clone();
+    bad_hash[5] ^= 1;
+    assert!(matches!(
+        Tree::decode_canonical(&bad_hash),
+        Err(TreeStreamError::HashMismatch { .. })
+    ));
+
+    let mut bad_payload = bytes;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    assert!(Tree::decode_canonical(&bad_payload).is_err());
 }
 
 #[test]

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -42,7 +42,12 @@ zstd = { workspace = true, optional = true }
 async-source = ["heddle-object-model/async-source"]
 bench = ["heddle-format/bench"]
 memory-backend = []
-zstd = ["dep:zstd", "heddle-format/zstd", "heddle-pack/zstd"]
+zstd = [
+    "dep:zstd",
+    "heddle-format/zstd",
+    "heddle-object-model/zstd",
+    "heddle-pack/zstd",
+]
 
 [dev-dependencies]
 criterion = "0.8"
@@ -90,6 +95,10 @@ required-features = ["bench"]
 
 [[example]]
 name = "train_tree_state_dictionary"
+required-features = ["zstd"]
+
+[[example]]
+name = "htr4_measure"
 required-features = ["zstd"]
 
 [[bench]]

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -1,0 +1,2702 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTR4 block-compression measurement and format-validation harness.
+//!
+//! Real-repository measurements exercise the production store codec and a
+//! file-backed `TreeEntryReader`. Synthetic measurements retain the original
+//! tunable prototype for comparison. Each block keeps its first complete HTR4
+//! frame raw as a restart anchor and compresses only the tail.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    env,
+    fs::File,
+    hint::black_box,
+    io::{BufRead, BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use bytes::Bytes;
+use heddle_format::compression::{
+    CompressionConfig, CompressionDictionary, compress_with_dictionary,
+};
+use objects::object::{
+    BytesTreeSource, ContentHash, EntryType, FileMode, FileTreeSource, SpoolId, StateId,
+    TREE_BLOCK_ENCODING_VERSION, TREE_HEADER_LEN, Tree, TreeEntry, TreeEntryReader, TreePageLimits,
+};
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+use tempfile::{NamedTempFile, TempDir};
+
+const SEED: u64 = 0x6874_7234_5f62_656e;
+const SIZES: [usize; 5] = [1, 10, 100, 1_000, 10_000];
+const SAMPLE_COUNT: usize = 15;
+const CALIBRATION_TIME: Duration = Duration::from_millis(25);
+const SAMPLE_TIME: Duration = Duration::from_millis(40);
+const DEFAULT_REAL_TREE_LIMIT: usize = 4_000;
+const REAL_FILE_SAMPLE_LIMIT: usize = 64;
+const RADICAL_ANCHOR_INTERVAL: usize = 128;
+const RADICAL_MAX_OPS: usize = 512;
+const RADICAL_HEADER_LEN: usize = 59;
+const RADICAL_MAGIC: &[u8; 4] = b"HDC1";
+const LEAN_MAGIC: &[u8; 4] = b"HLR1";
+
+const BLOCK_MAGIC: &[u8; 4] = b"HTB1";
+const BLOCK_VERSION: u8 = 1;
+const BLOCK_CODEC_ZSTD: u8 = 1;
+const BLOCK_HEADER_LEN: usize = 72;
+const BLOCK_INDEX_LEN: usize = 24;
+const BLOCK_LEVEL: i32 = 3;
+const TRAINED_DICTIONARY_ID: u32 = 0x4854_4231;
+const LEGACY_DICTIONARY_ID: u32 = 1;
+const LEGACY_DICTIONARY: &[u8] =
+    include_bytes!("../../format/src/compression/dictionaries/tree-state-v1.zdict");
+
+#[derive(Clone, Copy)]
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn fill(&mut self, bytes: &mut [u8]) {
+        for chunk in bytes.chunks_mut(8) {
+            let random = self.next().to_le_bytes();
+            chunk.copy_from_slice(&random[..chunk.len()]);
+        }
+    }
+}
+
+fn content_hash(index: usize, salt: u64) -> ContentHash {
+    let mut random = SplitMix64::new(SEED ^ (index as u64).rotate_left(17) ^ salt);
+    let mut content = [0u8; 96];
+    random.fill(&mut content);
+    ContentHash::compute(&content)
+}
+
+fn oid(index: usize) -> GitObjectId {
+    let sha256 = (index / 20) % 2 == 1;
+    let len = if sha256 { 32 } else { 20 };
+    let format = if sha256 {
+        GitObjectFormat::Sha256
+    } else {
+        GitObjectFormat::Sha1
+    };
+    let mut bytes = [0u8; 32];
+    SplitMix64::new(SEED ^ index as u64 ^ 0x6f69_645f_7361_6c74).fill(&mut bytes[..len]);
+    GitObjectId::from_raw(format, &bytes[..len]).expect("valid deterministic git oid")
+}
+
+fn entry(index: usize) -> TreeEntry {
+    let stems = [
+        "README",
+        "src__object__tree",
+        "crates__cli__status",
+        "wire_protocol",
+        "integration_spec",
+        "config_local",
+        "snapshot_manifest",
+        "test_fixture",
+    ];
+    let mut name_rng = SplitMix64::new(SEED ^ index as u64);
+    let suffix = name_rng.next() as u32;
+    let residue = index % 20;
+    let extension = match residue {
+        2 => "dir",
+        3 => "link",
+        4 => "submodule",
+        5 => "spool",
+        _ => ["rs", "toml", "md", "json"][index % 4],
+    };
+    let name = format!(
+        "{index:05}_{}_{suffix:08x}.{extension}",
+        stems[index % stems.len()]
+    );
+
+    match residue {
+        1 => TreeEntry::file(name, content_hash(index, 1), true),
+        2 => TreeEntry::directory(name, content_hash(index, 2)),
+        3 => TreeEntry::symlink(name, content_hash(index, 3)),
+        4 => TreeEntry::gitlink(name, oid(index)),
+        5 => TreeEntry::spoollink(
+            name,
+            SpoolId::parse(format!("bench/child-{}", index % 64)).expect("valid spool id"),
+            StateId::from_bytes(*content_hash(index, 5).as_bytes()),
+        ),
+        _ => TreeEntry::file(name, content_hash(index, 0), false),
+    }
+    .expect("valid deterministic tree entry")
+}
+
+fn fixture(entries: usize) -> Tree {
+    Tree::from_entries((0..entries).map(entry).collect())
+}
+
+fn training_dictionary() -> Result<Vec<u8>> {
+    // A disjoint ordinal range prevents the measured objects from appearing in
+    // the training set while retaining the same mix of entry shapes.
+    let samples = (0..192)
+        .map(|sample| {
+            let start = 100_000 + sample * 64;
+            let tree = Tree::from_entries((start..start + 64).map(entry).collect());
+            let htr4 = tree.encode_canonical()?;
+            Ok(htr4[TREE_HEADER_LEN..].to_vec())
+        })
+        .collect::<Result<Vec<_>, objects::object::TreeStreamError>>()?;
+    zstd::dict::from_samples(&samples, 8 * 1024).context("train HTR4 block dictionary")
+}
+
+#[derive(Clone, Copy)]
+struct Dictionary<'a> {
+    name: &'static str,
+    id: u32,
+    bytes: &'a [u8],
+    encoder: Option<&'a zstd::dict::EncoderDictionary<'static>>,
+    decoder: Option<&'a zstd::dict::DecoderDictionary<'static>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockHeader {
+    block_entries: usize,
+    tree_id: ContentHash,
+    entry_count: usize,
+    raw_payload_len: usize,
+    logical_len: u64,
+    block_count: usize,
+    dictionary_id: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockIndex {
+    first_entry: usize,
+    offset: usize,
+    stored_len: usize,
+    raw_len: usize,
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16> {
+    Ok(u16::from_le_bytes(
+        bytes
+            .get(offset..offset + 2)
+            .context("truncated u16")?
+            .try_into()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32> {
+    Ok(u32::from_le_bytes(
+        bytes
+            .get(offset..offset + 4)
+            .context("truncated u32")?
+            .try_into()?,
+    ))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset + 8)
+            .context("truncated u64")?
+            .try_into()?,
+    ))
+}
+
+fn usize_from(value: u64, field: &str) -> Result<usize> {
+    usize::try_from(value).with_context(|| format!("{field} exceeds usize"))
+}
+
+fn frame_ranges(htr4: &[u8]) -> Result<Vec<(usize, usize)>> {
+    let header = objects::object::decode_header(htr4)?;
+    let entry_count = usize_from(header.entry_count, "entry count")?;
+    let expected_len = TREE_HEADER_LEN
+        .checked_add(usize_from(header.payload_len, "payload length")?)
+        .context("HTR4 length overflow")?;
+    ensure!(htr4.len() == expected_len, "HTR4 length mismatch");
+    let mut ranges = Vec::with_capacity(entry_count);
+    let mut offset = TREE_HEADER_LEN;
+    for _ in 0..entry_count {
+        let frame_len = read_u32(htr4, offset)? as usize;
+        let end = offset
+            .checked_add(4)
+            .and_then(|start| start.checked_add(frame_len))
+            .context("frame end overflow")?;
+        ensure!(end <= htr4.len(), "truncated HTR4 entry frame");
+        ranges.push((offset, end));
+        offset = end;
+    }
+    ensure!(offset == htr4.len(), "trailing HTR4 payload bytes");
+    Ok(ranges)
+}
+
+fn encode_blocked(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    encode_blocked_htr4(&htr4, block_entries, dictionary)
+}
+
+fn encode_blocked_htr4(
+    htr4: &[u8],
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    ensure!(block_entries > 0 && block_entries <= u16::MAX as usize);
+    let htr4_header = objects::object::decode_header(htr4)?;
+    let ranges = frame_ranges(htr4)?;
+    let block_count = ranges.len().div_ceil(block_entries);
+    let mut compressor = if let Some(prepared) = dictionary.encoder {
+        zstd::bulk::Compressor::with_prepared_dictionary(prepared)?
+    } else {
+        zstd::bulk::Compressor::new(BLOCK_LEVEL)?
+    };
+    let mut blocks = Vec::with_capacity(block_count);
+    for chunk in ranges.chunks(block_entries) {
+        let start = chunk.first().context("empty block")?.0;
+        let anchor_end = chunk.first().context("empty block")?.1;
+        let end = chunk.last().context("empty block")?.1;
+        let raw = &htr4[start..end];
+        let anchor = &htr4[start..anchor_end];
+        let compressed_tail = compressor.compress(&htr4[anchor_end..end])?;
+        blocks.push(if anchor.len() + compressed_tail.len() < raw.len() {
+            let mut stored = Vec::with_capacity(anchor.len() + compressed_tail.len());
+            stored.extend_from_slice(anchor);
+            stored.extend_from_slice(&compressed_tail);
+            stored
+        } else {
+            raw.to_vec()
+        });
+    }
+
+    let index_bytes = block_count
+        .checked_mul(BLOCK_INDEX_LEN)
+        .context("block index overflow")?;
+    let mut payload_offset = BLOCK_HEADER_LEN
+        .checked_add(index_bytes)
+        .context("block payload offset overflow")?;
+    let capacity = payload_offset
+        .checked_add(blocks.iter().map(Vec::len).sum::<usize>())
+        .context("blocked tree length overflow")?;
+    let mut out = Vec::with_capacity(capacity);
+    out.extend_from_slice(BLOCK_MAGIC);
+    out.push(BLOCK_VERSION);
+    out.push(BLOCK_CODEC_ZSTD);
+    out.extend_from_slice(&(block_entries as u16).to_le_bytes());
+    out.extend_from_slice(htr4_header.tree_id.as_bytes());
+    out.extend_from_slice(&htr4_header.entry_count.to_le_bytes());
+    out.extend_from_slice(&htr4_header.payload_len.to_le_bytes());
+    out.extend_from_slice(&htr4_header.logical_len.to_le_bytes());
+    out.extend_from_slice(&(block_count as u32).to_le_bytes());
+    out.extend_from_slice(&dictionary.id.to_le_bytes());
+    ensure!(out.len() == BLOCK_HEADER_LEN);
+
+    for (block, stored) in blocks.iter().enumerate() {
+        let first_entry = block * block_entries;
+        let chunk = &ranges[first_entry..(first_entry + block_entries).min(ranges.len())];
+        let raw_len = chunk.last().context("empty indexed block")?.1 - chunk[0].0;
+        out.extend_from_slice(&(first_entry as u64).to_le_bytes());
+        out.extend_from_slice(&(payload_offset as u64).to_le_bytes());
+        out.extend_from_slice(&(stored.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(raw_len as u32).to_le_bytes());
+        payload_offset += stored.len();
+    }
+    for block in blocks {
+        out.extend_from_slice(&block);
+    }
+    ensure!(out.len() == capacity);
+    Ok(out)
+}
+
+fn encode_adaptive(
+    tree: &Tree,
+    block_entries: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<Vec<u8>> {
+    let htr4 = tree.encode_canonical()?;
+    let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+    Ok(if blocked.len() < htr4.len() {
+        blocked
+    } else {
+        htr4
+    })
+}
+
+fn parse_block_header(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<BlockHeader> {
+    parse_block_header_with_len(bytes, bytes.len(), dictionary)
+}
+
+fn parse_block_header_with_len(
+    bytes: &[u8],
+    stored_object_len: usize,
+    dictionary: Dictionary<'_>,
+) -> Result<BlockHeader> {
+    ensure!(bytes.len() >= BLOCK_HEADER_LEN, "truncated HTB1 header");
+    ensure!(&bytes[..4] == BLOCK_MAGIC, "not an HTB1 tree");
+    ensure!(bytes[4] == BLOCK_VERSION, "unsupported HTB1 version");
+    ensure!(bytes[5] == BLOCK_CODEC_ZSTD, "unsupported HTB1 codec");
+    let block_entries = read_u16(bytes, 6)? as usize;
+    ensure!(block_entries > 0, "zero entries per block");
+    let mut tree_id = [0; 32];
+    tree_id.copy_from_slice(&bytes[8..40]);
+    let entry_count = usize_from(read_u64(bytes, 40)?, "entry count")?;
+    let raw_payload_len = usize_from(read_u64(bytes, 48)?, "raw payload length")?;
+    let logical_len = read_u64(bytes, 56)?;
+    let block_count = read_u32(bytes, 64)? as usize;
+    let dictionary_id = read_u32(bytes, 68)?;
+    ensure!(dictionary_id == dictionary.id, "HTB1 dictionary mismatch");
+    ensure!(block_count == entry_count.div_ceil(block_entries));
+    ensure!(
+        BLOCK_HEADER_LEN
+            .checked_add(block_count * BLOCK_INDEX_LEN)
+            .is_some_and(|index_end| index_end <= stored_object_len),
+        "truncated HTB1 index"
+    );
+    Ok(BlockHeader {
+        block_entries,
+        tree_id: ContentHash::from_bytes(tree_id),
+        entry_count,
+        raw_payload_len,
+        logical_len,
+        block_count,
+        dictionary_id,
+    })
+}
+
+fn parse_block_index_entry(
+    bytes: &[u8],
+    at: usize,
+    stored_object_len: usize,
+    header: BlockHeader,
+    block: usize,
+) -> Result<BlockIndex> {
+    let entry = BlockIndex {
+        first_entry: usize_from(read_u64(bytes, at)?, "first entry")?,
+        offset: usize_from(read_u64(bytes, at + 8)?, "block offset")?,
+        stored_len: read_u32(bytes, at + 16)? as usize,
+        raw_len: read_u32(bytes, at + 20)? as usize,
+    };
+    ensure!(entry.first_entry == block * header.block_entries);
+    let index_end = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    ensure!(entry.offset >= index_end, "block overlaps index");
+    ensure!(entry.stored_len > 0 && entry.raw_len > 0, "empty block");
+    ensure!(
+        entry
+            .offset
+            .checked_add(entry.stored_len)
+            .is_some_and(|end| end <= stored_object_len),
+        "truncated block payload"
+    );
+    Ok(entry)
+}
+
+fn parse_block_index(bytes: &[u8], header: BlockHeader, block: usize) -> Result<BlockIndex> {
+    ensure!(block < header.block_count, "block index out of bounds");
+    let at = BLOCK_HEADER_LEN + block * BLOCK_INDEX_LEN;
+    parse_block_index_entry(bytes, at, bytes.len(), header, block)
+}
+
+fn decompress_block(
+    bytes: &[u8],
+    index: BlockIndex,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let stored = &bytes[index.offset..index.offset + index.stored_len];
+    decompress_stored_block(stored, index.raw_len, decoder)
+}
+
+fn decompress_stored_block(
+    stored: &[u8],
+    raw_len: usize,
+    decoder: &mut zstd::bulk::Decompressor<'_>,
+) -> Result<Vec<u8>> {
+    let raw = if stored.len() == raw_len {
+        stored.to_vec()
+    } else {
+        let anchor_end = raw_anchor_end(stored)?;
+        ensure!(anchor_end < raw_len, "compressed block has no tail");
+        let mut raw = Vec::with_capacity(raw_len);
+        raw.extend_from_slice(&stored[..anchor_end]);
+        raw.extend_from_slice(&decoder.decompress(&stored[anchor_end..], raw_len - anchor_end)?);
+        raw
+    };
+    ensure!(raw.len() == raw_len, "block decoded length mismatch");
+    Ok(raw)
+}
+
+fn raw_anchor_end(stored: &[u8]) -> Result<usize> {
+    let frame_len = read_u32(stored, 0)? as usize;
+    let end = 4usize
+        .checked_add(frame_len)
+        .context("anchor frame length overflow")?;
+    ensure!(end <= stored.len(), "truncated raw block anchor");
+    Ok(end)
+}
+
+fn decode_entry_frame(frame: &[u8]) -> Result<TreeEntry> {
+    ensure!(frame.len() >= 4, "truncated entry frame");
+    let mode = FileMode::from_byte(frame[0]).context("invalid entry mode")?;
+    let kind = EntryType::from_byte(frame[1]).context("invalid entry kind")?;
+    let name_len = read_u16(frame, 2)? as usize;
+    let name_end = 4usize
+        .checked_add(name_len)
+        .context("name length overflow")?;
+    let name = std::str::from_utf8(frame.get(4..name_end).context("truncated entry name")?)?;
+    let payload = frame.get(name_end..).context("truncated entry payload")?;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            ensure!(payload.len() == 32, "invalid content hash length");
+            let hash = ContentHash::from_bytes(payload.try_into()?);
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let (&format, oid_bytes) = payload.split_first().context("missing gitlink format")?;
+            let format = match format {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid gitlink format"),
+            };
+            TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid_bytes)?)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = read_u16(payload, 0)? as usize;
+            let spool_end = 2usize
+                .checked_add(spool_len)
+                .context("spool length overflow")?;
+            let spool =
+                std::str::from_utf8(payload.get(2..spool_end).context("truncated spool id")?)?;
+            let state: [u8; 32] = payload
+                .get(spool_end..)
+                .context("missing spool state")?
+                .try_into()
+                .context("invalid spool state length")?;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, StateId::from_bytes(state))?
+        }
+    };
+    ensure!(entry.mode() == mode, "entry kind/mode mismatch");
+    Ok(entry)
+}
+
+fn decode_frames(raw: &[u8]) -> Result<(Vec<TreeEntry>, u64)> {
+    let mut entries = Vec::new();
+    let mut logical_len = 0u64;
+    let mut offset = 0usize;
+    while offset < raw.len() {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated entry frame")?;
+        let entry = decode_entry_frame(frame)?;
+        logical_len = logical_len
+            .checked_add(semantic_encoded_len(&entry) as u64)
+            .context("logical length overflow")?;
+        entries.push(entry);
+        offset = end;
+    }
+    ensure!(offset == raw.len());
+    Ok((entries, logical_len))
+}
+
+fn semantic_encoded_len(entry: &TreeEntry) -> usize {
+    let target_len = match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => 32,
+        EntryType::Gitlink => entry
+            .gitlink_target()
+            .expect("decoded gitlink has a target")
+            .as_bytes()
+            .len(),
+        EntryType::Spoollink => {
+            let (spool, state) = entry
+                .spoollink_target()
+                .expect("decoded spoollink has a target");
+            4 + spool.as_str().len() + state.as_bytes().len()
+        }
+    };
+    3 + entry.name().len() + target_len
+}
+
+fn put_varint(mut value: usize, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+fn take_varint(bytes: &[u8], offset: &mut usize) -> Result<usize> {
+    let mut value = 0usize;
+    for shift in (0..usize::BITS).step_by(7) {
+        let byte = *bytes.get(*offset).context("truncated varint")?;
+        *offset += 1;
+        value |= ((byte & 0x7f) as usize)
+            .checked_shl(shift)
+            .context("varint overflow")?;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    bail!("varint overflow")
+}
+
+fn shared_prefix(left: &str, right: &str) -> usize {
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn encode_compact_entry(entry: &TreeEntry, previous_name: &str, out: &mut Vec<u8>) {
+    out.push((entry.mode().to_byte() << 3) | entry.entry_type().to_byte());
+    let prefix = shared_prefix(previous_name, entry.name());
+    put_varint(prefix, out);
+    put_varint(entry.name().len() - prefix, out);
+    out.extend_from_slice(&entry.name().as_bytes()[prefix..]);
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => out.extend_from_slice(
+            entry
+                .content_hash()
+                .expect("content-addressed compact entry")
+                .as_bytes(),
+        ),
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().expect("compact gitlink target");
+            out.push(match target.format() {
+                GitObjectFormat::Sha1 => 1,
+                GitObjectFormat::Sha256 => 2,
+            });
+            out.extend_from_slice(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().expect("compact spoollink target");
+            put_varint(spool.as_str().len(), out);
+            out.extend_from_slice(spool.as_str().as_bytes());
+            out.extend_from_slice(state.as_bytes());
+        }
+    }
+}
+
+fn decode_compact_entry(
+    bytes: &[u8],
+    offset: &mut usize,
+    previous_name: &str,
+) -> Result<TreeEntry> {
+    let tag = *bytes.get(*offset).context("truncated compact entry tag")?;
+    *offset += 1;
+    let mode = FileMode::from_byte(tag >> 3).context("invalid compact entry mode")?;
+    let kind = EntryType::from_byte(tag & 0x07).context("invalid compact entry kind")?;
+    let prefix = take_varint(bytes, offset)?;
+    let suffix_len = take_varint(bytes, offset)?;
+    ensure!(
+        prefix <= previous_name.len(),
+        "compact name prefix exceeds predecessor"
+    );
+    let suffix_end = offset
+        .checked_add(suffix_len)
+        .context("compact name length overflow")?;
+    let suffix = bytes
+        .get(*offset..suffix_end)
+        .context("truncated compact name suffix")?;
+    let mut name = previous_name.as_bytes()[..prefix].to_vec();
+    name.extend_from_slice(suffix);
+    let name = String::from_utf8(name)?;
+    *offset = suffix_end;
+    let entry = match kind {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            let end = offset.checked_add(32).context("compact hash overflow")?;
+            let hash = ContentHash::from_bytes(
+                bytes
+                    .get(*offset..end)
+                    .context("truncated compact content hash")?
+                    .try_into()?,
+            );
+            *offset = end;
+            match kind {
+                EntryType::Blob => TreeEntry::file(name, hash, mode == FileMode::Executable)?,
+                EntryType::Tree => TreeEntry::directory(name, hash)?,
+                EntryType::Symlink => TreeEntry::symlink(name, hash)?,
+                _ => unreachable!(),
+            }
+        }
+        EntryType::Gitlink => {
+            let format = match *bytes
+                .get(*offset)
+                .context("missing compact gitlink format")?
+            {
+                1 => GitObjectFormat::Sha1,
+                2 => GitObjectFormat::Sha256,
+                _ => bail!("invalid compact gitlink format"),
+            };
+            *offset += 1;
+            let oid_len = match format {
+                GitObjectFormat::Sha1 => 20,
+                GitObjectFormat::Sha256 => 32,
+            };
+            let end = offset
+                .checked_add(oid_len)
+                .context("compact gitlink length overflow")?;
+            let target = GitObjectId::from_raw(
+                format,
+                bytes
+                    .get(*offset..end)
+                    .context("truncated compact gitlink")?,
+            )?;
+            *offset = end;
+            TreeEntry::gitlink(name, target)?
+        }
+        EntryType::Spoollink => {
+            let spool_len = take_varint(bytes, offset)?;
+            let spool_end = offset
+                .checked_add(spool_len)
+                .context("compact spool length overflow")?;
+            let spool = std::str::from_utf8(
+                bytes
+                    .get(*offset..spool_end)
+                    .context("truncated compact spool id")?,
+            )?;
+            *offset = spool_end;
+            let state_end = offset.checked_add(32).context("compact state overflow")?;
+            let state = StateId::from_bytes(
+                bytes
+                    .get(*offset..state_end)
+                    .context("truncated compact spool state")?
+                    .try_into()?,
+            );
+            *offset = state_end;
+            TreeEntry::spoollink(name, SpoolId::parse(spool)?, state)?
+        }
+    };
+    ensure!(entry.mode() == mode, "compact entry kind/mode mismatch");
+    Ok(entry)
+}
+
+fn encode_lean(tree: &Tree) -> Vec<u8> {
+    encode_lean_entries(tree.entries())
+}
+
+fn encode_lean_prefix(tree: &Tree, count: usize) -> Vec<u8> {
+    encode_lean_entries(&tree.entries()[..count.min(tree.len())])
+}
+
+fn encode_lean_entries(entries: &[TreeEntry]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(LEAN_MAGIC);
+    put_varint(entries.len(), &mut out);
+    let mut previous = "";
+    for entry in entries {
+        encode_compact_entry(entry, previous, &mut out);
+        previous = entry.name();
+    }
+    out
+}
+
+fn decode_lean(bytes: &[u8], expected: ContentHash) -> Result<Tree> {
+    ensure!(bytes.starts_with(LEAN_MAGIC), "not a lean tree anchor");
+    let mut offset = LEAN_MAGIC.len();
+    let count = take_varint(bytes, &mut offset)?;
+    let mut entries = Vec::with_capacity(count);
+    let mut previous = String::new();
+    for _ in 0..count {
+        let entry = decode_compact_entry(bytes, &mut offset, &previous)?;
+        previous = entry.name().to_string();
+        entries.push(entry);
+    }
+    ensure!(offset == bytes.len(), "trailing lean tree bytes");
+    let tree = Tree::try_from_decoded_entries(entries)?;
+    ensure!(tree.hash() == expected, "lean tree hash mismatch");
+    Ok(tree)
+}
+
+#[derive(Clone, Debug)]
+enum DeltaOp {
+    Remove(String),
+    Upsert(TreeEntry),
+}
+
+impl DeltaOp {
+    fn name(&self) -> &str {
+        match self {
+            Self::Remove(name) => name,
+            Self::Upsert(entry) => entry.name(),
+        }
+    }
+}
+
+fn tree_delta(anchor: &Tree, current: &Tree) -> Vec<DeltaOp> {
+    let mut ops = Vec::new();
+    let mut anchor_index = 0usize;
+    let mut current_index = 0usize;
+    while anchor_index < anchor.len() || current_index < current.len() {
+        match (
+            anchor.entries().get(anchor_index),
+            current.entries().get(current_index),
+        ) {
+            (Some(anchor_entry), Some(current_entry)) => {
+                match anchor_entry.name().cmp(current_entry.name()) {
+                    std::cmp::Ordering::Less => {
+                        ops.push(DeltaOp::Remove(anchor_entry.name().to_string()));
+                        anchor_index += 1;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        ops.push(DeltaOp::Upsert(current_entry.clone()));
+                        current_index += 1;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if anchor_entry != current_entry {
+                            ops.push(DeltaOp::Upsert(current_entry.clone()));
+                        }
+                        anchor_index += 1;
+                        current_index += 1;
+                    }
+                }
+            }
+            (Some(anchor_entry), None) => {
+                ops.push(DeltaOp::Remove(anchor_entry.name().to_string()));
+                anchor_index += 1;
+            }
+            (None, Some(current_entry)) => {
+                ops.push(DeltaOp::Upsert(current_entry.clone()));
+                current_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    ops
+}
+
+fn apply_delta(anchor: &Tree, ops: &[DeltaOp]) -> Result<Tree> {
+    let mut entries = Vec::with_capacity(anchor.len() + ops.len());
+    let mut anchor_index = 0usize;
+    let mut op_index = 0usize;
+    while anchor_index < anchor.len() || op_index < ops.len() {
+        match (anchor.entries().get(anchor_index), ops.get(op_index)) {
+            (Some(anchor_entry), Some(op)) => match anchor_entry.name().cmp(op.name()) {
+                std::cmp::Ordering::Less => {
+                    entries.push(anchor_entry.clone());
+                    anchor_index += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    if let DeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    op_index += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    if let DeltaOp::Upsert(entry) = op {
+                        entries.push(entry.clone());
+                    }
+                    anchor_index += 1;
+                    op_index += 1;
+                }
+            },
+            (Some(anchor_entry), None) => {
+                entries.push(anchor_entry.clone());
+                anchor_index += 1;
+            }
+            (None, Some(op)) => {
+                if let DeltaOp::Upsert(entry) = op {
+                    entries.push(entry.clone());
+                }
+                op_index += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    Ok(Tree::try_from_decoded_entries(entries)?)
+}
+
+fn delta_prefix_counts(anchor: &Tree, current: &Tree, ops: &[DeltaOp], count: usize) -> (u16, u16) {
+    if current.is_empty() {
+        return (0, 0);
+    }
+    let boundary = current.entries()[count.min(current.len()) - 1].name();
+    let op_count = ops.partition_point(|op| op.name() <= boundary);
+    let base_count = anchor
+        .entries()
+        .partition_point(|entry| entry.name() <= boundary);
+    (
+        u16::try_from(op_count).expect("radical op bound fits u16"),
+        u16::try_from(base_count).expect("prefix base count fits u16"),
+    )
+}
+
+fn encode_delta(anchor_id: ContentHash, anchor: &Tree, current: &Tree, ops: &[DeltaOp]) -> Vec<u8> {
+    let (first_ops, first_base) = delta_prefix_counts(anchor, current, ops, 1);
+    let (hundred_ops, hundred_base) = delta_prefix_counts(anchor, current, ops, 100);
+    let mut body = Vec::new();
+    let mut ends = Vec::with_capacity(ops.len());
+    let mut previous = "";
+    for op in ops {
+        match op {
+            DeltaOp::Remove(name) => {
+                body.push(0);
+                let prefix = shared_prefix(previous, name);
+                put_varint(prefix, &mut body);
+                put_varint(name.len() - prefix, &mut body);
+                body.extend_from_slice(&name.as_bytes()[prefix..]);
+            }
+            DeltaOp::Upsert(entry) => {
+                body.push(1);
+                encode_compact_entry(entry, previous, &mut body);
+            }
+        }
+        previous = op.name();
+        ends.push(body.len());
+    }
+    let end_for = |count: u16| {
+        if count == 0 {
+            RADICAL_HEADER_LEN
+        } else {
+            RADICAL_HEADER_LEN + ends[count as usize - 1]
+        }
+    };
+    let mut out = Vec::with_capacity(RADICAL_HEADER_LEN + body.len());
+    out.extend_from_slice(RADICAL_MAGIC);
+    out.push(1);
+    out.extend_from_slice(anchor_id.as_bytes());
+    out.extend_from_slice(&(current.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(ops.len() as u16).to_le_bytes());
+    out.extend_from_slice(&first_ops.to_le_bytes());
+    out.extend_from_slice(&first_base.to_le_bytes());
+    out.extend_from_slice(&(end_for(first_ops) as u32).to_le_bytes());
+    out.extend_from_slice(&hundred_ops.to_le_bytes());
+    out.extend_from_slice(&hundred_base.to_le_bytes());
+    out.extend_from_slice(&(end_for(hundred_ops) as u32).to_le_bytes());
+    debug_assert_eq!(out.len(), RADICAL_HEADER_LEN);
+    out.extend_from_slice(&body);
+    out
+}
+
+fn decode_delta_ops(
+    bytes: &[u8],
+    wanted: usize,
+) -> Result<(ContentHash, usize, Vec<DeltaOp>, usize)> {
+    ensure!(
+        bytes.len() >= RADICAL_HEADER_LEN,
+        "truncated radical delta header"
+    );
+    ensure!(bytes.starts_with(RADICAL_MAGIC), "not a radical tree delta");
+    ensure!(bytes[4] == 1, "unsupported radical delta version");
+    let anchor = ContentHash::from_bytes(bytes[5..37].try_into()?);
+    let result_count = read_u32(bytes, 37)? as usize;
+    let op_count = read_u16(bytes, 41)? as usize;
+    ensure!(wanted <= op_count, "partial delta op count exceeds object");
+    let mut offset = RADICAL_HEADER_LEN;
+    let mut previous = String::new();
+    let mut ops = Vec::with_capacity(wanted);
+    for _ in 0..wanted {
+        let opcode = *bytes.get(offset).context("truncated radical delta op")?;
+        offset += 1;
+        let op = match opcode {
+            0 => {
+                let prefix = take_varint(bytes, &mut offset)?;
+                let suffix_len = take_varint(bytes, &mut offset)?;
+                ensure!(
+                    prefix <= previous.len(),
+                    "delta name prefix exceeds predecessor"
+                );
+                let end = offset
+                    .checked_add(suffix_len)
+                    .context("delta name overflow")?;
+                let mut name = previous.as_bytes()[..prefix].to_vec();
+                name.extend_from_slice(bytes.get(offset..end).context("truncated delta name")?);
+                offset = end;
+                DeltaOp::Remove(String::from_utf8(name)?)
+            }
+            1 => DeltaOp::Upsert(decode_compact_entry(bytes, &mut offset, &previous)?),
+            _ => bail!("invalid radical delta opcode"),
+        };
+        previous = op.name().to_string();
+        ops.push(op);
+    }
+    Ok((anchor, result_count, ops, offset))
+}
+
+fn decode_delta(bytes: &[u8], anchor: &Tree, expected: ContentHash) -> Result<Tree> {
+    let op_count = read_u16(bytes, 41)? as usize;
+    let (anchor_id, result_count, ops, consumed) = decode_delta_ops(bytes, op_count)?;
+    ensure!(consumed == bytes.len(), "trailing radical delta bytes");
+    ensure!(anchor.hash() == anchor_id, "radical delta anchor mismatch");
+    let tree = apply_delta(anchor, &ops)?;
+    ensure!(
+        tree.len() == result_count,
+        "radical delta entry count mismatch"
+    );
+    ensure!(tree.hash() == expected, "radical delta tree hash mismatch");
+    Ok(tree)
+}
+
+fn block_decoder(dictionary: Dictionary<'_>) -> Result<zstd::bulk::Decompressor<'_>> {
+    if let Some(prepared) = dictionary.decoder {
+        Ok(zstd::bulk::Decompressor::with_prepared_dictionary(
+            prepared,
+        )?)
+    } else {
+        Ok(zstd::bulk::Decompressor::new()?)
+    }
+}
+
+fn decode_blocked(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    let header = parse_block_header(bytes, dictionary)?;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut entries = Vec::with_capacity(header.entry_count);
+    let mut raw_payload_len = 0usize;
+    let mut logical_len = 0u64;
+    let mut expected_offset = BLOCK_HEADER_LEN + header.block_count * BLOCK_INDEX_LEN;
+    for block in 0..header.block_count {
+        let index = parse_block_index(bytes, header, block)?;
+        ensure!(
+            index.offset == expected_offset,
+            "non-contiguous block payload"
+        );
+        expected_offset += index.stored_len;
+        let raw = decompress_block(bytes, index, &mut decoder)?;
+        raw_payload_len += raw.len();
+        let (mut decoded, block_logical_len) = decode_frames(&raw)?;
+        let expected_entries = header
+            .block_entries
+            .min(header.entry_count - block * header.block_entries);
+        ensure!(
+            decoded.len() == expected_entries,
+            "block entry count mismatch"
+        );
+        logical_len += block_logical_len;
+        entries.append(&mut decoded);
+    }
+    ensure!(expected_offset == bytes.len(), "trailing HTB1 bytes");
+    ensure!(raw_payload_len == header.raw_payload_len);
+    ensure!(logical_len == header.logical_len);
+    ensure!(entries.len() == header.entry_count);
+    let tree = Tree::try_from_decoded_entries(entries)?;
+    ensure!(tree.hash() == header.tree_id, "HTB1 tree hash mismatch");
+    black_box(header.dictionary_id);
+    Ok(tree)
+}
+
+fn decode_adaptive(bytes: &[u8], dictionary: Dictionary<'_>) -> Result<Tree> {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        decode_blocked(bytes, dictionary)
+    } else {
+        Ok(Tree::decode_canonical(bytes)?)
+    }
+}
+
+struct PartialRead {
+    entries: Vec<TreeEntry>,
+    bytes_read: usize,
+}
+
+fn partial_blocked(
+    bytes: &[u8],
+    dictionary: Dictionary<'_>,
+    first: usize,
+    count: usize,
+) -> Result<PartialRead> {
+    let header = parse_block_header(bytes, dictionary)?;
+    ensure!(count > 0 && first + count <= header.entry_count);
+    let first_block = first / header.block_entries;
+    let last_block = (first + count - 1) / header.block_entries;
+    let mut decoder = block_decoder(dictionary)?;
+    let mut selected = Vec::with_capacity(count);
+    let mut bytes_read = BLOCK_HEADER_LEN;
+    for block in first_block..=last_block {
+        let index = parse_block_index(bytes, header, block)?;
+        bytes_read += BLOCK_INDEX_LEN;
+        let stored = &bytes[index.offset..index.offset + index.stored_len];
+        let wanted_start = first.saturating_sub(index.first_entry);
+        let wanted_end = (first + count - index.first_entry)
+            .min(header.block_entries)
+            .min(header.entry_count - index.first_entry);
+        let only_anchor = wanted_start == 0 && wanted_end == 1;
+        let raw = if index.stored_len == index.raw_len {
+            let (entries, consumed) = decode_frame_range(stored, wanted_start, wanted_end)?;
+            bytes_read += consumed;
+            selected.extend(entries);
+            continue;
+        } else if only_anchor {
+            let anchor_end = raw_anchor_end(stored)?;
+            bytes_read += anchor_end;
+            let (entries, consumed) = decode_frame_range(stored, 0, 1)?;
+            ensure!(consumed == anchor_end);
+            selected.extend(entries);
+            continue;
+        } else {
+            bytes_read += index.stored_len;
+            decompress_block(bytes, index, &mut decoder)?
+        };
+        let (entries, _) = decode_frame_range(&raw, wanted_start, wanted_end)?;
+        selected.extend(entries);
+    }
+    ensure!(selected.len() == count);
+    Ok(PartialRead {
+        entries: selected,
+        bytes_read,
+    })
+}
+
+fn decode_frame_range(
+    raw: &[u8],
+    wanted_start: usize,
+    wanted_end: usize,
+) -> Result<(Vec<TreeEntry>, usize)> {
+    ensure!(wanted_start < wanted_end, "empty frame range");
+    let mut entries = Vec::with_capacity(wanted_end - wanted_start);
+    let mut offset = 0usize;
+    for ordinal in 0..wanted_end {
+        let frame_len = read_u32(raw, offset)? as usize;
+        let start = offset.checked_add(4).context("frame start overflow")?;
+        let end = start.checked_add(frame_len).context("frame end overflow")?;
+        let frame = raw.get(start..end).context("truncated ranged frame")?;
+        if ordinal >= wanted_start {
+            entries.push(decode_entry_frame(frame)?);
+        }
+        offset = end;
+    }
+    Ok((entries, offset))
+}
+
+fn partial_htr4(bytes: &Bytes, tree_id: ContentHash, count: usize) -> PartialRead {
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree_id,
+        None,
+    )
+    .expect("open HTR4 reader");
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX).expect("page limits"))
+        .expect("decode partial HTR4 page")
+        .expect("nonempty page");
+    let bytes_read = reader.bytes_read() as usize;
+    PartialRead {
+        entries: page.entries,
+        bytes_read,
+    }
+}
+
+fn partial_adaptive(
+    bytes: &Bytes,
+    dictionary: Dictionary<'_>,
+    tree_id: ContentHash,
+    count: usize,
+) -> PartialRead {
+    if bytes.starts_with(BLOCK_MAGIC) {
+        partial_blocked(bytes, dictionary, 0, count).expect("partial HTB1")
+    } else {
+        partial_htr4(bytes, tree_id, count)
+    }
+}
+
+fn partial_whole_zstd(compressed: &[u8], tree_id: ContentHash, count: usize) -> PartialRead {
+    let htr4 = Bytes::from(zstd::decode_all(compressed).expect("decompress whole HTR4"));
+    let mut read = partial_htr4(&htr4, tree_id, count);
+    read.bytes_read = compressed.len();
+    read
+}
+
+fn partial_production_file(path: &Path, tree_id: ContentHash, count: usize) -> Result<PartialRead> {
+    let file = File::open(path)?;
+    let len = file.metadata()?.len();
+    let mut reader =
+        TreeEntryReader::open(FileTreeSource::sequential_verify(file, len), tree_id, None)?;
+    let page = reader
+        .next_page(TreePageLimits::new(count, usize::MAX)?)?
+        .context("nonempty production tree page")?;
+    Ok(PartialRead {
+        entries: page.entries,
+        bytes_read: reader.bytes_read() as usize,
+    })
+}
+
+fn partial_lean_bytes(bytes: &[u8], count: usize) -> Result<PartialRead> {
+    ensure!(bytes.starts_with(LEAN_MAGIC), "not a lean tree anchor");
+    let mut offset = LEAN_MAGIC.len();
+    let entries = take_varint(bytes, &mut offset)?;
+    let wanted = count.min(entries);
+    let mut decoded = Vec::with_capacity(wanted);
+    let mut previous = String::new();
+    for _ in 0..wanted {
+        let entry = decode_compact_entry(bytes, &mut offset, &previous)?;
+        previous = entry.name().to_string();
+        decoded.push(entry);
+    }
+    Ok(PartialRead {
+        entries: decoded,
+        bytes_read: offset,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RadicalMode {
+    LeanAnchor,
+    Htr4Anchor,
+    Delta,
+}
+
+#[derive(Clone, Debug)]
+struct RadicalPlan {
+    mode: RadicalMode,
+    anchor: usize,
+    epoch_depth: usize,
+    settled_len: usize,
+    hot_len: usize,
+    op_count: usize,
+}
+
+struct RadicalCorpus {
+    plans: Vec<RadicalPlan>,
+    lean_total: usize,
+    settled_total: usize,
+    hot_total: usize,
+    bases: usize,
+    deltas: usize,
+    parent_coverage: usize,
+    max_ops: usize,
+}
+
+fn build_radical_corpus(corpus: &RealCorpus) -> Result<RadicalCorpus> {
+    let config = CompressionConfig::default();
+    let indexes = corpus
+        .tree_ids
+        .iter()
+        .enumerate()
+        .map(|(index, oid)| (oid.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let parent_indexes = corpus
+        .tree_ids
+        .iter()
+        .map(|oid| {
+            corpus
+                .parent_tree_ids
+                .get(oid)
+                .and_then(|parent| indexes.get(parent.as_str()).copied())
+        })
+        .collect::<Vec<_>>();
+    let parent_coverage = parent_indexes
+        .iter()
+        .filter(|parent| parent.is_some())
+        .count();
+    let tree_hashes = corpus.trees.iter().map(Tree::hash).collect::<Vec<_>>();
+    let mut lean_sizes = Vec::with_capacity(corpus.trees.len());
+    let mut adaptive_sizes = Vec::with_capacity(corpus.trees.len());
+    let mut lean_total = 0usize;
+    for tree in &corpus.trees {
+        let lean = encode_lean(tree);
+        let adaptive = objects::store::codec::encode_tree_at_rest(tree, &config)?;
+        lean_total += lean.len();
+        lean_sizes.push(lean.len());
+        adaptive_sizes.push(adaptive.len());
+    }
+    let mut plans: Vec<Option<RadicalPlan>> = vec![None; corpus.trees.len()];
+    for start in 0..corpus.trees.len() {
+        if plans[start].is_some() {
+            continue;
+        }
+        let mut chain = Vec::new();
+        let mut cursor = start;
+        let mut seen = HashSet::new();
+        while plans[cursor].is_none() && seen.insert(cursor) {
+            chain.push(cursor);
+            let Some(parent) = parent_indexes[cursor] else {
+                break;
+            };
+            cursor = parent;
+        }
+        while let Some(index) = chain.pop() {
+            let lean_len = lean_sizes[index];
+            let htr4_with_porch = adaptive_sizes[index]
+                .checked_add(encode_lean_prefix(&corpus.trees[index], 100).len())
+                .context("radical anchor size overflow")?;
+            let (base_mode, base_len) = if lean_len <= htr4_with_porch {
+                (RadicalMode::LeanAnchor, lean_len)
+            } else {
+                (RadicalMode::Htr4Anchor, htr4_with_porch)
+            };
+            let mut plan = RadicalPlan {
+                mode: base_mode,
+                anchor: index,
+                epoch_depth: 0,
+                settled_len: base_len,
+                hot_len: lean_len,
+                op_count: 0,
+            };
+            if let Some(parent) = parent_indexes[index]
+                && let Some(parent_plan) = plans[parent].as_ref()
+                && parent_plan.epoch_depth + 1 < RADICAL_ANCHOR_INTERVAL
+            {
+                let anchor = parent_plan.anchor;
+                let ops = tree_delta(&corpus.trees[anchor], &corpus.trees[index]);
+                if ops.len() <= RADICAL_MAX_OPS {
+                    let encoded = encode_delta(
+                        tree_hashes[anchor],
+                        &corpus.trees[anchor],
+                        &corpus.trees[index],
+                        &ops,
+                    );
+                    let prefix_is_bounded =
+                        read_u16(&encoded, 45)? <= 1 && read_u16(&encoded, 53)? <= 100;
+                    if prefix_is_bounded && encoded.len() < base_len {
+                        plan = RadicalPlan {
+                            mode: RadicalMode::Delta,
+                            anchor,
+                            epoch_depth: parent_plan.epoch_depth + 1,
+                            settled_len: encoded.len(),
+                            hot_len: encoded.len(),
+                            op_count: ops.len(),
+                        };
+                    }
+                }
+            }
+            plans[index] = Some(plan);
+        }
+    }
+    let plans = plans
+        .into_iter()
+        .enumerate()
+        .map(|(index, plan)| plan.with_context(|| format!("unplanned tree {index}")))
+        .collect::<Result<Vec<_>>>()?;
+    let settled_total = plans.iter().map(|plan| plan.settled_len).sum();
+    let hot_total = plans.iter().map(|plan| plan.hot_len).sum();
+    let bases = plans
+        .iter()
+        .filter(|plan| plan.mode != RadicalMode::Delta)
+        .count();
+    let deltas = plans.len() - bases;
+    let max_ops = plans.iter().map(|plan| plan.op_count).max().unwrap_or(0);
+    Ok(RadicalCorpus {
+        plans,
+        lean_total,
+        settled_total,
+        hot_total,
+        bases,
+        deltas,
+        parent_coverage,
+        max_ops,
+    })
+}
+
+struct RadicalFileFixture {
+    raw: NamedTempFile,
+    delta: NamedTempFile,
+    anchor: NamedTempFile,
+    anchor_lean: bool,
+    anchor_id: ContentHash,
+    expected: ContentHash,
+    entries: usize,
+}
+
+fn radical_file_fixture(
+    corpus: &RealCorpus,
+    radical: &RadicalCorpus,
+    index: usize,
+) -> Result<RadicalFileFixture> {
+    let plan = &radical.plans[index];
+    ensure!(
+        plan.mode == RadicalMode::Delta,
+        "radical fixture must be a delta"
+    );
+    let anchor_plan = &radical.plans[plan.anchor];
+    ensure!(
+        anchor_plan.mode != RadicalMode::Delta,
+        "radical anchor must be materialized"
+    );
+    let anchor_tree = &corpus.trees[plan.anchor];
+    let current = &corpus.trees[index];
+    let ops = tree_delta(anchor_tree, current);
+    let delta = encode_delta(anchor_tree.hash(), anchor_tree, current, &ops);
+    let (anchor_lean, anchor) = if anchor_plan.mode == RadicalMode::LeanAnchor {
+        (true, encode_lean(anchor_tree))
+    } else {
+        (true, encode_lean_prefix(anchor_tree, 100))
+    };
+    ensure!(decode_delta(&delta, anchor_tree, current.hash())? == *current);
+    Ok(RadicalFileFixture {
+        raw: write_temp(&current.encode_canonical()?)?,
+        delta: write_temp(&delta)?,
+        anchor: write_temp(&anchor)?,
+        anchor_lean,
+        anchor_id: anchor_tree.hash(),
+        expected: current.hash(),
+        entries: current.len(),
+    })
+}
+
+fn measure_radical_partial(
+    fixtures: &[&RadicalFileFixture],
+    count: usize,
+) -> Result<(Timing, Timing, f64, f64)> {
+    ensure!(
+        !fixtures.is_empty(),
+        "no radical fixtures for {count}-entry read"
+    );
+    let mut raw_index = 0usize;
+    let raw_timing = measure(|| {
+        let fixture = &fixtures[raw_index % fixtures.len()];
+        raw_index += 1;
+        let read = partial_production_file(fixture.raw.path(), fixture.expected, count)
+            .expect("file-backed raw radical comparison");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut radical_index = 0usize;
+    let radical_timing = measure(|| {
+        let fixture = &fixtures[radical_index % fixtures.len()];
+        radical_index += 1;
+        let read = partial_radical_file(fixture, count).expect("file-backed radical partial");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut raw_bytes = 0usize;
+    let mut radical_bytes = 0usize;
+    for fixture in fixtures {
+        let raw = partial_production_file(fixture.raw.path(), fixture.expected, count)?;
+        let radical = partial_radical_file(fixture, count)?;
+        ensure!(
+            raw.entries == radical.entries,
+            "radical file partial mismatch"
+        );
+        raw_bytes += raw.bytes_read;
+        radical_bytes += radical.bytes_read;
+    }
+    Ok((
+        raw_timing,
+        radical_timing,
+        raw_bytes as f64 / fixtures.len() as f64,
+        radical_bytes as f64 / fixtures.len() as f64,
+    ))
+}
+
+fn partial_radical_file(fixture: &RadicalFileFixture, count: usize) -> Result<PartialRead> {
+    let mut delta_file = File::open(fixture.delta.path())?;
+    let mut header = [0u8; RADICAL_HEADER_LEN];
+    delta_file.read_exact(&mut header)?;
+    let (op_count, base_count, end) = if count == 1 {
+        (
+            read_u16(&header, 43)? as usize,
+            read_u16(&header, 45)? as usize,
+            read_u32(&header, 47)? as usize,
+        )
+    } else {
+        (
+            read_u16(&header, 51)? as usize,
+            read_u16(&header, 53)? as usize,
+            read_u32(&header, 55)? as usize,
+        )
+    };
+    ensure!(end >= RADICAL_HEADER_LEN, "invalid radical partial end");
+    let mut prefix = Vec::with_capacity(end);
+    prefix.extend_from_slice(&header);
+    prefix.resize(end, 0);
+    delta_file.read_exact(&mut prefix[RADICAL_HEADER_LEN..])?;
+    let (anchor_id, result_count, ops, consumed) = decode_delta_ops(&prefix, op_count)?;
+    ensure!(consumed == end, "radical partial index mismatch");
+    ensure!(
+        anchor_id == fixture.anchor_id,
+        "radical partial anchor mismatch"
+    );
+    let base = if base_count == 0 {
+        PartialRead {
+            entries: Vec::new(),
+            bytes_read: 0,
+        }
+    } else if fixture.anchor_lean {
+        let bytes = std::fs::read(fixture.anchor.path())?;
+        partial_lean_bytes(&bytes, base_count)?
+    } else {
+        partial_production_file(fixture.anchor.path(), fixture.anchor_id, base_count)?
+    };
+    let tree = apply_delta(&Tree::from_entries(base.entries), &ops)?;
+    let wanted = count.min(result_count);
+    ensure!(
+        tree.len() >= wanted,
+        "radical partial reconstruction is short"
+    );
+    let entries = tree.entries()[..wanted].to_vec();
+    if wanted == result_count {
+        ensure!(Tree::from_entries(entries.clone()).hash() == fixture.expected);
+    }
+    Ok(PartialRead {
+        entries,
+        bytes_read: end + base.bytes_read,
+    })
+}
+
+struct RealCorpus {
+    label: String,
+    path: PathBuf,
+    object_format: GitObjectFormat,
+    discovered_trees: usize,
+    skipped_trees: usize,
+    tree_ids: Vec<String>,
+    trees: Vec<Tree>,
+    parent_tree_ids: HashMap<String, String>,
+    git_loose_bytes: usize,
+    git_packed_bytes: usize,
+    git_pack_files: usize,
+}
+
+fn git_output(repo: &Path, arguments: &[&str]) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(arguments)
+        .output()
+        .with_context(|| format!("run git in {}", repo.display()))?;
+    ensure!(
+        output.status.success(),
+        "git {} failed in {}: {}",
+        arguments.join(" "),
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(output.stdout)
+}
+
+fn real_object_format(repo: &Path) -> Result<GitObjectFormat> {
+    let output = git_output(repo, &["rev-parse", "--show-object-format"])?;
+    match std::str::from_utf8(&output)?.trim() {
+        "sha1" => Ok(GitObjectFormat::Sha1),
+        "sha256" => Ok(GitObjectFormat::Sha256),
+        format => bail!("unsupported Git object format {format}"),
+    }
+}
+
+fn sample_evenly<T: Clone>(values: &[T], limit: usize) -> Vec<T> {
+    if values.len() <= limit {
+        return values.to_vec();
+    }
+    if limit == 1 {
+        return vec![values[values.len() / 2].clone()];
+    }
+    (0..limit)
+        .map(|index| values[index * (values.len() - 1) / (limit - 1)].clone())
+        .collect()
+}
+
+fn discover_tree_ids(repo: &Path, limit: usize) -> Result<(usize, Vec<String>)> {
+    let output = git_output(
+        repo,
+        &[
+            "cat-file",
+            "--batch-all-objects",
+            "--batch-check=%(objectname) %(objecttype)",
+        ],
+    )?;
+    let mut tree_ids = BTreeSet::new();
+    for line in output.split(|byte| *byte == b'\n') {
+        let mut fields = line.split(|byte| *byte == b' ');
+        let Some(oid) = fields.next() else {
+            continue;
+        };
+        if fields.next() == Some(b"tree") {
+            tree_ids.insert(std::str::from_utf8(oid)?.to_string());
+        }
+    }
+    let discovered = tree_ids.len();
+    let tree_ids = if limit == 0 {
+        tree_ids.into_iter().collect()
+    } else {
+        sample_evenly(&tree_ids.into_iter().collect::<Vec<_>>(), limit)
+    };
+    Ok((discovered, tree_ids))
+}
+
+fn discover_parent_tree_ids(repo: &Path, selected: &[String]) -> Result<HashMap<String, String>> {
+    let wanted = selected.iter().map(String::as_str).collect::<HashSet<_>>();
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "log",
+            "--all",
+            "--topo-order",
+            "--reverse",
+            "--raw",
+            "-r",
+            "-t",
+            "--root",
+            "--no-abbrev",
+            "--diff-merges=first-parent",
+            "--format=COMMIT %H %T %P",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("walk Git tree history in {}", repo.display()))?;
+    let stdout = child.stdout.take().context("Git log stdout")?;
+    let mut roots = HashMap::<String, String>::new();
+    let mut parents = HashMap::new();
+    for line in BufReader::new(stdout).lines() {
+        let line = line?;
+        if let Some(rest) = line.strip_prefix("COMMIT ") {
+            let fields = rest.split_ascii_whitespace().collect::<Vec<_>>();
+            ensure!(fields.len() >= 2, "malformed Git commit/tree record");
+            let commit = fields[0];
+            let root = fields[1];
+            if let Some(parent_commit) = fields.get(2)
+                && let Some(parent_root) = roots.get(*parent_commit)
+                && wanted.contains(root)
+                && root != parent_root
+            {
+                parents
+                    .entry(root.to_string())
+                    .or_insert_with(|| parent_root.clone());
+            }
+            roots.insert(commit.to_string(), root.to_string());
+            continue;
+        }
+        if !line.starts_with(':') {
+            continue;
+        }
+        let fields = line.split_ascii_whitespace().collect::<Vec<_>>();
+        if fields.len() < 5 || fields[0] != ":040000" || fields[1] != "040000" {
+            continue;
+        }
+        let old = fields[2];
+        let new = fields[3];
+        if wanted.contains(new) && old != new && !old.bytes().all(|byte| byte == b'0') {
+            parents
+                .entry(new.to_string())
+                .or_insert_with(|| old.to_string());
+        }
+    }
+    let output = child.wait_with_output()?;
+    ensure!(
+        output.status.success(),
+        "git log tree-history walk failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(parents)
+}
+
+fn git_loose_sizes(repo: &Path, tree_ids: &[String]) -> Result<usize> {
+    let temp = TempDir::new()?;
+    let object_dir = temp.path().join("objects");
+    std::fs::create_dir(&object_dir)?;
+    let mut pack = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "pack-objects",
+            "--stdout",
+            "--compression=1",
+            "--no-reuse-delta",
+            "--no-reuse-object",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let pack_stdout = pack.stdout.take().context("Git pack-objects stdout")?;
+    let unpack = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["unpack-objects", "-r"])
+        .env("GIT_OBJECT_DIRECTORY", &object_dir)
+        .stdin(Stdio::from(pack_stdout))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut requests = BufWriter::new(pack.stdin.take().context("Git pack-objects stdin")?);
+    for oid in tree_ids {
+        writeln!(requests, "{oid}")?;
+    }
+    drop(requests);
+    let unpack_output = unpack.wait_with_output()?;
+    let pack_output = pack.wait_with_output()?;
+    ensure!(
+        pack_output.status.success(),
+        "git pack-objects failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&pack_output.stderr)
+    );
+    ensure!(
+        unpack_output.status.success(),
+        "git unpack-objects failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&unpack_output.stderr)
+    );
+
+    let mut total = 0usize;
+    for oid in tree_ids {
+        ensure!(oid.len() > 2, "invalid Git object id {oid}");
+        let path = object_dir.join(&oid[..2]).join(&oid[2..]);
+        total = total
+            .checked_add(usize_from(
+                std::fs::metadata(&path)?.len(),
+                "Git loose size",
+            )?)
+            .context("Git loose total overflow")?;
+    }
+    Ok(total)
+}
+
+fn git_packed_sizes(repo: &Path, tree_ids: &[String]) -> Result<(usize, usize)> {
+    let git_dir = PathBuf::from(
+        std::str::from_utf8(&git_output(repo, &["rev-parse", "--absolute-git-dir"])?)?.trim(),
+    );
+    let pack_dir = git_dir.join("objects/pack");
+    let mut indexes = std::fs::read_dir(&pack_dir)
+        .with_context(|| format!("read Git pack directory {}", pack_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|extension| extension == "idx"))
+        .collect::<Vec<_>>();
+    indexes.sort();
+    ensure!(
+        !indexes.is_empty(),
+        "{} has no pack indexes; run `git -C {} gc --prune=now` first",
+        repo.display(),
+        repo.display()
+    );
+
+    let wanted = tree_ids.iter().map(String::as_str).collect::<HashSet<_>>();
+    let mut sizes = HashMap::with_capacity(wanted.len());
+    for index in &indexes {
+        let output = Command::new("git")
+            .args(["verify-pack", "-v"])
+            .arg(index)
+            .output()
+            .with_context(|| format!("verify Git pack {}", index.display()))?;
+        ensure!(
+            output.status.success(),
+            "git verify-pack failed for {}: {}",
+            index.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in output.stdout.split(|byte| *byte == b'\n') {
+            let fields = line
+                .split(|byte| byte.is_ascii_whitespace())
+                .filter(|field| !field.is_empty())
+                .collect::<Vec<_>>();
+            if fields.len() < 5 || fields[1] != b"tree" {
+                continue;
+            }
+            let oid = std::str::from_utf8(fields[0])?;
+            if wanted.contains(oid) {
+                let packed_size = std::str::from_utf8(fields[3])?.parse::<usize>()?;
+                sizes.entry(oid.to_string()).or_insert(packed_size);
+            }
+        }
+    }
+    let missing = tree_ids
+        .iter()
+        .filter(|oid| !sizes.contains_key(oid.as_str()))
+        .take(3)
+        .cloned()
+        .collect::<Vec<_>>();
+    ensure!(
+        missing.is_empty(),
+        "{} selected tree objects are not packed (examples: {}); run `git -C {} gc --prune=now` first",
+        tree_ids.len() - sizes.len(),
+        missing.join(","),
+        repo.display()
+    );
+    Ok((sizes.values().sum(), indexes.len()))
+}
+
+fn parse_git_tree(body: &[u8], format: GitObjectFormat) -> Result<Option<Tree>> {
+    let oid_len = match format {
+        GitObjectFormat::Sha1 => 20,
+        GitObjectFormat::Sha256 => 32,
+    };
+    let mut entries = Vec::new();
+    let mut offset = 0usize;
+    while offset < body.len() {
+        let mode_end = body[offset..]
+            .iter()
+            .position(|byte| *byte == b' ')
+            .map(|relative| offset + relative)
+            .context("Git tree mode terminator")?;
+        let mode = u32::from_str_radix(std::str::from_utf8(&body[offset..mode_end])?, 8)?;
+        let name_start = mode_end + 1;
+        let name_end = body[name_start..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|relative| name_start + relative)
+            .context("Git tree name terminator")?;
+        let Some(name) = std::str::from_utf8(&body[name_start..name_end]).ok() else {
+            return Ok(None);
+        };
+        let oid_start = name_end + 1;
+        let oid_end = oid_start
+            .checked_add(oid_len)
+            .context("Git tree oid length overflow")?;
+        let oid = body
+            .get(oid_start..oid_end)
+            .context("truncated Git tree oid")?;
+        let mapped_hash = ContentHash::compute(oid);
+        let entry = match mode {
+            0o040000 => TreeEntry::directory(name, mapped_hash),
+            0o120000 => TreeEntry::symlink(name, mapped_hash),
+            0o160000 => TreeEntry::gitlink(name, GitObjectId::from_raw(format, oid)?),
+            value if value & 0o170000 == 0o100000 => {
+                TreeEntry::file(name, mapped_hash, value & 0o111 != 0)
+            }
+            _ => return Ok(None),
+        };
+        let Ok(entry) = entry else {
+            return Ok(None);
+        };
+        entries.push(entry);
+        offset = oid_end;
+    }
+    let tree = Tree::from_entries(entries);
+    if tree
+        .entries()
+        .windows(2)
+        .any(|pair| pair[0].name() == pair[1].name())
+    {
+        return Ok(None);
+    }
+    Ok(Some(tree))
+}
+
+fn load_real_corpus(path: &Path, limit: usize) -> Result<RealCorpus> {
+    let path = path.canonicalize()?;
+    let label = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("repository")
+        .to_string();
+    let object_format = real_object_format(&path)?;
+    let (discovered_trees, tree_ids) = discover_tree_ids(&path, limit)?;
+    let parent_tree_ids = discover_parent_tree_ids(&path, &tree_ids)?;
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(&path)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdin = child.stdin.take().context("Git cat-file stdin")?;
+    let mut requests = BufWriter::new(stdin);
+    let stdout = child.stdout.take().context("Git cat-file stdout")?;
+    let mut reader = BufReader::new(stdout);
+    let mut trees = Vec::with_capacity(tree_ids.len());
+    let mut imported_tree_ids = Vec::with_capacity(tree_ids.len());
+    let mut skipped_trees = 0usize;
+    for expected_oid in &tree_ids {
+        writeln!(requests, "{expected_oid}")?;
+        requests.flush()?;
+        let mut header = String::new();
+        reader.read_line(&mut header)?;
+        let mut fields = header.split_whitespace();
+        let oid = fields.next().context("Git batch object id")?;
+        let kind = fields.next().context("Git batch object type")?;
+        let size: usize = fields.next().context("Git batch object size")?.parse()?;
+        ensure!(
+            oid == expected_oid && kind == "tree",
+            "unexpected Git batch response"
+        );
+        let mut body = vec![0u8; size];
+        reader.read_exact(&mut body)?;
+        let mut delimiter = [0u8; 1];
+        reader.read_exact(&mut delimiter)?;
+        ensure!(delimiter == *b"\n", "missing Git batch delimiter");
+        if let Some(tree) = parse_git_tree(&body, object_format)? {
+            imported_tree_ids.push(expected_oid.clone());
+            trees.push(tree);
+        } else {
+            skipped_trees += 1;
+        }
+    }
+    drop(requests);
+    let output = child.wait_with_output()?;
+    ensure!(
+        output.status.success(),
+        "Git tree batch failed in {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let git_loose_bytes = git_loose_sizes(&path, &imported_tree_ids)?;
+    let (git_packed_bytes, git_pack_files) = git_packed_sizes(&path, &imported_tree_ids)?;
+    Ok(RealCorpus {
+        label,
+        path,
+        object_format,
+        discovered_trees,
+        skipped_trees,
+        tree_ids: imported_tree_ids,
+        trees,
+        parent_tree_ids,
+        git_loose_bytes,
+        git_packed_bytes,
+        git_pack_files,
+    })
+}
+
+struct RealFileFixture {
+    raw: NamedTempFile,
+    adaptive: NamedTempFile,
+    tree_id: ContentHash,
+    entries: usize,
+}
+
+fn write_temp(bytes: &[u8]) -> Result<NamedTempFile> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(bytes)?;
+    file.as_file_mut().flush()?;
+    Ok(file)
+}
+
+fn percentile(sorted: &[usize], numerator: usize, denominator: usize) -> usize {
+    if sorted.is_empty() {
+        return 0;
+    }
+    sorted[(sorted.len() - 1) * numerator / denominator]
+}
+
+#[derive(Debug)]
+struct Timing {
+    median_ns: f64,
+    mean_ns: f64,
+    stddev_ns: f64,
+    cv_percent: f64,
+    iterations_per_sample: u64,
+}
+
+fn run_iterations<F, T>(operation: &mut F, iterations: u64) -> Duration
+where
+    F: FnMut() -> T,
+{
+    let started = Instant::now();
+    for _ in 0..iterations {
+        black_box(operation());
+    }
+    started.elapsed()
+}
+
+fn measure<F, T>(mut operation: F) -> Timing
+where
+    F: FnMut() -> T,
+{
+    let mut iterations = 1u64;
+    let elapsed = loop {
+        let elapsed = run_iterations(&mut operation, iterations);
+        if elapsed >= CALIBRATION_TIME || iterations >= (1 << 30) {
+            break elapsed;
+        }
+        iterations = iterations.saturating_mul(2);
+    };
+    let elapsed_ns = elapsed.as_nanos().max(1) as u64;
+    iterations = iterations
+        .saturating_mul(SAMPLE_TIME.as_nanos() as u64)
+        .div_ceil(elapsed_ns)
+        .max(1);
+
+    let mut samples = Vec::with_capacity(SAMPLE_COUNT);
+    for _ in 0..SAMPLE_COUNT {
+        let elapsed = run_iterations(&mut operation, iterations);
+        samples.push(elapsed.as_nanos() as f64 / iterations as f64);
+    }
+    samples.sort_by(f64::total_cmp);
+    let median_ns = samples[samples.len() / 2];
+    let mean_ns = samples.iter().sum::<f64>() / samples.len() as f64;
+    let variance = samples
+        .iter()
+        .map(|sample| (sample - mean_ns).powi(2))
+        .sum::<f64>()
+        / (samples.len() - 1) as f64;
+    let stddev_ns = variance.sqrt();
+    Timing {
+        median_ns,
+        mean_ns,
+        stddev_ns,
+        cv_percent: stddev_ns / mean_ns * 100.0,
+        iterations_per_sample: iterations,
+    }
+}
+
+fn print_timing(entries: usize, operation: &str, timing: &Timing) {
+    println!(
+        "TIMING,{entries},{operation},{:.3},{:.3},{:.3},{:.3},{}",
+        timing.median_ns,
+        timing.mean_ns,
+        timing.stddev_ns,
+        timing.cv_percent,
+        timing.iterations_per_sample
+    );
+}
+
+fn historical_loose(tree: &Tree) -> Vec<u8> {
+    let positional = rmp_serde::to_vec(tree).expect("encode positional MessagePack");
+    compress_with_dictionary(
+        &positional,
+        &CompressionConfig::default(),
+        CompressionDictionary::TreeStateV1,
+    )
+    .expect("compress historical loose-tree body")
+    .unwrap_or(positional)
+}
+
+fn measure_real_partial(
+    fixtures: &[&RealFileFixture],
+    count: usize,
+) -> Result<(Timing, Timing, f64, f64)> {
+    ensure!(
+        !fixtures.is_empty(),
+        "no real file fixtures for {count}-entry read"
+    );
+    let mut raw_index = 0usize;
+    let raw_timing = measure(|| {
+        let fixture = &fixtures[raw_index % fixtures.len()];
+        raw_index += 1;
+        let read = partial_production_file(fixture.raw.path(), fixture.tree_id, count)
+            .expect("file-backed raw read");
+        black_box(read.entries[count - 1].name().len())
+    });
+    let mut adaptive_index = 0usize;
+    let adaptive_timing = measure(|| {
+        let fixture = &fixtures[adaptive_index % fixtures.len()];
+        adaptive_index += 1;
+        let read = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)
+            .expect("file-backed adaptive read");
+        black_box(read.entries[count - 1].name().len())
+    });
+
+    let mut raw_bytes = 0usize;
+    let mut adaptive_bytes = 0usize;
+    for fixture in fixtures {
+        let raw = partial_production_file(fixture.raw.path(), fixture.tree_id, count)?;
+        let adaptive = partial_production_file(fixture.adaptive.path(), fixture.tree_id, count)?;
+        ensure!(
+            raw.entries == adaptive.entries,
+            "file-backed partial mismatch"
+        );
+        raw_bytes += raw.bytes_read;
+        adaptive_bytes += adaptive.bytes_read;
+    }
+    Ok((
+        raw_timing,
+        adaptive_timing,
+        raw_bytes as f64 / fixtures.len() as f64,
+        adaptive_bytes as f64 / fixtures.len() as f64,
+    ))
+}
+
+fn validate_real_corpora(corpora: &[RealCorpus]) -> Result<()> {
+    ensure!(!corpora.is_empty(), "no real repositories supplied");
+    println!(
+        "REAL_REPO,label,path,object_format,discovered_trees,measured_trees,skipped_trees,pack_files,min_entries,p50_entries,p95_entries,max_entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink"
+    );
+    println!(
+        "REAL_SIZE,label,trees,htr4_v5,htr4_raw,git_loose,git_packed,historical_loose,v5_over_git_loose,v5_over_git_packed,compressed_trees,raw_fallback_trees"
+    );
+    println!(
+        "RADICAL_SIZE,label,trees,parent_covered,bases,deltas,max_ops,lean_all,hot_bytes,settled_bytes,settled_over_git_loose,settled_over_git_packed,settled_over_raw,settled_over_v5"
+    );
+
+    let mut aggregate_raw = 0usize;
+    let mut aggregate_historical = 0usize;
+    let mut aggregate_adaptive = 0usize;
+    let mut aggregate_git_loose = 0usize;
+    let mut aggregate_git_packed = 0usize;
+    let mut aggregate_trees = 0usize;
+    let mut aggregate_compressed = 0usize;
+    let mut aggregate_lean = 0usize;
+    let mut aggregate_radical_hot = 0usize;
+    let mut aggregate_radical_settled = 0usize;
+    let mut aggregate_radical_bases = 0usize;
+    let mut aggregate_radical_deltas = 0usize;
+    let mut aggregate_parent_coverage = 0usize;
+    let mut aggregate_radical_max_ops = 0usize;
+    let mut file_candidates = Vec::new();
+    let mut radical_file_fixtures = Vec::new();
+    let config = CompressionConfig::default();
+
+    for corpus in corpora {
+        ensure!(
+            !corpus.trees.is_empty(),
+            "{} yielded no importable trees",
+            corpus.label
+        );
+        let mut entry_counts = corpus.trees.iter().map(Tree::len).collect::<Vec<_>>();
+        entry_counts.sort_unstable();
+        let mut name_lengths = Vec::new();
+        let mut variants = [0usize; 5];
+        let mut raw_total = 0usize;
+        let mut historical_total = 0usize;
+        let mut adaptive_total = 0usize;
+        let mut compressed_trees = 0usize;
+        let mut raw_fallback_trees = 0usize;
+        let mut eligible_files = Vec::new();
+
+        for tree in &corpus.trees {
+            for entry in tree.entries() {
+                name_lengths.push(entry.name().len());
+                let bucket = match (entry.entry_type(), entry.mode()) {
+                    (EntryType::Blob, FileMode::Normal) => 0,
+                    (EntryType::Blob, FileMode::Executable) => 1,
+                    (EntryType::Tree, _) => 2,
+                    (EntryType::Symlink, _) => 3,
+                    (EntryType::Gitlink, _) => 4,
+                    (EntryType::Spoollink, _) => continue,
+                    _ => continue,
+                };
+                variants[bucket] += 1;
+            }
+            let raw = tree.encode_canonical()?;
+            let historical = historical_loose(tree);
+            let adaptive = objects::store::codec::encode_tree_at_rest(tree, &config)?;
+            raw_total += raw.len();
+            historical_total += historical.len();
+            adaptive_total += adaptive.len();
+            if adaptive.get(4) == Some(&TREE_BLOCK_ENCODING_VERSION) {
+                compressed_trees += 1;
+                if !tree.is_empty() {
+                    eligible_files.push((tree.len(), tree.hash(), raw, adaptive));
+                }
+            } else {
+                raw_fallback_trees += 1;
+            }
+        }
+
+        name_lengths.sort_unstable();
+        let mean_name = if name_lengths.is_empty() {
+            0.0
+        } else {
+            name_lengths.iter().sum::<usize>() as f64 / name_lengths.len() as f64
+        };
+        println!(
+            "REAL_REPO,{},{},{:?},{},{},{},{},{},{},{},{},{},{},{:.2},{},{},{},{},{}",
+            corpus.label,
+            corpus.path.display(),
+            corpus.object_format,
+            corpus.discovered_trees,
+            corpus.trees.len(),
+            corpus.skipped_trees,
+            corpus.git_pack_files,
+            entry_counts[0],
+            percentile(&entry_counts, 50, 100),
+            percentile(&entry_counts, 95, 100),
+            entry_counts[entry_counts.len() - 1],
+            name_lengths.first().copied().unwrap_or(0),
+            name_lengths.last().copied().unwrap_or(0),
+            mean_name,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+        );
+        println!(
+            "REAL_SIZE,{},{},{},{},{},{},{},{:.6},{:.6},{},{}",
+            corpus.label,
+            corpus.trees.len(),
+            adaptive_total,
+            raw_total,
+            corpus.git_loose_bytes,
+            corpus.git_packed_bytes,
+            historical_total,
+            adaptive_total as f64 / corpus.git_loose_bytes as f64,
+            adaptive_total as f64 / corpus.git_packed_bytes as f64,
+            compressed_trees,
+            raw_fallback_trees,
+        );
+        let radical = build_radical_corpus(corpus)?;
+        println!(
+            "RADICAL_SIZE,{},{},{},{},{},{},{},{},{},{:.6},{:.6},{:.6},{:.6}",
+            corpus.label,
+            corpus.trees.len(),
+            radical.parent_coverage,
+            radical.bases,
+            radical.deltas,
+            radical.max_ops,
+            radical.lean_total,
+            radical.hot_total,
+            radical.settled_total,
+            radical.settled_total as f64 / corpus.git_loose_bytes as f64,
+            radical.settled_total as f64 / corpus.git_packed_bytes as f64,
+            radical.settled_total as f64 / raw_total as f64,
+            radical.settled_total as f64 / adaptive_total as f64,
+        );
+        let delta_candidates = radical
+            .plans
+            .iter()
+            .enumerate()
+            .filter(|(index, plan)| {
+                plan.mode == RadicalMode::Delta && !corpus.trees[*index].is_empty()
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        let per_corpus = (REAL_FILE_SAMPLE_LIMIT / corpora.len()).max(1);
+        for index in sample_evenly(&delta_candidates, per_corpus) {
+            radical_file_fixtures.push(radical_file_fixture(corpus, &radical, index)?);
+        }
+        aggregate_raw += raw_total;
+        aggregate_historical += historical_total;
+        aggregate_adaptive += adaptive_total;
+        aggregate_git_loose += corpus.git_loose_bytes;
+        aggregate_git_packed += corpus.git_packed_bytes;
+        aggregate_trees += corpus.trees.len();
+        aggregate_compressed += compressed_trees;
+        aggregate_lean += radical.lean_total;
+        aggregate_radical_hot += radical.hot_total;
+        aggregate_radical_settled += radical.settled_total;
+        aggregate_radical_bases += radical.bases;
+        aggregate_radical_deltas += radical.deltas;
+        aggregate_parent_coverage += radical.parent_coverage;
+        aggregate_radical_max_ops = aggregate_radical_max_ops.max(radical.max_ops);
+
+        eligible_files.sort_by_key(|candidate| candidate.0);
+        file_candidates.extend(sample_evenly(&eligible_files, REAL_FILE_SAMPLE_LIMIT));
+    }
+
+    println!(
+        "REAL_SIZE,ALL,{aggregate_trees},{aggregate_adaptive},{aggregate_raw},{aggregate_git_loose},{aggregate_git_packed},{aggregate_historical},{:.6},{:.6},{aggregate_compressed},{}",
+        aggregate_adaptive as f64 / aggregate_git_loose as f64,
+        aggregate_adaptive as f64 / aggregate_git_packed as f64,
+        aggregate_trees - aggregate_compressed,
+    );
+    println!(
+        "RADICAL_SIZE,ALL,{aggregate_trees},{aggregate_parent_coverage},{aggregate_radical_bases},{aggregate_radical_deltas},{aggregate_radical_max_ops},{aggregate_lean},{aggregate_radical_hot},{aggregate_radical_settled},{:.6},{:.6},{:.6},{:.6}",
+        aggregate_radical_settled as f64 / aggregate_git_loose as f64,
+        aggregate_radical_settled as f64 / aggregate_git_packed as f64,
+        aggregate_radical_settled as f64 / aggregate_raw as f64,
+        aggregate_radical_settled as f64 / aggregate_adaptive as f64,
+    );
+    ensure!(
+        aggregate_adaptive < aggregate_historical,
+        "real-tree adaptive size does not beat historical loose compression"
+    );
+
+    file_candidates.sort_by_key(|candidate| candidate.0);
+    let file_candidates = sample_evenly(&file_candidates, REAL_FILE_SAMPLE_LIMIT);
+    let mut file_fixtures = Vec::with_capacity(file_candidates.len());
+    for (entries, tree_id, raw, adaptive) in file_candidates {
+        file_fixtures.push(RealFileFixture {
+            raw: write_temp(&raw)?,
+            adaptive: write_temp(&adaptive)?,
+            tree_id,
+            entries,
+        });
+    }
+    println!(
+        "REAL_FILE_PARTIAL,count,trees,min_tree_entries,max_tree_entries,raw_mean_bytes,adaptive_mean_bytes,raw_median_ns,adaptive_median_ns,time_ratio"
+    );
+    for count in [1usize, 100] {
+        let eligible = file_fixtures
+            .iter()
+            .filter(|fixture| fixture.entries >= count)
+            .collect::<Vec<_>>();
+        ensure!(
+            !eligible.is_empty(),
+            "no compressed real trees with {count} entries"
+        );
+        let (raw_timing, adaptive_timing, raw_bytes, adaptive_bytes) =
+            measure_real_partial(&eligible, count)?;
+        let ratio = adaptive_timing.median_ns / raw_timing.median_ns;
+        println!(
+            "REAL_FILE_PARTIAL,{count},{},{},{},{raw_bytes:.2},{adaptive_bytes:.2},{:.3},{:.3},{ratio:.3}",
+            eligible.len(),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .min()
+                .unwrap_or(0),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .max()
+                .unwrap_or(0),
+            raw_timing.median_ns,
+            adaptive_timing.median_ns,
+        );
+        ensure!(
+            ratio <= 2.0,
+            "file-backed {count}-entry partial read is {ratio:.3}x raw HTR4"
+        );
+    }
+    println!(
+        "RADICAL_FILE_PARTIAL,count,trees,min_tree_entries,max_tree_entries,raw_mean_bytes,radical_mean_bytes,byte_ratio,raw_median_ns,radical_median_ns,time_ratio"
+    );
+    let mut radical_partial_within_2x = true;
+    for count in [1usize, 100] {
+        let eligible = radical_file_fixtures
+            .iter()
+            .filter(|fixture| fixture.entries >= count)
+            .collect::<Vec<_>>();
+        ensure!(
+            !eligible.is_empty(),
+            "no radical trees with {count} entries"
+        );
+        let (raw_timing, radical_timing, raw_bytes, radical_bytes) =
+            measure_radical_partial(&eligible, count)?;
+        let byte_ratio = radical_bytes / raw_bytes;
+        let time_ratio = radical_timing.median_ns / raw_timing.median_ns;
+        radical_partial_within_2x &= byte_ratio <= 2.0 && time_ratio <= 2.0;
+        println!(
+            "RADICAL_FILE_PARTIAL,{count},{},{},{},{raw_bytes:.2},{radical_bytes:.2},{byte_ratio:.3},{:.3},{:.3},{time_ratio:.3}",
+            eligible.len(),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .min()
+                .unwrap_or(0),
+            eligible
+                .iter()
+                .map(|fixture| fixture.entries)
+                .max()
+                .unwrap_or(0),
+            raw_timing.median_ns,
+            radical_timing.median_ns,
+        );
+    }
+    println!(
+        "REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true,radical_smaller_than_git_loose={},radical_partial_within_2x={radical_partial_within_2x}",
+        aggregate_radical_settled < aggregate_git_loose,
+    );
+    Ok(())
+}
+
+fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
+    let tree = fixture(1_000);
+    let lean = encode_lean(&tree);
+    ensure!(
+        tree.encode_lean()? == lean,
+        "production HLR1 bytes drifted from the spike"
+    );
+    ensure!(decode_lean(&lean, tree.hash())? == tree);
+    let mut changed = tree.clone();
+    let changed_name = tree.entries()[500].name().to_string();
+    changed.insert(TreeEntry::file(changed_name, content_hash(500, 99), false)?);
+    let ops = tree_delta(&tree, &changed);
+    ensure!(ops.len() == 1, "one-entry radical self-check delta");
+    let delta = encode_delta(tree.hash(), &tree, &changed, &ops);
+    let production_ops = objects::object::tree_delta(&tree, &changed);
+    let production_delta =
+        objects::object::encode_tree_delta(tree.hash(), &tree, &changed, &production_ops)?;
+    ensure!(
+        production_delta == delta,
+        "production HDC1 bytes drifted from the spike"
+    );
+    ensure!(
+        objects::object::decode_tree_delta(&production_delta, &tree, changed.hash())? == changed
+    );
+    ensure!(decode_delta(&delta, &tree, changed.hash())? == changed);
+    ensure!(decode_delta(&delta, &tree, tree.hash()).is_err());
+    let blocked = encode_blocked(&tree, block_entries, dictionary)?;
+    ensure!(decode_blocked(&blocked, dictionary)? == tree);
+    let range_start = block_entries.saturating_sub(20);
+    let partial = partial_blocked(&blocked, dictionary, range_start, 100)?;
+    ensure!(partial.entries == tree.entries()[range_start..range_start + 100]);
+    if block_entries < tree.len() {
+        let resumed = partial_blocked(&blocked, dictionary, block_entries, 1)?;
+        ensure!(resumed.entries == tree.entries()[block_entries..block_entries + 1]);
+    }
+
+    let mut bad_hash = blocked.clone();
+    bad_hash[8] ^= 1;
+    ensure!(decode_blocked(&bad_hash, dictionary).is_err());
+    let mut bad_payload = blocked;
+    let last = bad_payload.len() - 1;
+    bad_payload[last] ^= 1;
+    ensure!(decode_blocked(&bad_payload, dictionary).is_err());
+    Ok(())
+}
+
+fn measure_radical_capture() -> Result<()> {
+    let anchor = fixture(100_000);
+    let mut current = anchor.clone();
+    let changed_name = anchor.entries()[50_000].name().to_string();
+    current.insert(TreeEntry::file(
+        changed_name,
+        content_hash(50_000, 0xfeed),
+        false,
+    )?);
+    let ops = tree_delta(&anchor, &current);
+    ensure!(
+        ops.len() == 1,
+        "100k radical capture fixture must change one entry"
+    );
+    let raw = current.encode_canonical()?;
+    let v5 = objects::store::codec::encode_tree_at_rest(&current, &CompressionConfig::default())?;
+    let lean = encode_lean(&current);
+    let anchor_id = anchor.hash();
+    let delta = encode_delta(anchor_id, &anchor, &current, &ops);
+    ensure!(decode_lean(&lean, current.hash())? == current);
+    ensure!(decode_delta(&delta, &anchor, current.hash())? == current);
+    println!(
+        "RADICAL_CAPTURE,entries,changes,htr4_raw_bytes,htr4_v5_bytes,lean_bytes,delta_bytes,operation,median_ns,mean_ns,stddev_ns,cv_percent,iterations_per_sample"
+    );
+    for (operation, timing) in [
+        ("lean_anchor_encode", measure(|| encode_lean(&current))),
+        (
+            "htr4_raw_encode",
+            measure(|| current.encode_canonical().expect("100k raw encode")),
+        ),
+        (
+            "htr4_v5_encode",
+            measure(|| {
+                objects::store::codec::encode_tree_at_rest(&current, &CompressionConfig::default())
+                    .expect("100k v5 encode")
+            }),
+        ),
+        (
+            "htr4_raw_decode",
+            measure(|| Tree::decode_canonical(&raw).expect("100k raw decode")),
+        ),
+        (
+            "htr4_v5_decode",
+            measure(|| Tree::decode_canonical(&v5).expect("100k v5 decode")),
+        ),
+        (
+            "known_delta_encode",
+            measure(|| encode_delta(anchor_id, &anchor, &current, &ops)),
+        ),
+        (
+            "diff_and_delta_encode",
+            measure(|| {
+                let measured_ops = tree_delta(&anchor, &current);
+                encode_delta(anchor_id, &anchor, &current, &measured_ops)
+            }),
+        ),
+        (
+            "lean_anchor_decode",
+            measure(|| decode_lean(&lean, current.hash()).expect("100k lean decode")),
+        ),
+        (
+            "delta_decode",
+            measure(|| decode_delta(&delta, &anchor, current.hash()).expect("100k delta decode")),
+        ),
+    ] {
+        println!(
+            "RADICAL_CAPTURE,100000,1,{},{},{},{},{operation},{:.3},{:.3},{:.3},{:.3},{}",
+            raw.len(),
+            v5.len(),
+            lean.len(),
+            delta.len(),
+            timing.median_ns,
+            timing.mean_ns,
+            timing.stddev_ns,
+            timing.cv_percent,
+            timing.iterations_per_sample,
+        );
+    }
+    Ok(())
+}
+
+fn tune(dictionaries: &[Dictionary<'_>]) -> Result<()> {
+    let tree = fixture(10_000);
+    let htr4 = tree.encode_canonical()?;
+    let historical = historical_loose(&tree);
+    println!(
+        "TUNE,block_entries,dictionary,encoded_bytes,vs_raw_percent,vs_historical_percent,first_1_bytes,first_100_bytes,first_1_median_ns,first_100_median_ns"
+    );
+    for dictionary in dictionaries {
+        for block_entries in [1, 8, 16, 32, 64, 128, 256, 512] {
+            let blocked = Bytes::from(encode_blocked(&tree, block_entries, *dictionary)?);
+            let first_1 = partial_blocked(&blocked, *dictionary, 0, 1)?;
+            let first_100 = partial_blocked(&blocked, *dictionary, 0, 100)?;
+            let first_1_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 1).expect("partial");
+                black_box(read.entries[0].name());
+            });
+            let first_100_timing = measure(|| {
+                let read =
+                    partial_blocked(black_box(&blocked), *dictionary, 0, 100).expect("partial");
+                black_box(read.entries[99].name());
+            });
+            println!(
+                "TUNE,{block_entries},{},{},{:.3},{:.3},{},{},{:.3},{:.3}",
+                dictionary.name,
+                blocked.len(),
+                100.0 * (blocked.len() as f64 / htr4.len() as f64 - 1.0),
+                100.0 * (blocked.len() as f64 / historical.len() as f64 - 1.0),
+                first_1.bytes_read,
+                first_100.bytes_read,
+                first_1_timing.median_ns,
+                first_100_timing.median_ns,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn crossover(block_entries: usize, dictionary: Dictionary<'_>) -> Result<()> {
+    let mut first_raw_win = None;
+    let mut last_raw_loss = None;
+    let mut first_historical_win = None;
+    let mut last_historical_loss = None;
+    for entries in 1..=512 {
+        let tree = fixture(entries);
+        let htr4 = tree.encode_canonical()?;
+        let blocked = encode_blocked_htr4(&htr4, block_entries, dictionary)?;
+        let historical = historical_loose(&tree);
+        if blocked.len() < htr4.len() {
+            first_raw_win.get_or_insert(entries);
+        } else {
+            last_raw_loss = Some(entries);
+        }
+        if blocked.len() < historical.len() {
+            first_historical_win.get_or_insert(entries);
+        } else {
+            last_historical_loss = Some(entries);
+        }
+    }
+    println!(
+        "CROSSOVER,block_entries={},dictionary={},first_smaller_than_raw={},stable_smaller_than_raw_from={},first_smaller_than_historical={},stable_smaller_than_historical_from={},sweep_end=512",
+        block_entries,
+        dictionary.name,
+        first_raw_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_raw_loss.map_or(1, |value| value + 1),
+        first_historical_win.map_or_else(|| "none".into(), |value| value.to_string()),
+        last_historical_loss.map_or(1, |value| value + 1),
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let trained = training_dictionary()?;
+    // A production decoder would retain these prepared dictionaries in a
+    // process-wide lazy cell. Preparation is outside all retained samples.
+    let legacy_encoder = zstd::dict::EncoderDictionary::copy(LEGACY_DICTIONARY, BLOCK_LEVEL);
+    let legacy_decoder = zstd::dict::DecoderDictionary::copy(LEGACY_DICTIONARY);
+    let trained_encoder = zstd::dict::EncoderDictionary::copy(&trained, BLOCK_LEVEL);
+    let trained_decoder = zstd::dict::DecoderDictionary::copy(&trained);
+    let dictionaries = [
+        Dictionary {
+            name: "none",
+            id: 0,
+            bytes: &[],
+            encoder: None,
+            decoder: None,
+        },
+        Dictionary {
+            name: "legacy",
+            id: LEGACY_DICTIONARY_ID,
+            bytes: LEGACY_DICTIONARY,
+            encoder: Some(&legacy_encoder),
+            decoder: Some(&legacy_decoder),
+        },
+        Dictionary {
+            name: "trained_htr4",
+            id: TRAINED_DICTIONARY_ID,
+            bytes: &trained,
+            encoder: Some(&trained_encoder),
+            decoder: Some(&trained_decoder),
+        },
+    ];
+    let dictionary_name = env::var("HTR4_DICTIONARY").unwrap_or_else(|_| "none".into());
+    let dictionary = *dictionaries
+        .iter()
+        .find(|dictionary| dictionary.name == dictionary_name)
+        .with_context(|| format!("unknown HTR4_DICTIONARY={dictionary_name}"))?;
+    let block_entries = env::var("HTR4_BLOCK_ENTRIES")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(256usize);
+    let real_tree_limit = env::var("HTR4_REAL_TREE_LIMIT")
+        .ok()
+        .map(|value| value.parse())
+        .transpose()?
+        .unwrap_or(DEFAULT_REAL_TREE_LIMIT);
+    let real_paths = {
+        let supplied = env::args().skip(1).map(PathBuf::from).collect::<Vec<_>>();
+        if supplied.is_empty() {
+            vec![PathBuf::from(".")]
+        } else {
+            supplied
+        }
+    };
+    let real_corpora = real_paths
+        .iter()
+        .map(|path| load_real_corpus(path, real_tree_limit))
+        .collect::<Result<Vec<_>>>()?;
+
+    self_check(dictionary, block_entries)?;
+    println!("META,seed,0x{SEED:016x}");
+    println!("META,samples,{SAMPLE_COUNT}");
+    println!("META,target_sample_ms,{}", SAMPLE_TIME.as_millis());
+    println!("META,block_entries,{block_entries}");
+    println!("META,real_tree_limit_per_repo,{real_tree_limit}");
+    println!("META,git_loose,actual_git_loose_object_file_bytes(tree_header+body)");
+    println!(
+        "META,git_packed,sum_verify_pack_object_record_bytes_excluding_pack_and_index_fixed_overhead"
+    );
+    println!("META,dictionary,{}", dictionary.name);
+    println!("META,dictionary_bytes,{}", dictionary.bytes.len());
+    println!("META,dictionary_blake3,{}", blake3::hash(dictionary.bytes));
+    println!(
+        "META,self_check,v5_roundtrip+range+hash_corruption+payload_corruption;radical_lean+delta_roundtrip+hash_mismatch_ok"
+    );
+    validate_real_corpora(&real_corpora)?;
+    measure_radical_capture()?;
+    println!(
+        "FIXTURE,entries,min_name,max_name,mean_name,blob_normal,blob_exec,tree,symlink,gitlink,spoollink"
+    );
+    println!(
+        "SIZE,entries,htr4_raw,historical_loose,htr4_whole_zstd3,htb1_blocked,adaptive_size,adaptive_mode"
+    );
+    println!(
+        "TIMING,entries,operation,median_ns,mean_ns,stddev_ns,cv_percent,iterations_per_sample"
+    );
+
+    let fixtures: Vec<(usize, Tree)> = SIZES
+        .into_iter()
+        .map(|entries| (entries, fixture(entries)))
+        .collect();
+
+    for (entries, tree) in &fixtures {
+        let mut min_name = usize::MAX;
+        let mut max_name = 0usize;
+        let mut total_name = 0usize;
+        let mut variants = [0usize; 6];
+        for entry in tree.entries() {
+            min_name = min_name.min(entry.name().len());
+            max_name = max_name.max(entry.name().len());
+            total_name += entry.name().len();
+            let bucket = match (entry.entry_type(), entry.mode()) {
+                (EntryType::Blob, FileMode::Normal) => 0,
+                (EntryType::Blob, FileMode::Executable) => 1,
+                (EntryType::Tree, _) => 2,
+                (EntryType::Symlink, _) => 3,
+                (EntryType::Gitlink, _) => 4,
+                (EntryType::Spoollink, _) => 5,
+                _ => unreachable!("validated entry kind/mode"),
+            };
+            variants[bucket] += 1;
+        }
+        println!(
+            "FIXTURE,{entries},{min_name},{max_name},{:.2},{},{},{},{},{},{}",
+            total_name as f64 / *entries as f64,
+            variants[0],
+            variants[1],
+            variants[2],
+            variants[3],
+            variants[4],
+            variants[5]
+        );
+
+        let htr4 = tree.encode_canonical()?;
+        let historical = historical_loose(tree);
+        let whole_zstd = zstd::encode_all(htr4.as_slice(), BLOCK_LEVEL)?;
+        let blocked = encode_blocked(tree, block_entries, dictionary)?;
+        let adaptive = if blocked.len() < htr4.len() {
+            blocked.clone()
+        } else {
+            htr4.clone()
+        };
+        let mode = if adaptive.starts_with(BLOCK_MAGIC) {
+            "blocked"
+        } else {
+            "raw"
+        };
+        ensure!(Tree::decode_canonical(&htr4)? == *tree);
+        ensure!(decode_blocked(&blocked, dictionary)? == *tree);
+        ensure!(decode_adaptive(&adaptive, dictionary)? == *tree);
+        let whole_decoded = zstd::decode_all(whole_zstd.as_slice())?;
+        ensure!(Tree::decode_canonical(&whole_decoded)? == *tree);
+        println!(
+            "SIZE,{entries},{},{},{},{},{},{}",
+            htr4.len(),
+            historical.len(),
+            whole_zstd.len(),
+            blocked.len(),
+            adaptive.len(),
+            mode,
+        );
+
+        print_timing(
+            *entries,
+            "htr4_encode",
+            &measure(|| tree.encode_canonical().expect("encode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_encode",
+            &measure(|| {
+                let raw = tree.encode_canonical().expect("encode HTR4");
+                zstd::encode_all(raw.as_slice(), BLOCK_LEVEL).expect("compress whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_encode",
+            &measure(|| {
+                encode_adaptive(tree, block_entries, dictionary).expect("encode adaptive HTB1")
+            }),
+        );
+        print_timing(
+            *entries,
+            "htr4_decode",
+            &measure(|| Tree::decode_canonical(black_box(&htr4)).expect("decode HTR4")),
+        );
+        print_timing(
+            *entries,
+            "whole_zstd_decode",
+            &measure(|| {
+                let raw = zstd::decode_all(black_box(whole_zstd.as_slice()))
+                    .expect("decompress whole HTR4");
+                Tree::decode_canonical(&raw).expect("decode whole HTR4")
+            }),
+        );
+        print_timing(
+            *entries,
+            "adaptive_block_decode",
+            &measure(|| {
+                decode_adaptive(black_box(&adaptive), dictionary).expect("decode adaptive HTB1")
+            }),
+        );
+    }
+
+    let (entries, tree) = fixtures.last().context("10k fixture")?;
+    let htr4 = Bytes::from(tree.encode_canonical()?);
+    let whole_zstd = zstd::encode_all(htr4.as_ref(), BLOCK_LEVEL)?;
+    let adaptive = Bytes::from(encode_adaptive(tree, block_entries, dictionary)?);
+    let tree_id = tree.hash();
+    println!("PARTIAL,entries,count,format,bytes_read,median_ns");
+    for count in [1usize, 100] {
+        let raw_read = partial_htr4(&htr4, tree_id, count);
+        let raw_timing = measure(|| {
+            let read = partial_htr4(&htr4, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},htr4_raw,{},{:.3}",
+            raw_read.bytes_read, raw_timing.median_ns
+        );
+
+        let block_read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+        let block_timing = measure(|| {
+            let read = partial_adaptive(&adaptive, dictionary, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},adaptive_block,{},{:.3}",
+            block_read.bytes_read, block_timing.median_ns
+        );
+
+        let whole_read = partial_whole_zstd(&whole_zstd, tree_id, count);
+        let whole_timing = measure(|| {
+            let read = partial_whole_zstd(&whole_zstd, tree_id, count);
+            black_box(read.entries[count - 1].name());
+        });
+        println!(
+            "PARTIAL,{entries},{count},whole_zstd,{},{:.3}",
+            whole_read.bytes_read, whole_timing.median_ns
+        );
+    }
+
+    crossover(block_entries, dictionary)?;
+    if env::var_os("HTR4_TUNE").is_some() {
+        tune(&dictionaries)?;
+    }
+    Ok(())
+}

--- a/crates/objects/src/blame/run.rs
+++ b/crates/objects/src/blame/run.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! One-shot blame that loops storage-neutral slices until complete.
 
-use std::path::Path;
+use std::{cell::RefCell, collections::HashMap, path::Path};
 
-use crate::object::{FileProvenance, ObjectSource, State};
+use crate::object::{Blob, ContentHash, FileProvenance, ObjectSource, State, StateId, Tree};
 
 use super::{
     advance::advance_file_blame_slice,
@@ -15,6 +15,66 @@ use super::{
     },
 };
 
+/// Resolved objects shared by every slice of one local blame walk.
+///
+/// Preparing a blame and advancing its frontier revisit the target objects;
+/// parents are likewise loaded once while being claimed and again if they
+/// become the next frontier. Keeping this cache at the one-shot boundary
+/// avoids re-decoding those objects without making resumable slices stateful.
+struct BlameObjectCache<'source, S> {
+    source: &'source S,
+    trees: RefCell<HashMap<ContentHash, Option<Tree>>>,
+    states: RefCell<HashMap<StateId, Option<State>>>,
+    blobs: RefCell<HashMap<ContentHash, Option<Blob>>>,
+}
+
+impl<'source, S> BlameObjectCache<'source, S> {
+    fn new(source: &'source S) -> Self {
+        Self {
+            source,
+            trees: RefCell::new(HashMap::new()),
+            states: RefCell::new(HashMap::new()),
+            blobs: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl<S: ObjectSource> ObjectSource for BlameObjectCache<'_, S> {
+    fn get_tree(&self, hash: &ContentHash) -> crate::error::Result<Option<Tree>> {
+        if let Some(tree) = self.trees.borrow().get(hash).cloned() {
+            return Ok(tree);
+        }
+        let tree = self.source.get_tree(hash)?;
+        self.trees.borrow_mut().insert(*hash, tree.clone());
+        Ok(tree)
+    }
+
+    fn get_state(&self, id: &StateId) -> crate::error::Result<Option<State>> {
+        if let Some(state) = self.states.borrow().get(id).cloned() {
+            return Ok(state);
+        }
+        let state = self.source.get_state(id)?;
+        self.states.borrow_mut().insert(*id, state.clone());
+        Ok(state)
+    }
+
+    fn get_blob(&self, hash: &ContentHash) -> crate::error::Result<Option<Blob>> {
+        if let Some(blob) = self.blobs.borrow().get(hash).cloned() {
+            return Ok(blob);
+        }
+        let blob = self.source.get_blob(hash)?;
+        self.blobs.borrow_mut().insert(*hash, blob.clone());
+        Ok(blob)
+    }
+
+    fn decoded_blob_len(&self, hash: &ContentHash) -> crate::error::Result<Option<u64>> {
+        if let Some(blob) = self.blobs.borrow().get(hash) {
+            return Ok(blob.as_ref().map(|blob| blob.content().len() as u64));
+        }
+        self.source.decoded_blob_len(hash)
+    }
+}
+
 /// Walk `path` at `state` by repeating [`advance_file_blame_slice`] until the
 /// frontier is exhausted, then finalize. This is not an eager full-file shim;
 /// each slice stays inside `limits`.
@@ -24,7 +84,8 @@ pub fn blame_file<S: ObjectSource>(
     path: &Path,
     limits: BlameSliceLimits,
 ) -> Result<FileProvenance, BlameSliceError> {
-    match prepare_file_blame(source, state, path, limits)? {
+    let source = BlameObjectCache::new(source);
+    match prepare_file_blame(&source, state, path, limits)? {
         BlamePreparation::MissingPath => Err(BlameSliceError::MissingPath),
         BlamePreparation::Unblamable => Err(BlameSliceError::Unblamable),
         BlamePreparation::Empty { file_blob, origin } => finalize_file_provenance(
@@ -46,7 +107,7 @@ pub fn blame_file<S: ObjectSource>(
             let mut finalized = Vec::new();
             loop {
                 frontier.require_target(&expected)?;
-                match advance_file_blame_slice(source, path, frontier, limits)? {
+                match advance_file_blame_slice(&source, path, frontier, limits)? {
                     BlameSliceAdvance::Progress {
                         next,
                         finalized: more,

--- a/crates/objects/src/blame/tests/mod.rs
+++ b/crates/objects/src/blame/tests/mod.rs
@@ -7,12 +7,13 @@ mod golden;
 mod prop;
 mod restart;
 
-use std::path::Path;
+use std::{cell::RefCell, collections::HashMap, path::Path};
 
 use crate::blame::{
     BlamePreparation, BlameSliceAdvance, BlameSliceError, BlameSliceLimits,
     advance_file_blame_slice, blame_file, prepare_file_blame,
 };
+use crate::object::{Blob, ContentHash, ObjectSource, State, StateId, Tree};
 use crate::util::ResourceKind;
 
 use fixture::{principals_at, put_state_with_file, store};
@@ -106,6 +107,76 @@ fn no_overlap_parent_is_not_a_processed_frontier() {
             panic!("no-overlap parent must not become a next frontier")
         }
     }
+}
+
+struct CountingSource<'source> {
+    inner: &'source crate::store::InMemoryStore,
+    trees: RefCell<HashMap<ContentHash, u32>>,
+    states: RefCell<HashMap<StateId, u32>>,
+    blobs: RefCell<HashMap<ContentHash, u32>>,
+    blob_sizes: RefCell<HashMap<ContentHash, u32>>,
+}
+
+impl<'source> CountingSource<'source> {
+    fn new(inner: &'source crate::store::InMemoryStore) -> Self {
+        Self {
+            inner,
+            trees: RefCell::new(HashMap::new()),
+            states: RefCell::new(HashMap::new()),
+            blobs: RefCell::new(HashMap::new()),
+            blob_sizes: RefCell::new(HashMap::new()),
+        }
+    }
+}
+
+impl ObjectSource for CountingSource<'_> {
+    fn get_tree(&self, hash: &ContentHash) -> crate::error::Result<Option<Tree>> {
+        *self.trees.borrow_mut().entry(*hash).or_default() += 1;
+        ObjectSource::get_tree(self.inner, hash)
+    }
+
+    fn get_state(&self, id: &StateId) -> crate::error::Result<Option<State>> {
+        *self.states.borrow_mut().entry(*id).or_default() += 1;
+        ObjectSource::get_state(self.inner, id)
+    }
+
+    fn get_blob(&self, hash: &ContentHash) -> crate::error::Result<Option<Blob>> {
+        *self.blobs.borrow_mut().entry(*hash).or_default() += 1;
+        ObjectSource::get_blob(self.inner, hash)
+    }
+
+    fn decoded_blob_len(&self, hash: &ContentHash) -> crate::error::Result<Option<u64>> {
+        *self.blob_sizes.borrow_mut().entry(*hash).or_default() += 1;
+        ObjectSource::decoded_blob_len(self.inner, hash)
+    }
+}
+
+#[test]
+fn oneshot_blame_decodes_each_object_once() {
+    let store = store();
+    let parent = put_state_with_file(&store, "fixture.txt", b"old line\n", Vec::new(), "alice");
+    let tip = put_state_with_file(
+        &store,
+        "fixture.txt",
+        b"old line\nnew line\n",
+        vec![parent.id()],
+        "bob",
+    );
+    let path = Path::new("fixture.txt");
+    let expected = blame_file(&store, &tip, path, BlameSliceLimits::unlimited()).unwrap();
+    let source = CountingSource::new(&store);
+
+    let actual = blame_file(&source, &tip, path, BlameSliceLimits::unlimited()).unwrap();
+
+    assert_eq!(actual, expected, "memoization must not change provenance");
+    for calls in [&source.trees, &source.blobs, &source.blob_sizes] {
+        let calls = calls.borrow();
+        assert_eq!(calls.len(), 2, "tip and parent objects must be loaded");
+        assert!(calls.values().all(|count| *count == 1));
+    }
+    let state_calls = source.states.borrow();
+    assert_eq!(state_calls.len(), 2, "tip and parent states must be loaded");
+    assert!(state_calls.values().all(|count| *count == 1));
 }
 
 #[test]

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -77,6 +77,13 @@ pub fn encode_tree_hot(tree: &Tree, base: Option<TreeDeltaBase<'_>>) -> Result<E
             kind: TreeEncodingKind::Lean,
         });
     };
+    if hash == base.anchor_id {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    }
     let Some(depth) = base.parent_depth.checked_add(1) else {
         return Ok(EncodedTree {
             hash,
@@ -163,6 +170,12 @@ pub fn decode_tree_serialized_with_key(
     let tree = if is_lean_tree(data) {
         Tree::decode_lean(data, expected)?
     } else if is_delta_tree(data) {
+        let header = decode_tree_delta_header(data)?;
+        if header.anchor == expected {
+            return Err(HeddleError::InvalidObject(
+                "HDC1 result id must differ from its anchor id".to_string(),
+            ));
+        }
         let anchor = anchor.ok_or_else(|| {
             HeddleError::InvalidObject("HDC1 tree is missing its materialized anchor".to_string())
         })?;
@@ -287,6 +300,23 @@ mod tests {
             decode_tree_with_key(&delta.data, current.hash(), Some(&anchor)).unwrap(),
             current
         );
+    }
+
+    #[test]
+    fn result_equal_to_anchor_is_materialized_instead_of_delta_encoded() {
+        let anchor = tree_fixture(240, None);
+        let encoded = encode_tree_hot(
+            &anchor,
+            Some(TreeDeltaBase {
+                anchor_id: anchor.hash(),
+                anchor: &anchor,
+                parent_depth: 1,
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(encoded.kind, TreeEncodingKind::Lean);
+        assert!(crate::object::is_lean_tree(&encoded.data));
     }
 
     #[test]

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -7,9 +7,46 @@ use heddle_format::compression::{
 };
 
 use crate::{
-    object::{Action, ActionId, ContentHash, State, Tree},
+    object::{
+        Action, ActionId, ContentHash, State, TREE_DELTA_ANCHOR_INTERVAL, TREE_DELTA_MAX_OPS, Tree,
+        decode_tree_delta, decode_tree_delta_header, encode_tree_delta, is_canonical_tree,
+        is_delta_tree, is_lean_tree, tree_delta,
+    },
     store::{HeddleError, Result},
 };
+
+/// Store metadata needed to keep a future delta in the same bounded epoch.
+/// Losing this hint is safe: the next write falls back to a fresh HLR1 anchor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TreeLineage {
+    pub anchor: ContentHash,
+    pub depth: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TreeEncodingKind {
+    Lean,
+    Delta {
+        anchor: ContentHash,
+        depth: u8,
+        op_count: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncodedTree {
+    pub hash: ContentHash,
+    pub data: Vec<u8>,
+    pub kind: TreeEncodingKind,
+}
+
+/// Materialized anchor information inherited from the immediate parent.
+pub struct TreeDeltaBase<'a> {
+    pub anchor_id: ContentHash,
+    pub anchor: &'a Tree,
+    /// Delta descendants between `anchor` and the immediate parent.
+    pub parent_depth: u8,
+}
 
 pub fn encode_blob_content(content: &[u8], config: &CompressionConfig) -> Result<Vec<u8>> {
     Ok(compress(content, config)?.unwrap_or_else(|| content.to_vec()))
@@ -24,9 +61,72 @@ pub fn decode_blob_content(data: &[u8]) -> Result<Vec<u8>> {
 }
 
 pub fn encode_tree(tree: &Tree, _config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
-    // Canonical trees stay uncompressed so a resume cursor can seek to an
-    // entry frame without decompressing the prefix.
-    Ok((tree.hash(), tree.encode_canonical()?))
+    let encoded = encode_tree_hot(tree, None)?;
+    Ok((encoded.hash, encoded.data))
+}
+
+/// Encode the capture hot path. Materialized writes are cheap HLR1 anchors;
+/// eligible descendants are cumulative HDC1 deltas against the epoch anchor.
+pub fn encode_tree_hot(tree: &Tree, base: Option<TreeDeltaBase<'_>>) -> Result<EncodedTree> {
+    let hash = tree.hash();
+    let lean = tree.encode_lean()?;
+    let Some(base) = base else {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    };
+    let Some(depth) = base.parent_depth.checked_add(1) else {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    };
+    if depth >= TREE_DELTA_ANCHOR_INTERVAL {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    }
+    let ops = tree_delta(base.anchor, tree);
+    if ops.len() > TREE_DELTA_MAX_OPS {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    }
+    let delta = encode_tree_delta(base.anchor_id, base.anchor, tree, &ops)?;
+    let header = decode_tree_delta_header(&delta)?;
+    let porch_is_bounded = header.first_base_count <= 1 && header.hundred_base_count <= 100;
+    if !porch_is_bounded || delta.len() >= lean.len() {
+        return Ok(EncodedTree {
+            hash,
+            data: lean,
+            kind: TreeEncodingKind::Lean,
+        });
+    }
+    Ok(EncodedTree {
+        hash,
+        data: delta,
+        kind: TreeEncodingKind::Delta {
+            anchor: base.anchor_id,
+            depth,
+            op_count: ops.len(),
+        },
+    })
+}
+
+/// Heavy, seekable compression for repack/background use only.
+pub fn encode_tree_at_rest(tree: &Tree, config: &CompressionConfig) -> Result<Vec<u8>> {
+    if config.enabled && tree.len() >= crate::object::TREE_BLOCK_MIN_ENTRIES {
+        Ok(tree.encode_canonical_blocked(config.level, config.min_size)?)
+    } else {
+        Ok(tree.encode_canonical()?)
+    }
 }
 
 pub fn decode_tree(data: &[u8]) -> Result<Tree> {
@@ -35,7 +135,50 @@ pub fn decode_tree(data: &[u8]) -> Result<Tree> {
 }
 
 pub fn decode_tree_serialized(data: &[u8]) -> Result<Tree> {
+    if !is_canonical_tree(data) {
+        return Err(HeddleError::InvalidObject(
+            "HLR1/HDC1 tree decoding requires the external object key".to_string(),
+        ));
+    }
     Tree::decode_canonical(data).map_err(HeddleError::from)
+}
+
+/// Decode any production tree body and validate it against the external key.
+/// HDC1 callers must supply its materialized anchor; canonical and HLR1 bodies
+/// ignore `anchor`.
+pub fn decode_tree_with_key(
+    data: &[u8],
+    expected: ContentHash,
+    anchor: Option<&Tree>,
+) -> Result<Tree> {
+    let decoded = decode_tree_body(data)?;
+    decode_tree_serialized_with_key(&decoded, expected, anchor)
+}
+
+pub fn decode_tree_serialized_with_key(
+    data: &[u8],
+    expected: ContentHash,
+    anchor: Option<&Tree>,
+) -> Result<Tree> {
+    let tree = if is_lean_tree(data) {
+        Tree::decode_lean(data, expected)?
+    } else if is_delta_tree(data) {
+        let anchor = anchor.ok_or_else(|| {
+            HeddleError::InvalidObject("HDC1 tree is missing its materialized anchor".to_string())
+        })?;
+        decode_tree_delta(data, anchor, expected)?
+    } else if is_canonical_tree(data) {
+        Tree::decode_canonical(data)?
+    } else {
+        return Err(HeddleError::InvalidObject(
+            "unsupported tree storage body".to_string(),
+        ));
+    };
+    let found = tree.hash();
+    if found != expected {
+        return Err(HeddleError::Corruption { expected, found });
+    }
+    Ok(tree)
 }
 
 /// Return the serialized tree body stored in a loose object, decompressing
@@ -106,8 +249,125 @@ mod tests {
         for config in compression_configs() {
             let (hash, encoded) = encode_tree(&tree, &config).unwrap();
             assert_eq!(hash, tree.hash());
-            assert_eq!(decode_tree(&encoded).unwrap(), tree);
+            assert!(crate::object::is_lean_tree(&encoded));
+            assert_eq!(decode_tree_with_key(&encoded, hash, None).unwrap(), tree);
         }
+    }
+
+    #[test]
+    fn lean_and_delta_round_trip_against_external_keys() {
+        let anchor = tree_fixture(240, None);
+        let current = tree_fixture(240, Some((117, b"changed")));
+        let lean = encode_tree_hot(&anchor, None).unwrap();
+        assert_eq!(lean.kind, TreeEncodingKind::Lean);
+        assert_eq!(
+            decode_tree_with_key(&lean.data, anchor.hash(), None).unwrap(),
+            anchor
+        );
+
+        let delta = encode_tree_hot(
+            &current,
+            Some(TreeDeltaBase {
+                anchor_id: anchor.hash(),
+                anchor: &anchor,
+                parent_depth: 0,
+            }),
+        )
+        .unwrap();
+        assert!(matches!(
+            delta.kind,
+            TreeEncodingKind::Delta {
+                anchor: _,
+                depth: 1,
+                op_count: 1
+            }
+        ));
+        assert!(crate::object::is_delta_tree(&delta.data));
+        assert_eq!(
+            decode_tree_with_key(&delta.data, current.hash(), Some(&anchor)).unwrap(),
+            current
+        );
+    }
+
+    #[test]
+    fn delta_refreshes_anchor_after_127_descendants() {
+        let anchor = tree_fixture(240, None);
+        let current = tree_fixture(240, Some((117, b"changed")));
+
+        let last_descendant = encode_tree_hot(
+            &current,
+            Some(TreeDeltaBase {
+                anchor_id: anchor.hash(),
+                anchor: &anchor,
+                parent_depth: TREE_DELTA_ANCHOR_INTERVAL - 2,
+            }),
+        )
+        .unwrap();
+        assert!(matches!(
+            last_descendant.kind,
+            TreeEncodingKind::Delta { depth: 127, .. }
+        ));
+
+        let refreshed = encode_tree_hot(
+            &current,
+            Some(TreeDeltaBase {
+                anchor_id: anchor.hash(),
+                anchor: &anchor,
+                parent_depth: TREE_DELTA_ANCHOR_INTERVAL - 1,
+            }),
+        )
+        .unwrap();
+        assert_eq!(refreshed.kind, TreeEncodingKind::Lean);
+        assert!(crate::object::is_lean_tree(&refreshed.data));
+    }
+
+    #[test]
+    fn delta_over_512_operations_refreshes_the_anchor() {
+        let anchor = tree_fixture(600, None);
+        let current = Tree::from_entries(
+            anchor
+                .entries()
+                .iter()
+                .enumerate()
+                .map(|(index, entry)| {
+                    TreeEntry::file(
+                        entry.name(),
+                        ContentHash::compute(format!("changed-{index}").as_bytes()),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let ops = tree_delta(&anchor, &current);
+        assert_eq!(ops.len(), 600);
+        assert!(encode_tree_delta(anchor.hash(), &anchor, &current, &ops).is_err());
+        let encoded = encode_tree_hot(
+            &current,
+            Some(TreeDeltaBase {
+                anchor_id: anchor.hash(),
+                anchor: &anchor,
+                parent_depth: 0,
+            }),
+        )
+        .unwrap();
+        assert_eq!(encoded.kind, TreeEncodingKind::Lean);
+    }
+
+    #[test]
+    fn every_tree_form_validates_the_external_key() {
+        let anchor = tree_fixture(240, None);
+        let current = tree_fixture(240, Some((117, b"changed")));
+        let wrong = ContentHash::compute(b"wrong-tree-key");
+        let lean = anchor.encode_lean().unwrap();
+        assert!(decode_tree_with_key(&lean, wrong, None).is_err());
+
+        let ops = tree_delta(&anchor, &current);
+        let delta = encode_tree_delta(anchor.hash(), &anchor, &current, &ops).unwrap();
+        assert!(decode_tree_with_key(&delta, wrong, Some(&anchor)).is_err());
+
+        let raw = current.encode_canonical().unwrap();
+        assert!(decode_tree_with_key(&raw, wrong, None).is_err());
     }
 
     #[test]
@@ -132,14 +392,38 @@ mod tests {
         )
         .with_intent("dictionary frame verification ".repeat(32));
 
-        let (_, encoded_tree) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
+        let encoded_tree = encode_tree_at_rest(&tree, &CompressionConfig::default()).unwrap();
         let encoded_state = encode_state(&state, &CompressionConfig::default()).unwrap();
 
         assert!(
             crate::object::is_canonical_tree(&encoded_tree),
-            "trees stay uncompressed HTR4 so resume can seek"
+            "at-rest trees remain versioned HTR4 so resume can seek"
         );
         assert_eq!(&encoded_state[9..13], &1_u32.to_be_bytes());
+    }
+
+    #[test]
+    #[cfg(feature = "zstd")]
+    fn store_decoder_reads_raw_v4_and_blocked_v5() {
+        let tree = tree_fixture(600, None);
+        let raw = tree.encode_canonical().unwrap();
+        let blocked = encode_tree_at_rest(
+            &tree,
+            &CompressionConfig {
+                enabled: true,
+                level: 3,
+                min_size: 0,
+                max_delta_size: CompressionConfig::default().max_delta_size,
+            },
+        )
+        .unwrap();
+        assert_eq!(raw[4], crate::object::TREE_ENCODING_VERSION);
+        assert_eq!(blocked[4], crate::object::TREE_BLOCK_ENCODING_VERSION);
+        assert_eq!(decode_tree_with_key(&raw, tree.hash(), None).unwrap(), tree);
+        assert_eq!(
+            decode_tree_with_key(&blocked, tree.hash(), None).unwrap(),
+            tree
+        );
     }
 
     #[test]
@@ -162,9 +446,8 @@ mod tests {
                     })
                     .collect(),
             );
-            let serialized_tree = tree.encode_canonical().unwrap();
-            let (_, encoded_tree) = encode_tree(&tree, &config).unwrap();
-            assert_eq!(decode_tree_body(&encoded_tree).unwrap(), serialized_tree);
+            let encoded_tree = encode_tree_at_rest(&tree, &config).unwrap();
+            assert_eq!(Tree::decode_canonical(&encoded_tree).unwrap(), tree);
 
             let state = State::new(
                 tree.hash(),
@@ -228,6 +511,27 @@ mod tests {
 
     fn old_encode_raw(data: &[u8], config: &CompressionConfig) -> Result<Vec<u8>> {
         Ok(compress(data, config)?.unwrap_or_else(|| data.to_vec()))
+    }
+
+    fn tree_fixture(entries: usize, changed: Option<(usize, &[u8])>) -> Tree {
+        Tree::from_entries(
+            (0..entries)
+                .map(|index| {
+                    let payload = changed
+                        .filter(|(changed_index, _)| *changed_index == index)
+                        .map_or_else(
+                            || format!("blob-{index}").into_bytes(),
+                            |(_, payload)| payload.to_vec(),
+                        );
+                    TreeEntry::file(
+                        format!("module_{index:04}.rs"),
+                        ContentHash::compute(&payload),
+                        false,
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        )
     }
 
     fn compression_configs() -> Vec<CompressionConfig> {

--- a/crates/objects/src/store/delta_source.rs
+++ b/crates/objects/src/store/delta_source.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Lazy HDC1-to-HLR1 projection for entry-level store reads.
+
+use crate::object::{
+    OpenedTreeBody, TREE_DELTA_HEADER_LEN, TREE_LEAN_MAGIC, TreeBodyIntegrity, TreeByteSource,
+    TreeDeltaHeader, TreeDeltaOp, TreeEntry, TreeEntryReader, TreeStreamError,
+    decode_tree_delta_header_prefix, decode_tree_delta_ops_prefix, encode_lean_entry,
+};
+
+/// Exposes a cumulative delta as a virtual HLR1 body. The first-entry and
+/// first-100 porch bounds decide how much of the delta is transferred; the
+/// materialized anchor is paged through its own seekable reader.
+pub(super) struct DeltaTreeSource {
+    delta: OpenedTreeBody,
+    delta_len: usize,
+    header: TreeDeltaHeader,
+    ops: Vec<TreeDeltaOp>,
+    op_index: usize,
+    anchor: TreeEntryReader<OpenedTreeBody>,
+    anchor_next: Option<TreeEntry>,
+    anchor_done: bool,
+    body: Vec<u8>,
+    previous_name: String,
+    generated: usize,
+    finalized: bool,
+}
+
+impl DeltaTreeSource {
+    pub(super) fn open(
+        mut delta: OpenedTreeBody,
+        anchor: TreeEntryReader<OpenedTreeBody>,
+    ) -> Result<Self, TreeStreamError> {
+        let delta_len = usize::try_from(delta.len())
+            .map_err(|_| TreeStreamError::Malformed("HDC1 body exceeds usize".into()))?;
+        let mut header_bytes = [0u8; TREE_DELTA_HEADER_LEN];
+        delta.read_exact_at(0, &mut header_bytes)?;
+        let header = decode_tree_delta_header_prefix(&header_bytes, delta_len)?;
+        let mut body = Vec::new();
+        body.extend_from_slice(TREE_LEAN_MAGIC);
+        put_varint(header.result_count, &mut body);
+        let mut source = Self {
+            delta,
+            delta_len,
+            header,
+            ops: Vec::new(),
+            op_index: 0,
+            anchor,
+            anchor_next: None,
+            anchor_done: false,
+            body,
+            previous_name: String::new(),
+            generated: 0,
+            finalized: false,
+        };
+        if source.header.result_count == 0 {
+            source.load_ops(source.header.op_count)?;
+            source.finish_merge()?;
+        }
+        Ok(source)
+    }
+
+    fn load_ops(&mut self, wanted: usize) -> Result<(), TreeStreamError> {
+        if wanted <= self.ops.len() {
+            return Ok(());
+        }
+        let end = if wanted == self.header.first_op_count {
+            self.header.first_end
+        } else if wanted == self.header.hundred_op_count {
+            self.header.hundred_end
+        } else if wanted == self.header.op_count {
+            self.delta_len
+        } else {
+            return Err(TreeStreamError::Malformed(
+                "HDC1 read requested a non-porch operation count".into(),
+            ));
+        };
+        let mut prefix = vec![0u8; end];
+        self.delta.read_exact_at(0, &mut prefix)?;
+        let (header, ops, consumed) =
+            decode_tree_delta_ops_prefix(&prefix, self.delta_len, wanted)?;
+        if header != self.header || consumed != end {
+            return Err(TreeStreamError::Malformed(
+                "HDC1 porch does not end at its declared offset".into(),
+            ));
+        }
+        self.ops = ops;
+        Ok(())
+    }
+
+    fn prepare_ops_for_result(&mut self, ordinal: usize) -> Result<(), TreeStreamError> {
+        let wanted = if ordinal <= 1 {
+            self.header.first_op_count
+        } else if ordinal <= 100 {
+            self.header.hundred_op_count
+        } else {
+            self.header.op_count
+        };
+        self.load_ops(wanted)
+    }
+
+    fn fill_anchor_next(&mut self) -> Result<(), TreeStreamError> {
+        if self.anchor_next.is_none() && !self.anchor_done {
+            self.anchor_next = self.anchor.next_entry()?;
+            self.anchor_done = self.anchor_next.is_none();
+        }
+        Ok(())
+    }
+
+    fn next_merged_entry(&mut self) -> Result<Option<TreeEntry>, TreeStreamError> {
+        loop {
+            self.fill_anchor_next()?;
+            let op = self.ops.get(self.op_index);
+            match (self.anchor_next.as_ref(), op) {
+                (Some(anchor), Some(op)) => match anchor.name().cmp(op.name()) {
+                    std::cmp::Ordering::Less => return Ok(self.anchor_next.take()),
+                    std::cmp::Ordering::Greater => {
+                        self.op_index += 1;
+                        if let TreeDeltaOp::Upsert(entry) = op {
+                            return Ok(Some(entry.clone()));
+                        }
+                    }
+                    std::cmp::Ordering::Equal => {
+                        self.anchor_next = None;
+                        self.op_index += 1;
+                        if let TreeDeltaOp::Upsert(entry) = op {
+                            return Ok(Some(entry.clone()));
+                        }
+                    }
+                },
+                (Some(_), None) => return Ok(self.anchor_next.take()),
+                (None, Some(op)) => {
+                    self.op_index += 1;
+                    if let TreeDeltaOp::Upsert(entry) = op {
+                        return Ok(Some(entry.clone()));
+                    }
+                }
+                (None, None) => return Ok(None),
+            }
+        }
+    }
+
+    fn generate_entry(&mut self) -> Result<(), TreeStreamError> {
+        self.prepare_ops_for_result(self.generated + 1)?;
+        let entry = self.next_merged_entry()?.ok_or_else(|| {
+            TreeStreamError::Malformed("HDC1 result ended before its declared count".into())
+        })?;
+        encode_lean_entry(&entry, &self.previous_name, &mut self.body)?;
+        self.previous_name = entry.name().to_string();
+        self.generated += 1;
+        if self.generated == self.header.result_count {
+            self.load_ops(self.header.op_count)?;
+            self.finish_merge()?;
+        }
+        Ok(())
+    }
+
+    fn finish_merge(&mut self) -> Result<(), TreeStreamError> {
+        if self.next_merged_entry()?.is_some() {
+            return Err(TreeStreamError::Malformed(
+                "HDC1 result exceeds its declared count".into(),
+            ));
+        }
+        if self.op_index != self.header.op_count {
+            return Err(TreeStreamError::Malformed(
+                "HDC1 reconstruction did not consume every operation".into(),
+            ));
+        }
+        self.anchor.finish_and_verify()?;
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+impl TreeByteSource for DeltaTreeSource {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        let start =
+            usize::try_from(offset).map_err(|_| TreeStreamError::TruncatedFrame { offset })?;
+        let end = start
+            .checked_add(buf.len())
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        while self.body.len() < end && self.generated < self.header.result_count {
+            self.generate_entry()?;
+        }
+        let bytes = self
+            .body
+            .get(start..end)
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        buf.copy_from_slice(bytes);
+        Ok(())
+    }
+
+    fn len(&self) -> u64 {
+        self.body.len() as u64
+    }
+
+    fn integrity(&self) -> TreeBodyIntegrity {
+        TreeBodyIntegrity::SequentialVerify
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.delta
+            .bytes_read()
+            .saturating_add(self.anchor.bytes_read())
+    }
+}
+
+fn put_varint(mut value: usize, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -18,17 +18,21 @@ use super::{
         action_path, actions_dir, annotated_tags_dir, blobs_dir, hash_path, redaction_path,
         redactions_dir, state_attachment_index_lock_path, state_attachment_index_path,
         state_attachment_path, state_attachments_dir, state_path, state_visibility_dir,
-        state_visibility_path, states_dir, trees_dir,
+        state_visibility_path, states_dir, tree_lineage_path, trees_dir,
     },
 };
 use crate::{
     object::{
         Action, ActionId, AnnotatedTag, Blob, BytesTreeSource, ContentHash, FileTreeSource,
         OpenedTreeBody, State, StateAttachment, StateAttachmentId, StateId, TREE_CANONICAL_MAGIC,
-        Tree, TreeEntryReader, TreeResumeCursor, is_canonical_tree,
+        TREE_DELTA_HEADER_LEN, TREE_DELTA_MAGIC, TREE_LEAN_MAGIC, Tree, TreeByteSource,
+        TreeEntryReader, TreeResumeCursor, decode_tree_delta_header,
+        decode_tree_delta_header_prefix, decode_tree_delta_ops, is_delta_tree, is_streamable_tree,
     },
     store::{
-        HeddleError, ObjectStore, Result, SidecarStore, SnapshotCommitDescriptor, codec,
+        HeddleError, ObjectStore, Result, SidecarStore, SnapshotCommitDescriptor, TreeWrite, codec,
+        codec::{EncodedTree, TreeDeltaBase, TreeEncodingKind, TreeLineage},
+        delta_source::DeltaTreeSource,
         pack::{ObjectType, PackManager, PackObjectId},
     },
 };
@@ -62,7 +66,7 @@ fn validate_blob_bytes(data: &[u8], hash: ContentHash) -> Result<()> {
 }
 
 fn validate_tree_serialized(data: &[u8], hash: ContentHash) -> Result<Tree> {
-    let tree = codec::decode_tree_serialized(data)?;
+    let tree = codec::decode_tree_serialized_with_key(data, hash, None)?;
     let tree = validate_loaded_tree(tree)?;
     let found = tree.hash();
     if found != hash {
@@ -377,7 +381,18 @@ pub(super) fn validate_pack_entry(
             validate_annotated_tag(data, *hash).map(|_| ())
         }
         (PackObjectId::Hash(hash), ObjectType::Tree) => {
-            validate_tree_serialized(data, *hash).map(|_| ())
+            if is_delta_tree(data) {
+                let header = decode_tree_delta_header(data)?;
+                let (_, _, consumed) = decode_tree_delta_ops(data, header.op_count)?;
+                if consumed != data.len() {
+                    return Err(HeddleError::InvalidObject(
+                        "HDC1 pack tree has trailing bytes".to_string(),
+                    ));
+                }
+                Ok(())
+            } else {
+                validate_tree_serialized(data, *hash).map(|_| ())
+            }
         }
         (PackObjectId::Hash(hash), ObjectType::Action) => {
             validate_action_serialized(data, ActionId::from_hash(*hash)).map(|_| ())
@@ -581,36 +596,154 @@ impl FsStore {
         let path = hash_path(&trees_dir(&self.root), tree_id);
         if path.exists()
             && let Some((header, len)) = read_file_header(&path, TREE_CANONICAL_MAGIC.len())?
-            && header.starts_with(TREE_CANONICAL_MAGIC)
         {
-            let file = File::open(&path)?;
-            return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::File(FileTreeSource::sequential_verify(file, len)),
-                *tree_id,
-                cursor,
-            )?));
+            if header.starts_with(TREE_CANONICAL_MAGIC) || header.starts_with(TREE_LEAN_MAGIC) {
+                let file = File::open(&path)?;
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::File(FileTreeSource::sequential_verify(file, len)),
+                    *tree_id,
+                    cursor,
+                )?));
+            }
+            if header.starts_with(TREE_DELTA_MAGIC) {
+                let file = File::open(&path)?;
+                return self.open_delta_tree_source(
+                    *tree_id,
+                    cursor,
+                    OpenedTreeBody::File(FileTreeSource::sequential_verify(file, len)),
+                );
+            }
         }
         if path.exists()
             && let Some(data) = read_file_bytes(&path)?
         {
             let body = codec::decode_tree_body(data.as_slice())?;
-            if is_canonical_tree(&body) {
+            if is_streamable_tree(&body) {
                 return Ok(Some(TreeEntryReader::open(
                     OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
                     *tree_id,
                     cursor,
                 )?));
             }
+            if is_delta_tree(&body) {
+                return self.open_delta_tree_source(
+                    *tree_id,
+                    cursor,
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
+                );
+            }
         }
-        if let Ok(manager) = self.pack_manager().read()
-            && let Some((obj_type, data)) = manager.get_hashed_object(tree_id)?
-            && obj_type == ObjectType::Tree
-            && is_canonical_tree(&data)
+        let packed = if let Ok(manager) = self.pack_manager().read() {
+            manager.get_hashed_object(tree_id)?
+        } else {
+            None
+        };
+        if let Some((ObjectType::Tree, data)) = packed {
+            if is_streamable_tree(&data) {
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
+                    *tree_id,
+                    cursor,
+                )?));
+            }
+            if is_delta_tree(&data) {
+                return self.open_delta_tree_source(
+                    *tree_id,
+                    cursor,
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
+                );
+            }
+        }
+        Ok(None)
+    }
+
+    fn open_delta_tree_source(
+        &self,
+        tree_id: ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+        mut delta: OpenedTreeBody,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        let object_len = usize::try_from(delta.len())
+            .map_err(|_| HeddleError::InvalidObject("HDC1 body exceeds usize".to_string()))?;
+        let mut header_bytes = [0u8; TREE_DELTA_HEADER_LEN];
+        delta.read_exact_at(0, &mut header_bytes)?;
+        let header = decode_tree_delta_header_prefix(&header_bytes, object_len)?;
+        let anchor = self
+            .try_open_materialized_tree_once(&header.anchor)?
+            .ok_or_else(|| HeddleError::NotFound(format!("tree delta anchor {}", header.anchor)))?;
+        let source = DeltaTreeSource::open(delta, anchor)?;
+        Ok(Some(TreeEntryReader::open(
+            OpenedTreeBody::Dynamic(Box::new(source)),
+            tree_id,
+            cursor,
+        )?))
+    }
+
+    fn try_open_materialized_tree_once(
+        &self,
+        tree_id: &ContentHash,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        let path = hash_path(&trees_dir(&self.root), tree_id);
+        if path.exists()
+            && let Some((header, len)) = read_file_header(&path, TREE_CANONICAL_MAGIC.len())?
+        {
+            if header.starts_with(TREE_DELTA_MAGIC) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+                ));
+            }
+            if header.starts_with(TREE_CANONICAL_MAGIC) || header.starts_with(TREE_LEAN_MAGIC) {
+                let file = File::open(&path)?;
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::File(FileTreeSource::sequential_verify(file, len)),
+                    *tree_id,
+                    None,
+                )?));
+            }
+        }
+        if path.exists()
+            && let Some(data) = read_file_bytes(&path)?
+        {
+            let body = codec::decode_tree_body(data.as_slice())?;
+            if is_delta_tree(&body) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+                ));
+            }
+            if is_streamable_tree(&body) {
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
+                    *tree_id,
+                    None,
+                )?));
+            }
+        }
+        let packed = if let Ok(manager) = self.pack_manager().read() {
+            manager.get_hashed_object(tree_id)?
+        } else {
+            None
+        };
+        if let Some((ObjectType::Tree, data)) = packed {
+            if is_delta_tree(&data) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+                ));
+            }
+            if is_streamable_tree(&data) {
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
+                    *tree_id,
+                    None,
+                )?));
+            }
+        }
+        if let Some(source) = &self.external_source
+            && let Some(tree) = source.get_tree(tree_id)?
         {
             return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
+                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(tree.encode_lean()?)),
                 *tree_id,
-                cursor,
+                None,
             )?));
         }
         Ok(None)
@@ -635,7 +768,8 @@ impl FsStore {
             && let Some(data) = read_file_bytes(&path)?
         {
             trace!(size = data.as_slice().len(), "Tree data read");
-            let tree = validate_loaded_tree(codec::decode_tree(data.as_slice())?)?;
+            let body = codec::decode_tree_body(data.as_slice())?;
+            let tree = validate_loaded_tree(self.decode_tree_storage_body(*hash, &body)?)?;
             heddle_perf_contract::record_object_decode();
             if tree.hash() != *hash {
                 return Err(HeddleError::Corruption {
@@ -654,7 +788,7 @@ impl FsStore {
             && obj_type == ObjectType::Tree
         {
             trace!("Found tree in packfile");
-            let tree = validate_loaded_tree(codec::decode_tree_serialized(&data)?)?;
+            let tree = validate_loaded_tree(self.decode_tree_storage_body(*hash, &data)?)?;
             heddle_perf_contract::record_object_decode();
             if tree.hash() != *hash {
                 return Err(HeddleError::Corruption {
@@ -686,6 +820,115 @@ impl FsStore {
         }
 
         Ok(None)
+    }
+
+    fn decode_tree_storage_body(&self, hash: ContentHash, data: &[u8]) -> Result<Tree> {
+        let anchor = if is_delta_tree(data) {
+            let header = decode_tree_delta_header(data)?;
+            let anchor = if let Some(anchor_body) =
+                self.try_get_tree_serialized_once(&header.anchor)?
+            {
+                if is_delta_tree(&anchor_body) {
+                    return Err(HeddleError::InvalidObject(
+                        "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+                    ));
+                }
+                let tree =
+                    codec::decode_tree_serialized_with_key(&anchor_body, header.anchor, None)?;
+                self.cache_recent_tree(header.anchor, &tree);
+                Some(tree)
+            } else if let Some(tree) = self.recent_tree(&header.anchor) {
+                // This can only be a read-through external tree: native bodies
+                // were checked above so a cached delta cannot hide a chain.
+                Some(tree)
+            } else if let Some(source) = &self.external_source {
+                source.get_tree(&header.anchor)?
+            } else {
+                None
+            };
+            Some(anchor.ok_or_else(|| {
+                HeddleError::NotFound(format!("tree delta anchor {}", header.anchor))
+            })?)
+        } else {
+            None
+        };
+        codec::decode_tree_serialized_with_key(data, hash, anchor.as_ref())
+    }
+
+    pub(super) fn encode_tree_write(&self, write: &TreeWrite) -> Result<EncodedTree> {
+        let Some(parent) = write.parent else {
+            return codec::encode_tree_hot(&write.tree, None);
+        };
+        let Some(parent_body) = self.try_get_tree_serialized_once(&parent)? else {
+            return codec::encode_tree_hot(&write.tree, None);
+        };
+        let base = if is_delta_tree(&parent_body) {
+            let header = decode_tree_delta_header(&parent_body)?;
+            let Some(lineage) = self.read_tree_lineage(&parent)? else {
+                return codec::encode_tree_hot(&write.tree, None);
+            };
+            if lineage.anchor != header.anchor || lineage.depth == 0 {
+                return codec::encode_tree_hot(&write.tree, None);
+            }
+            let Some(anchor_body) = self.try_get_tree_serialized_once(&lineage.anchor)? else {
+                return codec::encode_tree_hot(&write.tree, None);
+            };
+            if is_delta_tree(&anchor_body) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 lineage points to another delta".to_string(),
+                ));
+            }
+            let anchor =
+                codec::decode_tree_serialized_with_key(&anchor_body, lineage.anchor, None)?;
+            Some((lineage.anchor, anchor, lineage.depth))
+        } else {
+            let anchor = codec::decode_tree_serialized_with_key(&parent_body, parent, None)?;
+            Some((parent, anchor, 0))
+        };
+        let Some((anchor_id, anchor, parent_depth)) = base else {
+            return codec::encode_tree_hot(&write.tree, None);
+        };
+        codec::encode_tree_hot(
+            &write.tree,
+            Some(TreeDeltaBase {
+                anchor_id,
+                anchor: &anchor,
+                parent_depth,
+            }),
+        )
+    }
+
+    fn read_tree_lineage(&self, hash: &ContentHash) -> Result<Option<TreeLineage>> {
+        let Some(bytes) = read_file_bytes(&tree_lineage_path(&self.root, hash))? else {
+            return Ok(None);
+        };
+        let data = bytes.as_slice();
+        if data.len() != 33 {
+            return Ok(None);
+        }
+        let anchor = match data[..32].try_into() {
+            Ok(bytes) => ContentHash::from_bytes(bytes),
+            Err(_) => return Ok(None),
+        };
+        let depth = data[32];
+        if depth == 0 || depth >= crate::object::TREE_DELTA_ANCHOR_INTERVAL {
+            return Ok(None);
+        }
+        Ok(Some(TreeLineage { anchor, depth }))
+    }
+
+    pub(super) fn remember_tree_encoding(
+        &self,
+        hash: ContentHash,
+        kind: TreeEncodingKind,
+    ) -> Result<()> {
+        let TreeEncodingKind::Delta { anchor, depth, .. } = kind else {
+            return Ok(());
+        };
+        let mut bytes = Vec::with_capacity(33);
+        bytes.extend_from_slice(anchor.as_bytes());
+        bytes.push(depth);
+        self.write_reconstructible_cache(&tree_lineage_path(&self.root, &hash), &bytes)
     }
 
     fn try_has_tree_once(&self, hash: &ContentHash) -> Result<bool> {
@@ -1225,11 +1468,18 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(reader));
         }
-        if let Some(data) = ObjectStore::get_tree_serialized(self, tree_id)?
-            && is_canonical_tree(&data)
-        {
+        if let Some(data) = ObjectStore::get_tree_serialized(self, tree_id)? {
+            let body = if is_streamable_tree(&data) {
+                data
+            } else if data.starts_with(TREE_DELTA_MAGIC) {
+                self.get_tree(tree_id)?
+                    .ok_or_else(|| HeddleError::NotFound(format!("tree {tree_id}")))?
+                    .encode_lean()?
+            } else {
+                return Ok(None);
+            };
             return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
+                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
                 *tree_id,
                 cursor,
             )?));
@@ -1262,7 +1512,7 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self, data), fields(hash = %hash.short(), size = data.len()))]
     fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
-        let tree = validate_tree_serialized(data, hash)?;
+        let tree = validate_loaded_tree(self.decode_tree_storage_body(hash, data)?)?;
 
         let path = hash_path(&trees_dir(&self.root), &hash);
         let should_write = match read_file_bytes(&path)? {
@@ -1626,8 +1876,15 @@ impl ObjectStore for FsStore {
         tree: &Tree,
         state: &State,
     ) -> Result<()> {
-        self.put_snapshot_objects_packed_impl(blobs, Vec::new(), tree, state, Vec::new(), None)
-            .map(|_| ())
+        self.put_snapshot_objects_packed_impl(
+            blobs,
+            Vec::new(),
+            &TreeWrite::anchor(tree.clone()),
+            state,
+            Vec::new(),
+            None,
+        )
+        .map(|_| ())
     }
 
     fn put_snapshot_objects_and_attachments_packed(
@@ -1637,8 +1894,15 @@ impl ObjectStore for FsStore {
         state: &State,
         attachments: Vec<StateAttachment>,
     ) -> Result<()> {
-        self.put_snapshot_objects_packed_impl(blobs, Vec::new(), tree, state, attachments, None)
-            .map(|_| ())
+        self.put_snapshot_objects_packed_impl(
+            blobs,
+            Vec::new(),
+            &TreeWrite::anchor(tree.clone()),
+            state,
+            attachments,
+            None,
+        )
+        .map(|_| ())
     }
 
     #[instrument(skip(self))]

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -27,7 +27,7 @@ use crate::{
         OpenedTreeBody, State, StateAttachment, StateAttachmentId, StateId, TREE_CANONICAL_MAGIC,
         TREE_DELTA_HEADER_LEN, TREE_DELTA_MAGIC, TREE_LEAN_MAGIC, Tree, TreeByteSource,
         TreeEntryReader, TreeResumeCursor, decode_tree_delta_header,
-        decode_tree_delta_header_prefix, decode_tree_delta_ops, is_delta_tree, is_streamable_tree,
+        decode_tree_delta_header_prefix, is_delta_tree, is_streamable_tree,
     },
     store::{
         HeddleError, ObjectStore, Result, SidecarStore, SnapshotCommitDescriptor, TreeWrite, codec,
@@ -322,9 +322,43 @@ impl FsStore {
 /// (`install_pack_streaming`) both run their pack through here, so
 /// both apply the same checksum validation and report the same
 /// installed ids regardless of how the bytes reach the store.
-fn validate_and_list_pack(reader: &crate::store::pack::PackReader) -> Result<Vec<PackObjectId>> {
+fn validate_and_list_pack(
+    store: &FsStore,
+    reader: &crate::store::pack::PackReader,
+) -> Result<Vec<PackObjectId>> {
     let ids = reader.list_ids()?;
-    reader.visit_objects(|id, object_type, data| validate_pack_entry(&id, object_type, data))?;
+    reader.visit_objects(|id, object_type, data| {
+        if let (PackObjectId::Hash(hash), ObjectType::Tree) = (id, object_type)
+            && is_delta_tree(data)
+        {
+            let header = decode_tree_delta_header(data)?;
+            if header.anchor == hash {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 result id must differ from its anchor id".to_string(),
+                ));
+            }
+            let anchor_body = match reader.get_object(&PackObjectId::Hash(header.anchor))? {
+                Some((ObjectType::Tree, body)) => Some(body),
+                Some((kind, _)) => {
+                    return Err(HeddleError::InvalidObject(format!(
+                        "HDC1 anchor {} is indexed as {kind:?}, expected Tree",
+                        header.anchor
+                    )));
+                }
+                None => store.try_get_tree_serialized_once(&header.anchor)?,
+            }
+            .ok_or_else(|| HeddleError::NotFound(format!("tree delta anchor {}", header.anchor)))?;
+            if is_delta_tree(&anchor_body) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+                ));
+            }
+            let anchor = codec::decode_tree_serialized_with_key(&anchor_body, header.anchor, None)?;
+            codec::decode_tree_serialized_with_key(data, hash, Some(&anchor))?;
+            return Ok(());
+        }
+        validate_pack_entry(&id, object_type, data)
+    })?;
     Ok(ids)
 }
 
@@ -381,18 +415,7 @@ pub(super) fn validate_pack_entry(
             validate_annotated_tag(data, *hash).map(|_| ())
         }
         (PackObjectId::Hash(hash), ObjectType::Tree) => {
-            if is_delta_tree(data) {
-                let header = decode_tree_delta_header(data)?;
-                let (_, _, consumed) = decode_tree_delta_ops(data, header.op_count)?;
-                if consumed != data.len() {
-                    return Err(HeddleError::InvalidObject(
-                        "HDC1 pack tree has trailing bytes".to_string(),
-                    ));
-                }
-                Ok(())
-            } else {
-                validate_tree_serialized(data, *hash).map(|_| ())
-            }
+            validate_tree_serialized(data, *hash).map(|_| ())
         }
         (PackObjectId::Hash(hash), ObjectType::Action) => {
             validate_action_serialized(data, ActionId::from_hash(*hash)).map(|_| ())
@@ -804,7 +827,10 @@ impl FsStore {
         Ok(None)
     }
 
-    fn try_get_tree_serialized_once(&self, hash: &ContentHash) -> Result<Option<Vec<u8>>> {
+    pub(super) fn try_get_tree_serialized_once(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<Option<Vec<u8>>> {
         let path = hash_path(&trees_dir(&self.root), hash);
         if path.exists()
             && let Some(data) = read_file_bytes(&path)?
@@ -1852,7 +1878,7 @@ impl ObjectStore for FsStore {
     #[instrument(skip(self, pack_data, index_data))]
     fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<PackObjectId>> {
         let reader = crate::store::pack::PackReader::from_slice(pack_data, index_data)?;
-        let ids = validate_and_list_pack(&reader)?;
+        let ids = validate_and_list_pack(self, &reader)?;
         let state_entries = state_entries_from_pack(&reader, &ids)?;
         let attachment_entries = attachment_entries_from_pack(&reader, &ids)?;
         self.install_pack_files(pack_data, index_data)?;
@@ -1918,7 +1944,7 @@ impl ObjectStore for FsStore {
         // the file move isn't racing an open mapping.
         let ids = {
             let reader = crate::store::pack::PackReader::open(pack_path, index_path)?;
-            validate_and_list_pack(&reader)?
+            validate_and_list_pack(self, &reader)?
         };
         let state_entries = {
             let reader = crate::store::pack::PackReader::open(pack_path, index_path)?;
@@ -1955,9 +1981,7 @@ impl ObjectStore for FsStore {
             }
             let index = path.with_extension("idx");
             let valid = crate::store::pack::PackReader::open(&path, &index)
-                .and_then(|reader| {
-                    reader.visit_objects(|id, kind, bytes| validate_pack_entry(&id, kind, bytes))
-                })
+                .and_then(|reader| validate_and_list_pack(self, &reader).map(|_| ()))
                 .is_ok();
             if !valid {
                 let _ = fs::remove_file(&path);

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -214,20 +214,46 @@ impl FsStore {
         let mut seen_trees = std::collections::HashSet::with_capacity(trees.len() + 1);
         for authored_tree in trees {
             let authored_hash = authored_tree.tree.hash();
+            let reuses_materialized = self
+                .try_get_tree_serialized_once(&authored_hash)?
+                .is_some_and(|body| !crate::object::is_delta_tree(&body));
             if seen_trees.insert(authored_hash)
+                && !reuses_materialized
                 && (commit_artifact.is_some()
                     || !ObjectStore::has_tree_locally(self, &authored_hash)?)
             {
                 let encoded = self.encode_tree_write(&authored_tree)?;
+                if matches!(
+                    encoded.kind,
+                    crate::store::codec::TreeEncodingKind::Delta { anchor, .. }
+                        if anchor == authored_hash
+                ) {
+                    return Err(HeddleError::InvalidObject(
+                        "HDC1 result id must differ from its anchor id".to_string(),
+                    ));
+                }
                 builder.add(authored_hash, PackObjectType::Tree, encoded.data);
                 staged_encodings.push((authored_hash, encoded.kind));
                 staged_trees.push((authored_hash, authored_tree.tree));
             }
         }
-        if (commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)?)
+        let reuses_materialized = self
+            .try_get_tree_serialized_once(&tree_hash)?
+            .is_some_and(|body| !crate::object::is_delta_tree(&body));
+        if !reuses_materialized
+            && (commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)?)
             && seen_trees.insert(tree_hash)
         {
             let encoded = self.encode_tree_write(tree)?;
+            if matches!(
+                encoded.kind,
+                crate::store::codec::TreeEncodingKind::Delta { anchor, .. }
+                    if anchor == tree_hash
+            ) {
+                return Err(HeddleError::InvalidObject(
+                    "HDC1 result id must differ from its anchor id".to_string(),
+                ));
+            }
             builder.add(tree_hash, PackObjectType::Tree, encoded.data);
             staged_encodings.push((tree_hash, encoded.kind));
             staged_trees.push((tree_hash, tree.tree.clone()));

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -15,11 +15,11 @@ use super::{
     fs_paths::{blobs_dir, hash_path, packs_dir, state_path, states_dir, trees_dir},
 };
 use crate::{
-    object::{ContentHash, State, StateAttachment, StateAttachmentId, Tree},
+    object::{ContentHash, State, StateAttachment, StateAttachmentId},
     store::{
         FsRepackOperation, HeddleError, ObjectStore, RepackPolicy, RepackResourceLimits,
         RepackSchedule, RepackScheduler, Result, SnapshotCommitArtifact, SnapshotCommitDescriptor,
-        codec,
+        TreeWrite, codec,
         pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId, PackReader},
         snapshot_commit::snapshot_commit_marker_path,
     },
@@ -152,8 +152,8 @@ impl FsStore {
     pub fn put_committed_snapshot_objects_packed(
         &self,
         blobs: Vec<(ContentHash, Vec<u8>)>,
-        trees: Vec<Tree>,
-        tree: &Tree,
+        trees: Vec<TreeWrite>,
+        tree: &TreeWrite,
         state: &State,
         attachments: Vec<StateAttachment>,
         artifact: SnapshotCommitArtifact,
@@ -180,8 +180,8 @@ impl FsStore {
     pub(super) fn put_snapshot_objects_packed_impl(
         &self,
         blobs: Vec<(ContentHash, Vec<u8>)>,
-        trees: Vec<Tree>,
-        tree: &Tree,
+        trees: Vec<TreeWrite>,
+        tree: &TreeWrite,
         state: &State,
         attachments: Vec<StateAttachment>,
         commit_artifact: Option<SnapshotCommitArtifact>,
@@ -208,28 +208,29 @@ impl FsStore {
             builder.add(hash, PackObjectType::Blob, data);
         }
 
-        let tree_hash = tree.hash();
+        let tree_hash = tree.tree.hash();
         let mut staged_trees = Vec::with_capacity(trees.len() + 1);
+        let mut staged_encodings = Vec::with_capacity(trees.len() + 1);
         let mut seen_trees = std::collections::HashSet::with_capacity(trees.len() + 1);
         for authored_tree in trees {
-            let authored_hash = authored_tree.hash();
+            let authored_hash = authored_tree.tree.hash();
             if seen_trees.insert(authored_hash)
                 && (commit_artifact.is_some()
                     || !ObjectStore::has_tree_locally(self, &authored_hash)?)
             {
-                builder.add(
-                    authored_hash,
-                    PackObjectType::Tree,
-                    authored_tree.encode_canonical()?,
-                );
-                staged_trees.push((authored_hash, authored_tree));
+                let encoded = self.encode_tree_write(&authored_tree)?;
+                builder.add(authored_hash, PackObjectType::Tree, encoded.data);
+                staged_encodings.push((authored_hash, encoded.kind));
+                staged_trees.push((authored_hash, authored_tree.tree));
             }
         }
         if (commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)?)
             && seen_trees.insert(tree_hash)
         {
-            builder.add(tree_hash, PackObjectType::Tree, tree.encode_canonical()?);
-            staged_trees.push((tree_hash, tree.clone()));
+            let encoded = self.encode_tree_write(tree)?;
+            builder.add(tree_hash, PackObjectType::Tree, encoded.data);
+            staged_encodings.push((tree_hash, encoded.kind));
+            staged_trees.push((tree_hash, tree.tree.clone()));
         }
 
         let state_id = state.id();
@@ -262,23 +263,29 @@ impl FsStore {
             .transpose()?;
         if let Some(artifact) = &commit_artifact {
             artifact.validate()?;
-            builder.add(
-                artifact.id(),
-                PackObjectType::SnapshotCommit,
-                artifact_bytes.clone().expect("artifact bytes are present"),
-            );
+            let bytes = artifact_bytes.as_ref().ok_or_else(|| {
+                HeddleError::InvalidObject(
+                    "snapshot commit artifact bytes were not encoded".to_string(),
+                )
+            })?;
+            builder.add(artifact.id(), PackObjectType::SnapshotCommit, bytes.clone());
         }
 
         let (pack_data, index_data, _stats, retained_objects) =
             builder.build_retaining_objects()?;
         let packs = packs_dir(&self.root);
         let installed_pack_name = if commit_artifact.is_some() {
+            let (Some(artifact_id), Some(artifact_bytes)) = (artifact_id, artifact_bytes) else {
+                return Err(HeddleError::InvalidObject(
+                    "snapshot commit artifact metadata is incomplete".to_string(),
+                ));
+            };
             super::pack_install_journal::install_committed_snapshot_pack_bytes(
                 &packs,
                 pack_data,
                 index_data,
-                artifact_id.expect("commit artifact id is present"),
-                artifact_bytes.expect("commit artifact bytes are present"),
+                artifact_id,
+                artifact_bytes,
             )?
         } else {
             super::pack_install_journal::install_snapshot_pack_bytes(&packs, pack_data, index_data)?
@@ -291,6 +298,9 @@ impl FsStore {
                 packs.join(format!("{installed_pack_name}.pack")),
                 packs.join(format!("{installed_pack_name}.idx")),
             )?;
+        }
+        for (hash, kind) in staged_encodings {
+            self.remember_tree_encoding(hash, kind)?;
         }
         self.materialize_packed_attachment_index(&state_id, &attachment_ids, state_was_present)?;
 
@@ -671,7 +681,11 @@ impl FsStore {
             let Some(loose_data) = read_file_bytes(&path)? else {
                 continue;
             };
-            let loose_tree = codec::decode_tree(loose_data.as_slice())?;
+            let loose_body = codec::decode_tree_body(loose_data.as_slice())?;
+            if crate::object::is_delta_tree(&loose_body) {
+                continue;
+            }
+            let loose_tree = codec::decode_tree_serialized_with_key(&loose_body, *hash, None)?;
             let found = loose_tree.hash();
             if found != *hash {
                 return Err(HeddleError::Corruption {
@@ -682,7 +696,11 @@ impl FsStore {
             // A loose current tree can intentionally shadow an older packed
             // schema at the same semantic hash. Preserve that migration copy
             // until consolidation replaces the legacy body.
-            let Ok(packed_tree) = codec::decode_tree_serialized(&packed_data) else {
+            if crate::object::is_delta_tree(&packed_data) {
+                continue;
+            }
+            let Ok(packed_tree) = codec::decode_tree_serialized_with_key(&packed_data, *hash, None)
+            else {
                 continue;
             };
             let packed_found = packed_tree.hash();

--- a/crates/objects/src/store/fs/fs_paths.rs
+++ b/crates/objects/src/store/fs/fs_paths.rs
@@ -17,6 +17,14 @@ pub(super) fn trees_dir(root: &Path) -> PathBuf {
     objects_dir(root).join("trees")
 }
 
+pub(super) fn tree_lineage_dir(root: &Path) -> PathBuf {
+    objects_dir(root).join("tree-lineage")
+}
+
+pub(super) fn tree_lineage_path(root: &Path, hash: &ContentHash) -> PathBuf {
+    hash_path(&tree_lineage_dir(root), hash)
+}
+
 pub(super) fn annotated_tags_dir(root: &Path) -> PathBuf {
     objects_dir(root).join("annotated-tags")
 }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -17,7 +17,7 @@ use heddle_format::compression::CompressionConfig;
 
 use super::{
     fs_io::{AtomicWriteMode, write_atomic},
-    fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, trees_dir},
+    fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, tree_lineage_dir, trees_dir},
 };
 use crate::{
     fs_atomic::sync_directory,
@@ -365,6 +365,7 @@ impl FsStore {
         // between mkdir and first object write (L6 residual migration).
         crate::fs_atomic::create_dir_all_durable(&blobs_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&trees_dir(&self.root))?;
+        crate::fs_atomic::create_dir_all_durable(&tree_lineage_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&states_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&actions_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&packs_dir(&self.root))?;

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -564,6 +564,77 @@ fn install_pack_rejects_hash_mismatch_without_partial_commit() {
 }
 
 #[test]
+fn install_pack_rejects_hdc1_result_hash_mismatch() {
+    let (_temp, store) = create_test_store();
+    let anchor = Tree::from_entries(
+        (0..240)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("anchor-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let anchor_id = store.put_tree(&anchor).unwrap();
+    let mut entries = anchor.entries().to_vec();
+    entries[117] =
+        TreeEntry::file("module_0117.rs", ContentHash::compute(b"changed"), false).unwrap();
+    let result = Tree::from_entries(entries);
+    let encoded = store
+        .encode_tree_write(&TreeWrite::descendant(result.clone(), anchor_id))
+        .unwrap();
+    assert!(crate::object::is_delta_tree(&encoded.data));
+
+    let claimed_id = Tree::from_entries(Vec::new()).hash();
+    assert_ne!(claimed_id, result.hash());
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(claimed_id, PackObjectType::Tree, encoded.data);
+    let (pack_data, index_data, _) = builder.build().unwrap();
+
+    let error = store
+        .install_pack(&pack_data, &index_data)
+        .expect_err("HDC1 stored under a mismatched result id must be rejected");
+    assert!(
+        matches!(error, HeddleError::TreeStream(crate::object::TreeStreamError::HashMismatch { expected, found }) if expected == claimed_id && found == result.hash()),
+        "expected reconstructed HDC1 hash mismatch, got {error:?}",
+    );
+}
+
+#[test]
+fn install_pack_rejects_hdc1_stored_under_its_anchor_id() {
+    let (_temp, store) = create_test_store();
+    let anchor = Tree::from_entries(
+        (0..240)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("anchor-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let anchor_id = store.put_tree(&anchor).unwrap();
+    let self_delta = crate::object::encode_tree_delta(anchor_id, &anchor, &anchor, &[]).unwrap();
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(anchor_id, PackObjectType::Tree, self_delta);
+    let (pack_data, index_data, _) = builder.build().unwrap();
+
+    let error = store
+        .install_pack(&pack_data, &index_data)
+        .expect_err("an HDC1 object must not shadow its own materialized anchor");
+    assert!(
+        matches!(error, HeddleError::InvalidObject(ref message) if message.contains("result id must differ")),
+        "expected self-anchor admission rejection, got {error:?}",
+    );
+    assert_eq!(store.get_tree(&anchor_id).unwrap(), Some(anchor));
+}
+
+#[test]
 fn install_pack_accepts_valid_mixed_native_pack() {
     let (_temp, store) = create_test_store();
 

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -20,7 +20,7 @@ use crate::{
         TreeEntry,
     },
     store::{
-        ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult,
+        ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult, TreeWrite,
         pack::{
             ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId,
             decode_tagged_entry_header,
@@ -1039,27 +1039,42 @@ fn test_tree_roundtrip() {
 }
 
 #[test]
-fn loose_htr4_open_is_sequential_and_hashes() {
-    use crate::object::{TreePageLimits, TreeStreamError};
+fn loose_hlr1_open_is_file_backed_bounded_and_hashes() {
+    use crate::object::{TREE_LEAN_MAGIC, TreePageLimits, TreeStreamError};
 
     let (_temp, store) = create_test_store();
-    let blob = ContentHash::compute(b"resume-leaf");
-    let tree = Tree::from_entries(vec![
-        TreeEntry::file("a.txt", blob, false).unwrap(),
-        TreeEntry::file("b.txt", blob, true).unwrap(),
-    ]);
+    let tree = Tree::from_entries(
+        (0..600)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("resume-leaf-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
     let hash = store.put_tree(&tree).unwrap();
+    let path = hash_path(&trees_dir(store.root()), &hash);
+    let stored = std::fs::read(&path).unwrap();
+    assert!(stored.starts_with(TREE_LEAN_MAGIC));
+
     let mut reader = store.open_tree(&hash, None).unwrap().unwrap();
     let first = reader
-        .next_page(TreePageLimits::new(1, usize::MAX).unwrap())
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
         .unwrap()
         .unwrap();
-    assert_eq!(first.entries[0].name(), "a.txt");
+    assert_eq!(first.entries, tree.entries()[..100]);
+    assert!(
+        reader.bytes_read() < tree.encode_canonical().unwrap().len() as u64 / 2,
+        "the first-100 porch must not transfer the full tree"
+    );
     let rest = reader
-        .next_page(TreePageLimits::new(8, usize::MAX).unwrap())
+        .next_page(TreePageLimits::new(500, usize::MAX).unwrap())
         .unwrap()
         .unwrap();
-    assert_eq!(rest.entries[0].name(), "b.txt");
+    assert_eq!(rest.entries, tree.entries()[100..]);
     reader.finish_and_verify().unwrap();
 
     let error = store
@@ -1069,6 +1084,72 @@ fn loose_htr4_open_is_sequential_and_hashes() {
         error,
         HeddleError::TreeStream(TreeStreamError::UnverifiedRange)
     ));
+}
+
+#[test]
+fn loose_hdc1_reconstructs_from_one_materialized_anchor() {
+    use crate::object::{
+        BytesTreeSource, TREE_DELTA_MAGIC, TreeEntryReader, TreePageLimits, is_delta_tree,
+    };
+
+    let (_temp, store) = create_test_store();
+    let anchor = Tree::from_entries(
+        (0..240)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("anchor-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let anchor_id = store.put_tree(&anchor).unwrap();
+    let mut entries = anchor.entries().to_vec();
+    entries[117] =
+        TreeEntry::file("module_0117.rs", ContentHash::compute(b"changed"), false).unwrap();
+    let current = Tree::from_entries(entries);
+    let encoded = store
+        .encode_tree_write(&TreeWrite::descendant(current.clone(), anchor_id))
+        .unwrap();
+    assert!(is_delta_tree(&encoded.data));
+    store
+        .put_tree_serialized(&encoded.data, encoded.hash)
+        .unwrap();
+    let path = hash_path(&trees_dir(store.root()), &encoded.hash);
+    assert!(std::fs::read(&path).unwrap().starts_with(TREE_DELTA_MAGIC));
+
+    let reopened = FsStore::new(store.root());
+    let mut reader = reopened.open_tree(&encoded.hash, None).unwrap().unwrap();
+    let first = reader
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.entries, current.entries()[..100]);
+
+    let raw = current.encode_canonical().unwrap();
+    let mut raw_reader = TreeEntryReader::open(
+        BytesTreeSource::sequential_verify(raw),
+        current.hash(),
+        None,
+    )
+    .unwrap();
+    raw_reader
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
+        .unwrap();
+    assert!(
+        reader.bytes_read() <= raw_reader.bytes_read() * 2,
+        "HDC1 first-100 transfer must stay within 2x raw HTR4"
+    );
+
+    let rest = reader
+        .next_page(TreePageLimits::new(usize::MAX, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(rest.entries, current.entries()[100..]);
+    reader.finish_and_verify().unwrap();
+    assert_eq!(reopened.get_tree(&encoded.hash).unwrap(), Some(current));
 }
 
 #[test]

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -10,9 +10,9 @@ use crate::{
     object::{
         Action, ActionId, AnnotatedTag, Blob, BytesTreeSource, ContentHash, OpenedTreeBody, State,
         StateAttachment, StateAttachmentId, StateId, Tree, TreeEntryReader, TreeResumeCursor,
-        is_canonical_tree,
+        decode_tree_delta_header, is_delta_tree, is_streamable_tree,
     },
-    store::{HeddleError, ObjectStore, Result, SidecarStore},
+    store::{HeddleError, ObjectStore, Result, SidecarStore, codec},
     sync::RwLockExt,
 };
 
@@ -49,6 +49,20 @@ impl InMemoryStore {
     /// Create a new, empty in-memory store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn materialized_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        let Some(bytes) = self.trees.read_or_poisoned().get(hash).cloned() else {
+            return Ok(None);
+        };
+        if is_delta_tree(&bytes) {
+            return Err(HeddleError::InvalidObject(
+                "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+            ));
+        }
+        Ok(Some(codec::decode_tree_serialized_with_key(
+            &bytes, *hash, None,
+        )?))
     }
 }
 
@@ -116,10 +130,20 @@ impl ObjectStore for InMemoryStore {
     }
 
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        match self.trees.read_or_poisoned().get(hash) {
-            Some(bytes) => Ok(Some(Tree::decode_canonical(bytes)?)),
-            None => Ok(None),
-        }
+        let Some(bytes) = self.trees.read_or_poisoned().get(hash).cloned() else {
+            return Ok(None);
+        };
+        let anchor = if is_delta_tree(&bytes) {
+            let header = decode_tree_delta_header(&bytes)?;
+            self.materialized_tree(&header.anchor)?
+        } else {
+            None
+        };
+        Ok(Some(codec::decode_tree_serialized_with_key(
+            &bytes,
+            *hash,
+            anchor.as_ref(),
+        )?))
     }
 
     fn open_tree(
@@ -130,11 +154,13 @@ impl ObjectStore for InMemoryStore {
         let Some(body) = self.trees.read_or_poisoned().get(tree_id).cloned() else {
             return Ok(None);
         };
-        if !is_canonical_tree(&body) {
-            return Err(HeddleError::InvalidObject(
-                "tree body is not the streamable canonical encoding".to_string(),
-            ));
-        }
+        let body = if is_streamable_tree(&body) {
+            body
+        } else {
+            self.get_tree(tree_id)?
+                .ok_or_else(|| HeddleError::NotFound(format!("tree {tree_id}")))?
+                .encode_lean()?
+        };
         Ok(Some(TreeEntryReader::open(
             OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
             *tree_id,
@@ -150,8 +176,20 @@ impl ObjectStore for InMemoryStore {
         let hash = tree.hash();
         self.trees
             .write_or_poisoned()
-            .insert(hash, tree.encode_canonical()?);
+            .insert(hash, tree.encode_lean()?);
         Ok(hash)
+    }
+
+    fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
+        let anchor = if is_delta_tree(data) {
+            let header = decode_tree_delta_header(data)?;
+            self.materialized_tree(&header.anchor)?
+        } else {
+            None
+        };
+        let tree = codec::decode_tree_serialized_with_key(data, hash, anchor.as_ref())?;
+        self.trees.write_or_poisoned().insert(hash, data.to_vec());
+        Ok(tree.hash())
     }
 
     fn has_tree(&self, hash: &ContentHash) -> Result<bool> {

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -5,10 +5,11 @@ use std::path::PathBuf;
 
 use crate::object::{
     Action, ActionId, AnnotatedTag, Blob, ContentHash, OpenedTreeBody, State, StateAttachment,
-    StateAttachmentId, StateId, Tree, TreeEntryReader, TreeResumeCursor, is_canonical_tree,
+    StateAttachmentId, StateId, Tree, TreeEntryReader, TreeResumeCursor, is_streamable_tree,
 };
 
 pub mod codec;
+mod delta_source;
 pub mod fs;
 pub mod liveness;
 #[cfg(any(test, feature = "memory-backend"))]
@@ -52,6 +53,28 @@ pub use writer_lease::{
     WriterLeaseReserveOutcome, WriterLeaseStatus, WriterLeaseStore, generate_writer_lease_id,
     generate_writer_lease_token,
 };
+
+/// A newly-authored tree plus its immediate parent, when capture already knows
+/// that relationship. Stores may use the hint for bounded HDC1 encoding; it
+/// never changes the tree's semantic content hash.
+#[derive(Clone, Debug)]
+pub struct TreeWrite {
+    pub tree: Tree,
+    pub parent: Option<ContentHash>,
+}
+
+impl TreeWrite {
+    pub fn anchor(tree: Tree) -> Self {
+        Self { tree, parent: None }
+    }
+
+    pub fn descendant(tree: Tree, parent: ContentHash) -> Self {
+        Self {
+            tree,
+            parent: Some(parent),
+        }
+    }
+}
 
 /// Read-only objects whose authoritative representation lives outside the
 /// native Heddle object directory. Git-overlay repositories use this seam to
@@ -311,11 +334,14 @@ pub trait ObjectStore: SidecarStore + Send + Sync {
         let Some(body) = self.get_tree_serialized(tree_id)? else {
             return Ok(None);
         };
-        if !is_canonical_tree(&body) {
-            return Err(HeddleError::InvalidObject(
-                "tree body is not the streamable canonical encoding".to_string(),
-            ));
-        }
+        let body = if is_streamable_tree(&body) {
+            body
+        } else {
+            let tree = self
+                .get_tree(tree_id)?
+                .ok_or_else(|| HeddleError::NotFound(format!("tree {tree_id}")))?;
+            tree.encode_lean()?
+        };
         Ok(Some(TreeEntryReader::open(
             OpenedTreeBody::Bytes(crate::object::BytesTreeSource::sequential_verify(body)),
             *tree_id,
@@ -365,13 +391,7 @@ pub trait ObjectStore: SidecarStore + Send + Sync {
     }
 
     fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
-        let tree = Tree::decode_canonical(data)?;
-        if tree.hash() != hash {
-            return Err(HeddleError::Corruption {
-                expected: hash,
-                found: tree.hash(),
-            });
-        }
+        let tree = codec::decode_tree_serialized_with_key(data, hash, None)?;
         self.put_tree(&tree)
     }
 

--- a/crates/objects/src/transfer/graph.rs
+++ b/crates/objects/src/transfer/graph.rs
@@ -9,6 +9,7 @@ use crate::{
         AnnotatedTag, BindingDelta, ContentHash, RedactionsBlob, ReverseDependencyIndex,
         SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State, StateAttachment,
         StateAttachmentBody, StateAttachmentId, StateAttachmentKind, StateId, TreeEntryTarget,
+        decode_tree_delta_header, is_delta_tree,
     },
     store::{ObjectStore, pack::ObjectType as PackObjectType},
 };
@@ -424,7 +425,8 @@ enum StateClosureEvent<'a> {
     },
     Tree {
         hash: ContentHash,
-        tree: &'a crate::object::Tree,
+        storage_size: u64,
+        delta_base: Option<ContentHash>,
     },
     Blob {
         hash: ContentHash,
@@ -577,10 +579,16 @@ fn walk_tree_closure_filtered(
             id: tree_hash.to_hex(),
         })?;
 
+    let (storage_size, delta_base) = tree_storage_metadata(store, tree_hash)?;
     visit(StateClosureEvent::Tree {
         hash: tree_hash,
-        tree: &tree,
+        storage_size,
+        delta_base,
     })?;
+
+    if let Some(anchor) = delta_base {
+        walk_tree_storage_anchor(store, anchor, seen, visit)?;
+    }
 
     for entry in tree.entries() {
         match entry.target() {
@@ -598,6 +606,59 @@ fn walk_tree_closure_filtered(
     }
 
     Ok(())
+}
+
+fn tree_storage_metadata(
+    store: &impl ObjectStore,
+    tree_hash: ContentHash,
+) -> Result<(u64, Option<ContentHash>)> {
+    let body =
+        store
+            .get_tree_serialized(&tree_hash)?
+            .ok_or_else(|| HeddleError::MissingObject {
+                object_type: "tree".to_string(),
+                id: tree_hash.to_hex(),
+            })?;
+    let delta_base = if is_delta_tree(&body) {
+        let header = decode_tree_delta_header(&body)?;
+        if header.anchor == tree_hash {
+            return Err(HeddleError::InvalidObject(
+                "HDC1 result id must differ from its anchor id".to_string(),
+            ));
+        }
+        Some(header.anchor)
+    } else {
+        None
+    };
+    Ok((body.len() as u64, delta_base))
+}
+
+fn walk_tree_storage_anchor(
+    store: &impl ObjectStore,
+    anchor_hash: ContentHash,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<()> {
+    if !seen.insert(anchor_hash) {
+        return Ok(());
+    }
+    if store.get_tree(&anchor_hash)?.is_none() {
+        return Err(HeddleError::MissingObject {
+            object_type: "tree delta anchor".to_string(),
+            id: anchor_hash.to_hex(),
+        });
+    }
+    let (storage_size, delta_base) = tree_storage_metadata(store, anchor_hash)?;
+    if delta_base.is_some() {
+        return Err(HeddleError::InvalidObject(
+            "HDC1 anchor must be materialized; delta chains are forbidden".to_string(),
+        ));
+    }
+    visit(StateClosureEvent::Tree {
+        hash: anchor_hash,
+        storage_size,
+        delta_base: None,
+    })
 }
 
 fn walk_blob_filtered(
@@ -828,15 +889,16 @@ fn object_info_from_event(
                 delta_base: None,
             }))
         }
-        StateClosureEvent::Tree { hash, tree } => {
-            let tree_bytes = tree.encode_canonical().map_err(HeddleError::from)?;
-            Ok(Some(ObjectInfo {
-                id: ObjectId::Hash(hash),
-                obj_type: ObjectType::Tree,
-                size: tree_bytes.len() as u64,
-                delta_base: None,
-            }))
-        }
+        StateClosureEvent::Tree {
+            hash,
+            storage_size,
+            delta_base,
+        } => Ok(Some(ObjectInfo {
+            id: ObjectId::Hash(hash),
+            obj_type: ObjectType::Tree,
+            size: storage_size,
+            delta_base,
+        })),
         StateClosureEvent::Blob { hash, .. } => {
             let Some(blob) = store.get_blob(&hash)? else {
                 if blob_has_purge_evidence(store, &hash)? {

--- a/crates/repo/src/history_instrumentation.rs
+++ b/crates/repo/src/history_instrumentation.rs
@@ -31,6 +31,10 @@ where
     fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
         record_decoded(self.source.get_blob(hash)?)
     }
+
+    fn decoded_blob_len(&self, hash: &ContentHash) -> objects::error::Result<Option<u64>> {
+        self.source.decoded_blob_len(hash)
+    }
 }
 
 fn record_decoded<T>(object: Option<T>) -> objects::error::Result<Option<T>> {

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -308,7 +308,7 @@ fn run_canonicalize_tree_entries(ctx: &mut MigrationCtx<'_>) -> Result<()> {
         let Some(raw) = ctx.repo.store().get_tree_serialized(&tree_hash)? else {
             continue;
         };
-        if objects::object::is_canonical_tree(&raw) {
+        if has_discriminated_tree_encoding(&raw) {
             continue;
         }
 
@@ -362,7 +362,7 @@ fn run_streamable_tree_encoding(ctx: &mut MigrationCtx<'_>) -> Result<()> {
         let Some(raw) = ctx.repo.store().get_tree_serialized(&tree_hash)? else {
             continue;
         };
-        if objects::object::is_canonical_tree(&raw) {
+        if has_discriminated_tree_encoding(&raw) {
             continue;
         }
         let tree = rmp_serde::from_slice::<objects::object::Tree>(&raw).map_err(|err| {
@@ -396,6 +396,14 @@ fn run_streamable_tree_encoding(ctx: &mut MigrationCtx<'_>) -> Result<()> {
             })?;
     }
     Ok(())
+}
+
+/// Legacy tree bodies were discriminator-less MessagePack. Keep every known
+/// self-identifying tree format away from those permissive migration decoders.
+fn has_discriminated_tree_encoding(raw: &[u8]) -> bool {
+    objects::object::is_canonical_tree(raw)
+        || objects::object::is_lean_tree(raw)
+        || objects::object::is_delta_tree(raw)
 }
 
 fn run_first_class_annotated_tags(ctx: &mut MigrationCtx<'_>) -> Result<()> {
@@ -699,6 +707,41 @@ mod tests {
         assert_eq!(
             config.repository.version,
             repo_config::SUPPORTED_REPO_FORMAT
+        );
+    }
+
+    #[test]
+    fn tree_migrations_skip_hlr1_and_hdc1_bodies() {
+        let (_temp, repo) = fresh_repo();
+        remove_ledger(&repo);
+
+        let anchor = Tree::from_entries(vec![
+            TreeEntry::file("file.txt", ContentHash::compute(b"anchor"), false).unwrap(),
+        ]);
+        let anchor_hash = anchor.hash();
+        let anchor_body = anchor.encode_lean().unwrap();
+        write_loose_tree_bytes(&repo, anchor_hash, &anchor_body);
+
+        let current = Tree::from_entries(vec![
+            TreeEntry::file("file.txt", ContentHash::compute(b"current"), false).unwrap(),
+        ]);
+        let current_hash = current.hash();
+        let ops = objects::object::tree_delta(&anchor, &current);
+        let delta_body =
+            objects::object::encode_tree_delta(anchor_hash, &anchor, &current, &ops).unwrap();
+        write_loose_tree_bytes(&repo, current_hash, &delta_body);
+
+        apply_pending(&repo).unwrap();
+
+        assert_eq!(
+            repo.store().get_tree_serialized(&anchor_hash).unwrap(),
+            Some(anchor_body),
+            "HLR1 must not enter either legacy MessagePack decoder",
+        );
+        assert_eq!(
+            repo.store().get_tree_serialized(&current_hash).unwrap(),
+            Some(delta_body),
+            "HDC1 must not enter either legacy MessagePack decoder",
         );
     }
 

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -446,12 +446,12 @@ fn split_path(path: &Path) -> Option<(&str, &Path)> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "tree-sitter-symbols")]
     use std::fs;
 
-    use objects::object::{
-        Annotation, AnnotationAnchorStatus, AnnotationKind, StalenessStatus, StateAttachment,
-        StateAttachmentBody,
-    };
+    use objects::object::{Annotation, AnnotationKind, StateAttachment, StateAttachmentBody};
+    #[cfg(feature = "tree-sitter-symbols")]
+    use objects::object::{AnnotationAnchorStatus, StalenessStatus};
     use tempfile::TempDir;
 
     use super::{Repository, *};

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -162,6 +162,27 @@ pub fn build_semantic_context(
         }
     }
 
+    let changed_symbols = crate::repository_semantic_corpus::collect_changed_symbols(
+        &changed_paths,
+        &prior_functions,
+        &new_functions,
+    );
+    // The signal registry emits tree-sitter-backed findings only for changed
+    // symbols. Once the changed leaf-to-root paths prove that set is empty,
+    // walking the new state's complete semantic directory forest cannot
+    // affect the result. This is especially important for capture: a change
+    // to one opaque file must stay proportional to that path instead of
+    // decoding every semantic directory node in the repository.
+    if corpus_complete && changed_symbols.is_empty() {
+        return Ok(CaptureSemanticContext {
+            prior_functions,
+            new_functions,
+            changed_paths,
+            changed_symbols,
+            corpus_complete,
+        });
+    }
+
     if corpus_complete {
         corpus_complete = crate::repository_semantic_corpus::populate_new_function_corpus(
             &overlay,
@@ -172,11 +193,6 @@ pub fn build_semantic_context(
             &mut new_functions,
         )?;
     }
-    let changed_symbols = crate::repository_semantic_corpus::collect_changed_symbols(
-        &changed_paths,
-        &prior_functions,
-        &new_functions,
-    );
 
     Ok(CaptureSemanticContext {
         prior_functions,

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -446,13 +446,15 @@ impl SnapshotMutation<'_> {
             state = state.with_lineage(self.details.lineage.clone());
         }
 
-        let mut inherited_context = if let Some(parent_id) = self.prev_head
+        let inherited_context = if let Some(parent_id) = self.prev_head
             && let Some(parent_state) = self.repo.store.get_state(&parent_id)?
         {
             self.repo.inherit_parent_context(&parent_state)?
         } else {
             None
         };
+        #[cfg(feature = "tree-sitter-symbols")]
+        let mut inherited_context = inherited_context;
 
         #[cfg(feature = "tree-sitter-symbols")]
         let mut risk_signals = None;
@@ -640,8 +642,12 @@ impl SnapshotMutation<'_> {
                 .flatten()
                 .map(|state| state.tree);
             let root_write = match parent_tree {
-                Some(parent) => TreeWrite::descendant(tree.clone(), parent),
-                None => TreeWrite::anchor(tree.clone()),
+                Some(parent)
+                    if parent != tree_hash && !self.repo.store.has_tree_locally(&tree_hash)? =>
+                {
+                    TreeWrite::descendant(tree.clone(), parent)
+                }
+                Some(_) | None => TreeWrite::anchor(tree.clone()),
             };
             self.prepared_artifact = Some(PreparedSnapshotArtifact {
                 blobs,

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -9,7 +9,8 @@ use objects::{
         Attribution, Blob, ChangeLineage, ContentHash, State, StateAttachment, StateAttachmentBody,
         StateId, Tree, TreeEntry,
     },
-    store::{ObjectStore, SnapshotCommitArtifact, SnapshotCommitDescriptor},
+    store::{ObjectStore, SnapshotCommitArtifact, SnapshotCommitDescriptor, TreeWrite},
+    worktree::WorktreeStatus,
 };
 use oplog::{IsolationKey, OpRecord};
 use refs::Head;
@@ -132,8 +133,8 @@ struct SnapshotDetails {
 
 struct PreparedSnapshotArtifact {
     blobs: Vec<(ContentHash, Vec<u8>)>,
-    trees: Vec<Tree>,
-    tree: Tree,
+    trees: Vec<TreeWrite>,
+    tree: TreeWrite,
     state: State,
     attachments: Vec<StateAttachment>,
 }
@@ -156,6 +157,7 @@ struct SnapshotMutation<'a> {
     worktree_revalidation_files: Option<BTreeMap<String, ManifestFile>>,
     worktree_revalidation_cutoff_ns: Option<i64>,
     worktree_monitor_token: Option<ChangeMonitorToken>,
+    known_worktree_changes: Option<WorktreeStatus>,
     require_worktree_change: bool,
 }
 
@@ -166,6 +168,7 @@ impl<'a> SnapshotMutation<'a> {
         details: SnapshotDetails,
         prev_head: Option<StateId>,
         head: Head,
+        known_worktree_changes: Option<WorktreeStatus>,
         require_worktree_change: bool,
     ) -> Self {
         Self {
@@ -181,6 +184,7 @@ impl<'a> SnapshotMutation<'a> {
             worktree_revalidation_files: None,
             worktree_revalidation_cutoff_ns: None,
             worktree_monitor_token: None,
+            known_worktree_changes,
             require_worktree_change,
         }
     }
@@ -472,7 +476,7 @@ impl SnapshotMutation<'_> {
                     .collect::<std::collections::HashMap<_, _>>();
                 let source_trees = trees
                     .iter()
-                    .map(|tree| (tree.hash(), tree))
+                    .map(|write| (write.tree.hash(), &write.tree))
                     .collect::<std::collections::HashMap<_, _>>();
                 self.repo.compute_semantic_index_for_tree_deferred(
                     prior_state.as_ref(),
@@ -511,7 +515,11 @@ impl SnapshotMutation<'_> {
             let mut source_trees = std::collections::HashMap::new();
             if let Some((blobs, trees)) = supplied_blobs.as_ref() {
                 source_blobs.extend(blobs.iter().map(|(hash, bytes)| (*hash, bytes.as_slice())));
-                source_trees.extend(trees.iter().map(|pending| (pending.hash(), pending)));
+                source_trees.extend(
+                    trees
+                        .iter()
+                        .map(|pending| (pending.tree.hash(), &pending.tree)),
+                );
             }
             source_trees.insert(tree.hash(), &tree);
             if let Some(computer) = crate::signals::effective_computer(self.repo.signal_computer())
@@ -622,13 +630,23 @@ impl SnapshotMutation<'_> {
         let worktree_tree_chain = supplied_blobs
             .as_ref()
             .filter(|(_, trees)| trees.len() <= 32)
-            .map(|(_, trees)| trees.clone())
+            .map(|(_, trees)| trees.iter().map(|write| write.tree.clone()).collect())
             .unwrap_or_default();
         if let Some((blobs, trees)) = supplied_blobs {
+            let parent_tree = self
+                .prev_head
+                .map(|id| self.repo.store.get_state(&id))
+                .transpose()?
+                .flatten()
+                .map(|state| state.tree);
+            let root_write = match parent_tree {
+                Some(parent) => TreeWrite::descendant(tree.clone(), parent),
+                None => TreeWrite::anchor(tree.clone()),
+            };
             self.prepared_artifact = Some(PreparedSnapshotArtifact {
                 blobs,
                 trees,
-                tree: tree.clone(),
+                tree: root_write,
                 state: state.clone(),
                 attachments,
             });
@@ -723,6 +741,7 @@ impl SnapshotMutation<'_> {
             &self.repo.root,
             baseline_tree.as_ref(),
             manifest_context.as_ref().map(|(_, manifest)| manifest),
+            self.known_worktree_changes.as_ref(),
         )?;
         if self.require_worktree_change
             && baseline_tree
@@ -746,6 +765,7 @@ impl SnapshotMutation<'_> {
                     baseline_tree.as_ref(),
                     manifest_context.as_ref().map(|(_, manifest)| manifest),
                     &options,
+                    None,
                 );
         }
         Ok(output)
@@ -1183,7 +1203,30 @@ impl Repository {
             confidence,
             attribution,
             Vec::new(),
+            None,
             false,
+        )
+    }
+
+    /// Create a profiled snapshot using the authoritative parent-relative
+    /// paths already discovered by capture preflight. Passing the status into
+    /// the snapshot prevents a second monitor session from losing the event
+    /// and rebuilding the complete directory forest.
+    pub fn snapshot_with_attribution_profiled_from_status(
+        &self,
+        intent: Option<String>,
+        confidence: Option<f32>,
+        attribution: Attribution,
+        status: WorktreeStatus,
+        require_worktree_change: bool,
+    ) -> Result<SnapshotExecution> {
+        self.snapshot_with_attribution_profiled_locked(
+            intent,
+            confidence,
+            attribution,
+            Vec::new(),
+            Some(status),
+            require_worktree_change,
         )
     }
 
@@ -1200,6 +1243,7 @@ impl Repository {
             confidence,
             attribution,
             Vec::new(),
+            None,
             true,
         )
     }
@@ -1216,6 +1260,7 @@ impl Repository {
             confidence,
             attribution,
             lineage,
+            None,
             false,
         )
         .map(|execution| execution.state)
@@ -1228,6 +1273,7 @@ impl Repository {
         confidence: Option<f32>,
         attribution: Attribution,
         lineage: Vec<ChangeLineage>,
+        mut known_worktree_changes: Option<WorktreeStatus>,
         require_worktree_change: bool,
     ) -> Result<SnapshotExecution> {
         const MAX_WORKTREE_CHANGE_ATTEMPTS: usize = 4;
@@ -1308,6 +1354,7 @@ impl Repository {
                 },
                 prev_head,
                 head.clone(),
+                known_worktree_changes.clone(),
                 require_worktree_change,
             );
             mutation.prepare()?;
@@ -1321,6 +1368,7 @@ impl Repository {
                 || self.head()? != prev_head;
             if head_changed {
                 drop(_lock);
+                known_worktree_changes = None;
                 retry_after_head_contention(&mut head_change_attempts)?;
                 continue;
             }
@@ -1331,6 +1379,7 @@ impl Repository {
                         "worktree changed during snapshot preparation".to_string(),
                     ));
                 }
+                known_worktree_changes = None;
                 continue;
             }
 
@@ -1448,6 +1497,7 @@ impl Repository {
                 },
                 prev_head,
                 head.clone(),
+                None,
                 false,
             );
             mutation.prepare()?;

--- a/crates/repo/src/repository_symbol_graph_frontier.rs
+++ b/crates/repo/src/repository_symbol_graph_frontier.rs
@@ -3,21 +3,8 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use objects::object::{ContentHash, ReverseDependencyIndex};
+use objects::object::ReverseDependencyIndex;
 use semantic::cross_file_resolution::{FileResolution, RepositorySemanticFile};
-
-/// Paths whose semantic file node appeared, disappeared, or changed hash.
-pub(crate) fn changed_file_paths(
-    parent: &BTreeMap<String, ContentHash>,
-    current: &BTreeMap<String, ContentHash>,
-) -> BTreeSet<String> {
-    parent
-        .keys()
-        .chain(current.keys())
-        .filter(|path| parent.get(*path) != current.get(*path))
-        .cloned()
-        .collect()
-}
 
 /// Walk file → importers from `changed` to the transitive invalidation frontier.
 pub(crate) fn invalidation_frontier(

--- a/crates/repo/src/repository_symbol_graph_load.rs
+++ b/crates/repo/src/repository_symbol_graph_load.rs
@@ -10,9 +10,7 @@ use objects::object::{
 };
 use semantic::cross_file_resolution::RepositorySemanticFile;
 
-use crate::{
-    HeddleError, Repository, Result, repository_symbol_graph_frontier::changed_file_paths,
-};
+use crate::{HeddleError, Repository, Result};
 
 impl Repository {
     pub(crate) fn changed_semantic_file_paths(
@@ -21,9 +19,88 @@ impl Repository {
         current_hash: ContentHash,
         pending_nodes: &HashMap<ContentHash, Vec<u8>>,
     ) -> Result<BTreeSet<String>> {
-        let parent = self.semantic_file_node_hashes(parent_hash, pending_nodes)?;
-        let current = self.semantic_file_node_hashes(current_hash, pending_nodes)?;
-        Ok(changed_file_paths(&parent, &current))
+        let mut changed = BTreeSet::new();
+        let mut stack = vec![(String::new(), Some(parent_hash), Some(current_hash), 0usize)];
+        while let Some((prefix, parent, current, depth)) = stack.pop() {
+            if parent == current {
+                continue;
+            }
+            if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
+                return Err(HeddleError::InvalidObject(
+                    "semantic index tree exceeds max depth".to_string(),
+                ));
+            }
+            let parent_entries = parent
+                .map(|hash| self.load_semantic_tree_with_pending(&hash, pending_nodes))
+                .transpose()?
+                .map(|node| {
+                    node.entries
+                        .into_iter()
+                        .map(|entry| (entry.name.clone(), entry))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            let current_entries = current
+                .map(|hash| self.load_semantic_tree_with_pending(&hash, pending_nodes))
+                .transpose()?
+                .map(|node| {
+                    node.entries
+                        .into_iter()
+                        .map(|entry| (entry.name.clone(), entry))
+                        .collect::<BTreeMap<_, _>>()
+                })
+                .unwrap_or_default();
+            let names = parent_entries
+                .keys()
+                .chain(current_entries.keys())
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            for name in names {
+                let path = join_semantic_path(&prefix, &name);
+                let parent_entry = parent_entries.get(&name);
+                let current_entry = current_entries.get(&name);
+                match (parent_entry, current_entry) {
+                    (Some(parent), Some(current))
+                        if parent.kind == SemanticEntryKind::Dir
+                            && current.kind == SemanticEntryKind::Dir =>
+                    {
+                        stack.push((path, Some(parent.node), Some(current.node), depth + 1));
+                    }
+                    (Some(parent), Some(current)) => {
+                        if parent.kind == SemanticEntryKind::Dir {
+                            stack.push((path.clone(), Some(parent.node), None, depth + 1));
+                        } else if parent.kind == SemanticEntryKind::File
+                            && (current.kind != SemanticEntryKind::File
+                                || parent.node != current.node)
+                        {
+                            changed.insert(path.clone());
+                        }
+                        if current.kind == SemanticEntryKind::Dir {
+                            stack.push((path.clone(), None, Some(current.node), depth + 1));
+                        } else if current.kind == SemanticEntryKind::File
+                            && (parent.kind != SemanticEntryKind::File
+                                || parent.node != current.node)
+                        {
+                            changed.insert(path);
+                        }
+                    }
+                    (Some(parent), None) if parent.kind == SemanticEntryKind::Dir => {
+                        stack.push((path, Some(parent.node), None, depth + 1));
+                    }
+                    (None, Some(current)) if current.kind == SemanticEntryKind::Dir => {
+                        stack.push((path, None, Some(current.node), depth + 1));
+                    }
+                    (Some(parent), None) if parent.kind == SemanticEntryKind::File => {
+                        changed.insert(path);
+                    }
+                    (None, Some(current)) if current.kind == SemanticEntryKind::File => {
+                        changed.insert(path);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(changed)
     }
 
     pub(crate) fn semantic_files_with_pending(
@@ -35,21 +112,6 @@ impl Repository {
         self.walk_semantic_files(root.tree, pending_nodes, |path, entry| {
             if entry.kind == SemanticEntryKind::File {
                 files.insert(path, self.load_repository_file(&entry.node, pending_nodes)?);
-            }
-            Ok(())
-        })?;
-        Ok(files)
-    }
-
-    fn semantic_file_node_hashes(
-        &self,
-        root_hash: ContentHash,
-        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
-    ) -> Result<BTreeMap<String, ContentHash>> {
-        let mut files = BTreeMap::new();
-        self.walk_semantic_files(root_hash, pending_nodes, |path, entry| {
-            if entry.kind == SemanticEntryKind::File {
-                files.insert(path, entry.node);
             }
             Ok(())
         })?;

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use objects::{
-    object::{Blob, ThreadName, Tree, TreeEntry},
+    object::{Blob, ThreadName, Tree, TreeEntry, is_delta_tree},
     store::{ObjectStore, ShallowInfo},
     util::{gitlink_placeholder_bytes, symlink_target_bytes},
 };
@@ -29,6 +29,55 @@ fn create_test_repo() -> (TempDir, Repository) {
     let temp_dir = TempDir::new().unwrap();
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     (temp_dir, repo)
+}
+
+#[test]
+fn snapshot_modify_then_revert_keeps_epoch_anchor_readable_after_reopen() {
+    let (temp_dir, repo) = create_test_repo();
+    for index in 0..128 {
+        fs::write(
+            temp_dir.path().join(format!("fixture-{index:03}.txt")),
+            format!("unchanged-{index}\n"),
+        )
+        .unwrap();
+    }
+    let root = temp_dir.path().join("root.txt");
+
+    fs::write(&root, "v1\n").unwrap();
+    let anchor_state = repo.snapshot(Some("anchor".to_string()), None).unwrap();
+    let anchor_tree = repo.store().get_tree(&anchor_state.tree).unwrap().unwrap();
+    fs::write(&root, "v2\n").unwrap();
+    let descendant_state = repo.snapshot(Some("descendant".to_string()), None).unwrap();
+    let descendant_tree = repo
+        .store()
+        .get_tree(&descendant_state.tree)
+        .unwrap()
+        .unwrap();
+    assert!(
+        is_delta_tree(
+            &repo
+                .store()
+                .get_tree_serialized(&descendant_state.tree)
+                .unwrap()
+                .unwrap()
+        ),
+        "fixture must store the modified tree as HDC1",
+    );
+
+    fs::write(&root, "v1\n").unwrap();
+    let reverted_state = repo.snapshot(Some("revert".to_string()), None).unwrap();
+    assert_eq!(reverted_state.tree, anchor_state.tree);
+    drop(repo);
+
+    let reopened = Repository::open(temp_dir.path()).unwrap();
+    assert_eq!(
+        reopened.store().get_tree(&anchor_state.tree).unwrap(),
+        Some(anchor_tree),
+    );
+    assert_eq!(
+        reopened.store().get_tree(&descendant_state.tree).unwrap(),
+        Some(descendant_tree),
+    );
 }
 
 #[cfg(unix)]

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -10,7 +10,7 @@ use std::{
 
 use objects::{
     object::{Blob, ContentHash, State, StateId, Tree, TreeEntry},
-    store::ObjectStore,
+    store::{ObjectStore, TreeWrite},
     util::gitlink_placeholder_bytes,
     worktree::WorktreeStatus,
 };
@@ -83,7 +83,7 @@ pub(crate) type SnapshotTreeBuildOutput = (
     TreeBuildProfile,
     BTreeMap<String, ManifestFile>,
     Vec<(ContentHash, Vec<u8>)>,
-    Vec<Tree>,
+    Vec<TreeWrite>,
     Option<ChangeMonitorToken>,
 );
 
@@ -110,7 +110,7 @@ struct TreeBuildOutput {
     profile: TreeBuildProfile,
     revalidation_files: BTreeMap<String, ManifestFile>,
     pending_blobs: Vec<(ContentHash, Vec<u8>)>,
-    pending_trees: Vec<Tree>,
+    pending_trees: Vec<TreeWrite>,
     monitor_token: Option<ChangeMonitorToken>,
 }
 
@@ -121,7 +121,7 @@ fn rewrite_single_tracked_file(
     blob_hash: ContentHash,
     executable: bool,
     cached_trees: &HashMap<ContentHash, Tree>,
-    descendant_trees: &mut Vec<Tree>,
+    descendant_trees: &mut Vec<TreeWrite>,
 ) -> Result<Option<Tree>> {
     let Some((name, rest)) = components.split_first() else {
         return Ok(None);
@@ -160,7 +160,7 @@ fn rewrite_single_tracked_file(
             return Ok(None);
         };
         let updated_hash = updated_child.hash();
-        descendant_trees.push(updated_child);
+        descendant_trees.push(TreeWrite::descendant(updated_child, child_hash));
         TreeEntry::directory((*name).to_string(), updated_hash)?
     };
     let mut updated = tree.clone();
@@ -249,7 +249,7 @@ impl Repository {
             false,
             &self.default_worktree_status_options(),
         )
-            .map(|output| (output.tree, output.profile))
+        .map(|output| (output.tree, output.profile))
     }
 
     pub(crate) fn build_tree_profiled_for_snapshot_against(
@@ -257,12 +257,14 @@ impl Repository {
         dir: &Path,
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
+        known_worktree_changes: Option<&WorktreeStatus>,
     ) -> Result<SnapshotTreeBuildOutput> {
         self.build_tree_profiled_for_snapshot_against_with_options(
             dir,
             baseline_tree,
             stat_cache,
             &self.default_worktree_status_options(),
+            known_worktree_changes,
         )
     }
 
@@ -272,11 +274,15 @@ impl Repository {
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
         options: &WorktreeStatusOptions,
+        known_worktree_changes: Option<&WorktreeStatus>,
     ) -> Result<SnapshotTreeBuildOutput> {
         let fast_start = Instant::now();
-        if let Some(mut output) =
-            self.try_build_single_changed_file_tree(dir, baseline_tree, options)?
-        {
+        if let Some(mut output) = self.try_build_single_changed_file_tree(
+            dir,
+            baseline_tree,
+            options,
+            known_worktree_changes,
+        )? {
             output.profile.tree_walk_ms = fast_start.elapsed().as_millis();
             return Ok((
                 output.tree,
@@ -287,7 +293,21 @@ impl Repository {
                 output.monitor_token,
             ));
         }
-        self.build_tree_profiled_output(dir, baseline_tree, stat_cache, true, options)
+        // Capture preflight may have advanced an fsmonitor cursor while
+        // discovering a shape that the one-file rewrite cannot handle. In
+        // that case the fallback must walk authoritatively instead of asking
+        // a second monitor session for an event that was already consumed.
+        let authoritative_options = WorktreeStatusOptions {
+            fsmonitor: crate::FsMonitorSettings {
+                mode: crate::FsMonitorMode::Off,
+            },
+        };
+        let fallback_options = if known_worktree_changes.is_some() {
+            &authoritative_options
+        } else {
+            options
+        };
+        self.build_tree_profiled_output(dir, baseline_tree, stat_cache, true, fallback_options)
             .map(|output| {
                 (
                     output.tree,
@@ -310,6 +330,7 @@ impl Repository {
         dir: &Path,
         baseline_tree: Option<&Tree>,
         options: &WorktreeStatusOptions,
+        known_worktree_changes: Option<&WorktreeStatus>,
     ) -> Result<Option<TreeBuildOutput>> {
         if dir != self.root() {
             return Ok(None);
@@ -318,10 +339,24 @@ impl Repository {
             return Ok(None);
         };
         let monitor = ChangeMonitorSession::prepare(self.root(), options.fsmonitor);
-        let Some(changed) = monitor.single_changed_path() else {
-            return Ok(None);
+        let changed = match known_worktree_changes {
+            Some(status)
+                if status.modified.len() == 1
+                    && status.added.is_empty()
+                    && status.deleted.is_empty() =>
+            {
+                status.modified[0].clone()
+            }
+            Some(_) => return Ok(None),
+            None => match monitor.single_changed_path() {
+                Some(path) => PathBuf::from(path),
+                None => return Ok(None),
+            },
         };
-        let rel_path = Path::new(changed);
+        let rel_path = changed.as_path();
+        if rel_path.as_os_str().is_empty() {
+            return Ok(None);
+        }
         let components = rel_path
             .components()
             .map(|component| match component {
@@ -949,7 +984,7 @@ struct TreeBuildPolicy<'a> {
     /// Hashes already queued in `pending_blobs` so we don't double-add
     /// content-equal files (which is common: README.md, .gitkeep, etc).
     seen: HashSet<ContentHash>,
-    pending_trees: Vec<Tree>,
+    pending_trees: Vec<TreeWrite>,
     defer_object_writes: bool,
 }
 
@@ -1290,7 +1325,7 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
     fn visit_directory_output(
         &mut self,
         entry: WalkEntry<'_>,
-        _tree_entry: Option<&TreeEntry>,
+        tree_entry: Option<&TreeEntry>,
         subtree: TreeBuildOutput,
         state: &mut Self::DirectoryState,
     ) -> Result<()> {
@@ -1303,7 +1338,11 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         state.revalidation_files.extend(subtree.revalidation_files);
         let hash = subtree.tree.hash();
         if self.defer_object_writes {
-            self.pending_trees.push(subtree.tree);
+            let write = match tree_entry.and_then(TreeEntry::tree_hash) {
+                Some(parent) => TreeWrite::descendant(subtree.tree, parent),
+                None => TreeWrite::anchor(subtree.tree),
+            };
+            self.pending_trees.push(write);
         } else {
             let store_start = Instant::now();
             self.repo.store.put_tree(&subtree.tree)?;

--- a/crates/repo/tests/transfer_planning_tests.rs
+++ b/crates/repo/tests/transfer_planning_tests.rs
@@ -17,7 +17,7 @@ use objects::{
         PurgeEvidence, Redaction, State, StateAttachment, StateAttachmentBody, StateId,
         StateSignature, StateVisibility, SymbolAnchor, Tree, TreeEntry, VisibilityTier,
     },
-    store::{ObjectStore, Result as StoreResult, SidecarStore},
+    store::{FsStore, ObjectStore, Result as StoreResult, SidecarStore},
     transfer::{
         ObjectId, ObjectInfo, ObjectType, PlannedObject, StateClosureOptions,
         enumerate_state_closure_plan_with_options,
@@ -77,6 +77,62 @@ fn assert_contains_object(
         objects.contains(&(id.clone(), obj_type)),
         "expected closure to contain {id:?} as {obj_type:?}: {objects:?}"
     );
+}
+
+#[test]
+fn depth_one_transfer_includes_hdc1_anchor_and_installs_a_readable_tip() {
+    let source_temp = TempDir::new().unwrap();
+    let source = Repository::init_default(source_temp.path()).unwrap();
+    for index in 0..128 {
+        std::fs::write(
+            source_temp.path().join(format!("fixture-{index:03}.txt")),
+            format!("unchanged-{index}\n"),
+        )
+        .unwrap();
+    }
+    let root = source_temp.path().join("root.txt");
+    std::fs::write(&root, "v1\n").unwrap();
+    let anchor = source.snapshot(Some("anchor".to_string()), None).unwrap();
+    std::fs::write(&root, "v2\n").unwrap();
+    let middle = source.snapshot(Some("middle".to_string()), None).unwrap();
+    std::fs::write(&root, "v3\n").unwrap();
+    let tip = source.snapshot(Some("tip".to_string()), None).unwrap();
+
+    let objects = enumerate_state_closure_with_options(
+        source.store(),
+        tip.state_id,
+        StateClosureOptions {
+            depth: Some(1),
+            exclude_states: Vec::new(),
+        },
+    )
+    .unwrap();
+    let bundle = wire::build_native_pack(source.store(), &objects).unwrap();
+    let destination_temp = TempDir::new().unwrap();
+    let destination = FsStore::new(destination_temp.path().join(".heddle"));
+    destination.init().unwrap();
+
+    wire::install_received_pack(&destination, &bundle.pack_data, &bundle.index_data).unwrap();
+    assert_eq!(
+        destination.get_tree(&tip.tree).unwrap(),
+        source.store().get_tree(&tip.tree).unwrap(),
+        "the transferred HDC1 tip must reconstruct after installation",
+    );
+
+    let tip_info = objects
+        .iter()
+        .find(|info| info.id == ObjectId::Hash(tip.tree) && info.obj_type == ObjectType::Tree)
+        .unwrap();
+    assert_eq!(tip_info.delta_base, Some(anchor.tree));
+    assert!(objects.iter().any(|info| {
+        info.id == ObjectId::Hash(anchor.tree) && info.obj_type == ObjectType::Tree
+    }));
+    assert!(objects.iter().any(|info| {
+        info.id == ObjectId::StateId(middle.state_id) && info.obj_type == ObjectType::State
+    }));
+    assert!(!objects.iter().any(|info| {
+        info.id == ObjectId::StateId(anchor.state_id) && info.obj_type == ObjectType::State
+    }));
 }
 
 struct CountingStore<'a, S> {

--- a/crates/verbs/src/save.rs
+++ b/crates/verbs/src/save.rs
@@ -193,6 +193,10 @@ pub struct SavePlan {
     /// separate preflight walk.
     pub require_worktree_change: bool,
     pub worktree_status_options: WorktreeStatusOptions,
+    /// Authoritative parent-relative paths found by capture preflight. The
+    /// snapshot builder consumes these before the monitor cursor advances so
+    /// it can rewrite only the affected leaf-to-root chain.
+    pub known_worktree_changes: Option<WorktreeStatus>,
     /// Run pre/post snapshot hooks when creating a new Heddle state.
     pub run_hooks: bool,
     /// Map post-verify "commit" next actions to `heddle status` (commit UX).
@@ -225,6 +229,7 @@ impl SavePlan {
             require_clean_worktree: false,
             require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
+            known_worktree_changes: None,
             run_hooks: true,
             commit_safe_post_verify: false,
             coalesce_snapshot_and_checkpoint: false,
@@ -250,6 +255,7 @@ impl SavePlan {
             require_clean_worktree: matches!(git_scope, GitScope::WorktreeAll),
             require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
+            known_worktree_changes: None,
             run_hooks: true,
             commit_safe_post_verify: true,
             coalesce_snapshot_and_checkpoint: matches!(
@@ -278,6 +284,7 @@ impl SavePlan {
             require_clean_worktree: !staged,
             require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
+            known_worktree_changes: None,
             run_hooks: true,
             commit_safe_post_verify: false,
             coalesce_snapshot_and_checkpoint: false,
@@ -559,12 +566,15 @@ pub fn capture(
     preflight_unimported_git_history(repo, "capture")?;
     let complete_thread_resolution = merge_resolution_is_complete(repo)?;
     let worktree_status_started = Instant::now();
-    if !complete_thread_resolution
-        && repo.capability() == RepositoryCapability::GitOverlay
-        && !capture_has_worktree_changes(repo, &options.worktree_status_options)?
-    {
-        return Err(map_capture_error(anyhow!(HeddleError::NoChanges)));
-    }
+    let known_worktree_changes = if complete_thread_resolution {
+        None
+    } else {
+        let status = capture_worktree_status(repo, &options.worktree_status_options)?;
+        if repo.capability() == RepositoryCapability::GitOverlay && status.is_clean() {
+            return Err(map_capture_error(anyhow!(HeddleError::NoChanges)));
+        }
+        Some(status)
+    };
 
     let worktree_status = repo.git_overlay_worktree_status();
     let worktree_status_ms = worktree_status_started.elapsed().as_millis();
@@ -603,6 +613,7 @@ pub fn capture(
         require_worktree_change: repo.capability() == RepositoryCapability::NativeHeddle
             && !complete_thread_resolution,
         worktree_status_options: options.worktree_status_options,
+        known_worktree_changes,
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,
@@ -880,22 +891,20 @@ fn merge_resolution_is_complete(repo: &Repository) -> Result<bool> {
 /// Heddle's persisted worktree index, which the following snapshot consumes.
 /// In particular, retaining this check prevents a fast forced retry after a
 /// refused directory deletion from being misclassified as an unchanged tree.
-fn capture_has_worktree_changes(
+fn capture_worktree_status(
     repo: &Repository,
     options: &WorktreeStatusOptions,
-) -> Result<bool> {
+) -> Result<WorktreeStatus> {
     if repo.current_state_for_worktree_status()?.is_none()
         && let Some(status) = repo.git_overlay_worktree_status()?
     {
-        return Ok(!status.is_clean());
+        return Ok(status);
     }
     let tree = match repo.current_state_for_worktree_status()? {
         Some(state) => repo.require_tree_for_worktree_status(&state.tree)?,
         None => Tree::new(),
     };
-    Ok(!repo
-        .compare_worktree_cached_with_options(&tree, options)?
-        .is_clean())
+    Ok(repo.compare_worktree_cached_with_options(&tree, options)?)
 }
 
 /// Complete a captured manual resolution and return its contextual land action.
@@ -1372,6 +1381,14 @@ fn create_heddle_state(repo: &Repository, plan: &SavePlan) -> Result<CreatedStat
             plan.intent.clone(),
             plan.confidence,
             plan.attribution.clone(),
+        )?
+    } else if let Some(status) = plan.known_worktree_changes.clone() {
+        repo.snapshot_with_attribution_profiled_from_status(
+            plan.intent.clone(),
+            plan.confidence,
+            plan.attribution.clone(),
+            status,
+            plan.require_worktree_change,
         )?
     } else if plan.require_worktree_change {
         repo.snapshot_with_attribution_profiled_if_changed(

--- a/crates/verbs/src/save.rs
+++ b/crates/verbs/src/save.rs
@@ -1345,9 +1345,10 @@ struct CreatedState {
 fn create_heddle_state(repo: &Repository, plan: &SavePlan) -> Result<CreatedState> {
     let hook_manager = HookManager::new(repo);
     let hook_ctx = HookContext::new(repo);
+    let mut post_hook_worktree_changes = None;
 
     if plan.run_hooks {
-        hook_manager.run(Hook::PreSnapshot, &hook_ctx)?;
+        let pre_snapshot_ran = hook_manager.run(Hook::PreSnapshot, &hook_ctx)?;
         let pre_capture_payload = serde_json::json!({
             "thread": current_thread_name(repo),
             "intent": plan.intent.clone().unwrap_or_default(),
@@ -1373,8 +1374,19 @@ fn create_heddle_state(repo: &Repository, plan: &SavePlan) -> Result<CreatedStat
                 .with_recovery_commands(vec!["heddle hook list".to_string()]),
             )));
         }
+        if pre_snapshot_ran && plan.supplied_tree.is_none() {
+            // Hooks can mutate paths outside capture's preflight set. Rewalk
+            // authoritatively so a settled monitor token cannot vouch for a
+            // tree built from that stale set. No-hook captures keep the fast path.
+            let authoritative_options = WorktreeStatusOptions {
+                fsmonitor: repo::FsMonitorSettings {
+                    mode: repo::FsMonitorMode::Off,
+                },
+            };
+            post_hook_worktree_changes =
+                Some(capture_worktree_status(repo, &authoritative_options)?);
+        }
     }
-
     let mut execution = if let Some(tree) = plan.supplied_tree.clone() {
         repo.snapshot_tree_with_attribution_profiled(
             tree,
@@ -1382,7 +1394,9 @@ fn create_heddle_state(repo: &Repository, plan: &SavePlan) -> Result<CreatedStat
             plan.confidence,
             plan.attribution.clone(),
         )?
-    } else if let Some(status) = plan.known_worktree_changes.clone() {
+    } else if let Some(status) =
+        post_hook_worktree_changes.or_else(|| plan.known_worktree_changes.clone())
+    {
         repo.snapshot_with_attribution_profiled_from_status(
             plan.intent.clone(),
             plan.confidence,

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use objects::{
-    object::{AnnotatedTag, State, Tree},
+    object::{AnnotatedTag, State},
     store::ObjectStore,
 };
 
@@ -237,18 +237,15 @@ pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Res
             store.put_blob_bytes_with_hash(&data.data, *hash)?;
         }
         (ObjectId::Hash(hash), ObjectType::Tree) => {
-            let tree = Tree::decode_canonical(&data.data).map_err(|error| {
-                ProtocolError::InvalidState(format!("invalid tree object: {error}"))
-            })?;
-            tree.validate().map_err(|error| {
-                ProtocolError::InvalidState(format!("invalid tree object: {error}"))
-            })?;
-            if &tree.hash() != hash {
-                return Err(ProtocolError::InvalidState(
-                    "tree hash mismatch".to_string(),
-                ));
-            }
-            store.put_tree_serialized(&data.data, *hash)?;
+            store
+                .put_tree_serialized(&data.data, *hash)
+                .map_err(|error| match error {
+                    objects::error::HeddleError::Corruption { .. }
+                    | objects::error::HeddleError::TreeStream(
+                        objects::object::TreeStreamError::HashMismatch { .. },
+                    ) => ProtocolError::InvalidState("tree hash mismatch".to_string()),
+                    error => ProtocolError::InvalidState(format!("invalid tree object: {error}")),
+                })?;
         }
         (ObjectId::Hash(hash), ObjectType::AnnotatedTag) => {
             let tag = AnnotatedTag::decode_current_msgpack(&data.data)
@@ -394,7 +391,15 @@ mod tests {
         )
         .unwrap();
         assert_eq!(tree_data.obj_type, ObjectType::Tree);
-        assert_eq!(Tree::decode_canonical(&tree_data.data).unwrap(), tree);
+        assert_eq!(
+            objects::store::codec::decode_tree_serialized_with_key(
+                &tree_data.data,
+                tree_hash,
+                None,
+            )
+            .unwrap(),
+            tree,
+        );
         store_received_object(&dest, &tree_data).unwrap();
         assert_eq!(dest.get_tree(&tree_hash).unwrap().unwrap(), tree);
 


### PR DESCRIPTION
## Summary

- make capture consume the authoritative preflight status and rewrite only the known changed leaf-to-root chain, reusing unchanged parent subtrees by hash
- add production HLR1 lean anchors and bounded one-hop HDC1 deltas, including the 127-descendant refresh and 512-op cap
- preserve raw HTR4 v4 and blocked v5 decoding, validate full decodes against the external tree key, and keep compression off the hot write path
- add lazy file-backed HDC1 porch reads plus lineage metadata for future cumulative deltas

## Capture gate

```text
RESULT case=capture_one mode=warm_repo paths=100000 samples=20 wall_ms=p50=66.041,p95=71.637,p99=74.431,max=74.431
COUNTERS case=capture_one paths=100000 ... object_decodes=p50=9.000,p95=9.000,p99=9.000,max=9.000
TARGET case=capture_one paths=100000 budget_p95_ms=100.000 observed_p95_ms=71.637
GATES green: absolute p95 targets, scale invariance, structural bounds, repository opens, zero network
```

## Storage measurement

Complete 212,832-tree corpus using the preserved spike mirrors and synthetic repositories:

```text
RADICAL_SIZE,ALL,212832,197412,24955,187877,503,2774340416,512144438,511721061,0.283620,6.134748,0.151902,0.192905
RADICAL_FILE_PARTIAL,1,48,3,10000,115.33,118.21,1.025,7223.146,8020.010,1.110
RADICAL_FILE_PARTIAL,100,21,130,10000,5313.24,4947.43,0.931,169638.363,23355.185,0.138
REAL_VALIDATION,size_beats_historical=true,file_partial_within_2x=true,radical_smaller_than_git_loose=true,radical_partial_within_2x=true
```

Settled storage is 511,721,061 bytes: 0.283620x Git loose and 6.134748x Git packed. The harness byte-compares production HLR1/HDC1 output with the spike encoding before measuring.

## Verification

- `cargo test -p heddle-objects -p heddle-object-model`
- zstd codec tests for raw v4, blocked v5, HLR1, and HDC1
- `cargo test -p heddle-cli --test cli_basics capture -- --nocapture` (24 passed)
- `cargo clippy -p heddle-cli -p heddle-verbs -p heddle-repo -p heddle-objects -p heddle-object-model --all-targets --all-features -- -D warnings`
- `git diff --check`

No docs, clap arguments, or schema surfaces changed, so docs/type regeneration was not required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790440899&installation_model_id=21489&pr_number=1587&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1587&signature=8ca005d35401c3240e1403ef0c11bc46abbe36c430f629e5e96742c3b27148ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->