### PR TITLE
release: heddle v0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -2314,11 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.2"
+version = "0.15.3"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base32",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base32",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "blake3",
  "bytes",
@@ -2576,11 +2576,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.2"
+version = "0.15.3"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "fs2",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base32",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -4650,6 +4650,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,11 +5410,11 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
- "pem",
+ "pem 4.0.0",
  "ring",
  "rustls-pki-types",
  "time",
@@ -7089,7 +7099,7 @@ dependencies = [
  "futures",
  "log",
  "num-bigint",
- "pem",
+ "pem 3.0.6",
  "proc-macro2",
  "rcgen",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.2", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.2", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.2", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.2" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.2" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.2", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.2" }
-heddle-pack = { path = "crates/pack", version = "0.15.2" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.2" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.2", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.2" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.2" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.2" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.2" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.2", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.2", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.2" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.2" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.2" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.2", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.2" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.2", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.2" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.2" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.2" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.2", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.2", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.3", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.3", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.3", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.3" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.3" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.3", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.3" }
+heddle-pack = { path = "crates/pack", version = "0.15.3" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.3" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.3", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.3" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.3" }
+config = { path = "crates/config", package = "heddle-config", version = "0.15.3" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.3" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.3", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.3", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.3" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.3" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.3" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.3", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.3" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.3", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.3" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.3" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.3" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.3", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.3", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.2",
+  "schemaVersion": "0.15.3",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.2" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.3" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/cli-args/CHANGELOG.md
+++ b/crates/cli-args/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-cli-args-v0.15.2...heddle-cli-args-v0.15.3) - 2026-08-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-args-v0.15.1...heddle-cli-args-v0.15.2) - 2026-08-28
 
 ### Other

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-cli-v0.15.2...heddle-cli-v0.15.3) - 2026-08-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-v0.15.1...heddle-cli-v0.15.2) - 2026-08-28
 
 ### Added

--- a/crates/docsgen/CHANGELOG.md
+++ b/crates/docsgen/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-docsgen-v0.15.2...heddle-docsgen-v0.15.3) - 2026-08-28
+
+### Other
+
+- heddle v0.15.2
+- *(release)* heddle 0.15.1 (adopt api 0.17 + cv 0.6, via release-plz) ([#1573](https://github.com/HeddleCo/heddle/pull/1573))
+- Port agent docs generator to Rust ([#1571](https://github.com/HeddleCo/heddle/pull/1571))
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-docsgen-v0.15.1...heddle-docsgen-v0.15.2) - 2026-08-28
 
 ### Other

--- a/crates/hosted-client/CHANGELOG.md
+++ b/crates/hosted-client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.2...heddle-hosted-client-v0.15.3) - 2026-08-28
+
+### Fixed
+
+- *(agent)* allow host-only spool provisioning in the agent ceiling ([#1592](https://github.com/HeddleCo/heddle/pull/1592))
+
+### Other
+
+- *(deps)* adopt heddle-api 0.18
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.1...heddle-hosted-client-v0.15.2) - 2026-08-28
 
 ### Other

--- a/crates/repo/CHANGELOG.md
+++ b/crates/repo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-repo-v0.15.2...heddle-repo-v0.15.3) - 2026-08-28
+
+### Other
+
+- *(deps)* adopt heddle-api 0.18
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-repo-v0.15.1...heddle-repo-v0.15.2) - 2026-08-28
 
 ### Added


### PR DESCRIPTION
Release **heddle v0.15.3** (patch). Computed by release-plz.

## Included
- **chore(deps):** adopt heddle-api 0.18 (#1596) — the ListByThreadRef/DiscussionKind coordination-mailbox proto
- agent-ceiling host-only spool provisioning (#1592/#1594) + other main commits since 0.15.2

## Regenerated
- `clients/npm/generated/heddle-schemas.{ts,json}` (embed 0.15.3), `docs/llms*.txt` — via gen-ts-types.sh + heddle-docsgen. Source-free release commit.

On merge, publish-crates.yml publishes the crates; `v0.15.3` tag on the merge commit cuts binaries. **Unblocks weft#1788** (ListByThreadRef handler) + the discuss verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790551981&installation_model_id=21489&pr_number=1597&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1597&signature=43aa69a1f91b35784ce50600aa7deeb651a6f7968f9932fe7fa728388f67d1d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->