### PR TITLE
fix(hosted): hash stream opening ids so weft admits Push/Pull

### DIFF
--- a/crates/hosted-client/CHANGELOG.md
+++ b/crates/hosted-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Hash Push/Pull `StreamOpeningProof.stream_id` to 64-byte blake3 hex so weft admits the opening (the long transfer identity stays on the checkpoint).
+
 ## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.2...heddle-hosted-client-v0.15.3) - 2026-08-28
 
 ### Fixed

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -47,7 +47,8 @@ use wire::{
 };
 
 use super::{
-    BidirectionalRequestStream, HostedClient, PullMaterialization, ServerStream, ServerStreamItem,
+    BidirectionalRequestStream, CallContextFactory, HostedClient, PullMaterialization,
+    ServerStream, ServerStreamItem,
     helpers::{
         descriptor_id, descriptor_id_from_info, hosted_to_protocol_error,
         object_descriptor_with_status, parse_descriptor_to_info, to_proto_object_info,
@@ -507,22 +508,20 @@ pub enum ExpectedRemoteHead {
 impl HostedClient {
     fn sync_stream_opening_proof(
         &self,
-        stream_id: &str,
+        transfer_id: &str,
         route: &str,
         repository: &str,
         resume_cursor: &str,
         capability_context: Vec<u8>,
     ) -> Result<StreamOpeningProof, ProtocolError> {
-        self.stream_opening_proof(
+        sync_stream_opening_proof(
+            &self.context,
+            transfer_id,
             route,
-            stream_id,
-            super::helpers::repository_ref(repository).ok_or_else(|| {
-                ProtocolError::InvalidState("invalid repository path".to_string())
-            })?,
+            repository,
             resume_cursor,
             capability_context,
         )
-        .map_err(hosted_to_protocol_error)
     }
 
     pub async fn list_refs(&mut self, repo_path: &str) -> Result<Vec<RefEntry>, ProtocolError> {
@@ -1572,8 +1571,9 @@ impl HostedClient {
             uuid::Uuid::new_v4(),
         );
         let remote_thread_id = self.pull_thread_id(repo_path, remote_thread).await?;
+        let stream_id = stream_opening_id(&transfer_id);
         let (provider_session, provider_capability_context) =
-            self.begin_provider_pull(&transfer_id, repo_path)?;
+            self.begin_provider_pull(&stream_id, repo_path)?;
         let request_message = PullClientFrame {
             frame: Some(pull_client_frame::Frame::Request(PullRequest {
                 repo_path: super::helpers::repository_ref(repo_path),
@@ -4085,6 +4085,43 @@ mod on_demand_hydration_tests {
     }
 }
 
+/// weft `verify_stream_opening` fail-closes when `stream_id` is empty or
+/// longer than this. The bound is an LRU admission cap on the request-proof
+/// cache, not a hint to grow the identifier.
+const STREAM_OPENING_ID_MAX_LEN: usize = 64;
+
+/// Short, stable StreamOpeningProof.stream_id for a transfer identity.
+///
+/// The long `transfer_id` stays on TransferCheckpoint so reconnects of one
+/// operation resume the same transfer. weft admits only `1..=64` bytes here;
+/// blake3 hex is exactly 64, which the `>` check still admits.
+fn stream_opening_id(transfer_id: &str) -> String {
+    let stream_id = hex::encode(blake3::hash(transfer_id.as_bytes()).as_bytes());
+    debug_assert!((1..=STREAM_OPENING_ID_MAX_LEN).contains(&stream_id.len()));
+    stream_id
+}
+
+fn sync_stream_opening_proof(
+    context: &CallContextFactory,
+    transfer_id: &str,
+    route: &str,
+    repository: &str,
+    resume_cursor: &str,
+    capability_context: Vec<u8>,
+) -> Result<StreamOpeningProof, ProtocolError> {
+    context
+        .stream_opening_proof(
+            route,
+            stream_opening_id(transfer_id),
+            super::helpers::repository_ref(repository).ok_or_else(|| {
+                ProtocolError::InvalidState("invalid repository path".to_string())
+            })?,
+            resume_cursor,
+            capability_context,
+        )
+        .map_err(hosted_to_protocol_error)
+}
+
 fn pull_transfer_id(
     repo_path: &str,
     remote_thread: &str,
@@ -4119,7 +4156,9 @@ fn push_transfer_id(
 mod transfer_id_tests {
     use std::{collections::HashSet, time::Instant};
 
-    use api::heddle::api::v1alpha1::PushRequest;
+    use api::{heddle::api::v1alpha1::PushRequest, signing};
+    use config::ClientConfig;
+    use crypto::{Ed25519Signer, Signer as _};
     use objects::{
         object::{Blob, ContentHash, StateId, Tree, TreeEntry},
         store::{SnapshotCommitArtifact, SnapshotCommitDescriptor, pack::PackObjectId},
@@ -4132,9 +4171,10 @@ mod transfer_id_tests {
     };
 
     use super::{
-        ExpectedRemoteHead, apply_expected_remote_head, native_push_boundaries,
+        CallContextFactory, ExpectedRemoteHead, STREAM_OPENING_ID_MAX_LEN,
+        apply_expected_remote_head, native_push_boundaries,
         native_push_boundaries_from_expected_head, pull_transfer_id, push_transfer_id,
-        select_snapshot_pack_reuse_descriptor,
+        select_snapshot_pack_reuse_descriptor, stream_opening_id, sync_stream_opening_proof,
     };
 
     fn descriptor(state: StateId, object_ids: Vec<PackObjectId>) -> SnapshotCommitDescriptor {
@@ -4354,6 +4394,109 @@ mod transfer_id_tests {
             push_transfer_id("org/repo", state, "main", "heddle:state", "op-1"),
             "transport reconnects inside one Push operation must resume the same transfer"
         );
+    }
+
+    #[test]
+    fn stream_opening_proof_admits_a_short_stable_id_for_a_realistic_transfer() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let config = ClientConfig::default()
+            .with_token(wire::AuthToken::new("token", "alice"))
+            .with_auth_proof_key_pem(signer.to_pem().unwrap())
+            .with_authenticated_principal("principal:alice");
+        let context = CallContextFactory::from_client_config(&config).unwrap();
+        let state = StateId::from_bytes([0xab; 32]);
+        let repo = "cedar-jay-9dce33/spool-d";
+        let revision = format!("heddle:{}", state.to_string_full());
+        let push_route = "/heddle.api.v1alpha1.RepoSyncService/Push";
+        let pull_route = "/heddle.api.v1alpha1.RepoSyncService/Pull";
+        let first_op = "6bd5b04c-1111-4000-8000-000000000001";
+        let later_op = "6bd5b04c-1111-4000-8000-000000000002";
+
+        let push = push_transfer_id(repo, state, "main", &revision, first_op);
+        assert!(
+            push.len() > STREAM_OPENING_ID_MAX_LEN,
+            "a real Push transfer_id must exceed weft's stream_id cap so this test covers the fail-closed case (len={})",
+            push.len()
+        );
+        assert_eq!(
+            push,
+            push_transfer_id(repo, state, "main", &revision, first_op),
+            "the long transfer identity stays on the checkpoint"
+        );
+
+        let first = sync_stream_opening_proof(&context, &push, push_route, repo, "", Vec::new())
+            .expect("sign first push opening");
+        let retry = sync_stream_opening_proof(&context, &push, push_route, repo, "", Vec::new())
+            .expect("sign retried push opening");
+        let later = sync_stream_opening_proof(
+            &context,
+            &push_transfer_id(repo, state, "main", &revision, later_op),
+            push_route,
+            repo,
+            "",
+            Vec::new(),
+        )
+        .expect("sign later push opening");
+
+        assert!(
+            (1..=STREAM_OPENING_ID_MAX_LEN).contains(&first.stream_id.len()),
+            "weft admits only 1..=64 byte stream_id (len={})",
+            first.stream_id.len()
+        );
+        assert_eq!(first.stream_id, stream_opening_id(&push));
+        assert_eq!(
+            first.stream_id, retry.stream_id,
+            "retries of one operation must keep the same anti-replay stream_id"
+        );
+        assert_ne!(
+            first.stream_id, later.stream_id,
+            "a different operation id must not reuse the stream_id"
+        );
+        let canonical = signing::stream_open_bytes(
+            "principal:alice",
+            &first.stream_id,
+            push_route,
+            repo,
+            "",
+            &[],
+        );
+        Ed25519Signer::verify_with_public_key(&canonical, signer.public_key(), &first.signature)
+            .expect("opening signature must be bound to the short stream_id");
+
+        let pull_nonce = uuid::Uuid::nil();
+        let pull = pull_transfer_id(repo, "main", Some("main"), None, Some(state), pull_nonce);
+        assert!(
+            pull.len() > STREAM_OPENING_ID_MAX_LEN,
+            "a real Pull transfer_id must exceed weft's stream_id cap (len={})",
+            pull.len()
+        );
+        let pull_proof =
+            sync_stream_opening_proof(&context, &pull, pull_route, repo, "", Vec::new())
+                .expect("sign pull opening");
+        let later_pull = pull_transfer_id(
+            repo,
+            "main",
+            Some("main"),
+            None,
+            Some(state),
+            uuid::Uuid::from_u128(1),
+        );
+        let later_pull_proof =
+            sync_stream_opening_proof(&context, &later_pull, pull_route, repo, "", Vec::new())
+                .expect("sign later pull opening");
+        assert!(
+            (1..=STREAM_OPENING_ID_MAX_LEN).contains(&pull_proof.stream_id.len()),
+            "weft admits only 1..=64 byte stream_id (len={})",
+            pull_proof.stream_id.len()
+        );
+        assert_eq!(pull_proof.stream_id, stream_opening_id(&pull));
+        assert_eq!(
+            pull_proof.stream_id,
+            sync_stream_opening_proof(&context, &pull, pull_route, repo, "", Vec::new())
+                .expect("sign retried pull opening")
+                .stream_id
+        );
+        assert_ne!(pull_proof.stream_id, later_pull_proof.stream_id);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Hosted Push after CreateSpool died exit 77 with `authorization failed: stream opening route or identifier is invalid`. weft `verify_stream_opening` fail-closes when `stream_id` is empty or longer than 64 bytes (LRU admission on the request-proof cache). The signed route already matches.
- Confirmed hypothesis: `push_transfer_id` / `pull_transfer_id` embed a full `StateId` (`hs-` + crockford32 ≈ 55 chars) plus path, revision, and operation id. Every real transfer identity is already over 64. That string was used as both `TransferCheckpoint.transfer_id` and `StreamOpeningProof.stream_id`.
- Keep the long transfer identity on the checkpoint so reconnects of one operation resume. Derive `stream_id` as blake3 hex (exactly 64, which weft's `>` check still admits). Same short id for provider-pull plan signatures. Retries stay stable; a different operation id changes the id.

## Closes

Refs HeddleCo/heddle#1599

Production failure on api-staging after that PR's CreateSpool path (`cedar-jay-9dce33/spool-d`). This is the follow-on Push/Pull stream-opening reject, not a weft cap change.

## Red commit

N/A — the defect is on current heddle 0.15.3 (`6bd5b04` / #1599): a realistic `push_transfer_id` is passed through as `StreamOpeningProof.stream_id` and weft fail-closes before the signature check. Reproduced as exit 77 on api-staging.heddle.sh. No failing test commit was pushed before the hash.

## Test evidence

Advertised tests ran on HEAD `d59fbc36ed0d427b48bde997e99e374b62edd40c`:

```
$ cargo test -p heddle-hosted-client --features client --lib stream_opening_proof_admits_a_short_stable_id_for_a_realistic_transfer -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 42s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-59f1b0704ff9de1e)

running 1 test
test hosted_runtime::hosted::sync::transfer_id_tests::stream_opening_proof_admits_a_short_stable_id_for_a_realistic_transfer ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 310 filtered out; finished in 0.01s

$ cargo test -p heddle-hosted-client --features client
    Finished `test` profile [unoptimized + debuginfo] target(s) in 9.60s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-59f1b0704ff9de1e)

running 311 tests
test hosted_runtime::hosted::sync::transfer_id_tests::stream_opening_proof_admits_a_short_stable_id_for_a_realistic_transfer ... ok
...
test result: ok. 310 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 16.06s

   Doc-tests hosted_client
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Named invariant: a realistic `push_transfer_id` / `pull_transfer_id` (both > 64 bytes) produces a `StreamOpeningProof.stream_id` whose len is in `1..=64`, is stable for the same inputs, changes when the operation id changes, and is the id the opening signature is bound to. The production path is `sync_stream_opening_proof`, which Push and Pull already call.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc9c7fb3-b2d9-4522-9612-817e76540371?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc9c7fb3-b2d9-4522-9612-817e76540371&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790568952&installation_model_id=21489&pr_number=1602&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1602&signature=9c9b4f04f2d2a4972fb54727fcd6da700ed7c615e5ac166ad356118e3f0250c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->