### PR TITLE
fix(agent): allow host-only spool provisioning (GetCurrentUserSpool/CreateSpool) in the agent ceiling

### DIFF
--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -215,6 +215,14 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     "Pull",
     "ListRefs",
     "UpdateRef",
+    // Personal spool discovery + provisioning. Host-only auto-provision push
+    // (`auto_provision_hosted_repo`) resolves the caller's own spool and, when
+    // the target child spool is absent, creates it under the agent's own
+    // handle. Without these the client aborts before the RPCs are ever sent,
+    // so an unclaimed agent-rooted account cannot `heddle push <host>`. weft
+    // admits both for unclaimed agent-rooted accounts (weft#1852/#1853).
+    "GetCurrentUserSpool",
+    "CreateSpool",
     // Repository reads.
     "GetRefs",
     "ListStates",

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -277,6 +277,9 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
     "GetDiscussion",
     "ListByState",
     "ListBySymbol",
+    // Read of the caller's own spool; paired with CreateSpool in the
+    // contributor writes for host-only auto-provision push.
+    "GetCurrentUserSpool",
     "WhoAmI",
 ];
 
@@ -290,6 +293,8 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
     "OpenDiscussion",
     "AppendTurn",
     "ResolveDiscussion",
+    // Provision the caller's own child spool (host-only auto-provision push).
+    "CreateSpool",
 ];
 
 /// The push/pull/ref-move set a CI lander needs to run `ready`/`land`.

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -205,3 +205,19 @@ fn restricted_agent_capability_keeps_the_deny_floor() {
         );
     }
 }
+
+/// Regression: the agent ceiling must carry the personal-spool discovery +
+/// provisioning ops. Without them, an unclaimed agent-rooted account's
+/// `heddle push <host>` aborts client-side inside `auto_provision_hosted_repo`
+/// before `GetCurrentUserSpool`/`CreateSpool` are ever sent — the account can
+/// mint, WhoAmI, and ListRefs, but never provision its own spool. weft admits
+/// both server-side for unclaimed agent-rooted accounts (weft#1852/#1853).
+#[test]
+fn safe_ceiling_allows_host_only_spool_provisioning() {
+    for op in ["GetCurrentUserSpool", "CreateSpool"] {
+        assert!(
+            SAFE_AGENT_OPERATIONS.contains(&op),
+            "agent ceiling missing {op}: host-only auto-provision push cannot fire it"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

An unclaimed agent-rooted account can create its account, `WhoAmI`, and `ListRefs`, but **`heddle push <host>` fails** — the account cannot provision its own spool.

Client console (cedar-jay session, staging, heddle 0.15.1):
```
heddle push https://api-staging.heddle.sh
[ok] connected …
Error: authorization failed: valid Heddle access token required   (exit 77)
```
Named-path push after that just loops on `ListRefs` and returns `remote failure (PermissionDenied): access denied` — because the child spool was never created.

## Root cause

Agent login runs `restrict_agent_account_root`, which mints the agent biscuit **straight from `SAFE_AGENT_OPERATIONS`** (`crates/hosted-client/src/hosted_runtime/device_flow.rs`). That ceiling lists `Push`, `Pull`, `ListRefs`, `UpdateRef`, the read RPCs, context, discussions, and `WhoAmI` — but **omits `GetCurrentUserSpool` and `CreateSpool`**. So host-only auto-provision push (`auto_provision_hosted_repo` → `GetCurrentUserSpool` then `CreateSpool`) fails the client's *own* capability check and aborts before either RPC is sent. That's why the "valid access token required" is client-side and weft logs show **zero `CreateSpool` and no `PermissionDenied`** — the deny never reaches the server.

## Fix

Add `GetCurrentUserSpool` + `CreateSpool` to `SAFE_AGENT_OPERATIONS`. Safe by construction:
- weft **already admits** both for unclaimed agent-rooted accounts (the RPC sweep in weft#1852/#1853: "CreateSpool beneath personal spool: Admit").
- Neither is in the deny floor (which stays: `CreateServiceAccount`, `Delete*`, `CreateAgentAccount`, `RevokeSession`).
- This is exactly the "free account provisions its own spool" behavior from weft#1469/#1852.

Regression test `safe_ceiling_allows_host_only_spool_provisioning` asserts both stay in the ceiling; the existing `templates_stay_within_safe_ceiling` confirms they land in the minted biscuit block.

## Verified

`cargo test -p heddle-hosted-client --features client` — ceiling tests green (12 passed). This unblocks unclaimed agent-rooted host-only push end-to-end (pairs with the weft-side grant already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790527350&installation_model_id=21489&pr_number=1594&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1594&signature=0707205053aaf32b105089ea52f8c1940e625c17e887be46f475b9204b4f8914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->