### PR TITLE
release: heddle v0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,13 +50,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
 dependencies = [
  "aead 0.6.1",
- "aes 0.9.2",
+ "aes 0.9.3",
  "cipher 0.5.2",
  "ctr 0.10.1",
  "ctutils",
@@ -313,7 +313,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -464,7 +464,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -620,12 +620,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1063,7 +1063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -1667,12 +1667,12 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -2314,11 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.1"
+version = "0.15.2"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "base32",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "base32",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "blake3",
  "bytes",
@@ -2576,11 +2576,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.1"
+version = "0.15.2"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "base32",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -2969,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3638,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3733,6 +3733,15 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4716,7 +4725,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
 dependencies = [
- "aes 0.9.2",
+ "aes 0.9.3",
  "aes-gcm 0.11.1",
  "cbc",
  "der 0.8.1",
@@ -4831,7 +4840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "universal-hash 0.6.1",
 ]
 
@@ -6085,7 +6094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -6126,7 +6135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.1", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.1", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.1", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.1" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.1" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.1", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.1" }
-heddle-pack = { path = "crates/pack", version = "0.15.1" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.1" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.1", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.1" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.1" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.1" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.1" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.1", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.1", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.1" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.1" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.1" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.1", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.1" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.1", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.1" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.1" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.1" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.1", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.1", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.2", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.2", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.2", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.2" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.2" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.2", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.2" }
+heddle-pack = { path = "crates/pack", version = "0.15.2" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.2" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.2", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.2" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.2" }
+config = { path = "crates/config", package = "heddle-config", version = "0.15.2" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.2" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.2", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.2", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.2" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.2" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.2" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.2", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.2" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.2", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.2" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.2" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.2" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.2", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.2", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.1",
+  "schemaVersion": "0.15.2",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.1" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.2" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/agent-relay/CHANGELOG.md
+++ b/crates/agent-relay/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-agent-relay-v0.15.1...heddle-agent-relay-v0.15.2) - 2026-08-28
+
+### Other
+
+- Rematch context anchors across file renames ([#1580](https://github.com/HeddleCo/heddle/pull/1580))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-agent-relay-v0.15.0...heddle-agent-relay-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/cli-args/CHANGELOG.md
+++ b/crates/cli-args/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-args-v0.15.1...heddle-cli-args-v0.15.2) - 2026-08-28
+
+### Other
+
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+- Stop claim links from following unbound remote web_origin ([#1575](https://github.com/HeddleCo/heddle/pull/1575))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-cli-args-v0.15.0...heddle-cli-args-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/cli-contract/CHANGELOG.md
+++ b/crates/cli-contract/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-contract-v0.15.1...heddle-cli-contract-v0.15.2) - 2026-08-28
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-cli-contract-v0.15.0...heddle-cli-contract-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-v0.15.1...heddle-cli-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+- Rematch context anchors across file renames ([#1580](https://github.com/HeddleCo/heddle/pull/1580))
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-cli-v0.15.0...heddle-cli-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/docsgen/CHANGELOG.md
+++ b/crates/docsgen/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-docsgen-v0.15.1...heddle-docsgen-v0.15.2) - 2026-08-28
+
+### Other
+
+- *(release)* heddle 0.15.1 (adopt api 0.17 + cv 0.6, via release-plz) ([#1573](https://github.com/HeddleCo/heddle/pull/1573))
+- Port agent docs generator to Rust ([#1571](https://github.com/HeddleCo/heddle/pull/1571))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-docsgen-v0.15.0...heddle-docsgen-v0.15.1) - 2026-08-27
 
 ### Other

--- a/crates/hosted-client/CHANGELOG.md
+++ b/crates/hosted-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.1...heddle-hosted-client-v0.15.2) - 2026-08-28
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+- Rematch context anchors across file renames ([#1580](https://github.com/HeddleCo/heddle/pull/1580))
+- Stop claim links from following unbound remote web_origin ([#1575](https://github.com/HeddleCo/heddle/pull/1575))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.0...heddle-hosted-client-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/object-model/CHANGELOG.md
+++ b/crates/object-model/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-object-model-v0.15.1...heddle-object-model-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Fixed
+
+- *(objects)* bound HTR4 v5 block raw_len to prevent decompression OOM ([#1589](https://github.com/HeddleCo/heddle/pull/1589))
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+- Rematch context anchors across file renames ([#1580](https://github.com/HeddleCo/heddle/pull/1580))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-object-model-v0.15.0...heddle-object-model-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/objects/CHANGELOG.md
+++ b/crates/objects/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-objects-v0.15.1...heddle-objects-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Other
+
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-objects-v0.15.0...heddle-objects-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/repo/CHANGELOG.md
+++ b/crates/repo/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-repo-v0.15.1...heddle-repo-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+- Rematch context anchors across file renames ([#1580](https://github.com/HeddleCo/heddle/pull/1580))
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-repo-v0.15.0...heddle-repo-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/semantic/CHANGELOG.md
+++ b/crates/semantic/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-semantic-v0.15.1...heddle-semantic-v0.15.2) - 2026-08-28
+
+### Other
+
+- Discuss anchors: rebind on in-file symbol rename ([#1581](https://github.com/HeddleCo/heddle/pull/1581))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-semantic-v0.15.0...heddle-semantic-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/verbs/CHANGELOG.md
+++ b/crates/verbs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-verbs-v0.15.1...heddle-verbs-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Other
+
+- Add last-turn diff base ([#1582](https://github.com/HeddleCo/heddle/pull/1582))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-verbs-v0.15.0...heddle-verbs-v0.15.1) - 2026-08-27
 
 ### Fixed

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-wire-v0.15.1...heddle-wire-v0.15.2) - 2026-08-28
+
+### Added
+
+- productionize incremental HLR1/HDC1 tree storage ([#1587](https://github.com/HeddleCo/heddle/pull/1587))
+
+### Fixed
+
+- *(objects)* bound HTR4 v5 block raw_len to prevent decompression OOM ([#1589](https://github.com/HeddleCo/heddle/pull/1589))
+
 ## [0.15.1](https://github.com/HeddleCo/heddle/compare/heddle-wire-v0.15.0...heddle-wire-v0.15.1) - 2026-08-27
 
 ### Fixed


### PR DESCRIPTION
Release **heddle v0.15.2** (patch bump; under 0.x semver neither change is breaking).

Computed by `release-plz` from `v0.15.0` baseline; all 30 workspace crates + inter-crate pins → `0.15.2` (workspace-version, so the bump lives in the root `Cargo.toml`).

## Included
- **feat:** productionize incremental HLR1/HDC1 tree storage (#1587)
- **fix (security):** bound HTR4 v5 block `raw_len` to prevent a ~4 GiB zstd decompression OOM (#1589)

## Regenerated artifacts
- `clients/npm/generated/heddle-schemas.{ts,json}` — regenerated via `scripts/gen-ts-types.sh`, now embed `0.15.2` (byte-stable on re-run).
- `docs/llms.txt` / `docs/llms-full.txt` — regenerated via `heddle-docsgen` (byte-stable; version-independent, no content change).

## Verification
- `cargo check --locked` — passed.
- `cargo run -p heddle-docsgen -- --check` — passed.
- `git diff --check` — passed.
- No `.rs` source touched; the release commit is versions + changelogs + generated artifacts only.

On merge, `publish-crates.yml` publishes the crates. The `v0.15.2` binary-release tag will be pushed on the merge commit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790523437&installation_model_id=21489&pr_number=1591&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1591&signature=ae248654f5f1babb634ddb575fe581aaa42402428889ce50468e7274a1516f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->