### PR TITLE
feat(identity): mint claimable deferred-human owner root on agent login

### DIFF
--- a/crates/hosted-client/src/hosted_runtime/auth_login.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login.rs
@@ -114,6 +114,9 @@ fn cred_bound_to_node_key(resolved: &ResolvedHostedCredential, node_id: &str) ->
 }
 
 fn reuse(server: &str, resolved: &ResolvedHostedCredential) -> Result<()> {
+    if let Some(pem) = resolved.proof_key_pem.as_deref() {
+        super::auth_login_agent::record_claimable_root_for_stored_account(server, pem)?;
+    }
     let subject = resolved
         .subject
         .clone()

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -39,7 +39,7 @@ pub(crate) fn record_claimable_root_for_stored_account(
     let Some(mut state) = identity_state::load()? else {
         return Ok(());
     };
-    if !super::hosted::server_keys_match(&state.server, server) {
+    if !super::hosted::server_keys_match(&state.server, server) || state.is_claimed() {
         return Ok(());
     }
     let signer = Ed25519Signer::from_pem(private_key_pem)
@@ -89,11 +89,13 @@ pub(crate) async fn create_with_invite(
             return Err(error);
         }
     };
+    let signer = Ed25519Signer::from_pem(&minted.private_key_pem)
+        .context("loading the agent proof key for BootstrapOwnerRoot")?;
     let output = finish_invite_create(server, minted, response)?;
     if let Some(state) = identity_state::load()?
         && let Some(root) = super::owner_root::load_recorded_root(&state)?
     {
-        let upload = super::owner_root::upload_claimable_root(&mut client, root).await;
+        let upload = super::owner_root::upload_claimable_root(&mut client, &signer, root).await;
         client.close().await;
         upload?;
     } else {

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -20,6 +20,7 @@ use super::{
 
 pub(crate) async fn remint(server: &str) -> Result<()> {
     let stored = mint_restricted_agent_root()?;
+    record_claimable_root_for_stored_account(server, &stored.private_key_pem)?;
     store_agent_root(
         server,
         stored.token,
@@ -29,6 +30,26 @@ pub(crate) async fn remint(server: &str) -> Result<()> {
     )?;
     print_success(&stored.subject);
     Ok(())
+}
+
+pub(crate) fn record_claimable_root_for_stored_account(
+    server: &str,
+    private_key_pem: &str,
+) -> Result<()> {
+    let Some(mut state) = identity_state::load()? else {
+        return Ok(());
+    };
+    if !super::hosted::server_keys_match(&state.server, server) {
+        return Ok(());
+    }
+    let signer = Ed25519Signer::from_pem(private_key_pem)
+        .context("loading the agent proof key for the claimable owner root")?;
+    super::owner_root::mint_and_record_claimable_root(
+        &mut state,
+        &signer,
+        chrono::Utc::now().timestamp(),
+    )?;
+    identity_state::store(&state)
 }
 
 pub(crate) async fn create_with_invite(
@@ -61,9 +82,23 @@ pub(crate) async fn create_with_invite(
         .map_err(|error| {
             anyhow::anyhow!("creating placeholder account on behalf of human: {error}")
         });
-    client.close().await;
-    let response = response?;
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            client.close().await;
+            return Err(error);
+        }
+    };
     let output = finish_invite_create(server, minted, response)?;
+    if let Some(state) = identity_state::load()?
+        && let Some(root) = super::owner_root::load_recorded_root(&state)?
+    {
+        let upload = super::owner_root::upload_claimable_root(&mut client, root).await;
+        client.close().await;
+        upload?;
+    } else {
+        client.close().await;
+    }
     emit_created(ctx, &output)?;
     Ok(())
 }
@@ -94,6 +129,7 @@ fn finish_invite_create(
         value => Some(value.to_string()),
     };
     let subject = minted.subject.clone();
+    let private_key_pem = minted.private_key_pem.clone();
     store_agent_root(
         server,
         minted.token,
@@ -105,14 +141,22 @@ fn finish_invite_create(
     let pet_name = response.pet_name;
     // Stored for later routing. `heddle claim` binds this to the configured
     // hosted server before minting the local claim bearer.
-    identity_state::store(&ClaimState::new(
+    let mut claim_state = ClaimState::new(
         server.to_string(),
         owner_id,
         subject.clone(),
         pet_name.clone(),
         hex::encode(minted.public_key),
         web_origin,
-    ))?;
+    );
+    let signer = Ed25519Signer::from_pem(&private_key_pem)
+        .context("loading the agent proof key for the claimable owner root")?;
+    super::owner_root::mint_and_record_claimable_root(
+        &mut claim_state,
+        &signer,
+        chrono::Utc::now().timestamp(),
+    )?;
+    identity_state::store(&claim_state)?;
     Ok(AgentAccountCreatedOutput {
         output_kind: "agent_account_created",
         account_id: account_id.clone(),

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -320,6 +320,10 @@ fn login_invite_create_succeeds_with_a_claim_next_directive() {
         state.web_origin.as_deref(),
         Some("https://claims.heddle.test/")
     );
+    assert!(
+        state.signed_owner_root_hex.is_some(),
+        "invite create must mint the claimable deferred-human owner root"
+    );
 }
 
 #[tokio::test]
@@ -343,4 +347,11 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         .expect("load")
         .expect("reminted into the keystore");
     assert!(!stored.token.is_empty());
+    let state = identity_state::load()
+        .expect("load")
+        .expect("claim state");
+    assert!(
+        state.signed_owner_root_hex.is_some(),
+        "remint must lazy-mint the claimable deferred-human owner root"
+    );
 }

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -88,17 +88,24 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     drop(offer.secret);
 
     let outcome = wait_for_claim(&offer.authorization_hash, args.timeout, completion).await;
-    let cleanup = (!matches!(outcome, Ok(ClaimWaitOutcome::Claimed)))
+    let claimed = matches!(outcome, Ok(ClaimWaitOutcome::Claimed));
+    let owner_root_claim = if claimed {
+        super::owner_root::send_pending_register_public_key_claim(&mut client).await
+    } else {
+        Ok(None)
+    };
+    let cleanup = (!claimed)
         .then(|| deactivate_offer(&offer.authorization_hash))
         .transpose();
     client.close().await;
     cleanup?;
+    owner_root_claim?;
 
     match outcome? {
         ClaimWaitOutcome::Claimed => {
-            // Human promotion attaches the handle via the Iroh ceremony.
-            // Owner-root claim is ClaimDeferredHuman over the existing
-            // sequence-0 agent key — never a replacement OwnerRootInstall.
+            // Iroh promotes the handle. Owner-root claim is RegisterPublicKey
+            // plus ClaimDeferredHuman (tag 16) over the existing sequence-0
+            // agent key — never a replacement OwnerRootInstall.
             println!("Claim complete. This agent account now has a human owner.")
         }
         ClaimWaitOutcome::Expired => println!("Claim offer expired without changing the account."),

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -56,12 +56,18 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
         Some(server.clone()),
         HostedAuthMode::CredentialFallback,
     )?;
-    let client = session
+    let mut client = session
         .connect(([127, 0, 0, 1], 0).into())
         .await
         .with_context(|| {
             format!("connecting to {server} and bringing the claim listener online")
         })?;
+    // Upload the claimable seq-0 root before the Iroh ceremony so claim
+    // works even if this account never created a project spool.
+    if let Err(error) = client.ensure_claimable_owner_root().await {
+        client.close().await;
+        return Err(error);
+    }
     let completion = client.claim_completion();
 
     let offer = match activate_offer(&state, args.timeout) {
@@ -90,6 +96,9 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
 
     match outcome? {
         ClaimWaitOutcome::Claimed => {
+            // Human promotion attaches the handle via the Iroh ceremony.
+            // Owner-root claim is ClaimDeferredHuman over the existing
+            // sequence-0 agent key — never a replacement OwnerRootInstall.
             println!("Claim complete. This agent account now has a human owner.")
         }
         ClaimWaitOutcome::Expired => println!("Claim offer expired without changing the account."),

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -223,6 +223,9 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     // admits both for unclaimed agent-rooted accounts (weft#1852/#1853).
     "GetCurrentUserSpool",
     "CreateSpool",
+    // Install the claimable deferred-human owner root (heddle#1600).
+    "BootstrapOwnerRoot",
+    "GetCurrentOwnerKeyring",
     // Repository reads.
     "GetRefs",
     "ListStates",
@@ -281,6 +284,8 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
     // contributor writes for host-only auto-provision push.
     "GetCurrentUserSpool",
     "WhoAmI",
+    // Read of the installed owner keyring after BootstrapOwnerRoot (heddle#1600).
+    "GetCurrentOwnerKeyring",
 ];
 
 /// Collaboration writes a `contributor` adds on top of the read set.
@@ -295,6 +300,8 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
     "ResolveDiscussion",
     // Provision the caller's own child spool (host-only auto-provision push).
     "CreateSpool",
+    // Install the claimable deferred-human owner root (heddle#1600).
+    "BootstrapOwnerRoot",
 ];
 
 /// The push/pull/ref-move set a CI lander needs to run `ready`/`land`.

--- a/crates/hosted-client/src/hosted_runtime/hosted/context.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/context.rs
@@ -6,7 +6,7 @@ use std::{
 use api::{
     heddle::api::v1alpha1::{
         BearerProof, CallContext, HumanVerification, RepositoryRef, RequestProof,
-        StreamOpeningProof, TraceContext, repository_ref,
+        SignedSpoolOwnerGenesis, StreamOpeningProof, TraceContext, repository_ref,
     },
     signing,
 };
@@ -80,6 +80,40 @@ impl CallContextFactory {
 
     pub fn signing_identity(&self) -> Option<&str> {
         self.signing_identity.as_deref()
+    }
+
+    pub(super) fn proof_signer(&self) -> Option<&Ed25519Signer> {
+        self.signer.as_deref()
+    }
+
+    /// Mint CreateSpool genesis with the same device/proof key used for PoP.
+    ///
+    /// When a sequence-0 owner-root public key is already stored, refuse a
+    /// different genesis key so purge/claim stay bound to the account root.
+    pub(crate) fn mint_spool_owner_genesis(&self) -> Result<SignedSpoolOwnerGenesis> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        if let Some(seq0) = crate::hosted_runtime::owner_root::stored_seq0_public_key()
+            .map_err(|error| HostedError::Framing(error.to_string()))?
+            && seq0 != signer.public_key()
+        {
+            return Err(HostedError::Framing(
+                "CreateSpool genesis owner key does not match the account sequence-0 owner root"
+                    .to_owned(),
+            ));
+        }
+        let spool_uuid = uuid::Uuid::now_v7();
+        let signed = repo::sign_spool_owner_genesis(signer.as_ref(), *spool_uuid.as_bytes())
+            .map_err(HostedError::from)?;
+        if let Some(seq0) = crate::hosted_runtime::owner_root::stored_seq0_public_key()
+            .map_err(|error| HostedError::Framing(error.to_string()))?
+        {
+            repo::require_genesis_matches_seq0(&signed, &seq0)
+                .map_err(|error| HostedError::Framing(error.to_string()))?;
+        }
+        Ok(signed)
     }
 
     pub fn with_bearer_capability(mut self, capability: impl Into<Vec<u8>>) -> Self {
@@ -573,5 +607,36 @@ mod tests {
             )
             .unwrap();
         assert!(context.deadline.is_none());
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_requires_the_device_proof_key() {
+        let error = CallContextFactory::default()
+            .mint_spool_owner_genesis()
+            .expect_err("CreateSpool must not invent a throwaway owner key");
+        assert!(matches!(error, HostedError::SigningIdentityRequired));
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_uses_the_configured_proof_key_and_a_uuidv7() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let factory = CallContextFactory::default()
+            .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:test")
+            .unwrap();
+        let signed = factory.mint_spool_owner_genesis().unwrap();
+        let genesis = signed.genesis.expect("signed genesis payload");
+        let spool_uuid: [u8; 16] = genesis
+            .spool_uuid
+            .as_slice()
+            .try_into()
+            .expect("spool UUID is 16 bytes");
+        assert_eq!(uuid::Uuid::from_bytes(spool_uuid).get_version_num(), 7);
+        assert_eq!(
+            genesis
+                .owner_public_key
+                .expect("owner public key")
+                .public_key,
+            signer.public_key()
+        );
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
@@ -91,6 +91,20 @@ impl HostedRoutes<'_> {
         WhoAmIRequest,
         WhoAmIResponse
     );
+    unary_method!(
+        bootstrap_owner_root,
+        "OwnerAuthorizationService",
+        "BootstrapOwnerRoot",
+        BootstrapOwnerRootRequest,
+        BootstrapOwnerRootResponse
+    );
+    unary_method!(
+        get_current_owner_keyring,
+        "OwnerAuthorizationService",
+        "GetCurrentOwnerKeyring",
+        GetCurrentOwnerKeyringRequest,
+        GetCurrentOwnerKeyringResponse
+    );
 
     unary_method!(
         create_grant,

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -315,17 +315,30 @@ impl HostedClient {
         Request: Message,
         Response: Message + Default,
     {
-        let encoded = request.encode_to_vec();
+        self.call_unary_encoded(method, &request.encode_to_vec())
+            .await
+    }
+
+    /// Send a pre-encoded unary body so additive prost extensions (weft#1863
+    /// BootstrapOwnerRoot tag 5 / RegisterPublicKey tag 16) are covered by PoP.
+    pub async fn call_unary_encoded<Response>(
+        &self,
+        method: &str,
+        encoded: &[u8],
+    ) -> Result<Response>
+    where
+        Response: Message + Default,
+    {
         let descriptor = api::method_descriptor(method)
             .ok_or_else(|| HostedError::Framing(format!("unknown hosted method {method}")))?;
         let client_operation_id = descriptor
-            .client_operation_id(&encoded)?
+            .client_operation_id(encoded)?
             .unwrap_or_default();
         if descriptor.client_operation_id_required && client_operation_id.is_empty() {
             return Err(HostedError::MissingClientOperationId);
         }
-        let signed = self.context.unary(method, &encoded, client_operation_id)?;
-        match call::unary_encoded(&self.connection, method, &signed.context, &encoded).await {
+        let signed = self.context.unary(method, encoded, client_operation_id)?;
+        match call::unary_encoded(&self.connection, method, &signed.context, encoded).await {
             Ok(response) => Ok(response),
             Err(HostedError::Call {
                 code: api::heddle::api::v1alpha1::CallFailureCode::Unauthenticated,
@@ -362,7 +375,7 @@ impl HostedClient {
                         user_handle: assertion.user_handle.unwrap_or_default(),
                     },
                 )?;
-                call::unary_encoded(&self.connection, method, &context, &encoded).await
+                call::unary_encoded(&self.connection, method, &context, encoded).await
             }
             Err(error) => Err(error),
         }

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -1,11 +1,12 @@
 use api::heddle::api::v1alpha1::{
-    ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, CheckMergeEligibilityRequest,
-    CheckMergeEligibilityResponse, CreateAgentAccountRequest, CreateAgentAccountResponse,
-    CreateGrantRequest, CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest,
-    DeleteGrantRequest, DeleteNamespaceRequest, DeleteRepositoryRequest,
-    GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
-    Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest, IssuedCredentialResponse,
-    ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
+    ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, BootstrapOwnerRootRequest,
+    BootstrapOwnerRootResponse, CheckMergeEligibilityRequest, CheckMergeEligibilityResponse,
+    CreateAgentAccountRequest, CreateAgentAccountResponse, CreateGrantRequest,
+    CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest, DeleteGrantRequest,
+    DeleteNamespaceRequest, DeleteRepositoryRequest, GetCurrentOwnerKeyringRequest,
+    GetCurrentOwnerKeyringResponse, GetCurrentUserSpoolRequest, GrantSupportAccessRequest,
+    GrantTargetRef, Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest,
+    IssuedCredentialResponse, ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
     ListThreadApprovalsRequest, MonorepoNode, ResolveMonorepoRequest, RevokeApprovalRequest,
     RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SupportAccessGrant,
     ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest, UpdateRepositoryRequest,
@@ -152,6 +153,50 @@ impl HostedClient {
         Ok(response.spools)
     }
 
+    pub(crate) async fn ensure_claimable_owner_root(&mut self) -> anyhow::Result<()> {
+        let Some(mut state) = crate::hosted_runtime::identity_state::load()? else {
+            return Ok(());
+        };
+        let signed = {
+            let Some(signer) = self.context.proof_signer() else {
+                return Ok(());
+            };
+            crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
+                &mut state,
+                signer,
+                chrono::Utc::now().timestamp(),
+            )?
+        };
+        crate::hosted_runtime::owner_root::persist_claimable_root(&state)?;
+        crate::hosted_runtime::owner_root::upload_claimable_root(self, signed).await
+    }
+
+    pub async fn bootstrap_owner_root(
+        &mut self,
+        request: BootstrapOwnerRootRequest,
+    ) -> Result<BootstrapOwnerRootResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            bootstrap_owner_root,
+            "/heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot",
+            request
+        ))
+    }
+
+    pub async fn get_current_owner_keyring(
+        &mut self,
+        request: GetCurrentOwnerKeyringRequest,
+    ) -> Result<GetCurrentOwnerKeyringResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            get_current_owner_keyring,
+            "/heddle.api.v1alpha1.OwnerAuthorizationService/GetCurrentOwnerKeyring",
+            request
+        ))
+    }
+
     pub async fn create_spool(
         &mut self,
         parent_path: &str,
@@ -159,8 +204,16 @@ impl HostedClient {
         kind: wire::HostedSpoolKind,
         display_name: Option<String>,
     ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
+        self.ensure_claimable_owner_root()
+            .await
+            .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
         let operation_id =
             ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/CreateSpool");
+        let owner_genesis = Some(
+            self.context
+                .mint_spool_owner_genesis()
+                .map_err(hosted_to_protocol_error)?,
+        );
         let spool = authed_call!(
             self,
             create_spool,
@@ -173,8 +226,7 @@ impl HostedClient {
                 visibility: Visibility::Private as i32,
                 client_operation_id: operation_id.to_wire(),
                 settings: None,
-                // Local genesis materialization is tracked separately by weft#1532.
-                owner_genesis: None,
+                owner_genesis,
             }
         );
         Ok(to_protocol_spool(spool))

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -157,18 +157,28 @@ impl HostedClient {
         let Some(mut state) = crate::hosted_runtime::identity_state::load()? else {
             return Ok(());
         };
-        let signed = {
+        if state.is_claimed() {
+            return Ok(());
+        }
+        if let Some(server) = self.server_key.as_deref()
+            && !crate::hosted_runtime::hosted::server_keys_match(&state.server, server)
+        {
+            return Ok(());
+        }
+        let (signed, signer_pem) = {
             let Some(signer) = self.context.proof_signer() else {
                 return Ok(());
             };
-            crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
+            let signed = crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
                 &mut state,
                 signer,
                 chrono::Utc::now().timestamp(),
-            )?
+            )?;
+            (signed, signer.to_pem()?)
         };
         crate::hosted_runtime::owner_root::persist_claimable_root(&state)?;
-        crate::hosted_runtime::owner_root::upload_claimable_root(self, signed).await
+        let signer = crypto::Ed25519Signer::from_pem(&signer_pem)?;
+        crate::hosted_runtime::owner_root::upload_claimable_root(self, &signer, signed).await
     }
 
     pub async fn bootstrap_owner_root(

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -59,6 +59,12 @@ pub(crate) struct ClaimState {
     status: ClaimStatus,
     prepared_handle: Option<String>,
     prepared_nonce_hash: Option<String>,
+    /// Hex of the sequence-0 owner-root authority public key, when minted.
+    #[serde(default)]
+    pub(crate) seq0_public_key_hex: Option<String>,
+    /// Canonical protobuf hex of the claimable SignedOwnerRoot, when minted.
+    #[serde(default)]
+    pub(crate) signed_owner_root_hex: Option<String>,
 }
 
 impl ClaimState {
@@ -85,7 +91,23 @@ impl ClaimState {
             status: ClaimStatus::Dormant,
             prepared_handle: None,
             prepared_nonce_hash: None,
+            seq0_public_key_hex: None,
+            signed_owner_root_hex: None,
         }
+    }
+
+    pub(crate) fn seq0_public_key(&self) -> Option<Vec<u8>> {
+        let hex = self.seq0_public_key_hex.as_deref()?;
+        hex::decode(hex).ok()
+    }
+
+    pub(crate) fn record_claimable_owner_root(
+        &mut self,
+        seq0_public_key: &[u8],
+        signed_owner_root: &[u8],
+    ) {
+        self.seq0_public_key_hex = Some(hex::encode(seq0_public_key));
+        self.signed_owner_root_hex = Some(hex::encode(signed_owner_root));
     }
 
     /// Mint and activate a fresh one-time claim capability.

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -65,6 +65,9 @@ pub(crate) struct ClaimState {
     /// Canonical protobuf hex of the claimable SignedOwnerRoot, when minted.
     #[serde(default)]
     pub(crate) signed_owner_root_hex: Option<String>,
+    /// Encoded RegisterPublicKey + ClaimDeferredHuman (tag 16), waiting to send.
+    #[serde(default)]
+    pub(crate) pending_register_public_key_hex: Option<String>,
 }
 
 impl ClaimState {
@@ -93,6 +96,7 @@ impl ClaimState {
             prepared_nonce_hash: None,
             seq0_public_key_hex: None,
             signed_owner_root_hex: None,
+            pending_register_public_key_hex: None,
         }
     }
 
@@ -108,6 +112,19 @@ impl ClaimState {
     ) {
         self.seq0_public_key_hex = Some(hex::encode(seq0_public_key));
         self.signed_owner_root_hex = Some(hex::encode(signed_owner_root));
+    }
+
+    pub(crate) fn record_pending_register_public_key(&mut self, encoded: &[u8]) {
+        self.pending_register_public_key_hex = Some(hex::encode(encoded));
+    }
+
+    pub(crate) fn take_pending_register_public_key(&mut self) -> Result<Option<Vec<u8>>> {
+        let Some(hex) = self.pending_register_public_key_hex.take() else {
+            return Ok(None);
+        };
+        Ok(Some(
+            hex::decode(hex).context("decode pending RegisterPublicKey claim")?,
+        ))
     }
 
     /// Mint and activate a fresh one-time claim capability.

--- a/crates/hosted-client/src/hosted_runtime/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/mod.rs
@@ -21,6 +21,9 @@ pub(crate) mod credential_file;
 pub(crate) mod device_flow;
 pub mod hosted;
 mod identity_state;
+mod owner_root;
+#[cfg(test)]
+mod owner_root_tests;
 pub(crate) mod root_mint;
 #[cfg(test)]
 mod root_mint_tests;

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -2,20 +2,37 @@
 
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
-    BootstrapOwnerRootRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
+    AccessTokenResponse, BootstrapOwnerRootRequest, BootstrapOwnerRootResponse, OwnerKeyBinding,
+    RegisterPublicKeyRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
 };
 use crypto::{Ed25519Signer, Signer as _};
 use prost::Message;
 use repo::{
-    ClaimDeferredHuman, seq0_authority_public_key, sign_claim_deferred_human,
-    sign_claimable_deferred_human_root,
+    ClaimDeferredHuman, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_claim_deferred_human, sign_claimable_deferred_human_root,
 };
-use wire::ProtocolError;
-
 use super::{
-    hosted::{HostedClient, operation_id::ClientOperationId},
+    hosted::{HostedClient, HostedError, operation_id::ClientOperationId},
     identity_state::{self, ClaimState},
 };
+
+const BOOTSTRAP_OWNER_ROOT: &str =
+    "/heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot";
+const REGISTER_PUBLIC_KEY: &str = "/heddle.api.v1alpha1.IdentityService/RegisterPublicKey";
+
+/// Additive weft#1863 field on the raw BootstrapOwnerRoot request.
+#[derive(Clone, PartialEq, Message)]
+pub struct BootstrapOwnerRootExtension {
+    #[prost(message, optional, tag = "5")]
+    pub owner_key_binding: Option<OwnerKeyBinding>,
+}
+
+/// Additive weft#1863 field on the raw RegisterPublicKey request.
+#[derive(Clone, PartialEq, Message)]
+pub struct RegisterPublicKeyClaimExtension {
+    #[prost(message, optional, tag = "16")]
+    pub claim_deferred_human: Option<SignedOwnerKeyTransition>,
+}
 
 pub(crate) fn mint_and_record_claimable_root(
     state: &mut ClaimState,
@@ -62,23 +79,74 @@ pub(crate) fn stored_seq0_public_key() -> Result<Option<Vec<u8>>> {
     Ok(identity_state::load()?.and_then(|state| state.seq0_public_key()))
 }
 
+pub(crate) fn encode_bootstrap_owner_root(
+    request: &BootstrapOwnerRootRequest,
+    binding: &OwnerKeyBinding,
+) -> Vec<u8> {
+    let mut encoded = request.encode_to_vec();
+    encoded.extend_from_slice(
+        &BootstrapOwnerRootExtension {
+            owner_key_binding: Some(binding.clone()),
+        }
+        .encode_to_vec(),
+    );
+    encoded
+}
+
+pub(crate) fn encode_register_public_key_claim(
+    request: &RegisterPublicKeyRequest,
+    transition: &SignedOwnerKeyTransition,
+) -> Result<Vec<u8>> {
+    if request.owner_root.is_some()
+        || request.owner_root_proof_of_possession.is_some()
+        || request.owner_key_binding.is_some()
+    {
+        bail!(
+            "RegisterPublicKey claim must not send owner_root, owner_root_proof_of_possession, or owner_key_binding; those replace sequence-0"
+        );
+    }
+    let kind = transition
+        .transition
+        .as_ref()
+        .context("ClaimDeferredHuman has no body")?
+        .kind();
+    if kind != api::heddle::api::v1alpha1::OwnerKeyTransitionKind::ClaimDeferredHuman {
+        bail!("RegisterPublicKey claim extension must be ClaimDeferredHuman, got {kind:?}");
+    }
+    let mut encoded = request.encode_to_vec();
+    encoded.extend_from_slice(
+        &RegisterPublicKeyClaimExtension {
+            claim_deferred_human: Some(transition.clone()),
+        }
+        .encode_to_vec(),
+    );
+    Ok(encoded)
+}
+
 pub(crate) async fn upload_claimable_root(
     client: &mut HostedClient,
+    signer: &Ed25519Signer,
     signed: SignedOwnerRoot,
 ) -> Result<()> {
-    let operation_id =
-        ClientOperationId::fresh("heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot");
+    let operation_id = ClientOperationId::fresh(BOOTSTRAP_OWNER_ROOT);
+    let binding = sign_agent_claim_binding(signer, &signed, operation_id.as_str())
+        .context("signing AgentClaim owner-key binding for BootstrapOwnerRoot")?;
+    let request = BootstrapOwnerRootRequest {
+        owner_root: Some(signed),
+        approval: None,
+        client_operation_id: operation_id.to_wire(),
+    };
+    let encoded = encode_bootstrap_owner_root(&request, &binding);
     match client
-        .bootstrap_owner_root(BootstrapOwnerRootRequest {
-            owner_root: Some(signed),
-            approval: None,
-            client_operation_id: operation_id.to_wire(),
-        })
+        .call_unary_encoded::<BootstrapOwnerRootResponse>(BOOTSTRAP_OWNER_ROOT, &encoded)
         .await
     {
         Ok(_) => Ok(()),
-        Err(ProtocolError::AlreadyExists(_)) => Ok(()),
-        Err(ProtocolError::InvalidState(message)) if already_installed(&message) => Ok(()),
+        Err(HostedError::Call {
+            code: api::heddle::api::v1alpha1::CallFailureCode::AlreadyExists,
+            ..
+        }) => Ok(()),
+        Err(HostedError::Call { message, .. }) if already_installed(&message) => Ok(()),
         Err(error) => Err(error.into()),
     }
 }
@@ -104,6 +172,37 @@ pub(crate) fn build_claim_deferred_human(
         now_unix_seconds,
         nonce,
     })
+}
+
+pub(crate) fn prepare_register_public_key_claim(
+    state: &mut ClaimState,
+    request: RegisterPublicKeyRequest,
+    transition: SignedOwnerKeyTransition,
+) -> Result<()> {
+    let encoded = encode_register_public_key_claim(&request, &transition)?;
+    state.record_pending_register_public_key(&encoded);
+    Ok(())
+}
+
+pub(crate) async fn send_pending_register_public_key_claim(
+    client: &mut HostedClient,
+) -> Result<Option<AccessTokenResponse>> {
+    let encoded = {
+        let _guard = identity_state::write_lock()?;
+        let Some(mut state) = identity_state::load_while_locked()? else {
+            return Ok(None);
+        };
+        let Some(encoded) = state.take_pending_register_public_key()? else {
+            return Ok(None);
+        };
+        identity_state::store_while_locked(&state)?;
+        encoded
+    };
+    Ok(Some(
+        client
+            .call_unary_encoded(REGISTER_PUBLIC_KEY, &encoded)
+            .await?,
+    ))
 }
 
 fn already_installed(message: &str) -> bool {

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -1,0 +1,112 @@
+//! Claimable deferred-human owner-root mint for agent login / provision / claim.
+
+use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::{
+    BootstrapOwnerRootRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
+};
+use crypto::{Ed25519Signer, Signer as _};
+use prost::Message;
+use repo::{
+    ClaimDeferredHuman, seq0_authority_public_key, sign_claim_deferred_human,
+    sign_claimable_deferred_human_root,
+};
+use wire::ProtocolError;
+
+use super::{
+    hosted::{HostedClient, operation_id::ClientOperationId},
+    identity_state::{self, ClaimState},
+};
+
+pub(crate) fn mint_and_record_claimable_root(
+    state: &mut ClaimState,
+    signer: &Ed25519Signer,
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerRoot> {
+    if let Some(existing) = load_recorded_root(state)? {
+        let seq0 = seq0_authority_public_key(&existing)?;
+        if seq0 != signer.public_key() {
+            bail!(
+                "stored sequence-0 owner root is not this device/proof key; refusing to remint a different authority"
+            );
+        }
+        return Ok(existing);
+    }
+    let mut nonce = [0u8; 32];
+    getrandom::fill(&mut nonce).context("minting claimable owner-root nonce")?;
+    let signed = sign_claimable_deferred_human_root(
+        signer,
+        *state.owner_id.as_bytes(),
+        nonce,
+        now_unix_seconds,
+    )?;
+    let seq0 = seq0_authority_public_key(&signed)?.to_vec();
+    state.record_claimable_owner_root(&seq0, &signed.encode_to_vec());
+    Ok(signed)
+}
+
+pub(crate) fn persist_claimable_root(state: &ClaimState) -> Result<()> {
+    identity_state::store(state)
+}
+
+pub(crate) fn load_recorded_root(state: &ClaimState) -> Result<Option<SignedOwnerRoot>> {
+    let Some(hex) = state.signed_owner_root_hex.as_deref() else {
+        return Ok(None);
+    };
+    let bytes = hex::decode(hex).context("decode stored claimable owner root")?;
+    let signed =
+        SignedOwnerRoot::decode(bytes.as_slice()).context("parse stored claimable owner root")?;
+    Ok(Some(signed))
+}
+
+pub(crate) fn stored_seq0_public_key() -> Result<Option<Vec<u8>>> {
+    Ok(identity_state::load()?.and_then(|state| state.seq0_public_key()))
+}
+
+pub(crate) async fn upload_claimable_root(
+    client: &mut HostedClient,
+    signed: SignedOwnerRoot,
+) -> Result<()> {
+    let operation_id =
+        ClientOperationId::fresh("heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot");
+    match client
+        .bootstrap_owner_root(BootstrapOwnerRootRequest {
+            owner_root: Some(signed),
+            approval: None,
+            client_operation_id: operation_id.to_wire(),
+        })
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(ProtocolError::AlreadyExists(_)) => Ok(()),
+        Err(ProtocolError::InvalidState(message)) if already_installed(&message) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Build ClaimDeferredHuman. Do not send this as ClaimAgentOwner / a
+/// replacement sequence-0 OwnerRootInstall — those rewrite genesis.
+pub(crate) fn build_claim_deferred_human(
+    agent: &Ed25519Signer,
+    human: &Ed25519Signer,
+    signed_root: &SignedOwnerRoot,
+    next_recovery_policy: api::heddle::api::v1alpha1::RecoveryPolicy,
+    next_guardian_signers: &[Ed25519Signer],
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerKeyTransition> {
+    let mut nonce = [0u8; 32];
+    getrandom::fill(&mut nonce).context("minting ClaimDeferredHuman nonce")?;
+    sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: agent,
+        next_authority: human,
+        signed_root,
+        next_recovery_policy,
+        next_guardian_signers,
+        now_unix_seconds,
+        nonce,
+    })
+}
+
+fn already_installed(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    lowered.contains("already") && (lowered.contains("owner") || lowered.contains("root"))
+}

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{ffi::OsString, sync::MutexGuard};
+
+use api::heddle::api::v1alpha1::{
+    CreateAgentAccountResponse, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
+    RecoveryPolicy,
+};
+use config::credentials;
+use crypto::{Ed25519Signer, Signer as _};
+use repo::{authorization_key_id, ed25519_verification_key, seq0_authority_public_key};
+use tempfile::TempDir;
+
+use super::{
+    auth_login_agent::finish_invite_create_from_response,
+    hosted::{CallContextFactory, HostedError},
+    identity_state,
+    owner_root::{build_claim_deferred_human, load_recorded_root},
+};
+
+struct IsolatedHome {
+    _guard: MutexGuard<'static, ()>,
+    _temp: TempDir,
+    prev_home: Option<OsString>,
+    prev_heddle_home: Option<OsString>,
+    prev_credential: Option<OsString>,
+}
+
+impl IsolatedHome {
+    fn new() -> Self {
+        let guard = credentials::lock_test_env();
+        let temp = TempDir::new().expect("temp home");
+        let prev_home = std::env::var_os("HOME");
+        let prev_heddle_home = std::env::var_os("HEDDLE_HOME");
+        let prev_credential = std::env::var_os("HEDDLE_CREDENTIAL");
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("HEDDLE_HOME");
+            std::env::remove_var("HEDDLE_CREDENTIAL");
+        }
+        Self {
+            _guard: guard,
+            _temp: temp,
+            prev_home,
+            prev_heddle_home,
+            prev_credential,
+        }
+    }
+}
+
+impl Drop for IsolatedHome {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.prev_heddle_home {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match &self.prev_credential {
+                Some(value) => std::env::set_var("HEDDLE_CREDENTIAL", value),
+                None => std::env::remove_var("HEDDLE_CREDENTIAL"),
+            }
+        }
+    }
+}
+
+#[test]
+fn invite_create_mints_a_claimable_seq0_root_on_the_agent_proof_key() {
+    let _home = IsolatedHome::new();
+    let server = "api.owner-root.test";
+    let output = finish_invite_create_from_response(
+        server,
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("invite create");
+    let state = identity_state::load()
+        .expect("load")
+        .expect("claim state stored");
+    let signed = load_recorded_root(&state)
+        .expect("load root")
+        .expect("claimable root minted on signup");
+    let root = signed.root.as_ref().expect("body");
+    assert!(root.claimable_deferred_human);
+    assert_eq!(root.format_version, 1);
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0"),
+        hex::decode(&state.node_id).expect("node id").as_slice()
+    );
+    assert_eq!(
+        state.seq0_public_key().expect("recorded seq-0"),
+        hex::decode(&state.node_id).expect("node id")
+    );
+    assert_eq!(output.next.command, "heddle claim");
+}
+
+#[test]
+fn claim_transition_is_claim_deferred_human_not_a_replacement_seq0() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.claim-transition.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let agent_pem = credentials::get_server_credential("api.claim-transition.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&agent_pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    let body = transition.transition.as_ref().expect("body");
+    assert_eq!(body.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
+    assert_eq!(body.sequence, 1);
+    assert_eq!(
+        body.next_authority_key.as_ref().expect("next").public_key,
+        human.public_key()
+    );
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 survives claim"),
+        agent.public_key(),
+        "claim must not mint a replacement human sequence-0"
+    );
+}
+
+#[test]
+fn create_spool_genesis_refuses_a_key_that_is_not_seq0() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.seq0-mismatch.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let other = Ed25519Signer::generate().expect("other key");
+    let factory = CallContextFactory::default()
+        .with_signing_key_pem(&other.to_pem().expect("pem"), "principal:other")
+        .expect("factory");
+    let error = factory
+        .mint_spool_owner_genesis()
+        .expect_err("CreateSpool must refuse a genesis key that is not seq-0");
+    assert!(
+        matches!(error, HostedError::Framing(ref message) if message.contains("sequence-0")),
+        "{error}"
+    );
+}
+
+#[test]
+fn create_spool_genesis_matches_the_stored_seq0_proof_key() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.seq0-match.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let pem = credentials::get_server_credential("api.seq0-match.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let signer = Ed25519Signer::from_pem(&pem).expect("agent");
+    let factory = CallContextFactory::default()
+        .with_signing_key_pem(&pem, "principal:agent")
+        .expect("factory");
+    let genesis = factory
+        .mint_spool_owner_genesis()
+        .expect("same proof key as seq-0");
+    assert_eq!(
+        genesis
+            .genesis
+            .expect("body")
+            .owner_public_key
+            .expect("key")
+            .public_key,
+        signer.public_key()
+    );
+}

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -3,19 +3,28 @@
 use std::{ffi::OsString, sync::MutexGuard};
 
 use api::heddle::api::v1alpha1::{
-    CreateAgentAccountResponse, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
-    RecoveryPolicy,
+    BootstrapOwnerRootRequest, CreateAgentAccountResponse, OwnerKeyBindingKind,
+    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+    RegisterPublicKeyRequest, SignedOwnerRoot,
 };
 use config::credentials;
 use crypto::{Ed25519Signer, Signer as _};
-use repo::{authorization_key_id, ed25519_verification_key, seq0_authority_public_key};
+use prost::Message;
+use repo::{
+    authorization_key_id, ed25519_verification_key, seq0_authority_public_key,
+    sign_agent_claim_binding,
+};
 use tempfile::TempDir;
 
 use super::{
     auth_login_agent::finish_invite_create_from_response,
     hosted::{CallContextFactory, HostedError},
     identity_state,
-    owner_root::{build_claim_deferred_human, load_recorded_root},
+    owner_root::{
+        BootstrapOwnerRootExtension, RegisterPublicKeyClaimExtension, build_claim_deferred_human,
+        encode_bootstrap_owner_root, encode_register_public_key_claim, load_recorded_root,
+        prepare_register_public_key_claim,
+    },
 };
 
 struct IsolatedHome {
@@ -222,5 +231,213 @@ fn create_spool_genesis_matches_the_stored_seq0_proof_key() {
             .expect("key")
             .public_key,
         signer.public_key()
+    );
+}
+
+#[test]
+fn bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.bootstrap-binding.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.bootstrap-binding.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let operation_id = "op-bootstrap-1";
+    let binding = sign_agent_claim_binding(&agent, &signed, operation_id).expect("binding");
+    assert_eq!(binding.kind(), OwnerKeyBindingKind::AgentClaim);
+    let encoded = encode_bootstrap_owner_root(
+        &BootstrapOwnerRootRequest {
+            owner_root: Some(signed.clone()),
+            approval: None,
+            client_operation_id: operation_id.to_string(),
+        },
+        &binding,
+    );
+    let official = BootstrapOwnerRootRequest::decode(encoded.as_slice()).expect("official fields");
+    assert!(official.owner_root.is_some());
+    assert_eq!(official.client_operation_id, operation_id);
+    let extension = BootstrapOwnerRootExtension::decode(encoded.as_slice()).expect("tag 5");
+    let decoded = extension.owner_key_binding.expect("owner_key_binding");
+    assert_eq!(decoded.kind(), OwnerKeyBindingKind::AgentClaim);
+    assert_eq!(decoded.challenge_nonce, binding.challenge_nonce);
+}
+
+#[test]
+fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.register-claim.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.register-claim.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    let request = RegisterPublicKeyRequest {
+        challenge_id: "challenge-1".into(),
+        device_public_key: human.public_key().to_vec(),
+        client_operation_id: "op-claim-1".into(),
+        ..Default::default()
+    };
+    let encoded = encode_register_public_key_claim(&request, &transition).expect("wire");
+    let official = RegisterPublicKeyRequest::decode(encoded.as_slice()).expect("official");
+    assert!(official.owner_root.is_none());
+    assert!(official.owner_root_proof_of_possession.is_none());
+    assert!(official.owner_key_binding.is_none());
+    assert_eq!(official.device_public_key, human.public_key());
+    let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
+    let sent = extension.claim_deferred_human.expect("claim_deferred_human");
+    assert_eq!(
+        sent.transition.as_ref().expect("body").kind(),
+        OwnerKeyTransitionKind::ClaimDeferredHuman
+    );
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 survives claim encode"),
+        agent.public_key()
+    );
+}
+
+#[test]
+fn register_public_key_claim_refuses_a_replacement_seq0() {
+    let error = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            owner_root: Some(SignedOwnerRoot::default()),
+            client_operation_id: "op-bad".into(),
+            ..Default::default()
+        },
+        &Default::default(),
+    )
+    .expect_err("replacement seq-0 must not be encoded");
+    assert!(
+        error.to_string().contains("must not send owner_root"),
+        "{error}"
+    );
+}
+
+#[test]
+fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.prepare-claim.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let mut state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.prepare-claim.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    prepare_register_public_key_claim(
+        &mut state,
+        RegisterPublicKeyRequest {
+            challenge_id: "challenge-prepare".into(),
+            device_public_key: human.public_key().to_vec(),
+            client_operation_id: "op-prepare".into(),
+            ..Default::default()
+        },
+        transition,
+    )
+    .expect("prepare");
+    let encoded = state
+        .take_pending_register_public_key()
+        .expect("take")
+        .expect("pending");
+    let official = RegisterPublicKeyRequest::decode(encoded.as_slice()).expect("official");
+    assert!(official.owner_root.is_none());
+    assert!(official.owner_key_binding.is_none());
+    let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
+    assert_eq!(
+        extension
+            .claim_deferred_human
+            .expect("transition")
+            .transition
+            .expect("body")
+            .kind(),
+        OwnerKeyTransitionKind::ClaimDeferredHuman
     );
 }

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -214,10 +214,15 @@ fn restricted_agent_capability_keeps_the_deny_floor() {
 /// both server-side for unclaimed agent-rooted accounts (weft#1852/#1853).
 #[test]
 fn safe_ceiling_allows_host_only_spool_provisioning() {
-    for op in ["GetCurrentUserSpool", "CreateSpool"] {
+    for op in [
+        "GetCurrentUserSpool",
+        "CreateSpool",
+        "BootstrapOwnerRoot",
+        "GetCurrentOwnerKeyring",
+    ] {
         assert!(
             SAFE_AGENT_OPERATIONS.contains(&op),
-            "agent ceiling missing {op}: host-only auto-provision push cannot fire it"
+            "agent ceiling missing {op}: host-only auto-provision / claimable owner-root cannot fire it"
         );
     }
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -46,6 +46,15 @@ pub mod operation_dedup;
 mod owner_authorization;
 #[cfg(test)]
 mod owner_authorization_tests;
+mod owner_root;
+#[cfg(test)]
+mod owner_root_tests;
+pub use owner_root::{
+    CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, authorization_key_id,
+    ed25519_verification_key, genesis_owner_public_key, require_genesis_matches_seq0,
+    seq0_authority_public_key, sign_canonical, sign_claim_deferred_human,
+    sign_claimable_deferred_human_root, sign_spool_owner_genesis,
+};
 mod repository;
 mod repository_key_binding;
 mod repository_redaction;

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -51,9 +51,10 @@ mod owner_root;
 mod owner_root_tests;
 pub use owner_root::{
     CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, authorization_key_id,
-    ed25519_verification_key, genesis_owner_public_key, require_genesis_matches_seq0,
-    seq0_authority_public_key, sign_canonical, sign_claim_deferred_human,
-    sign_claimable_deferred_human_root, sign_spool_owner_genesis,
+    ed25519_verification_key, genesis_owner_public_key, registration_binding_nonce,
+    require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_canonical, sign_claim_deferred_human, sign_claimable_deferred_human_root,
+    sign_spool_owner_genesis,
 };
 mod repository;
 mod repository_key_binding;

--- a/crates/repo/src/owner_root.rs
+++ b/crates/repo/src/owner_root.rs
@@ -9,18 +9,22 @@
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
     AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
-    OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot, RecoveryPolicy, SignedOwnerKeyTransition,
-    SignedOwnerRoot, SignedSpoolOwnerGenesis, SpoolOwnerGenesis,
+    OwnerKeyBinding, OwnerKeyBindingKind, OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot,
+    RecoveryPolicy, SignedOwnerKeyTransition, SignedOwnerRoot, SignedSpoolOwnerGenesis,
+    SpoolOwnerGenesis,
 };
 use crypto::{Signer, SignerError};
 use heddleco_capability_verifier::{
-    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+    VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
+    verify_spool_owner_genesis,
 };
 use sha2::{Digest, Sha256};
 
 const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
 const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
 const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+const OWNER_BINDING_DOMAIN: &[u8] = b"heddle-owner-key-binding-v1";
+const REGISTRATION_BINDING_NONCE_DOMAIN: &[u8] = b"heddle-owner-registration-binding-nonce-v1";
 const OWNER_ROOT_FORMAT_VERSION: u32 = 1;
 const DEFAULT_RECOVERY_WINDOW_SECS: u64 = 604_800;
 
@@ -191,6 +195,58 @@ pub fn genesis_owner_public_key(signed: &SignedSpoolOwnerGenesis) -> Result<&[u8
         .as_ref()
         .context("signed spool genesis has no owner key")?;
     Ok(key.public_key.as_slice())
+}
+
+/// Nonce weft hashes as `registration_binding_nonce(client_operation_id)`.
+pub fn registration_binding_nonce(client_operation_id: &str) -> [u8; 32] {
+    Sha256::new()
+        .chain_update(REGISTRATION_BINDING_NONCE_DOMAIN)
+        .chain_update(client_operation_id.as_bytes())
+        .finalize()
+        .into()
+}
+
+/// Self-asserted AgentClaim binding of the claimable seq-0 root to the account UUID.
+///
+/// `challenge_nonce` is [`registration_binding_nonce`]. The proof must verify
+/// with `verify_owner_key_binding` against the same root.
+pub fn sign_agent_claim_binding(
+    signer: &impl Signer,
+    signed_root: &SignedOwnerRoot,
+    client_operation_id: &str,
+) -> Result<OwnerKeyBinding> {
+    let state = verify_owner_root(signed_root).context("verify claimable sequence-0 root")?;
+    let root = signed_root
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
+    let account_uuid: [u8; 16] = root
+        .account_uuid
+        .as_slice()
+        .try_into()
+        .context("owner root account_uuid must be 16 bytes")?;
+    if root
+        .authority_key
+        .as_ref()
+        .is_none_or(|key| key.public_key != signer.public_key())
+    {
+        bail!("owner-key binding signer is not the sequence-0 device/proof key");
+    }
+    let mut binding = OwnerKeyBinding {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        stable_owner_uuid: account_uuid.to_vec(),
+        root_public_key: Some(ed25519_verification_key(signer.public_key())?),
+        root_state_hash: state.state_hash().to_vec(),
+        kind: OwnerKeyBindingKind::AgentClaim as i32,
+        binding_epoch: 1,
+        challenge_nonce: registration_binding_nonce(client_operation_id).to_vec(),
+        root_proof_of_possession: None,
+    };
+    let body = owner_binding_body(&binding)?;
+    binding.root_proof_of_possession = Some(sign_canonical(signer, OWNER_BINDING_DOMAIN, &body)?);
+    verify_owner_key_binding(&binding, &state, &account_uuid)
+        .context("minted AgentClaim binding failed local verify")?;
+    Ok(binding)
 }
 
 /// Refuse CreateSpool genesis whose owner key is not the stored sequence-0 key.
@@ -380,6 +436,24 @@ fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()>
     }
     encoder.u64(policy.window_secs.unwrap_or(DEFAULT_RECOVERY_WINDOW_SECS));
     Ok(())
+}
+
+fn owner_binding_body(binding: &OwnerKeyBinding) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(binding.format_version);
+    encoder.bytes(&binding.stable_owner_uuid)?;
+    verification_key(
+        &mut encoder,
+        binding
+            .root_public_key
+            .as_ref()
+            .context("OwnerKeyBinding.root_public_key")?,
+    )?;
+    encoder.bytes(&binding.root_state_hash)?;
+    encoder.i32(binding.kind);
+    encoder.u64(binding.binding_epoch);
+    encoder.bytes(&binding.challenge_nonce)?;
+    Ok(encoder.finish())
 }
 
 fn owner_root_without_id(root: &OwnerRoot) -> Result<Vec<u8>> {

--- a/crates/repo/src/owner_root.rs
+++ b/crates/repo/src/owner_root.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Client mint for protocol-1 owner roots and ClaimDeferredHuman.
+//!
+//! Weft verifies; it does not hold the owner private key. Sequence-0 of a
+//! claimable deferred-human root is the same device/proof key CreateSpool
+//! pins as spool genesis. Claim advances authority with ClaimDeferredHuman
+//! and must not mint a replacement human sequence-0.
+
+use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::{
+    AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
+    OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot, RecoveryPolicy, SignedOwnerKeyTransition,
+    SignedOwnerRoot, SignedSpoolOwnerGenesis, SpoolOwnerGenesis,
+};
+use crypto::{Signer, SignerError};
+use heddleco_capability_verifier::{
+    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+};
+use sha2::{Digest, Sha256};
+
+const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
+const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
+const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+const OWNER_ROOT_FORMAT_VERSION: u32 = 1;
+const DEFAULT_RECOVERY_WINDOW_SECS: u64 = 604_800;
+
+/// Claim window for an agent-rooted deferred human root.
+pub const CLAIMABLE_DEFERRED_HUMAN_TTL_SECS: i64 = 90 * 24 * 60 * 60;
+
+/// Protocol-2 self-signature: the owner key signs `SHA-256(public_key || uuid)`.
+///
+/// CreateSpool callers mint this locally. Use a UUIDv7 — weft checks the version.
+pub fn sign_spool_owner_genesis(
+    signer: &impl Signer,
+    spool_uuid: [u8; 16],
+) -> Result<SignedSpoolOwnerGenesis, SignerError> {
+    let owner_public_key = ed25519_verification_key(signer.public_key())?;
+    let signer_key_id = authorization_key_id(&owner_public_key).to_vec();
+    let digest = Sha256::new()
+        .chain_update(&owner_public_key.public_key)
+        .chain_update(spool_uuid)
+        .finalize();
+    Ok(SignedSpoolOwnerGenesis {
+        genesis: Some(SpoolOwnerGenesis {
+            spool_uuid: spool_uuid.to_vec(),
+            owner_public_key: Some(owner_public_key),
+        }),
+        owner_signature: Some(AuthorizationSignature {
+            signer_key_id,
+            signature: signer.sign(&digest)?,
+        }),
+    })
+}
+
+/// Protocol-1 claimable deferred-human owner root.
+///
+/// Authority is the caller's device/proof key. Recovery is empty: the verifier
+/// allows that only while `claimable_deferred_human` is set. `nonce` must be
+/// 32 random bytes. `now_unix_seconds` plus [`CLAIMABLE_DEFERRED_HUMAN_TTL_SECS`]
+/// is the claim deadline.
+pub fn sign_claimable_deferred_human_root(
+    signer: &impl Signer,
+    account_uuid: [u8; 16],
+    nonce: [u8; 32],
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerRoot> {
+    if now_unix_seconds <= 0 {
+        bail!("claimable owner-root clock must be a positive unix timestamp");
+    }
+    let claimable_until_unix_seconds = now_unix_seconds
+        .checked_add(CLAIMABLE_DEFERRED_HUMAN_TTL_SECS)
+        .context("claimable owner-root deadline overflows")?;
+    let authority_key = ed25519_verification_key(signer.public_key())?;
+    let mut root = OwnerRoot {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        owner_id: Vec::new(),
+        account_uuid: account_uuid.to_vec(),
+        authority_key: Some(authority_key),
+        recovery_policy: Some(RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        }),
+        claimable_deferred_human: true,
+        nonce: nonce.to_vec(),
+        claimable_until_unix_seconds,
+    };
+    root.owner_id = domain_digest(OWNER_ROOT_DOMAIN, &owner_root_without_id(&root)?).to_vec();
+    let body = owner_root_body(&root)?;
+    let authority_proof = sign_canonical(signer, OWNER_ROOT_DOMAIN, &body)?;
+    let signed = SignedOwnerRoot {
+        root: Some(root),
+        authority_proof: Some(authority_proof),
+        recovery_key_proofs: Vec::new(),
+    };
+    verify_owner_root(&signed).context("minted claimable owner root failed local verify")?;
+    Ok(signed)
+}
+
+/// Inputs for a ClaimDeferredHuman transition. Sequence-0 stays the agent key.
+pub struct ClaimDeferredHuman<'a, C, N, G> {
+    pub current_authority: &'a C,
+    pub next_authority: &'a N,
+    pub signed_root: &'a SignedOwnerRoot,
+    pub next_recovery_policy: RecoveryPolicy,
+    pub next_guardian_signers: &'a [G],
+    pub now_unix_seconds: i64,
+    pub nonce: [u8; 32],
+}
+
+/// Build ClaimDeferredHuman signed by the agent proof key and the human root.
+///
+/// Does not mint a replacement sequence-0 OwnerRoot. The agent key remains
+/// genesis; the human key becomes current authority at sequence 1.
+pub fn sign_claim_deferred_human<C, N, G>(
+    claim: ClaimDeferredHuman<'_, C, N, G>,
+) -> Result<SignedOwnerKeyTransition>
+where
+    C: Signer,
+    N: Signer,
+    G: Signer,
+{
+    let state = verify_owner_root(claim.signed_root).context("verify claimable sequence-0 root")?;
+    let root = claim
+        .signed_root
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
+    let current_key = root
+        .authority_key
+        .as_ref()
+        .context("signed owner root has no authority")?;
+    if current_key.public_key != claim.current_authority.public_key() {
+        bail!("claim current authority is not the sequence-0 device/proof key");
+    }
+    if claim.next_authority.public_key() == claim.current_authority.public_key() {
+        bail!("claim next authority must be the human device root, not the agent key");
+    }
+    if claim.now_unix_seconds <= 0 {
+        bail!("claim clock must be a positive unix timestamp");
+    }
+    let next_authority_key = ed25519_verification_key(claim.next_authority.public_key())?;
+    let transition = OwnerKeyTransition {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        owner_id: state.owner_id().to_vec(),
+        previous_state_hash: state.state_hash().to_vec(),
+        sequence: 1,
+        kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
+        next_authority_key: Some(next_authority_key),
+        next_recovery_policy: Some(claim.next_recovery_policy),
+        valid_from_unix_seconds: claim.now_unix_seconds,
+        previous_key_valid_until_unix_seconds: 0,
+        nonce: claim.nonce.to_vec(),
+    };
+    let body = transition_body(&transition)?;
+    let current_proof = sign_canonical(claim.current_authority, OWNER_TRANSITION_DOMAIN, &body)?;
+    let next_proof = sign_canonical(claim.next_authority, OWNER_TRANSITION_DOMAIN, &body)?;
+    let next_recovery_key_proofs =
+        guardian_proofs_in_policy_order(&transition, claim.next_guardian_signers, &body)?;
+    let signed = SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: vec![current_proof],
+        next_authority_key_proof: Some(next_proof),
+        next_recovery_key_proofs,
+    };
+    let limits = VerificationLimits::new(MAX_CAPABILITY_TTL_SECONDS)
+        .context("construct claim transition verifier limits")?;
+    apply_transition(&state, &signed, claim.now_unix_seconds, limits)
+        .context("minted ClaimDeferredHuman failed local verify")?;
+    Ok(signed)
+}
+
+/// Sequence-0 authority public key from a verified owner root.
+pub fn seq0_authority_public_key(signed: &SignedOwnerRoot) -> Result<&[u8]> {
+    let root = signed.root.as_ref().context("signed owner root has no body")?;
+    let key = root
+        .authority_key
+        .as_ref()
+        .context("signed owner root has no authority")?;
+    Ok(key.public_key.as_slice())
+}
+
+/// CreateSpool genesis owner public key.
+pub fn genesis_owner_public_key(signed: &SignedSpoolOwnerGenesis) -> Result<&[u8]> {
+    let genesis = signed
+        .genesis
+        .as_ref()
+        .context("signed spool genesis has no body")?;
+    let key = genesis
+        .owner_public_key
+        .as_ref()
+        .context("signed spool genesis has no owner key")?;
+    Ok(key.public_key.as_slice())
+}
+
+/// Refuse CreateSpool genesis whose owner key is not the stored sequence-0 key.
+pub fn require_genesis_matches_seq0(
+    genesis: &SignedSpoolOwnerGenesis,
+    seq0_public_key: &[u8],
+) -> Result<()> {
+    let verified =
+        verify_spool_owner_genesis(genesis).context("verify CreateSpool owner genesis")?;
+    if verified.owner_public_key().public_key != seq0_public_key {
+        bail!(
+            "CreateSpool genesis owner key does not match the account sequence-0 owner root; refusing to pin a different key"
+        );
+    }
+    Ok(())
+}
+
+/// Ed25519 verification key for a 32-byte public key.
+pub fn ed25519_verification_key(
+    public_key: &[u8],
+) -> Result<AuthorizationVerificationKey, SignerError> {
+    if public_key.len() != 32 {
+        return Err(SignerError::InvalidKey(format!(
+            "authorization public key must be 32 bytes, got {}",
+            public_key.len()
+        )));
+    }
+    Ok(AuthorizationVerificationKey {
+        algorithm: AuthorizationKeyAlgorithm::Ed25519 as i32,
+        public_key: public_key.to_vec(),
+    })
+}
+
+/// SHA-256("heddle-key-v1" || algorithm || public_key).
+pub fn authorization_key_id(key: &AuthorizationVerificationKey) -> [u8; 32] {
+    let mut body = Vec::with_capacity(4 + key.public_key.len());
+    body.extend_from_slice(&key.algorithm.to_be_bytes());
+    body.extend_from_slice(&key.public_key);
+    domain_digest(OWNER_KEY_ID_DOMAIN, &body)
+}
+
+/// Sign a domain-separated canonical body the way the verifier checks it.
+pub fn sign_canonical(
+    signer: &impl Signer,
+    domain: &[u8],
+    body: &[u8],
+) -> Result<AuthorizationSignature, SignerError> {
+    let key = ed25519_verification_key(signer.public_key())?;
+    Ok(AuthorizationSignature {
+        signer_key_id: authorization_key_id(&key).to_vec(),
+        signature: signer.sign(&domain_digest(domain, body))?,
+    })
+}
+
+const MAX_CAPABILITY_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
+
+fn guardian_proofs_in_policy_order<G: Signer>(
+    transition: &OwnerKeyTransition,
+    signers: &[G],
+    body: &[u8],
+) -> Result<Vec<AuthorizationSignature>> {
+    let policy = transition
+        .next_recovery_policy
+        .as_ref()
+        .context("transition has no next recovery policy")?;
+    if signers.len() != policy.guardians.len() {
+        bail!(
+            "claim guardian signer count {} does not match next recovery policy {}",
+            signers.len(),
+            policy.guardians.len()
+        );
+    }
+    let mut unused: Vec<&G> = signers.iter().collect();
+    let mut proofs = Vec::with_capacity(policy.guardians.len());
+    for guardian in &policy.guardians {
+        let expected = authorization_key_id(
+            guardian
+                .key
+                .as_ref()
+                .context("next recovery guardian has no key")?,
+        );
+        let index = unused
+            .iter()
+            .position(|signer| {
+                ed25519_verification_key(signer.public_key())
+                    .ok()
+                    .is_some_and(|key| authorization_key_id(&key) == expected)
+            })
+            .context("claim guardian signer does not match the next recovery policy")?;
+        let signer = unused.swap_remove(index);
+        proofs.push(sign_canonical(signer, OWNER_TRANSITION_DOMAIN, body)?);
+    }
+    Ok(proofs)
+}
+
+fn domain_digest(domain: &[u8], body: &[u8]) -> [u8; 32] {
+    Sha256::new()
+        .chain_update(domain)
+        .chain_update(body)
+        .finalize()
+        .into()
+}
+
+struct Encoder {
+    bytes: Vec<u8>,
+}
+
+impl Encoder {
+    const fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn raw(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn bool(&mut self, value: bool) {
+        self.bytes.push(u8::from(value));
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn i32(&mut self, value: i32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn i64(&mut self, value: i64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn bytes(&mut self, value: &[u8]) -> Result<()> {
+        let len = u32::try_from(value.len()).context("canonical collection exceeds u32 length")?;
+        self.u32(len);
+        self.raw(value);
+        Ok(())
+    }
+}
+
+fn verification_key(encoder: &mut Encoder, key: &AuthorizationVerificationKey) -> Result<()> {
+    encoder.i32(key.algorithm);
+    encoder.bytes(&key.public_key)
+}
+
+fn guardian(
+    encoder: &mut Encoder,
+    guardian: &api::heddle::api::v1alpha1::RecoveryGuardian,
+) -> Result<()> {
+    encoder.i32(guardian.kind);
+    let key = guardian
+        .key
+        .as_ref()
+        .context("recovery guardian has no key")?;
+    verification_key(encoder, key)
+}
+
+fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()> {
+    let ids = policy
+        .guardians
+        .iter()
+        .map(|value| {
+            value
+                .key
+                .as_ref()
+                .map(authorization_key_id)
+                .unwrap_or([0; 32])
+        })
+        .collect::<Vec<_>>();
+    if ids.windows(2).any(|pair| pair[0] >= pair[1]) {
+        bail!("recovery guardians are not unique and sorted by key id");
+    }
+    encoder.u32(policy.threshold);
+    encoder.u32(
+        u32::try_from(policy.guardians.len()).context("guardian count exceeds u32 length")?,
+    );
+    for value in &policy.guardians {
+        guardian(encoder, value)?;
+    }
+    encoder.u64(policy.window_secs.unwrap_or(DEFAULT_RECOVERY_WINDOW_SECS));
+    Ok(())
+}
+
+fn owner_root_without_id(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        root.authority_key
+            .as_ref()
+            .context("OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        root.recovery_policy
+            .as_ref()
+            .context("OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+fn owner_root_body(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.owner_id)?;
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        root.authority_key
+            .as_ref()
+            .context("OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        root.recovery_policy
+            .as_ref()
+            .context("OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+fn transition_body(transition: &OwnerKeyTransition) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(transition.format_version);
+    encoder.bytes(&transition.owner_id)?;
+    encoder.bytes(&transition.previous_state_hash)?;
+    encoder.u64(transition.sequence);
+    encoder.i32(transition.kind);
+    verification_key(
+        &mut encoder,
+        transition
+            .next_authority_key
+            .as_ref()
+            .context("OwnerKeyTransition.next_authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        transition
+            .next_recovery_policy
+            .as_ref()
+            .context("OwnerKeyTransition.next_recovery_policy")?,
+    )?;
+    encoder.i64(transition.valid_from_unix_seconds);
+    encoder.i64(transition.previous_key_valid_until_unix_seconds);
+    encoder.bytes(&transition.nonce)?;
+    Ok(encoder.finish())
+}

--- a/crates/repo/src/owner_root_tests.rs
+++ b/crates/repo/src/owner_root_tests.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use api::heddle::api::v1alpha1::{
+    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+};
+use crypto::Signer;
+use heddleco_capability_verifier::{
+    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+};
+
+use crate::{
+    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, require_genesis_matches_seq0,
+    seq0_authority_public_key, sign_claim_deferred_human, sign_claimable_deferred_human_root,
+    sign_spool_owner_genesis,
+};
+
+const NOW: i64 = 1_700_000_000;
+const ACCOUNT: [u8; 16] = [0x11; 16];
+
+fn paper_policy(left: &impl Signer, right: &impl Signer) -> RecoveryPolicy {
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(left.public_key()).expect("left guardian")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(right.public_key()).expect("right guardian")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| {
+        authorization_key_id(guardian.key.as_ref().expect("guardian key"))
+    });
+    RecoveryPolicy {
+        threshold: 2,
+        guardians,
+        window_secs: None,
+    }
+}
+
+#[test]
+fn claimable_deferred_human_root_is_protocol_1_with_the_device_key() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x42; 32], NOW)
+        .expect("mint claimable root");
+    let state = verify_owner_root(&signed).expect("verifier accepts the minted root");
+    let root = signed.root.as_ref().expect("root body");
+
+    assert_eq!(root.format_version, 1);
+    assert!(root.claimable_deferred_human);
+    assert_eq!(
+        root.claimable_until_unix_seconds,
+        NOW + crate::CLAIMABLE_DEFERRED_HUMAN_TTL_SECS
+    );
+    assert_eq!(root.account_uuid, ACCOUNT);
+    assert_eq!(
+        root.authority_key.as_ref().expect("authority").public_key,
+        agent.public_key()
+    );
+    assert_eq!(state.sequence(), 0);
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 key"),
+        agent.public_key()
+    );
+    let policy = root
+        .recovery_policy
+        .as_ref()
+        .expect("empty recovery while claimable");
+    assert_eq!(policy.threshold, 0);
+    assert!(policy.guardians.is_empty());
+}
+
+#[test]
+fn claim_deferred_human_advances_authority_without_replacing_sequence_0() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let human = crypto::Ed25519Signer::generate().expect("human device root");
+    let g1 = crypto::Ed25519Signer::generate().expect("guardian 1");
+    let g2 = crypto::Ed25519Signer::generate().expect("guardian 2");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x7; 32], NOW)
+        .expect("mint claimable root");
+    let seq0 = seq0_authority_public_key(&signed)
+        .expect("seq-0")
+        .to_vec();
+    let policy = paper_policy(&g1, &g2);
+
+    let signed_transition = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &agent,
+        next_authority: &human,
+        signed_root: &signed,
+        next_recovery_policy: policy,
+        next_guardian_signers: &[g1, g2],
+        now_unix_seconds: NOW + 60,
+        nonce: [0x9; 32],
+    })
+    .expect("claim transition");
+
+    let transition = signed_transition.transition.as_ref().expect("transition");
+    assert_eq!(transition.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
+    assert_eq!(transition.sequence, 1);
+    assert_eq!(
+        transition
+            .next_authority_key
+            .as_ref()
+            .expect("next")
+            .public_key,
+        human.public_key()
+    );
+
+    let limits = VerificationLimits::new(30 * 24 * 60 * 60).expect("limits");
+    let claimed = apply_transition(
+        &verify_owner_root(&signed).expect("root"),
+        &signed_transition,
+        NOW + 60,
+        limits,
+    )
+    .expect("verifier applies ClaimDeferredHuman");
+    assert_eq!(claimed.sequence(), 1);
+    assert_eq!(claimed.authority_key().public_key, human.public_key());
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 after claim"),
+        seq0.as_slice(),
+        "claim must not rewrite sequence-0"
+    );
+    assert_eq!(seq0, agent.public_key());
+}
+
+#[test]
+fn create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0() {
+    let agent = crypto::Ed25519Signer::generate().expect("device proof key");
+    let other = crypto::Ed25519Signer::generate().expect("throwaway key");
+    let spool_uuid = uuid::Uuid::now_v7();
+    assert_eq!(spool_uuid.get_version_num(), 7);
+
+    let matched = sign_spool_owner_genesis(&agent, *spool_uuid.as_bytes()).expect("genesis");
+    verify_spool_owner_genesis(&matched).expect("genesis verifies");
+    require_genesis_matches_seq0(&matched, agent.public_key()).expect("same key as seq-0");
+
+    let mismatched = sign_spool_owner_genesis(&other, *spool_uuid.as_bytes()).expect("other genesis");
+    let error = require_genesis_matches_seq0(&mismatched, agent.public_key())
+        .expect_err("throwaway per-spool key must not pass the seq-0 check");
+    assert!(
+        error.to_string().contains("sequence-0"),
+        "mismatch must name the seq-0 pin: {error}"
+    );
+}
+
+#[test]
+fn claim_refuses_to_install_the_agent_key_as_the_human_next_authority() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent");
+    let signed =
+        sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x3; 32], NOW).expect("root");
+    let error = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &agent,
+        next_authority: &agent,
+        signed_root: &signed,
+        next_recovery_policy: RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        },
+        next_guardian_signers: &[] as &[crypto::Ed25519Signer],
+        now_unix_seconds: NOW + 1,
+        nonce: [0x4; 32],
+    })
+    .expect_err("human next authority is required");
+    assert!(error.to_string().contains("human device root"), "{error}");
+}

--- a/crates/repo/src/owner_root_tests.rs
+++ b/crates/repo/src/owner_root_tests.rs
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use api::heddle::api::v1alpha1::{
-    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+    OwnerKeyBindingKind, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
+    RecoveryPolicy,
 };
 use crypto::Signer;
 use heddleco_capability_verifier::{
-    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+    VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
+    verify_spool_owner_genesis,
 };
 
 use crate::{
-    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, require_genesis_matches_seq0,
-    seq0_authority_public_key, sign_claim_deferred_human, sign_claimable_deferred_human_root,
-    sign_spool_owner_genesis,
+    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, registration_binding_nonce,
+    require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_claim_deferred_human, sign_claimable_deferred_human_root, sign_spool_owner_genesis,
 };
 
 const NOW: i64 = 1_700_000_000;
@@ -164,4 +166,21 @@ fn claim_refuses_to_install_the_agent_key_as_the_human_next_authority() {
     })
     .expect_err("human next authority is required");
     assert!(error.to_string().contains("human device root"), "{error}");
+}
+
+#[test]
+fn agent_claim_binding_uses_registration_nonce_and_verifies_against_the_root() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x5; 32], NOW)
+        .expect("mint claimable root");
+    let operation_id = "op-bind-1";
+    let binding = sign_agent_claim_binding(&agent, &signed, operation_id).expect("binding");
+    assert_eq!(binding.kind(), OwnerKeyBindingKind::AgentClaim);
+    assert_eq!(binding.binding_epoch, 1);
+    assert_eq!(
+        binding.challenge_nonce.as_slice(),
+        registration_binding_nonce(operation_id).as_slice()
+    );
+    let state = verify_owner_root(&signed).expect("root");
+    verify_owner_key_binding(&binding, &state, &ACCOUNT).expect("weft verifies the binding");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Agent signup, remint, and next `auth login` mint a protocol-1 `SignedOwnerRoot` with `claimable_deferred_human=true` and a 90-day deadline. Authority is the same device/proof key CreateSpool pins as genesis.
- **weft#1863 wire:** `BootstrapOwnerRoot` now also sends `owner_key_binding` as additive prost tag 5 (`BootstrapOwnerRootExtension`). Kind is `OwnerKeyBindingKind::AgentClaim`. `challenge_nonce` is `SHA-256(b"heddle-owner-registration-binding-nonce-v1" || client_operation_id)` and the binding verifies against the claimable root (`verify_owner_key_binding`). Approval stays `None`.
- **Claim:** production path prepares and sends `RegisterPublicKeyClaimExtension` (additive tag 16) with `ClaimDeferredHuman` (agent + human both sign). `owner_root` / `owner_root_proof_of_possession` / `owner_key_binding` are refused on that request so sequence-0 stays the agent key.
- CreateSpool genesis is unchanged (same proof key; refuse a different stored seq-0). `#1599` is still a separate PR; this branch has one `repo::sign_spool_owner_genesis`.

## Closes

Closes HeddleCo/heddle#1600

## Red commit

N/A — the missing claimable seq-0 root is on current heddle main `ac3f8827` (v0.15.3). #1599 mints spool genesis only and stays a separate PR.

## Test evidence

Advertised tests ran on HEAD `72d867bb6b11e3457404bda3c9e45190a094ab05`:

```
=== HEAD 72d867bb6b11e3457404bda3c9e45190a094ab05 ===

=== heddle-repo --lib owner_root ===
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running unittests src/lib.rs (target/debug/deps/repo-31bf75f0985b1b7a)

running 5 tests
test owner_root_tests::claim_refuses_to_install_the_agent_key_as_the_human_next_authority ... ok
test owner_root_tests::claimable_deferred_human_root_is_protocol_1_with_the_device_key ... ok
test owner_root_tests::agent_claim_binding_uses_registration_nonce_and_verifies_against_the_root ... ok
test owner_root_tests::create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0 ... ok
test owner_root_tests::claim_deferred_human_advances_authority_without_replacing_sequence_0 ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 729 filtered out; finished in 0.07s

=== heddle-hosted-client --features client --lib owner_root ===
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-59f1b0704ff9de1e)

running 8 tests
test hosted_runtime::owner_root_tests::bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5 ... ok
test hosted_runtime::owner_root_tests::claim_prepares_register_public_key_claim_deferred_human_for_send ... ok
test hosted_runtime::owner_root_tests::claim_transition_is_claim_deferred_human_not_a_replacement_seq0 ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_refuses_a_replacement_seq0 ... ok
test hosted_runtime::owner_root_tests::create_spool_genesis_matches_the_stored_seq0_proof_key ... ok
test hosted_runtime::owner_root_tests::create_spool_genesis_refuses_a_key_that_is_not_seq0 ... ok
test hosted_runtime::owner_root_tests::invite_create_mints_a_claimable_seq0_root_on_the_agent_proof_key ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_sends_claim_deferred_human_on_tag_16 ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 309 filtered out; finished in 0.32s
```

Also ran on the same tree (login, Iroh claim bytes, ceiling, CreateSpool, administration): 24 passed.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Surfaces

- **The verb.** No new flag. `auth login` / remint / invite-create mint. CreateSpool genesis unchanged. `heddle claim` uploads the claimable root, then sends pending RegisterPublicKey + ClaimDeferredHuman (tag 16) when prepared.
- **Human and agent.** Default invite-create text and `--json` `next.command` unchanged.
- **Git interop.** Not touched.
- **The wire.** Additive prost only: BootstrapOwnerRoot tag 5 `owner_key_binding`; RegisterPublicKey tag 16 `claim_deferred_human`. No second view RPC. No replacement seq-0 on RegisterPublicKey.
- **Reverse states.** Way in: login mint + BootstrapOwnerRoot + AgentClaim binding. Way out: ClaimDeferredHuman on RegisterPublicKey (seq-0 unchanged). Way to see: stored seq-0 on claim state.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-889c8f47-aee6-416c-99cf-ed328e314b61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-889c8f47-aee6-416c-99cf-ed328e314b61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790564371&installation_model_id=21489&pr_number=1601&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1601&signature=b5591fbf252a7354540f3c1b6d0411a251dfdc3336528d33bf209ae573f3cc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->