### PR TITLE
fix(auth): let the unclaimed agent account root mint signup invites

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -13513,6 +13513,100 @@
       "title": "AuthCreateServiceTokenSchema",
       "type": "object"
     },
+    "auth invite": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "allowance_remaining": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "invite_code": {
+          "description": "The server returns this code only on surfaces where it may be shown.",
+          "type": "string"
+        },
+        "invite_id": {
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "auth_invite"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "invite_id",
+        "invite_code",
+        "allowance_remaining"
+      ],
+      "title": "AuthSignupInviteCreatedSchema",
+      "type": "object"
+    },
+    "auth invite list": {
+      "$defs": {
+        "AuthSignupInviteSchema": {
+          "properties": {
+            "consumed": {
+              "type": "boolean"
+            },
+            "consumed_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "invite_code": {
+              "description": "Present because `ListSignupInvites` includes it. Clients must not derive\nor fabricate invite codes from IDs or other metadata.",
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "invite_code",
+            "status",
+            "consumed"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "allowance_remaining": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "invites": {
+          "items": {
+            "$ref": "#/$defs/AuthSignupInviteSchema"
+          },
+          "type": "array"
+        },
+        "output_kind": {
+          "enum": [
+            "auth_invite_list"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "invites",
+        "allowance_remaining"
+      ],
+      "title": "AuthSignupInviteListSchema",
+      "type": "object"
+    },
     "auth login": {
       "$defs": {
         "HumanPromotionDirective": {

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -13521,6 +13521,12 @@
           "minimum": 0,
           "type": "integer"
         },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "invite_code": {
           "description": "The server returns this code only on surfaces where it may be shown.",
           "type": "string"
@@ -13528,11 +13534,53 @@
         "invite_id": {
           "type": "string"
         },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "output_kind": {
           "enum": [
             "auth_invite"
           ],
           "type": "string"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -567,10 +567,14 @@ export interface AuthLogoutSchema {
 
 export interface AuthSignupInviteCreatedSchema {
   allowance_remaining: number;
+  idempotency_status?: string | null;
   /** The server returns this code only on surfaces where it may be shown. */
   invite_code: string;
   invite_id: string;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "auth_invite";
+  replayed?: boolean | null;
 }
 
 export interface AuthSignupInviteListSchema {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -565,6 +565,29 @@ export interface AuthLogoutSchema {
   server: string;
 }
 
+export interface AuthSignupInviteCreatedSchema {
+  allowance_remaining: number;
+  /** The server returns this code only on surfaces where it may be shown. */
+  invite_code: string;
+  invite_id: string;
+  output_kind: "auth_invite";
+}
+
+export interface AuthSignupInviteListSchema {
+  allowance_remaining: number;
+  invites: AuthSignupInviteSchema[];
+  output_kind: "auth_invite_list";
+}
+
+export interface AuthSignupInviteSchema {
+  consumed: boolean;
+  consumed_at?: string | null;
+  created_at?: string | null;
+  /** Present because `ListSignupInvites` includes it. Clients must not derive or fabricate invite codes from IDs or other metadata. */
+  invite_code: string;
+  status: string;
+}
+
 export interface AuthStatusSchema {
   authenticated: boolean;
   credential_id?: string | null;
@@ -3475,6 +3498,8 @@ export interface HeddleVerbOutputs {
   "agent timeline reset": AgentTimelineResetSchema;
   "agent timeline status": TimelineStatusSchema;
   "auth create-service-token": AuthCreateServiceTokenSchema;
+  "auth invite": AuthSignupInviteCreatedSchema;
+  "auth invite list": AuthSignupInviteListSchema;
   "auth login": AgentAccountCreatedSchema;
   "auth logout": AuthLogoutSchema;
   "auth status": AuthStatusSchema;
@@ -3637,6 +3662,8 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "agent timeline reset",
   "agent timeline status",
   "auth create-service-token",
+  "auth invite",
+  "auth invite list",
   "auth login",
   "auth logout",
   "auth status",

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -123,6 +123,22 @@ pub enum AuthCommands {
         server: Option<String>,
     },
 
+    /// Create or list signup invites owned by the signed-in account.
+    #[command(args_conflicts_with_subcommands = true)]
+    Invite {
+        /// Bind the new invite to an email address.
+        #[arg(long)]
+        email: Option<String>,
+
+        /// Heddle server address. Omit to use the configured default
+        /// (`api.heddle.sh` when none is stored).
+        #[arg(long, global = true)]
+        server: Option<String>,
+
+        #[command(subcommand)]
+        command: Option<AuthInviteCommands>,
+    },
+
     /// Inspect or explicitly replace descriptor-signing trust
     Trust {
         #[command(subcommand)]
@@ -184,6 +200,12 @@ pub enum AuthCommands {
 }
 
 #[derive(Subcommand, Clone, Debug)]
+pub enum AuthInviteCommands {
+    /// List signup invites owned by the signed-in account.
+    List,
+}
+
+#[derive(Subcommand, Clone, Debug)]
 pub enum AuthTrustCommands {
     /// Show the descriptor trust controlling a server connection
     Show(AuthTrustShowArgs),
@@ -218,7 +240,7 @@ pub struct AuthTrustReplaceArgs {
 mod tests {
     use clap::Parser;
 
-    use crate::cli::{AuthCommands, AuthTrustCommands, Cli, Commands};
+    use crate::cli::{AuthCommands, AuthInviteCommands, AuthTrustCommands, Cli, Commands};
 
     #[test]
     fn trust_replace_parses_compare_and_swap_inputs() {
@@ -369,6 +391,70 @@ mod tests {
         assert_eq!(invite.as_deref(), Some("invite-secret"));
         assert_eq!(credential, None);
         assert!(!open_browser);
+    }
+
+    #[test]
+    fn signup_invite_create_and_list_parse() {
+        let create = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "invite",
+            "--server",
+            "api.heddle.test",
+            "--email",
+            "alice@example.com",
+        ])
+        .expect("auth invite create flags parse");
+        let Commands::Auth {
+            command:
+                AuthCommands::Invite {
+                    email,
+                    server,
+                    command,
+                },
+        } = create.command
+        else {
+            panic!("expected auth invite");
+        };
+        assert_eq!(email.as_deref(), Some("alice@example.com"));
+        assert_eq!(server.as_deref(), Some("api.heddle.test"));
+        assert!(command.is_none());
+
+        let list = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "invite",
+            "list",
+            "--server",
+            "api.heddle.test",
+        ])
+        .expect("auth invite list flags parse");
+        let Commands::Auth {
+            command:
+                AuthCommands::Invite {
+                    email,
+                    server,
+                    command: Some(AuthInviteCommands::List),
+                },
+        } = list.command
+        else {
+            panic!("expected auth invite list");
+        };
+        assert_eq!(email, None);
+        assert_eq!(server.as_deref(), Some("api.heddle.test"));
+
+        assert!(
+            Cli::try_parse_from([
+                "heddle",
+                "auth",
+                "invite",
+                "--email",
+                "alice@example.com",
+                "list",
+            ])
+            .is_err(),
+            "create-only --email must not be accepted by list"
+        );
     }
 
     #[test]

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -55,7 +55,8 @@ pub use commands_args::{
 pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
 pub use commands_client::{
-    AgentTemplateArg, AuthCommands, AuthTrustCommands, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN,
+    AgentTemplateArg, AuthCommands, AuthInviteCommands, AuthTrustCommands, ClaimArgs,
+    DEFAULT_CLAIM_WEB_ORIGIN,
 };
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1470,6 +1470,44 @@ const CONTRACTS: &[CommandContractEntry] = &[
         ),
     ),
     entry(
+        &["auth", "invite"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(
+                    user_scoped(NETWORK_METADATA_MUTATION_NO_OP_ID),
+                    &["auth invite"],
+                ),
+                &[json_discriminator(
+                    Some("auth invite"),
+                    "output_kind",
+                    "auth_invite",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["auth", "invite", "list"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(
+                    user_scoped(CommandContract {
+                        observe_only: false,
+                        network_io: true,
+                        ..READ_JSON
+                    }),
+                    &["auth invite list"],
+                ),
+                &[json_discriminator(
+                    Some("auth invite list"),
+                    "output_kind",
+                    "auth_invite_list",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
         &["auth", "trust"],
         feature_gated(user_scoped(GROUP), "client"),
     ),
@@ -4523,6 +4561,12 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             AuthCommands::Login { .. } => vec!["auth", "login"],
             AuthCommands::Logout { .. } => vec!["auth", "logout"],
             AuthCommands::Status { .. } => vec!["auth", "status"],
+            AuthCommands::Invite { command, .. } => match command {
+                None => vec!["auth", "invite"],
+                Some(crate::cli::AuthInviteCommands::List) => {
+                    vec!["auth", "invite", "list"]
+                }
+            },
             AuthCommands::Trust { command } => match command {
                 crate::cli::AuthTrustCommands::Show(_) => vec!["auth", "trust", "show"],
                 crate::cli::AuthTrustCommands::Replace(_) => vec!["auth", "trust", "replace"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1473,10 +1473,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["auth", "invite"],
         feature_gated(
             json_discriminators(
-                documented_schemas(
-                    user_scoped(NETWORK_METADATA_MUTATION_NO_OP_ID),
-                    &["auth invite"],
-                ),
+                documented_schemas(user_scoped(NETWORK_METADATA_MUTATION), &["auth invite"]),
                 &[json_discriminator(
                     Some("auth invite"),
                     "output_kind",
@@ -1490,14 +1487,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["auth", "invite", "list"],
         feature_gated(
             json_discriminators(
-                documented_schemas(
-                    user_scoped(CommandContract {
-                        observe_only: false,
-                        network_io: true,
-                        ..READ_JSON
-                    }),
-                    &["auth invite list"],
-                ),
+                documented_schemas(user_scoped(READ_JSON), &["auth invite list"]),
                 &[json_discriminator(
                     Some("auth invite list"),
                     "output_kind",

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -13,6 +13,8 @@ use std::collections::BTreeSet;
 use clap::Parser;
 
 use super::*;
+#[cfg(feature = "client")]
+use crate::cli::CliContext;
 
 struct RuntimeContractParseSample {
     path: &'static [&'static str],
@@ -1534,6 +1536,43 @@ fn auth_commands_are_user_scoped() {
             path.join(" "),
         );
     }
+}
+
+#[cfg(feature = "client")]
+#[test]
+fn auth_invite_accepts_op_id_and_list_is_observe_only() {
+    const OP_ID: &str = "8c576b0e-091d-4a8c-9811-db127ab36c36";
+    let cli = Cli::try_parse_from([
+        "heddle",
+        "auth",
+        "invite",
+        "--email",
+        "alice@example.com",
+        "--op-id",
+        OP_ID,
+    ])
+    .expect("auth invite should accept --op-id");
+    assert_eq!(cli.operation_id_wire(), OP_ID);
+    assert!(command_supports_op_id_for_command(&cli.command));
+
+    let catalog = build_command_catalog();
+    let create = catalog
+        .commands
+        .iter()
+        .find(|entry| entry.display == "auth invite")
+        .expect("auth invite should be cataloged");
+    assert!(create.supports_op_id);
+    assert_eq!(create.op_id_behavior, "explicit_replay");
+
+    let list = catalog
+        .commands
+        .iter()
+        .find(|entry| entry.display == "auth invite list")
+        .expect("auth invite list should be cataloged");
+    assert!(list.observe_only);
+    assert!(!list.mutates);
+    assert_eq!(list.side_effects, vec![CommandSideEffect::ObserveOnly]);
+    assert_eq!(list.side_effect_class, "observe_only");
 }
 
 #[test]

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -127,6 +127,13 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["auth", "status"], &["auth", "status"]),
     #[cfg(feature = "client")]
     sample(
+        &["auth", "invite"],
+        &["auth", "invite", "--email", "alice@example.com"],
+    ),
+    #[cfg(feature = "client")]
+    sample(&["auth", "invite", "list"], &["auth", "invite", "list"]),
+    #[cfg(feature = "client")]
+    sample(
         &["auth", "trust", "show"],
         &["auth", "trust", "show", "--server", "api.heddle.test"],
     ),
@@ -1513,6 +1520,8 @@ fn auth_commands_are_user_scoped() {
         &["auth", "login"][..],
         &["auth", "logout"],
         &["auth", "status"],
+        &["auth", "invite"],
+        &["auth", "invite", "list"],
         &["auth", "derive-agent"],
         &["auth", "create-service-token"],
         &["claim"],
@@ -1727,6 +1736,8 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "auth login",
             "auth logout",
             "auth status",
+            "auth invite",
+            "auth invite list",
             // heddle#1130: descriptor-trust inspection and explicit
             // compare-and-swap replacement emit stable trust records.
             "auth trust show",

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -46,7 +46,7 @@ use super::{
         },
         auth::{
             AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput,
-            ServiceTokenOutput, WhoamiOutput,
+            ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput, WhoamiOutput,
         },
         thread::{
             ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, ThreadAbsorbOutput,
@@ -177,6 +177,8 @@ schema_registry! {
     (&["auth trust show", "auth trust replace"], AuthTrustOutput),
     (&["whoami"], WhoamiOutput),
     (&["auth create-service-token"], ServiceTokenOutput),
+    (&["auth invite"], SignupInviteCreatedOutput),
+    (&["auth invite list"], SignupInviteListOutput),
     (&["agent provenance begin", "agent provenance end", "agent provenance show"], SessionEnvelope),
     (&["agent provenance segment"], SegmentEnvelope),
     (&["agent provenance list"], SessionListOutput),

--- a/crates/cli-contract/src/cli/commands/wire/auth.rs
+++ b/crates/cli-contract/src/cli/commands/wire/auth.rs
@@ -94,6 +94,36 @@ pub struct ServiceTokenOutput {
     pub expires_in_days: u32,
 }
 
+#[derive(Serialize, JsonSchema)]
+#[schemars(rename = "AuthSignupInviteCreatedSchema")]
+pub struct SignupInviteCreatedOutput {
+    pub output_kind: &'static str,
+    pub invite_id: String,
+    /// The server returns this code only on surfaces where it may be shown.
+    pub invite_code: String,
+    pub allowance_remaining: u32,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(rename = "AuthSignupInviteSchema")]
+pub struct SignupInviteOutput {
+    /// Present because `ListSignupInvites` includes it. Clients must not derive
+    /// or fabricate invite codes from IDs or other metadata.
+    pub invite_code: String,
+    pub status: String,
+    pub created_at: Option<String>,
+    pub consumed: bool,
+    pub consumed_at: Option<String>,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(rename = "AuthSignupInviteListSchema")]
+pub struct SignupInviteListOutput {
+    pub output_kind: &'static str,
+    pub invites: Vec<SignupInviteOutput>,
+    pub allowance_remaining: u32,
+}
+
 // ---- whoami ----------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/crates/cli-contract/src/cli/commands/wire/mod.rs
+++ b/crates/cli-contract/src/cli/commands/wire/mod.rs
@@ -36,7 +36,8 @@ pub use agent::{
 };
 pub use auth::{
     AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, CaptureActor,
-    HumanPromotionDirective, ServiceTokenOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
+    HumanPromotionDirective, ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput,
+    SignupInviteOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
 };
 pub use bridge::{
     ExportGitOutput, ExportedRefOutput, ImportGitOutput, IntegrationStatusOutput,

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -416,6 +416,11 @@ fn command_path_from_raw_help_request(cmd: &clap::Command, raw: &[String]) -> Op
         if let Some(subcommand) = find_subcommand_or_alias(current, token) {
             path.push(subcommand.get_name().to_string());
             current = subcommand;
+        } else if current.get_subcommands().next().is_some() {
+            // An unknown token below a subcommand group is not a request for
+            // the group's help. Let clap report the invalid subcommand so the
+            // invocation keeps the EX_USAGE (64) contract.
+            return None;
         }
     }
 

--- a/crates/cli/tests/auth_invite.rs
+++ b/crates/cli/tests/auth_invite.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "client")]
+
+use std::process::Command;
+
+fn heddle(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .output()
+        .expect("run built heddle binary")
+}
+
+#[test]
+fn auth_invite_help_exposes_create_and_list_surface() {
+    let output = heddle(&["auth", "invite", "--help"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: heddle auth invite"));
+    assert!(stdout.contains("--email"));
+    assert!(stdout.contains("list"));
+}
+
+#[test]
+fn unknown_auth_subcommands_exit_usage_instead_of_showing_parent_help() {
+    for args in [
+        &["auth", "garbage"][..],
+        &["auth", "garbage", "--help"],
+        &["auth", "create-invite", "--help"],
+    ] {
+        let output = heddle(args);
+        assert_eq!(
+            output.status.code(),
+            Some(64),
+            "{args:?} must be an EX_USAGE error; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "invalid auth input must not print parent help"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("unrecognized subcommand"),
+            "clap should identify the unknown nested command"
+        );
+    }
+}

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -72,6 +72,8 @@ const SWEPT: &[&str] = &[
     "auth login",
     "auth logout",
     "auth status",
+    "auth invite",
+    "auth invite list",
     "auth trust show",
     "auth trust replace",
     "auth create-service-token",

--- a/crates/hosted-client/src/extensions.rs
+++ b/crates/hosted-client/src/extensions.rs
@@ -10,7 +10,9 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use heddle_cli_args::{AgentTemplateArg, AuthCommands, AuthTrustCommands, ClaimArgs, CliContext};
+use heddle_cli_args::{
+    AgentTemplateArg, AuthCommands, AuthInviteCommands, AuthTrustCommands, ClaimArgs, CliContext,
+};
 
 use crate::hosted_runtime::{
     auth_requests::{AuthCommand, AuthTrustCommand},
@@ -65,6 +67,15 @@ fn auth_command(command: AuthCommands) -> AuthCommand {
         },
         AuthCommands::Logout { server } => AuthCommand::Logout { server },
         AuthCommands::Status { server } => AuthCommand::Status { server },
+        AuthCommands::Invite {
+            email,
+            server,
+            command,
+        } => AuthCommand::Invite {
+            email,
+            server,
+            list: matches!(command, Some(AuthInviteCommands::List)),
+        },
         AuthCommands::Trust { command } => AuthCommand::Trust {
             command: match command {
                 AuthTrustCommands::Show(args) => AuthTrustCommand::Show {

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -4,9 +4,11 @@ use std::{collections::BTreeSet, io::IsTerminal, path::Path};
 
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
-    CreateDeviceAuthorizationRequest, CreateServiceAccountRequest, DeviceAuthorizationEvent,
-    DeviceAuthorizationResponse, DeviceAuthorizationStatus, ExchangeDeviceAuthorizationRequest,
-    IssueServiceAccountCredentialRequest, WaitForDeviceAuthorizationRequest,
+    CreateDeviceAuthorizationRequest, CreateServiceAccountRequest, CreateSignupInviteRequest,
+    DeviceAuthorizationEvent, DeviceAuthorizationResponse, DeviceAuthorizationStatus,
+    ExchangeDeviceAuthorizationRequest, IssueServiceAccountCredentialRequest,
+    ListSignupInvitesRequest, SignupInviteOwnerStatus, SignupInviteSummary,
+    WaitForDeviceAuthorizationRequest,
 };
 use config::{UserConfig, credentials, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer};
@@ -14,6 +16,7 @@ use heddle_cli_args::CliContext;
 use heddle_cli_contract::cli::commands::RecoveryAdvice;
 pub(crate) use heddle_cli_contract::cli::commands::wire::auth::{
     AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, ServiceTokenOutput,
+    SignupInviteCreatedOutput, SignupInviteListOutput, SignupInviteOutput,
 };
 use objects::{HeddleError, RecoveryDetails};
 use sha2::{Digest, Sha256};
@@ -70,6 +73,11 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
         AuthCommand::Status { server } => cmd_auth_status(ctx, server.as_deref()),
+        AuthCommand::Invite {
+            email,
+            server,
+            list,
+        } => cmd_auth_invite(ctx, server.as_deref(), email, list).await,
         AuthCommand::Trust { command } => cmd_auth_trust(ctx, command),
         AuthCommand::DeriveAgent {
             server,
@@ -98,6 +106,154 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             cmd_create_service_token(ctx, server.as_deref(), name, namespace, out.as_deref()).await
         }
     }
+}
+
+const CREATE_SIGNUP_INVITE_METHOD: &str = "heddle.api.v1alpha1.IdentityService/CreateSignupInvite";
+const SIGNUP_INVITE_PAGE_SIZE: u32 = 200;
+
+async fn cmd_auth_invite(
+    ctx: &dyn CliContext,
+    server: Option<&str>,
+    email: Option<String>,
+    list: bool,
+) -> Result<()> {
+    let server = resolve_server(server)?;
+    let user_config = UserConfig::load_default()?;
+    // HostedSession is the same authenticated credential + device-proof
+    // chokepoint used by the other durable identity writes under `auth`.
+    let session = HostedSession::build(
+        &user_config,
+        Some(server),
+        HostedAuthMode::CredentialFallback,
+    )?;
+    let mut auth_client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let result = if list {
+        list_signup_invites_connected(ctx, &mut auth_client).await
+    } else {
+        create_signup_invite_connected(ctx, &mut auth_client, email).await
+    };
+    auth_client.close().await;
+    result
+}
+
+async fn create_signup_invite_connected(
+    ctx: &dyn CliContext,
+    auth_client: &mut HostedClient,
+    email: Option<String>,
+) -> Result<()> {
+    let operation_id =
+        ClientOperationId::caller_or_fresh(CREATE_SIGNUP_INVITE_METHOD, ctx.operation_id_wire());
+    let request = create_signup_invite_request(email, operation_id.to_wire());
+    let response = auth_client
+        .create_signup_invite(request)
+        .await
+        .map_err(|error| anyhow::anyhow!("create_signup_invite failed: {error}"))?;
+
+    if ctx.should_output_json(None) {
+        println!(
+            "{}",
+            serde_json::to_string(&SignupInviteCreatedOutput {
+                output_kind: "auth_invite",
+                invite_id: response.invite_id,
+                invite_code: response.invite_code,
+                allowance_remaining: response.allowance_remaining,
+            })?
+        );
+    } else {
+        // The code deliberately appears on exactly one output line.
+        println!("{}", response.invite_code);
+        println!("Allowance remaining: {}", response.allowance_remaining);
+    }
+    Ok(())
+}
+
+fn create_signup_invite_request(
+    recipient_email: Option<String>,
+    client_operation_id: String,
+) -> CreateSignupInviteRequest {
+    CreateSignupInviteRequest {
+        recipient_email,
+        client_operation_id,
+    }
+}
+
+async fn list_signup_invites_connected(
+    ctx: &dyn CliContext,
+    auth_client: &mut HostedClient,
+) -> Result<()> {
+    let mut page_token = String::new();
+    let mut seen_page_tokens = BTreeSet::new();
+    let mut invites = Vec::new();
+    let allowance_remaining = loop {
+        let response = auth_client
+            .list_signup_invites(list_signup_invites_request(page_token))
+            .await
+            .map_err(|error| anyhow::anyhow!("list_signup_invites failed: {error}"))?;
+        invites.extend(response.invites.into_iter().map(signup_invite_output));
+        if response.next_page_token.is_empty() {
+            break response.allowance_remaining;
+        }
+        if !seen_page_tokens.insert(response.next_page_token.clone()) {
+            bail!("list_signup_invites returned a repeated page token");
+        }
+        page_token = response.next_page_token;
+    };
+
+    if ctx.should_output_json(None) {
+        println!(
+            "{}",
+            serde_json::to_string(&SignupInviteListOutput {
+                output_kind: "auth_invite_list",
+                invites,
+                allowance_remaining,
+            })?
+        );
+    } else {
+        if invites.is_empty() {
+            println!("No signup invites.");
+        } else {
+            println!("CODE\tSTATUS\tCREATED_AT\tCONSUMED_AT");
+            for invite in invites {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    invite.invite_code,
+                    invite.status,
+                    invite.created_at.as_deref().unwrap_or("-"),
+                    invite.consumed_at.as_deref().unwrap_or("-")
+                );
+            }
+        }
+        println!("Allowance remaining: {allowance_remaining}");
+    }
+    Ok(())
+}
+
+fn list_signup_invites_request(page_token: String) -> ListSignupInvitesRequest {
+    ListSignupInvitesRequest {
+        page_size: SIGNUP_INVITE_PAGE_SIZE,
+        page_token,
+    }
+}
+
+fn signup_invite_output(invite: SignupInviteSummary) -> SignupInviteOutput {
+    let status = match SignupInviteOwnerStatus::try_from(invite.status) {
+        Ok(SignupInviteOwnerStatus::Open) => "open",
+        Ok(SignupInviteOwnerStatus::Consumed) => "consumed",
+        Ok(SignupInviteOwnerStatus::Unspecified) | Err(_) => "unknown",
+    };
+    SignupInviteOutput {
+        invite_code: invite.invite_code,
+        status: status.to_string(),
+        created_at: invite.created_at.as_ref().and_then(format_proto_timestamp),
+        consumed: invite.consumed,
+        consumed_at: invite.consumed_at.as_ref().and_then(format_proto_timestamp),
+    }
+}
+
+fn format_proto_timestamp(timestamp: &prost_types::Timestamp) -> Option<String> {
+    let nanos = u32::try_from(timestamp.nanos).ok()?;
+    chrono::DateTime::<chrono::Utc>::from_timestamp(timestamp.seconds, nanos)
+        .map(|value| value.to_rfc3339())
 }
 
 fn cmd_auth_trust(ctx: &dyn CliContext, command: AuthTrustCommand) -> Result<()> {
@@ -1464,6 +1620,20 @@ fn open_url(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signup_invite_commands_construct_the_declared_requests() {
+        let create = create_signup_invite_request(
+            Some("alice@example.com".to_string()),
+            "invite-op".to_string(),
+        );
+        assert_eq!(create.recipient_email.as_deref(), Some("alice@example.com"));
+        assert_eq!(create.client_operation_id, "invite-op");
+
+        let list = list_signup_invites_request("next-page".to_string());
+        assert_eq!(list.page_size, 200);
+        assert_eq!(list.page_token, "next-page");
+    }
 
     #[test]
     fn validate_browser_url_accepts_https() {

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -2214,6 +2214,8 @@ mod tests {
             "IssueServiceAccountCredential",
             "DeleteRepository",
             "DeleteNamespace",
+            "CreateSignupInvite",
+            "ListSignupInvites",
         ] {
             let error = resolve_agent_operations(None, vec![operation.to_string()])
                 .expect_err("unsafe operation must be outside CLI ceiling");
@@ -2241,6 +2243,8 @@ mod tests {
         assert!(contributor.contains(&"Push".to_string()));
         assert!(contributor.contains(&"SetContext".to_string()));
         assert!(contributor.contains(&"OpenDiscussion".to_string()));
+        assert!(!contributor.contains(&"CreateSignupInvite".to_string()));
+        assert!(!contributor.contains(&"ListSignupInvites".to_string()));
 
         let ci = resolve_agent_operations(Some(AgentTemplate::CiLanding), Vec::new())
             .expect("ci-landing template resolves");
@@ -2250,6 +2254,7 @@ mod tests {
         // CI landing grants no collaboration writes.
         assert!(!ci.contains(&"OpenDiscussion".to_string()));
         assert!(!ci.contains(&"SetContext".to_string()));
+        assert!(!ci.contains(&"CreateSignupInvite".to_string()));
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -160,7 +160,7 @@ fn mint_restricted_agent_root() -> Result<RestrictedAgentRoot> {
         bail!("agent independent root is not bound to this node key");
     }
     let restricted = restrict_agent_account_root(&root.token, &signer, root.expires_at)
-        .context("applying the local agent deny floor and safe operation ceiling")?;
+        .context("applying the local agent account-root deny floor")?;
     let metadata = headless_token_metadata(&restricted)
         .context("validating the restricted client-minted agent capability")?;
     if !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id)

--- a/crates/hosted-client/src/hosted_runtime/auth_requests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_requests.rs
@@ -18,6 +18,11 @@ pub enum AuthCommand {
     Status {
         server: Option<String>,
     },
+    Invite {
+        email: Option<String>,
+        server: Option<String>,
+        list: bool,
+    },
     Trust {
         command: AuthTrustCommand,
     },

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -113,9 +113,13 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
         "BindSignupInviteEmail",
         AgentAuthOperationDisposition::Denied,
     ),
-    // Creating an invite spends the authenticated member's allowance, so a
-    // derived agent must not issue invitations on the parent's behalf.
-    ("CreateSignupInvite", AgentAuthOperationDisposition::Denied),
+    // Everyday account-root capability (heddle#1592 lock 2026-08-28). Off the
+    // deny floor so the unclaimed agent-rooted login root can mint. Derived
+    // children stay unable to mint because this is not in SAFE_AGENT_OPERATIONS.
+    (
+        "CreateSignupInvite",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
     // The server derives the owner from the caller and returns no claimer
     // identity, making invite listing a caller-bound read.
     (
@@ -205,6 +209,10 @@ fn mandatory_agent_denied_operations() -> impl Iterator<Item = &'static str> {
 }
 
 /// Curated W1 operation ceiling for `heddle auth derive-agent`.
+///
+/// This is the derive-agent child ceiling only. The unclaimed agent-rooted
+/// login root is the account: `restrict_agent_account_root` applies the deny
+/// floor without this allowlist.
 ///
 /// `--allow` may select a subset of these methods. Parent and child blocks are
 /// both evaluated by the server, so sub-derivation computes an intersection
@@ -433,10 +441,12 @@ impl AgentAttenuation {
 /// chains off the parent's keys, and the server validates the full
 /// chain against its trust list when the agent presents the token.
 /// The CLI never holds the server's signing key.
-/// Narrow a client-minted agent account root with the same deny floor and
-/// safe-operation ceiling that `heddle auth derive-agent` applies. The leaf
-/// PoP stays the registered Iroh key (self-delegation) so `auth login` can
-/// remint from that seed after expiry.
+/// Narrow a client-minted agent account root with the deny floor that
+/// `heddle auth derive-agent` applies. The login-minted root IS the account:
+/// it keeps human-like everyday ops, including minting signup invites.
+/// [`SAFE_AGENT_OPERATIONS`] is the derive-agent child ceiling only — do not
+/// apply it here. The leaf PoP stays the registered Iroh key (self-delegation)
+/// so `auth login` can remint from that seed after expiry.
 pub(crate) fn restrict_agent_account_root(
     root_token: &str,
     signer: &Ed25519Signer,
@@ -447,12 +457,7 @@ pub(crate) fn restrict_agent_account_root(
         AgentAttenuation {
             agent_id: "local-agent-root".to_string(),
             expires_at,
-            allowed_operations: Some(
-                SAFE_AGENT_OPERATIONS
-                    .iter()
-                    .map(|operation| (*operation).to_string())
-                    .collect(),
-            ),
+            allowed_operations: None,
             allowed_resources: None,
             declared_scopes: Vec::new(),
         },

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -432,15 +432,6 @@ impl AgentAttenuation {
     }
 }
 
-/// Attenuate a parent Biscuit (decoded base64 string) with the
-/// supplied restrictions and return the attenuated Biscuit's
-/// base64-encoded bytes.
-///
-/// Uses `UnverifiedBiscuit` because attenuation appends a new block
-/// to bytes the parent already holds; the new block's signature
-/// chains off the parent's keys, and the server validates the full
-/// chain against its trust list when the agent presents the token.
-/// The CLI never holds the server's signing key.
 /// Narrow a client-minted agent account root with the deny floor that
 /// `heddle auth derive-agent` applies. The login-minted root IS the account:
 /// it keeps human-like everyday ops, including minting signup invites.
@@ -466,6 +457,15 @@ pub(crate) fn restrict_agent_account_root(
     )
 }
 
+/// Attenuate a parent Biscuit (decoded base64 string) with the
+/// supplied restrictions and return the attenuated Biscuit's
+/// base64-encoded bytes.
+///
+/// Uses `UnverifiedBiscuit` because attenuation appends a new block
+/// to bytes the parent already holds; the new block's signature
+/// chains off the parent's keys, and the server validates the full
+/// chain against its trust list when the agent presents the token.
+/// The CLI never holds the server's signing key.
 pub fn attenuate_for_agent(
     parent_token_b64: &str,
     restrictions: AgentAttenuation,

--- a/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
@@ -64,6 +64,13 @@ impl HostedRoutes<'_> {
         ServiceAccountResponse
     );
     unary_method!(
+        create_signup_invite,
+        "IdentityService",
+        "CreateSignupInvite",
+        CreateSignupInviteRequest,
+        CreateSignupInviteResponse
+    );
+    unary_method!(
         exchange_device_authorization,
         "IdentityService",
         "ExchangeDeviceAuthorization",
@@ -76,6 +83,13 @@ impl HostedRoutes<'_> {
         "IssueServiceAccountCredential",
         IssueServiceAccountCredentialRequest,
         IssuedCredentialResponse
+    );
+    unary_method!(
+        list_signup_invites,
+        "IdentityService",
+        "ListSignupInvites",
+        ListSignupInvitesRequest,
+        ListSignupInvitesResponse
     );
     unary_method!(
         create_agent_account,

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -1,15 +1,17 @@
 use api::heddle::api::v1alpha1::{
     ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, CheckMergeEligibilityRequest,
     CheckMergeEligibilityResponse, CreateAgentAccountRequest, CreateAgentAccountResponse,
-    CreateGrantRequest, CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest,
-    DeleteGrantRequest, DeleteNamespaceRequest, DeleteRepositoryRequest,
-    GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
-    Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest, IssuedCredentialResponse,
-    ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
-    ListThreadApprovalsRequest, MonorepoNode, ResolveMonorepoRequest, RevokeApprovalRequest,
-    RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SupportAccessGrant,
-    ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest, UpdateRepositoryRequest,
-    Visibility, grant_target_ref::Target as GrantTargetKind,
+    CreateGrantRequest, CreateInvitationRequest, CreateServiceAccountRequest,
+    CreateSignupInviteRequest, CreateSignupInviteResponse, CreateSpoolRequest, DeleteGrantRequest,
+    DeleteNamespaceRequest, DeleteRepositoryRequest, GetCurrentUserSpoolRequest,
+    GrantSupportAccessRequest, GrantTargetRef, Invitation as ProtoInvitation,
+    IssueServiceAccountCredentialRequest, IssuedCredentialResponse, ListGrantsRequest,
+    ListSignupInvitesRequest, ListSignupInvitesResponse, ListSpoolsRequest,
+    ListSupportAccessGrantsRequest, ListThreadApprovalsRequest, MonorepoNode,
+    ResolveMonorepoRequest, RevokeApprovalRequest, RevokeSupportAccessRequest,
+    ServiceAccountResponse, SpoolSummary, SupportAccessGrant, ThreadApproval, UpdateGrantRequest,
+    UpdateNamespaceRequest, UpdateRepositoryRequest, Visibility,
+    grant_target_ref::Target as GrantTargetKind,
 };
 use wire::ProtocolError;
 
@@ -99,6 +101,19 @@ impl HostedClient {
         ))
     }
 
+    pub async fn create_signup_invite(
+        &mut self,
+        request: CreateSignupInviteRequest,
+    ) -> Result<CreateSignupInviteResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            create_signup_invite,
+            "/heddle.api.v1alpha1.IdentityService/CreateSignupInvite",
+            request
+        ))
+    }
+
     pub async fn issue_service_account_credential(
         &mut self,
         request: IssueServiceAccountCredentialRequest,
@@ -107,6 +122,19 @@ impl HostedClient {
             .issue_service_account_credential(&request)
             .await
             .map_err(hosted_to_protocol_error)
+    }
+
+    pub async fn list_signup_invites(
+        &mut self,
+        request: ListSignupInvitesRequest,
+    ) -> Result<ListSignupInvitesResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            list_signup_invites,
+            "/heddle.api.v1alpha1.IdentityService/ListSignupInvites",
+            request
+        ))
     }
 
     pub async fn begin_login(
@@ -638,7 +666,19 @@ mod tests {
             .create_service_account(CreateServiceAccountRequest::default())
             .await;
         let _ = client
+            .create_signup_invite(CreateSignupInviteRequest {
+                recipient_email: Some("alice@example.com".to_string()),
+                client_operation_id: "signup-invite-op".to_string(),
+            })
+            .await;
+        let _ = client
             .issue_service_account_credential(IssueServiceAccountCredentialRequest::default())
+            .await;
+        let _ = client
+            .list_signup_invites(ListSignupInvitesRequest {
+                page_size: 200,
+                page_token: String::new(),
+            })
             .await;
         client.begin_login("alice@example.com").await.unwrap();
         let _ = client.get_current_user_spool().await;

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -8,7 +8,7 @@ use super::root_mint::{
 };
 use crate::hosted_runtime::{
     auth::headless_token_metadata,
-    device_flow::{SAFE_AGENT_OPERATIONS, restrict_agent_account_root},
+    device_flow::{AgentTemplate, SAFE_AGENT_OPERATIONS, restrict_agent_account_root},
 };
 
 #[test]
@@ -192,18 +192,102 @@ fn restricted_agent_capability_keeps_the_deny_floor() {
         "DeleteNamespace",
         "RevokeSession",
         "CreateAgentAccount",
+        "ClaimHandle",
+        "ClaimSignupInvite",
+        "PromoteAgentAccount",
     ] {
         assert!(
             block.contains(&format!(r#"$op != "{denied}""#)),
             "deny floor missing {denied}: {block}"
         );
     }
-    for allowed in SAFE_AGENT_OPERATIONS {
+    for everyday in ["CreateSignupInvite", "ListSignupInvites"] {
         assert!(
-            block.contains(&format!(r#"$op == "{allowed}""#)),
-            "safe ceiling missing {allowed}: {block}"
+            !block.contains(&format!(r#"$op != "{everyday}""#)),
+            "account-root deny floor must not include {everyday}: {block}"
         );
     }
+    assert!(
+        !block.contains("$op =="),
+        "account root must not carry the SAFE child allowlist: {block}"
+    );
+}
+
+/// The unclaimed agent-rooted login root is the account. Remint keeps the
+/// deny floor but not the derive-agent child ceiling, so everyday account
+/// ops including signup-invite mint/list must authorize.
+#[test]
+fn restricted_agent_root_can_mint_and_list_signup_invites() {
+    let signer = Ed25519Signer::generate().expect("seed");
+    let seed = signer.to_seed();
+    let root = mint_agent_root(&seed).expect("agent root");
+    let restricted =
+        restrict_agent_account_root(&root.token, &signer, root.expires_at).expect("restrict");
+    for allowed in ["CreateSignupInvite", "ListSignupInvites", "WhoAmI"] {
+        authorize_restricted_root(&restricted, &seed, allowed)
+            .unwrap_or_else(|error| panic!("account root must authorize {allowed}: {error}"));
+    }
+    for denied in [
+        "CreateServiceAccount",
+        "CreateAgentAccount",
+        "RevokeSession",
+        "ClaimSignupInvite",
+    ] {
+        assert!(
+            authorize_restricted_root(&restricted, &seed, denied).is_err(),
+            "account root must still deny {denied}"
+        );
+    }
+}
+
+/// Derived children stay on the SAFE / template ceiling. Invite mint and
+/// list are everyday account-root ops, not child grants.
+#[test]
+fn derived_contributor_cannot_mint_or_list_signup_invites() {
+    let contributor = AgentTemplate::Contributor.operations();
+    for template in AgentTemplate::ALL {
+        let operations = template.operations();
+        for denied in ["CreateSignupInvite", "ListSignupInvites"] {
+            assert!(
+                !operations.iter().any(|operation| operation == denied),
+                "template {:?} must not grant {denied}",
+                template.as_str()
+            );
+        }
+    }
+    for denied in ["CreateSignupInvite", "ListSignupInvites"] {
+        assert!(
+            !SAFE_AGENT_OPERATIONS.contains(&denied),
+            "SAFE_AGENT_OPERATIONS is the derive-agent child ceiling and must not include {denied}"
+        );
+        assert!(
+            !contributor.iter().any(|operation| operation == denied),
+            "contributor child must not receive {denied}"
+        );
+    }
+}
+
+fn authorize_restricted_root(
+    token: &str,
+    seed: &[u8; 32],
+    operation: &str,
+) -> Result<(), biscuit_auth::error::Token> {
+    use biscuit_auth::{builder::AuthorizerBuilder, datalog::RunLimits};
+
+    let authority = authority_keypair(seed).expect("authority");
+    let root_public = authority.public();
+    let biscuit = biscuit_auth::Biscuit::from_base64(token.as_bytes(), move |_| Ok(root_public))?;
+    let mut authorizer = AuthorizerBuilder::new()
+        .set_limits(RunLimits {
+            max_facts: 1000,
+            max_iterations: 100,
+            max_time: std::time::Duration::from_secs(1),
+        })
+        .fact(format!("time({})", Utc::now().to_rfc3339()).as_str())?
+        .fact(format!(r#"operation("{operation}")"#).as_str())?
+        .policy("allow if true")?
+        .build(&biscuit)?;
+    authorizer.authorize().map(|_| ())
 }
 
 /// Regression: the agent ceiling must carry the personal-spool discovery +

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2047,6 +2047,46 @@ contract.
 
 ---
 
+## `heddle auth invite --output json`
+
+```json
+{
+  "output_kind": "auth_invite",
+  "invite_id": "invite-018f",
+  "invite_code": "hdi_example_signup_code",
+  "allowance_remaining": 2
+}
+```
+
+`invite_code` is emitted once in the mint response. Treat it as a secret and
+deliver it to its recipient; the client does not derive or reconstruct it.
+
+---
+
+## `heddle auth invite list --output json`
+
+```json
+{
+  "output_kind": "auth_invite_list",
+  "invites": [
+    {
+      "invite_code": "hdi_example_signup_code",
+      "status": "open",
+      "created_at": "2026-08-28T12:00:00+00:00",
+      "consumed": false,
+      "consumed_at": null
+    }
+  ],
+  "allowance_remaining": 2
+}
+```
+
+The list includes invite codes because `ListSignupInvites` returns them. A
+future wire contract that omits codes must be rendered without fabricating
+them.
+
+---
+
 ## `heddle agent provenance begin --output json`
 
 `heddle agent provenance begin|show|end --output json` emit:
@@ -3183,26 +3223,26 @@ as one; no `help advanced`).
       "visibility set",
       "visibility promote"
     ],
-    "advanced_scope_json_commands_total": 99,
+    "advanced_scope_json_commands_total": 101,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 56,
+    "advanced_scope_mutating_commands_total": 57,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
-    "catalog_commands_total": 184,
-    "catalog_mutating_commands_total": 89,
-    "json_commands_total": 147,
+    "catalog_commands_total": 186,
+    "catalog_mutating_commands_total": 90,
+    "json_commands_total": 149,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 108,
+    "json_commands_with_schema": 110,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 86,
+    "json_mutating_commands_total": 87,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 86,
+    "mutating_commands_total": 87,
     "mutating_commands_with_accepted_opaque_schema": 21,
-    "mutating_commands_with_schema": 65,
+    "mutating_commands_with_schema": 66,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "188 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3240,7 +3280,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "188 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6092,6 +6092,46 @@ contract.
 
 ---
 
+## `heddle auth invite --output json`
+
+```json
+{
+  "output_kind": "auth_invite",
+  "invite_id": "invite-018f",
+  "invite_code": "hdi_example_signup_code",
+  "allowance_remaining": 2
+}
+```
+
+`invite_code` is emitted once in the mint response. Treat it as a secret and
+deliver it to its recipient; the client does not derive or reconstruct it.
+
+---
+
+## `heddle auth invite list --output json`
+
+```json
+{
+  "output_kind": "auth_invite_list",
+  "invites": [
+    {
+      "invite_code": "hdi_example_signup_code",
+      "status": "open",
+      "created_at": "2026-08-28T12:00:00+00:00",
+      "consumed": false,
+      "consumed_at": null
+    }
+  ],
+  "allowance_remaining": 2
+}
+```
+
+The list includes invite codes because `ListSignupInvites` returns them. A
+future wire contract that omits codes must be rendered without fabricating
+them.
+
+---
+
 ## `heddle agent provenance begin --output json`
 
 `heddle agent provenance begin|show|end --output json` emit:
@@ -7228,26 +7268,26 @@ as one; no `help advanced`).
       "visibility set",
       "visibility promote"
     ],
-    "advanced_scope_json_commands_total": 99,
+    "advanced_scope_json_commands_total": 101,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 56,
+    "advanced_scope_mutating_commands_total": 57,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 21,
-    "catalog_commands_total": 184,
-    "catalog_mutating_commands_total": 89,
-    "json_commands_total": 147,
+    "catalog_commands_total": 186,
+    "catalog_mutating_commands_total": 90,
+    "json_commands_total": 149,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 108,
+    "json_commands_with_schema": 110,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 86,
+    "json_mutating_commands_total": 87,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 86,
+    "mutating_commands_total": 87,
     "mutating_commands_with_accepted_opaque_schema": 21,
-    "mutating_commands_with_schema": 65,
+    "mutating_commands_with_schema": 66,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "188 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -7285,7 +7325,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "186 command(s), 147 JSON command(s), 89 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "188 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 48 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rebase `heddle auth invite` / `invite list` from #1593 onto current `main` (keeps the host-only spool child-ceiling work from #1594 / `a2838863`).
- Stop applying `SAFE_AGENT_OPERATIONS` to `restrict_agent_account_root`. That remint path is the unclaimed agent-rooted login root, which **is** the account and keeps human-like everyday ops, including `CreateSignupInvite` / `ListSignupInvites`.
- Keep the deny floor (`CreateServiceAccount`, `Delete*`, `RevokeSession`, `CreateAgentAccount`, claim/owner/purge). `CreateSignupInvite` stays off that floor and off `SAFE_AGENT_OPERATIONS` / reviewer / contributor / ci-landing, so derived children still cannot mint.
- Unknown `heddle auth <garbage>` still exits 64.

## Closes

Part of HeddleCo/heddle#1592

Continues the CLI in #1593. Hypothesis confirmed: `restrict_agent_account_root` is the production remint path (`auth_login_agent`), and invite does **not** bypass capability checks — it rides `HostedSession` + the reminted biscuit. Weft still needs starter allowance / list registration for a live mint-to-login.

## Red commit
`ae117f8e`

## Test evidence
```
$ cargo test -p heddle-hosted-client --features client
running 310 tests
...
test hosted_runtime::auth::tests::derive_agent_allow_flag_cannot_select_unsafe_operations ... ok
test hosted_runtime::auth::tests::signup_invite_commands_construct_the_declared_requests ... ok
test hosted_runtime::auth::tests::template_expands_to_a_curated_allow_set ... ok
test hosted_runtime::device_flow::tests::contributor_ceiling_equals_safe_agent_operations ... ok
test hosted_runtime::device_flow::tests::identity_service_agent_policy_exactly_matches_the_shared_descriptor ... ok
test hosted_runtime::root_mint_tests::derived_contributor_cannot_mint_or_list_signup_invites ... ok
test hosted_runtime::root_mint_tests::restricted_agent_capability_keeps_the_deny_floor ... ok
test hosted_runtime::root_mint_tests::restricted_agent_root_can_mint_and_list_signup_invites ... ok
test hosted_runtime::root_mint_tests::safe_ceiling_allows_host_only_spool_provisioning ... ok
...
test result: ok. 309 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 16.06s

$ cargo test -p heddle-cli --test auth_invite --features client
running 2 tests
test auth_invite_help_exposes_create_and_list_surface ... ok
test unknown_auth_subcommands_exit_usage_instead_of_showing_parent_help ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aad6b95-9099-4daa-a4ab-3574498d826b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aad6b95-9099-4daa-a4ab-3574498d826b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790535489&installation_model_id=21489&pr_number=1595&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1595&signature=9dc91e794e070695fa0736e1f4acc59a0c331bbe9c9099c74799319e4db4cd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->