### PR TITLE
chore(deps): adopt heddle-api 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fe575ff77dc9181bc08a04be060a1b876cb86dbc1778b01ffda050215f1ff0"
+checksum = "87bab7f235f10ebacdd4f3a92d029c558fd1b43f787172009ee635d329aa6bc2"
 dependencies = [
  "blake3",
  "bytes",
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e21a209952178ff354b92b050859051e60f4caafff9edc6f94dd2049fbdd279"
+checksum = "08fa9793f1cb62472aba71f5337d172f65c8d56e032ab02c6234a23d2ac70cb0"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.17.0" }
+api = { package = "heddle-api", version = "0.18.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -17,10 +17,10 @@
 //! `Discussion.opened_against_state`.
 
 use api::heddle::api::v1alpha1::{
-    AppendTurnRequest, ContextAnnotationKind, Discussion as ProtoDiscussion, DiscussionSeverity,
-    DiscussionStatusFilter, ListDiscussionsByStateRequest, OpenDiscussionRequest, PathSymbolRef,
-    ResolveDiscussionRequest, StateId as ProtoStateId, list_discussions_response,
-    resolve_discussion_request,
+    AppendTurnRequest, ContextAnnotationKind, Discussion as ProtoDiscussion, DiscussionKind,
+    DiscussionSeverity, DiscussionStatusFilter, ListDiscussionsByStateRequest,
+    OpenDiscussionRequest, PathSymbolRef, ResolveDiscussionRequest, StateId as ProtoStateId,
+    list_discussions_response, resolve_discussion_request,
 };
 use objects::object::{AnnotationKind, ChangeId, StateId};
 use wire::ProtocolError;
@@ -263,6 +263,7 @@ fn open_discussion_request(
         client_operation_id,
         thread_id: String::new(),
         severity: DiscussionSeverity::Unspecified as i32,
+        kind: DiscussionKind::CodeAnchored as i32,
     }
 }
 
@@ -363,6 +364,7 @@ mod tests {
         assert_eq!(request.anchor.unwrap().file, "src/lib.rs");
         assert_eq!(request.body, "keep this stable");
         assert_eq!(request.severity, DiscussionSeverity::Unspecified as i32);
+        assert_eq!(request.kind, DiscussionKind::CodeAnchored as i32);
     }
 
     #[test]

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.6"
+heddleco-capability-verifier = "0.7"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
## Summary

- bump the workspace `heddle-api` dependency from 0.17.0 to 0.18.0
- bump `heddleco-capability-verifier` from 0.6 to 0.7, the published companion release required to resolve against API 0.18
- populate the existing hosted `OpenDiscussionRequest.kind` with `DISCUSSION_KIND_CODE_ANCHORED`
- keep the existing optional anchor and empty `thread_id` behavior unchanged

## Compatibility decisions

No new behavior decision was required. Every existing open path is code-anchored, so the new kind is explicit `CODE_ANCHORED`. The current local discussion model carries `thread_ref` but no stable thread identity, so `thread_id` remains empty. No coordination discussions or `ListByThreadRef` call sites are added.

## Verification

Using `CARGO_TARGET_DIR=/home/scratch/heddle-api018-target`:

- `cargo build --workspace --locked`
- `cargo test --locked -p heddle-hosted-client -p heddle-repo -p heddle-cli-args -p heddle-cli`
- `cargo clippy --locked -p heddle-hosted-client -p heddle-repo -p heddle-cli-args -p heddle-cli --all-targets -- -D warnings`
- agent API schema snapshot and generated TypeScript/JSON freshness tests passed within the CLI test suite

## Out of scope

The discuss verbs (heddle#1536/#1534) and weft#1788 remain follow-on work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790545969&installation_model_id=21489&pr_number=1596&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1596&signature=2995f8c56f4deb9de724972f98bea19bb8e9d6daef398715f68948f4cc554a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->