### PR TITLE
fix(hosted): mint SignedSpoolOwnerGenesis on CreateSpool

### DIFF
--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -2088,6 +2088,13 @@ mod tests {
 
         let permission = ProtocolError::AuthorizationFailed("missing grant".to_string());
         assert!(!auto_provision_create_already_exists(&permission));
+
+        let missing_genesis =
+            ProtocolError::InvalidState("owner_genesis is required".to_string());
+        assert!(
+            !auto_provision_create_already_exists(&missing_genesis),
+            "weft's CreateSpool genesis require is a hard failure, not AlreadyExists"
+        );
     }
 
     #[cfg(feature = "client")]

--- a/crates/hosted-client/src/hosted_runtime/hosted/context.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/context.rs
@@ -6,7 +6,7 @@ use std::{
 use api::{
     heddle::api::v1alpha1::{
         BearerProof, CallContext, HumanVerification, RepositoryRef, RequestProof,
-        StreamOpeningProof, TraceContext, repository_ref,
+        SignedSpoolOwnerGenesis, StreamOpeningProof, TraceContext, repository_ref,
     },
     signing,
 };
@@ -80,6 +80,19 @@ impl CallContextFactory {
 
     pub fn signing_identity(&self) -> Option<&str> {
         self.signing_identity.as_deref()
+    }
+
+    /// Mint CreateSpool genesis with the same device/proof key used for PoP.
+    ///
+    /// A generated-per-spool key would pass CreateSpool and fail later
+    /// purge/claim: `genesis.owner_public_key` must be the account owner-root.
+    pub(super) fn mint_spool_owner_genesis(&self) -> Result<SignedSpoolOwnerGenesis> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        let spool_uuid = uuid::Uuid::now_v7();
+        repo::sign_spool_owner_genesis(signer.as_ref(), *spool_uuid.as_bytes()).map_err(Into::into)
     }
 
     pub fn with_bearer_capability(mut self, capability: impl Into<Vec<u8>>) -> Self {
@@ -573,5 +586,48 @@ mod tests {
             )
             .unwrap();
         assert!(context.deadline.is_none());
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_requires_the_device_proof_key() {
+        let error = CallContextFactory::default()
+            .mint_spool_owner_genesis()
+            .expect_err("CreateSpool must not invent a throwaway owner key");
+        assert!(matches!(error, HostedError::SigningIdentityRequired));
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_uses_the_configured_proof_key_and_a_uuidv7() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let factory = CallContextFactory::default()
+            .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:test")
+            .unwrap();
+        let signed = factory.mint_spool_owner_genesis().unwrap();
+        let genesis = signed.genesis.expect("signed genesis payload");
+        let spool_uuid: [u8; 16] = genesis
+            .spool_uuid
+            .as_slice()
+            .try_into()
+            .expect("spool UUID is 16 bytes");
+        assert_eq!(uuid::Uuid::from_bytes(spool_uuid).get_version_num(), 7);
+        assert_eq!(
+            genesis
+                .owner_public_key
+                .expect("owner public key")
+                .public_key,
+            signer.public_key()
+        );
+        use sha2::{Digest, Sha256};
+
+        let digest = Sha256::new()
+            .chain_update(signer.public_key())
+            .chain_update(spool_uuid)
+            .finalize();
+        Ed25519Signer::verify_with_public_key(
+            &digest,
+            signer.public_key(),
+            &signed.owner_signature.expect("owner signature").signature,
+        )
+        .unwrap();
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -13,14 +13,15 @@ use api::{
         encode_stream_message, encode_success_response,
     },
     heddle::api::v1alpha1::{
-        BlobResponse, GetBlobRequest, GetContextHistoryPageEnd, GetContextHistoryResponse,
-        ListContextPageEnd, ListContextResponse, ListDiscussionsPageEnd, ListDiscussionsResponse,
-        ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk,
-        PackStreamKind, PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete,
-        PushReady, PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint,
-        TransportMode, get_context_history_response, list_context_response,
-        list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
-        push_client_frame, push_server_frame,
+        BlobResponse, CreateSpoolRequest, GetBlobRequest, GetContextHistoryPageEnd,
+        GetContextHistoryResponse, HostedSpool, ListContextPageEnd, ListContextResponse,
+        ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd, ListRefsResponse,
+        ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind, PullComplete,
+        PullReady, PullServerFrame, PushClientFrame, PushComplete, PushReady, PushServerFrame,
+        SignedSpoolOwnerGenesis, StateId, TransferCheckpoint, TransportMode,
+        get_context_history_response, list_context_response, list_discussions_response,
+        list_refs_response, list_threads_response, pull_server_frame, push_client_frame,
+        push_server_frame,
     },
     method_descriptor,
 };
@@ -35,6 +36,7 @@ use super::{CallContextFactory, HostedClient};
 
 const OWNER_GENESIS_FIXTURE_HEX: &str = "0a380a10222222222222222222222222222222221224080112208a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c12640a20def88318e44a809464c1022f22230567bae6805d17b1ccfc2bebe5326232c58a1240bfe677c0b6fec8d28e379f584f36dee7258d834222f9b75f61dc75b7db2d836d76d4fb6eaf9e7f561925b2e6882b51eadaf3ec77c565f5b638ad0febfc8cd304";
 const GET_BLOB_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/GetBlob";
+const CREATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/CreateSpool";
 
 fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
     let bytes = hex::decode(OWNER_GENESIS_FIXTURE_HEX).expect("published v2 fixture hex");
@@ -42,7 +44,18 @@ fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
 }
 
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None, BlobFixture::default()).await
+    start_inner(None, BlobFixture::default(), None).await
+}
+
+pub(crate) async fn start_recording_create_spool() -> (
+    HostedClient,
+    JoinHandle<()>,
+    Arc<Mutex<Vec<CreateSpoolRequest>>>,
+) {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (client, server) =
+        start_inner(None, BlobFixture::default(), Some(Arc::clone(&captured))).await;
+    (client, server, captured)
 }
 
 pub(crate) async fn start_with_remote_state(
@@ -54,6 +67,7 @@ pub(crate) async fn start_with_remote_state(
             pack: None,
         }),
         BlobFixture::default(),
+        None,
     )
     .await
 }
@@ -69,6 +83,7 @@ pub(crate) async fn start_with_pull_pack(
             pack: Some((pack_data, index_data)),
         }),
         BlobFixture::default(),
+        None,
     )
     .await
 }
@@ -104,7 +119,7 @@ async fn start_with_get_blob_contents_and_pull(
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(pull, fixture).await;
+    let (client, server) = start_inner(pull, fixture, None).await;
     (client, server, requested)
 }
 
@@ -123,6 +138,7 @@ struct BlobFixture {
 async fn start_inner(
     pull: Option<PullFixture>,
     blobs: BlobFixture,
+    create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
 ) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
@@ -141,7 +157,13 @@ async fn start_inner(
             .await
             .unwrap();
         while let Ok((send, recv)) = connection.accept_bi().await {
-            tokio::spawn(serve_call(send, recv, pull.clone(), blobs.clone()));
+            tokio::spawn(serve_call(
+                send,
+                recv,
+                pull.clone(),
+                blobs.clone(),
+                create_spool.clone(),
+            ));
         }
         server.close().await;
     });
@@ -167,6 +189,7 @@ async fn serve_call(
     mut recv: iroh::endpoint::RecvStream,
     pull: Option<PullFixture>,
     blobs: BlobFixture,
+    create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -183,7 +206,9 @@ async fn serve_call(
     let descriptor = method_descriptor(&method).expect("registered hosted method");
     match descriptor.streaming {
         StreamingShape::Unary | StreamingShape::ClientStreaming => {
-            if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
+            if method == CREATE_SPOOL_METHOD {
+                serve_create_spool(&mut send, &mut recv, &mut request, create_spool).await;
+            } else if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
                 serve_get_blob(&mut send, &mut recv, &mut request, blobs).await;
             } else {
                 send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
@@ -376,6 +401,45 @@ fn bidi_responses(method: &str, pull: Option<PullFixture>) -> Vec<Vec<u8>> {
         }
         _ => Vec::new(),
     }
+}
+
+async fn serve_create_spool(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    captured: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
+) {
+    while let Ok(Some(chunk)) = recv.read_chunk(api::framing::MAX_CONTROL_BODY + 6).await {
+        request.extend_from_slice(&chunk);
+    }
+    let body = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| CreateSpoolRequest::decode(frame.body).ok());
+    if let (Some(captured), Some(body)) = (captured.as_ref(), body.as_ref()) {
+        captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .push(body.clone());
+    }
+    let response = match body {
+        Some(request) => HostedSpool {
+            full_path: format!("{}/{}", request.parent_path, request.slug),
+            kind: if request.is_repo {
+                "project".to_string()
+            } else {
+                "namespace".to_string()
+            },
+            is_repo: request.is_repo,
+            display_name: request.display_name.unwrap_or_default(),
+            ..HostedSpool::default()
+        },
+        None => HostedSpool::default(),
+    };
+    send.write_chunk(Bytes::from(
+        encode_success_response(&response.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
 }
 
 async fn serve_get_blob(

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -161,6 +161,11 @@ impl HostedClient {
     ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
         let operation_id =
             ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/CreateSpool");
+        let owner_genesis = Some(
+            self.context
+                .mint_spool_owner_genesis()
+                .map_err(hosted_to_protocol_error)?,
+        );
         let spool = authed_call!(
             self,
             create_spool,
@@ -173,8 +178,7 @@ impl HostedClient {
                 visibility: Visibility::Private as i32,
                 client_operation_id: operation_id.to_wire(),
                 settings: None,
-                // Local genesis materialization is tracked separately by weft#1532.
-                owner_genesis: None,
+                owner_genesis,
             }
         );
         Ok(to_protocol_spool(spool))
@@ -643,14 +647,15 @@ mod tests {
         client.begin_login("alice@example.com").await.unwrap();
         let _ = client.get_current_user_spool().await;
         assert!(client.list_spools(true).await.unwrap().is_empty());
-        let _ = client
+        client
             .create_spool(
                 "acme",
                 "widgets",
                 wire::HostedSpoolKind::Project,
                 Some("Widgets".to_string()),
             )
-            .await;
+            .await
+            .expect("CreateSpool mints owner genesis and reaches the server");
         client
             .create_invitation("alice@example.com", "acme", "developer")
             .await
@@ -780,5 +785,62 @@ mod tests {
         assert!(build_target_ref(Some(""), None).is_err());
         assert!(build_target_ref(None, Some("")).is_err());
         assert!(build_target_ref(Some(""), Some("")).is_err());
+    }
+
+    #[tokio::test]
+    async fn create_spool_sends_device_key_signed_uuidv7_owner_genesis() {
+        use sha2::{Digest, Sha256};
+
+        use crypto::Ed25519Signer;
+
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_create_spool().await;
+        let created = client
+            .create_spool(
+                "cedar-jay-9dce33",
+                "spool-d",
+                wire::HostedSpoolKind::Project,
+                None,
+            )
+            .await
+            .expect("CreateSpool with minted genesis");
+        assert_eq!(created.full_path, "cedar-jay-9dce33/spool-d");
+
+        let request = captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .pop()
+            .expect("CreateSpool reached the server");
+        let signed = request
+            .owner_genesis
+            .expect("CreateSpool must send SignedSpoolOwnerGenesis");
+        let genesis = signed.genesis.expect("signed genesis payload");
+        let spool_uuid: [u8; 16] = genesis
+            .spool_uuid
+            .as_slice()
+            .try_into()
+            .expect("spool UUID is 16 bytes");
+        assert_eq!(
+            uuid::Uuid::from_bytes(spool_uuid).get_version_num(),
+            7,
+            "weft takes the new spool UUID from genesis and checks version 7"
+        );
+        let owner_public_key = genesis
+            .owner_public_key
+            .expect("owner public key")
+            .public_key;
+        let digest = Sha256::new()
+            .chain_update(&owner_public_key)
+            .chain_update(spool_uuid)
+            .finalize();
+        Ed25519Signer::verify_with_public_key(
+            &digest,
+            &owner_public_key,
+            &signed.owner_signature.expect("owner signature").signature,
+        )
+        .expect("genesis is a protocol-2 self-signature");
+
+        client.close().await;
+        server.await.unwrap();
     }
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -46,6 +46,7 @@ pub mod operation_dedup;
 mod owner_authorization;
 #[cfg(test)]
 mod owner_authorization_tests;
+pub use owner_authorization::sign_spool_owner_genesis;
 mod repository;
 mod repository_key_binding;
 mod repository_redaction;

--- a/crates/repo/src/owner_authorization.rs
+++ b/crates/repo/src/owner_authorization.rs
@@ -5,8 +5,11 @@ use std::fs;
 
 use anyhow::{Context, Result};
 use api::heddle::api::v1alpha1::{
+    AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
     PurgeOperationSigningBody, PurgeSidecarIdentity, SidecarAuthorization, SignedSpoolOwnerGenesis,
+    SpoolOwnerGenesis,
 };
+use crypto::Signer;
 use heddleco_capability_verifier::{
     Decision, PurgeContext, VerificationLimits, verify_authorization_bundle,
     verify_purge_authorization, verify_spool_owner_genesis,
@@ -21,6 +24,44 @@ use crate::{HeddleError, Repository};
 const OWNER_GENESIS_PIN_FILE: &str = "owner-authorization.bin";
 const OWNER_AUTHORIZATION_PROTOCOL_VERSION: u32 = 2;
 const MAX_CAPABILITY_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
+const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
+
+/// Protocol-2 self-signature: the owner key signs `SHA-256(public_key || uuid)`.
+///
+/// CreateSpool callers mint this locally. Weft only verifies the
+/// self-signature and takes the new spool UUID from the genesis; it has no
+/// owner private key. Use a UUIDv7 — weft checks the version.
+pub fn sign_spool_owner_genesis(
+    signer: &impl Signer,
+    spool_uuid: [u8; 16],
+) -> Result<SignedSpoolOwnerGenesis, crypto::SignerError> {
+    let owner_public_key = AuthorizationVerificationKey {
+        algorithm: AuthorizationKeyAlgorithm::Ed25519 as i32,
+        public_key: signer.public_key().to_vec(),
+    };
+    let mut key_id_body = Vec::with_capacity(4 + owner_public_key.public_key.len());
+    key_id_body.extend_from_slice(&owner_public_key.algorithm.to_be_bytes());
+    key_id_body.extend_from_slice(&owner_public_key.public_key);
+    let signer_key_id = Sha256::new()
+        .chain_update(OWNER_KEY_ID_DOMAIN)
+        .chain_update(key_id_body)
+        .finalize()
+        .to_vec();
+    let digest = Sha256::new()
+        .chain_update(&owner_public_key.public_key)
+        .chain_update(spool_uuid)
+        .finalize();
+    Ok(SignedSpoolOwnerGenesis {
+        genesis: Some(SpoolOwnerGenesis {
+            spool_uuid: spool_uuid.to_vec(),
+            owner_public_key: Some(owner_public_key),
+        }),
+        owner_signature: Some(AuthorizationSignature {
+            signer_key_id,
+            signature: signer.sign(&digest)?,
+        }),
+    })
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 struct PinnedOwnerGenesis {

--- a/crates/repo/src/owner_authorization_tests.rs
+++ b/crates/repo/src/owner_authorization_tests.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use api::heddle::api::v1alpha1::{
-    AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
-    PurgeOperationSigningBody, SidecarAuthorization, SignedSpoolOwnerGenesis, SpoolOwnerGenesis,
+    PurgeOperationSigningBody, SidecarAuthorization, SignedSpoolOwnerGenesis,
 };
 use crypto::Signer;
 use heddleco_capability_verifier::{
@@ -11,7 +10,6 @@ use heddleco_capability_verifier::{
     verify_authorization_bundle, verify_purge_authorization, verify_spool_owner_genesis,
 };
 use prost::Message;
-use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
 use crate::Repository;
@@ -41,32 +39,32 @@ fn pinned_repository() -> (TempDir, Repository, ConformanceFixture) {
 
 fn generated_genesis(spool_uuid: [u8; 16]) -> SignedSpoolOwnerGenesis {
     let signer = crypto::Ed25519Signer::generate().expect("owner keypair");
-    let owner_public_key = AuthorizationVerificationKey {
-        algorithm: AuthorizationKeyAlgorithm::Ed25519 as i32,
-        public_key: signer.public_key().to_vec(),
-    };
-    let mut key_id_body = Vec::with_capacity(36);
-    key_id_body.extend_from_slice(&owner_public_key.algorithm.to_be_bytes());
-    key_id_body.extend_from_slice(&owner_public_key.public_key);
-    let signer_key_id = Sha256::new()
-        .chain_update(b"heddle-key-v1")
-        .chain_update(key_id_body)
-        .finalize()
-        .to_vec();
-    let digest = Sha256::new()
-        .chain_update(&owner_public_key.public_key)
-        .chain_update(spool_uuid)
-        .finalize();
-    SignedSpoolOwnerGenesis {
-        genesis: Some(SpoolOwnerGenesis {
-            spool_uuid: spool_uuid.to_vec(),
-            owner_public_key: Some(owner_public_key),
-        }),
-        owner_signature: Some(AuthorizationSignature {
-            signer_key_id,
-            signature: signer.sign(&digest).expect("sign owner genesis"),
-        }),
-    }
+    crate::sign_spool_owner_genesis(&signer, spool_uuid).expect("sign owner genesis")
+}
+
+#[test]
+fn create_spool_genesis_is_uuidv7_self_signature_over_the_device_key() {
+    let signer = crypto::Ed25519Signer::generate().expect("device proof key");
+    let spool_uuid = uuid::Uuid::now_v7();
+    assert_eq!(spool_uuid.get_version_num(), 7);
+
+    let signed = crate::sign_spool_owner_genesis(&signer, *spool_uuid.as_bytes())
+        .expect("mint owner genesis");
+    let verified = verify_spool_owner_genesis(&signed).expect("weft-equivalent genesis verify");
+
+    assert_eq!(verified.spool_uuid(), *spool_uuid.as_bytes());
+    assert_eq!(verified.owner_public_key().public_key, signer.public_key());
+
+    let other = crypto::Ed25519Signer::generate().expect("other key");
+    let mismatched = crate::sign_spool_owner_genesis(&other, *spool_uuid.as_bytes())
+        .expect("mint with a different key");
+    let mismatched_verified =
+        verify_spool_owner_genesis(&mismatched).expect("self-signature still verifies");
+    assert_ne!(
+        mismatched_verified.owner_public_key().public_key,
+        signer.public_key(),
+        "a throwaway per-spool key must not be confused with the device proof key"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `HostedClient::create_spool` now mints a protocol-2 `SignedSpoolOwnerGenesis` with the existing device/proof key and a client-chosen UUIDv7, instead of sending `owner_genesis: None`.
- That is the host-only `heddle push <host>` auto-provision path. After weft#1857, GetCurrentUserSpool works for agent-key subjects, but CreateSpool rejected the empty genesis (`owner_genesis is required`, CLI exit 74).
- Weft cannot invent the bytes (no owner private key). A generated-per-spool key would pass CreateSpool and break later purge/claim. Biscuit subject stays `agent-key:<hex>`. Stale weft#1532 comment is gone.

## Closes

Closes HeddleCo/heddle#1598

## Red commit

N/A — the defect is on current heddle main `ac3f882` (v0.15.3): `create_spool` still sent `owner_genesis: None` and was reproduced against api-staging.heddle.sh. No failing test commit was pushed before the mint.

## Test evidence

Advertised tests ran on HEAD `6bd5b048de5cebecb14b39dc23516d797d7275e5`:

```
=== HEAD 6bd5b048de5cebecb14b39dc23516d797d7275e5 ===

=== heddle-repo (owner genesis / authorization) ===
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running unittests src/lib.rs (target/debug/deps/repo-31bf75f0985b1b7a)

running 5 tests
test owner_authorization_tests::create_spool_genesis_is_uuidv7_self_signature_over_the_device_key ... ok
test owner_authorization_tests::purge_without_authorization_is_denied_even_with_legacy_trust_tables ... ok
test owner_authorization_tests::clone_pin_rejects_forged_and_later_first_seen_genesis ... ok
test owner_authorization_tests::verifier_consumes_the_current_owner_authorization_wire_contract ... ok
test owner_authorization_tests::published_purge_accept_deny_matrix_holds_against_clone_pin ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 725 filtered out; finished in 0.76s


=== heddle-hosted-client --features client (CreateSpool / mint) ===
   Compiling heddle-hosted-client v0.15.3 (/workspace/crates/hosted-client)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.37s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-59f1b0704ff9de1e)

running 3 tests
test hosted_runtime::hosted::context::tests::mint_spool_owner_genesis_requires_the_device_proof_key ... ok
test hosted_runtime::hosted::context::tests::mint_spool_owner_genesis_uses_the_configured_proof_key_and_a_uuidv7 ... ok
test hosted_runtime::hosted::user::tests::create_spool_sends_device_key_signed_uuidv7_owner_genesis ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 307 filtered out; finished in 0.04s


=== heddle-cli --features client (auto_provision) ===
   Compiling heddle-hosted-client v0.15.3 (/workspace/crates/hosted-client)
   Compiling heddle-agent-relay v0.15.3 (/workspace/crates/agent-relay)
   Compiling heddle-cli v0.15.3 (/workspace/crates/cli)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.88s
     Running unittests src/lib.rs (target/debug/deps/cli-ea504d09319b77bd)

running 3 tests
test cli::commands::remote::tests::auto_provision_hides_internal_user_namespace_paths_in_cli_text ... ok
test cli::commands::remote::tests::auto_provision_reuses_create_spool_already_exists ... ok
test cli::commands::remote::tests::auto_provision_remote_name_uses_existing_or_origin_remote ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 435 filtered out; finished in 0.03s
```

Also ran on the same HEAD:

```
cargo test -p heddle-hosted-client --features client --lib -- administration_facade
test hosted_runtime::hosted::user::tests::administration_facade_builds_and_dispatches_every_native_request ... ok
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Surfaces

- **The verb.** `heddle push <host>` auto-provision now sends genesis on CreateSpool. No new flag.
- **Human and agent.** Default push text unchanged; `--json` unchanged.
- **Git interop.** Not touched.
- **The wire.** Uses the existing `CreateSpoolRequest.owner_genesis` field. No new RPC.
- **Reverse states.** Create is the way in; clones still TOFU-pin from PullReady. No new state to exit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7abca90-356a-4aa6-98b2-5fe2cfa153a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7abca90-356a-4aa6-98b2-5fe2cfa153a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790562521&installation_model_id=21489&pr_number=1599&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1599&signature=feb2d798f7b922e0f8871994ac67a75b976df19d66b6db5f94d4dd7987546a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->