### PR TITLE
feat(identity): ClaimOwnerRoot device co-sign for the owner-root ceremony (heddle#1603)

### DIFF
--- a/crates/hosted-client/Cargo.toml
+++ b/crates/hosted-client/Cargo.toml
@@ -69,6 +69,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 [dev-dependencies]
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 rcgen = "0.14.8"
+tempfile.workspace = true
 tracing-subscriber.workspace = true
 
 [features]

--- a/crates/hosted-client/src/hosted_runtime/auth_login.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login.rs
@@ -114,6 +114,9 @@ fn cred_bound_to_node_key(resolved: &ResolvedHostedCredential, node_id: &str) ->
 }
 
 fn reuse(server: &str, resolved: &ResolvedHostedCredential) -> Result<()> {
+    if let Some(pem) = resolved.proof_key_pem.as_deref() {
+        super::auth_login_agent::record_claimable_root_for_stored_account(server, pem)?;
+    }
     let subject = resolved
         .subject
         .clone()

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -39,7 +39,7 @@ pub(crate) fn record_claimable_root_for_stored_account(
     let Some(mut state) = identity_state::load()? else {
         return Ok(());
     };
-    if !super::hosted::server_keys_match(&state.server, server) {
+    if !super::hosted::server_keys_match(&state.server, server) || state.is_claimed() {
         return Ok(());
     }
     let signer = Ed25519Signer::from_pem(private_key_pem)
@@ -89,11 +89,13 @@ pub(crate) async fn create_with_invite(
             return Err(error);
         }
     };
+    let signer = Ed25519Signer::from_pem(&minted.private_key_pem)
+        .context("loading the agent proof key for BootstrapOwnerRoot")?;
     let output = finish_invite_create(server, minted, response)?;
     if let Some(state) = identity_state::load()?
         && let Some(root) = super::owner_root::load_recorded_root(&state)?
     {
-        let upload = super::owner_root::upload_claimable_root(&mut client, root).await;
+        let upload = super::owner_root::upload_claimable_root(&mut client, &signer, root).await;
         client.close().await;
         upload?;
     } else {

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -20,6 +20,7 @@ use super::{
 
 pub(crate) async fn remint(server: &str) -> Result<()> {
     let stored = mint_restricted_agent_root()?;
+    record_claimable_root_for_stored_account(server, &stored.private_key_pem)?;
     store_agent_root(
         server,
         stored.token,
@@ -29,6 +30,26 @@ pub(crate) async fn remint(server: &str) -> Result<()> {
     )?;
     print_success(&stored.subject);
     Ok(())
+}
+
+pub(crate) fn record_claimable_root_for_stored_account(
+    server: &str,
+    private_key_pem: &str,
+) -> Result<()> {
+    let Some(mut state) = identity_state::load()? else {
+        return Ok(());
+    };
+    if !super::hosted::server_keys_match(&state.server, server) {
+        return Ok(());
+    }
+    let signer = Ed25519Signer::from_pem(private_key_pem)
+        .context("loading the agent proof key for the claimable owner root")?;
+    super::owner_root::mint_and_record_claimable_root(
+        &mut state,
+        &signer,
+        chrono::Utc::now().timestamp(),
+    )?;
+    identity_state::store(&state)
 }
 
 pub(crate) async fn create_with_invite(
@@ -61,9 +82,23 @@ pub(crate) async fn create_with_invite(
         .map_err(|error| {
             anyhow::anyhow!("creating placeholder account on behalf of human: {error}")
         });
-    client.close().await;
-    let response = response?;
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            client.close().await;
+            return Err(error);
+        }
+    };
     let output = finish_invite_create(server, minted, response)?;
+    if let Some(state) = identity_state::load()?
+        && let Some(root) = super::owner_root::load_recorded_root(&state)?
+    {
+        let upload = super::owner_root::upload_claimable_root(&mut client, root).await;
+        client.close().await;
+        upload?;
+    } else {
+        client.close().await;
+    }
     emit_created(ctx, &output)?;
     Ok(())
 }
@@ -94,6 +129,7 @@ fn finish_invite_create(
         value => Some(value.to_string()),
     };
     let subject = minted.subject.clone();
+    let private_key_pem = minted.private_key_pem.clone();
     store_agent_root(
         server,
         minted.token,
@@ -105,14 +141,22 @@ fn finish_invite_create(
     let pet_name = response.pet_name;
     // Stored for later routing. `heddle claim` binds this to the configured
     // hosted server before minting the local claim bearer.
-    identity_state::store(&ClaimState::new(
+    let mut claim_state = ClaimState::new(
         server.to_string(),
         owner_id,
         subject.clone(),
         pet_name.clone(),
         hex::encode(minted.public_key),
         web_origin,
-    ))?;
+    );
+    let signer = Ed25519Signer::from_pem(&private_key_pem)
+        .context("loading the agent proof key for the claimable owner root")?;
+    super::owner_root::mint_and_record_claimable_root(
+        &mut claim_state,
+        &signer,
+        chrono::Utc::now().timestamp(),
+    )?;
+    identity_state::store(&claim_state)?;
     Ok(AgentAccountCreatedOutput {
         output_kind: "agent_account_created",
         account_id: account_id.clone(),

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -320,6 +320,10 @@ fn login_invite_create_succeeds_with_a_claim_next_directive() {
         state.web_origin.as_deref(),
         Some("https://claims.heddle.test/")
     );
+    assert!(
+        state.signed_owner_root_hex.is_some(),
+        "invite create must mint the claimable deferred-human owner root"
+    );
 }
 
 #[tokio::test]
@@ -343,4 +347,11 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         .expect("load")
         .expect("reminted into the keystore");
     assert!(!stored.token.is_empty());
+    let state = identity_state::load()
+        .expect("load")
+        .expect("claim state");
+    assert!(
+        state.signed_owner_root_hex.is_some(),
+        "remint must lazy-mint the claimable deferred-human owner root"
+    );
 }

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
@@ -4,18 +4,23 @@
 #![allow(clippy::result_large_err)]
 
 use anyhow::{Context, Result, bail};
-use api::heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode};
+use api::heddle::api::v1alpha1::{
+    AuthChallengeResponse, CallContext, CallFailure, CallFailureCode, RegisterPublicKeyRequest,
+    SignedOwnerKeyTransition, SignedOwnerRoot,
+};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{Ed25519Signer, Signer as _};
+use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use super::{
     auth::headless_token_metadata,
     hosted::claim_protocol::{
-        CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimSecretVerifier,
-        VerifiedClaimPrincipal,
+        CLAIM_CONSENT_METHOD, CLAIM_OWNER_ROOT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler,
+        ClaimSecretVerifier, VerifiedClaimPrincipal,
     },
     identity_state::{self, ClaimState},
+    owner_root::BrowserClaimDeferredHuman,
     root_mint::is_local_agent_root,
 };
 
@@ -25,12 +30,146 @@ const PROMOTE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-promote-consent-v1";
 #[derive(Clone, Debug)]
 pub(crate) struct StoredClaimAuthorization {
     completion: tokio::sync::watch::Sender<bool>,
+    owner_root_calls: tokio::sync::mpsc::Sender<ClaimOwnerRootCall>,
 }
 
 impl StoredClaimAuthorization {
-    pub(crate) fn new() -> (Self, tokio::sync::watch::Receiver<bool>) {
+    pub(crate) fn new() -> (
+        Self,
+        tokio::sync::watch::Receiver<bool>,
+        tokio::sync::mpsc::Receiver<ClaimOwnerRootCall>,
+    ) {
         let (completion, receiver) = tokio::sync::watch::channel(false);
-        (Self { completion }, receiver)
+        let (owner_root_calls, calls) = tokio::sync::mpsc::channel(1);
+        (
+            Self {
+                completion,
+                owner_root_calls,
+            },
+            receiver,
+            calls,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ClaimOwnerRootOperation {
+    resolve_handle: Option<String>,
+    registration: Option<RegisterPublicKeyRequest>,
+    browser_claim: Option<BrowserClaimDeferredHuman>,
+}
+
+pub(crate) enum ClaimOwnerRootOperationRef<'a> {
+    Resolve(&'a str),
+    CoSign {
+        registration: &'a RegisterPublicKeyRequest,
+        browser_claim: &'a BrowserClaimDeferredHuman,
+    },
+}
+
+impl ClaimOwnerRootOperation {
+    fn resolve(handle: String) -> Self {
+        Self {
+            resolve_handle: Some(handle),
+            registration: None,
+            browser_claim: None,
+        }
+    }
+
+    fn co_sign(
+        registration: RegisterPublicKeyRequest,
+        browser_claim: BrowserClaimDeferredHuman,
+    ) -> Self {
+        Self {
+            resolve_handle: None,
+            registration: Some(registration),
+            browser_claim: Some(browser_claim),
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> Option<ClaimOwnerRootOperationRef<'_>> {
+        match (
+            self.resolve_handle.as_deref(),
+            self.registration.as_ref(),
+            self.browser_claim.as_ref(),
+        ) {
+            (Some(handle), None, None) => Some(ClaimOwnerRootOperationRef::Resolve(handle)),
+            (None, Some(registration), Some(browser_claim)) => {
+                Some(ClaimOwnerRootOperationRef::CoSign {
+                    registration,
+                    browser_claim,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ClaimOwnerRootResult {
+    signed_owner_root: Option<SignedOwnerRoot>,
+    webauthn_challenge: Option<AuthChallengeResponse>,
+    signed_transition: Option<SignedOwnerKeyTransition>,
+}
+
+enum ClaimOwnerRootResultRef<'a> {
+    Resolved {
+        signed_owner_root: &'a SignedOwnerRoot,
+        webauthn_challenge: &'a AuthChallengeResponse,
+    },
+    CoSigned(&'a SignedOwnerKeyTransition),
+}
+
+impl ClaimOwnerRootResult {
+    pub(crate) fn resolved(
+        signed_owner_root: SignedOwnerRoot,
+        webauthn_challenge: AuthChallengeResponse,
+    ) -> Self {
+        Self {
+            signed_owner_root: Some(signed_owner_root),
+            webauthn_challenge: Some(webauthn_challenge),
+            signed_transition: None,
+        }
+    }
+
+    pub(crate) fn co_signed(signed_transition: SignedOwnerKeyTransition) -> Self {
+        Self {
+            signed_owner_root: None,
+            webauthn_challenge: None,
+            signed_transition: Some(signed_transition),
+        }
+    }
+
+    fn as_ref(&self) -> Option<ClaimOwnerRootResultRef<'_>> {
+        match (
+            self.signed_owner_root.as_ref(),
+            self.webauthn_challenge.as_ref(),
+            self.signed_transition.as_ref(),
+        ) {
+            (Some(signed_owner_root), Some(webauthn_challenge), None) => {
+                Some(ClaimOwnerRootResultRef::Resolved {
+                    signed_owner_root,
+                    webauthn_challenge,
+                })
+            }
+            (None, None, Some(signed_transition)) => {
+                Some(ClaimOwnerRootResultRef::CoSigned(signed_transition))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ClaimOwnerRootCall {
+    pub(crate) principal: VerifiedClaimPrincipal,
+    pub(crate) operation: ClaimOwnerRootOperation,
+    response: tokio::sync::oneshot::Sender<Result<ClaimOwnerRootResult, CallFailure>>,
+}
+
+impl ClaimOwnerRootCall {
+    pub(crate) fn respond(self, response: Result<ClaimOwnerRootResult, CallFailure>) {
+        let _ = self.response.send(response);
     }
 }
 
@@ -66,6 +205,9 @@ impl ClaimHandler for StoredClaimAuthorization {
         principal: VerifiedClaimPrincipal,
         body: &[u8],
     ) -> Result<Vec<u8>, CallFailure> {
+        if method == CLAIM_OWNER_ROOT_METHOD {
+            return self.owner_root_reply(principal, body).await;
+        }
         // Serialize the generation check and consent write. Without this
         // lock, two browser requests verified against the same one-time
         // secret could both load Active state before either consumed it.
@@ -101,11 +243,62 @@ impl ClaimHandler for StoredClaimAuthorization {
     }
 
     async fn response_delivered(&self, method: &str, body: &[u8]) {
-        if method == CLAIM_CONSENT_METHOD
-            && matches!(parse_request(body), Ok(ClaimRequest::PromoteConsent { .. }))
+        if method == CLAIM_OWNER_ROOT_METHOD
+            && matches!(parse_request(body), Ok(ClaimRequest::ClaimOwnerRoot { .. }))
         {
             self.completion.send_replace(true);
         }
+    }
+}
+
+impl StoredClaimAuthorization {
+    async fn owner_root_reply(
+        &self,
+        principal: VerifiedClaimPrincipal,
+        body: &[u8],
+    ) -> Result<Vec<u8>, CallFailure> {
+        let operation = {
+            let _guard = identity_state::write_lock().map_err(internal_failure)?;
+            let state = identity_state::load_while_locked()
+                .map_err(internal_failure)?
+                .ok_or_else(auth_failure)?;
+            let now = chrono::Utc::now().timestamp_millis();
+            if state.owner_id.to_string() != principal.subject
+                || state.authorization_hash() != principal.authorization_hash
+                || !state.is_active(now)
+            {
+                return Err(auth_failure());
+            }
+            owner_root_operation(body)?
+        };
+        let (response, receive) = tokio::sync::oneshot::channel();
+        self.owner_root_calls
+            .send(ClaimOwnerRootCall {
+                principal,
+                operation,
+                response,
+            })
+            .await
+            .map_err(|_| internal_failure("claim owner-root session is unavailable"))?;
+        let result = receive
+            .await
+            .map_err(|_| internal_failure("claim owner-root session stopped"))??;
+        let reply = match result
+            .as_ref()
+            .ok_or_else(|| internal_failure("claim owner-root result has an invalid shape"))?
+        {
+            ClaimOwnerRootResultRef::Resolved {
+                signed_owner_root,
+                webauthn_challenge,
+            } => ClaimReply::OwnerRootResolved {
+                signed_owner_root: encode_message(signed_owner_root),
+                webauthn_challenge: encode_message(webauthn_challenge),
+            },
+            ClaimOwnerRootResultRef::CoSigned(signed_transition) => ClaimReply::OwnerRootCoSigned {
+                signed_transition: encode_message(signed_transition),
+            },
+        };
+        serde_json::to_vec(&reply).map_err(internal_failure)
     }
 }
 
@@ -118,6 +311,9 @@ impl ClaimHandler for StoredClaimAuthorization {
 )]
 enum ClaimRequest {
     Resolve,
+    ResolveOwnerRoot {
+        handle: String,
+    },
     PreConsent {
         handle: String,
         nonce: String,
@@ -126,15 +322,43 @@ enum ClaimRequest {
         handle: String,
         credential_id: String,
     },
+    ClaimOwnerRoot {
+        registration: String,
+        next_authority_key: String,
+        next_authority_key_proof: String,
+        next_recovery_policy: String,
+        next_recovery_key_proofs: Vec<String>,
+        valid_from_unix_seconds: i64,
+        nonce: String,
+    },
 }
 
 #[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 enum ClaimReply {
-    Resolved { agent: AgentAccountSummary },
-    PreConsented { consent: AgentConsent },
-    PromoteConsented { consent: AgentConsent },
-    Refused { refusal: &'static str },
+    Resolved {
+        agent: AgentAccountSummary,
+    },
+    PreConsented {
+        consent: AgentConsent,
+    },
+    PromoteConsented {
+        consent: AgentConsent,
+    },
+    OwnerRootResolved {
+        signed_owner_root: String,
+        webauthn_challenge: String,
+    },
+    OwnerRootCoSigned {
+        signed_transition: String,
+    },
+    Refused {
+        refusal: &'static str,
+    },
 }
 
 #[derive(Serialize)]
@@ -228,8 +452,79 @@ pub(crate) fn consent_reply(
             let consent = signed_promote_consent(state, &handle, &credential_id, signer)?;
             serde_json::to_vec(&ClaimReply::PromoteConsented { consent }).map_err(internal_failure)
         }
-        ClaimRequest::Resolve => Err(invalid_failure("consent body has the wrong kind")),
+        ClaimRequest::Resolve
+        | ClaimRequest::ResolveOwnerRoot { .. }
+        | ClaimRequest::ClaimOwnerRoot { .. } => {
+            Err(invalid_failure("consent body has the wrong kind"))
+        }
     }
+}
+
+fn owner_root_operation(body: &[u8]) -> Result<ClaimOwnerRootOperation, CallFailure> {
+    match parse_request(body)? {
+        ClaimRequest::ResolveOwnerRoot { handle } => {
+            validate_handle(&handle)?;
+            Ok(ClaimOwnerRootOperation::resolve(handle))
+        }
+        ClaimRequest::ClaimOwnerRoot {
+            registration,
+            next_authority_key,
+            next_authority_key_proof,
+            next_recovery_policy,
+            next_recovery_key_proofs,
+            valid_from_unix_seconds,
+            nonce,
+        } => Ok(ClaimOwnerRootOperation::co_sign(
+            decode_message(&registration, "RegisterPublicKey request")?,
+            BrowserClaimDeferredHuman {
+                next_authority_key: decode_message(&next_authority_key, "next authority key")?,
+                next_authority_key_proof: decode_message(
+                    &next_authority_key_proof,
+                    "next authority key proof",
+                )?,
+                next_recovery_policy: decode_message(
+                    &next_recovery_policy,
+                    "next recovery policy",
+                )?,
+                next_recovery_key_proofs: next_recovery_key_proofs
+                    .iter()
+                    .map(|proof| decode_message(proof, "next recovery key proof"))
+                    .collect::<Result<_, _>>()?,
+                valid_from_unix_seconds,
+                nonce: decode_fixed(&nonce, "claim transition nonce")?,
+            },
+        )),
+        ClaimRequest::Resolve
+        | ClaimRequest::PreConsent { .. }
+        | ClaimRequest::PromoteConsent { .. } => {
+            Err(invalid_failure("owner-root body has the wrong kind"))
+        }
+    }
+}
+
+fn encode_message(message: &impl Message) -> String {
+    URL_SAFE_NO_PAD.encode(message.encode_to_vec())
+}
+
+fn decode_message<M: Message + Default>(
+    encoded: &str,
+    field: &'static str,
+) -> Result<M, CallFailure> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| invalid_failure(&format!("invalid {field}")))?;
+    M::decode(bytes.as_slice()).map_err(|_| invalid_failure(&format!("invalid {field}")))
+}
+
+fn decode_fixed<const N: usize>(
+    encoded: &str,
+    field: &'static str,
+) -> Result<[u8; N], CallFailure> {
+    URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| invalid_failure(&format!("invalid {field}")))?
+        .try_into()
+        .map_err(|_| invalid_failure(&format!("{field} must contain {N} bytes")))
 }
 
 pub(crate) fn signed_pre_consent(

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -6,25 +6,31 @@ use std::{
 
 use api::{
     framing::{ResponseFrame, decode_response_frame, encode_request_frame},
-    heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode},
+    heddle::api::v1alpha1::{
+        AuthChallengeResponse, AuthorizationSignature, AuthorizationVerificationKey, CallContext,
+        CallFailure, CallFailureCode, RecoveryPolicy, RegisterPublicKeyRequest,
+        SignedOwnerKeyTransition, SignedOwnerRoot,
+    },
 };
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{Ed25519Signer, Signer as _};
 use iroh::{Endpoint, RelayMode, endpoint::presets, protocol::Router};
+use prost::Message;
 use tokio::sync::Mutex;
 
 use super::{
     agent_node_identity,
     auth_login::store_agent_root,
     claim_authorization::{
-        AgentConsent, StoredClaimAuthorization, consent_reply, pre_consent_message,
-        promote_consent_message, resolved_reply, signed_pre_consent, signed_promote_consent,
-        validate_credential_id, validate_handle, verify_promotion_consents,
+        AgentConsent, ClaimOwnerRootOperationRef, ClaimOwnerRootResult, StoredClaimAuthorization,
+        consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
+        signed_pre_consent, signed_promote_consent, validate_credential_id, validate_handle,
+        verify_promotion_consents,
     },
     device_flow::restrict_agent_account_root,
     hosted::claim_protocol::{
-        CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimProtocol,
-        ClaimSecretVerifier, VerifiedClaimPrincipal,
+        CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_OWNER_ROOT_METHOD, CLAIM_RESOLVE_METHOD,
+        ClaimHandler, ClaimProtocol, ClaimSecretVerifier, VerifiedClaimPrincipal,
     },
     identity_state,
     identity_state::ClaimState,
@@ -405,6 +411,7 @@ async fn stored_endpoints() -> (
     Endpoint,
     iroh::EndpointAddr,
     tokio::sync::watch::Receiver<bool>,
+    tokio::sync::mpsc::Receiver<super::claim_authorization::ClaimOwnerRootCall>,
 ) {
     let server = Endpoint::builder(presets::Minimal)
         .relay_mode(RelayMode::Disabled)
@@ -414,7 +421,7 @@ async fn stored_endpoints() -> (
         .await
         .unwrap();
     let address = server.addr();
-    let (authorization, completion) = StoredClaimAuthorization::new();
+    let (authorization, completion, owner_root_calls) = StoredClaimAuthorization::new();
     let authorization = Arc::new(authorization);
     let router = Router::builder(server)
         .accept(
@@ -429,7 +436,7 @@ async fn stored_endpoints() -> (
         .bind()
         .await
         .unwrap();
-    (router, client, address, completion)
+    (router, client, address, completion, owner_root_calls)
 }
 
 struct IsolatedHeddleHome {
@@ -548,7 +555,7 @@ enum OwnedResponse {
 async fn production_activation_serves_full_iroh_browser_round_trip() {
     let _home = IsolatedHeddleHome::new();
     let (secret, signer) = store_production_claim_state(true);
-    let (router, client, address, mut completion) = stored_endpoints().await;
+    let (router, client, address, completion, _owner_root_calls) = stored_endpoints().await;
 
     let OwnedResponse::Success(resolved) = call(
         &client,
@@ -611,11 +618,10 @@ async fn production_activation_serves_full_iroh_browser_round_trip() {
     };
     let promote: serde_json::Value = serde_json::from_slice(&promote).unwrap();
     let promote = consent_from_reply(&promote);
-    tokio::time::timeout(std::time::Duration::from_secs(2), completion.changed())
-        .await
-        .expect("promote response delivery signal must not hang")
-        .expect("claim listener remains online");
-    assert!(*completion.borrow());
+    assert!(
+        !*completion.borrow(),
+        "legacy string consent must not complete the MODEL B owner-root claim"
+    );
     let promote_signature = URL_SAFE_NO_PAD.decode(&promote.signature).unwrap();
     let claimed = identity_state::load().unwrap().unwrap();
     Ed25519Signer::verify_with_public_key(
@@ -656,10 +662,108 @@ async fn production_activation_serves_full_iroh_browser_round_trip() {
 }
 
 #[tokio::test]
+async fn claim_owner_root_routes_resolve_and_cosign_over_the_authenticated_channel() {
+    let _home = IsolatedHeddleHome::new();
+    let (secret, _signer) = store_production_claim_state(true);
+    let (router, client, address, mut completion, mut owner_root_calls) = stored_endpoints().await;
+
+    let resolve_client = client.clone();
+    let resolve_address = address.clone();
+    let resolve_secret = secret.clone();
+    let resolve = tokio::spawn(async move {
+        call(
+            &resolve_client,
+            resolve_address,
+            CLAIM_OWNER_ROOT_METHOD,
+            &resolve_secret,
+            br#"{"kind":"resolveOwnerRoot","handle":"human-handle"}"#,
+        )
+        .await
+    });
+    let pending = owner_root_calls
+        .recv()
+        .await
+        .expect("resolve reaches cmd_claim");
+    assert!(matches!(
+        pending.operation.as_ref(),
+        Some(ClaimOwnerRootOperationRef::Resolve("human-handle"))
+    ));
+    pending.respond(Ok(ClaimOwnerRootResult::resolved(
+        SignedOwnerRoot::default(),
+        AuthChallengeResponse {
+            challenge_id: "challenge-1".to_string(),
+            challenge: "challenge".to_string(),
+            username: "human-handle".to_string(),
+            ..Default::default()
+        },
+    )));
+    let OwnedResponse::Success(resolved) = resolve.await.expect("resolve task") else {
+        panic!("owner-root resolve must succeed");
+    };
+    let resolved: serde_json::Value = serde_json::from_slice(&resolved).expect("resolve JSON");
+    assert_eq!(resolved["kind"], "ownerRootResolved");
+    SignedOwnerRoot::decode(
+        URL_SAFE_NO_PAD
+            .decode(resolved["signedOwnerRoot"].as_str().expect("root base64"))
+            .expect("root bytes")
+            .as_slice(),
+    )
+    .expect("root protobuf");
+
+    let cosign_body = serde_json::json!({
+        "kind": "claimOwnerRoot",
+        "registration": URL_SAFE_NO_PAD.encode(RegisterPublicKeyRequest::default().encode_to_vec()),
+        "nextAuthorityKey": URL_SAFE_NO_PAD.encode(AuthorizationVerificationKey::default().encode_to_vec()),
+        "nextAuthorityKeyProof": URL_SAFE_NO_PAD.encode(AuthorizationSignature::default().encode_to_vec()),
+        "nextRecoveryPolicy": URL_SAFE_NO_PAD.encode(RecoveryPolicy::default().encode_to_vec()),
+        "nextRecoveryKeyProofs": [],
+        "validFromUnixSeconds": 1,
+        "nonce": URL_SAFE_NO_PAD.encode([0x42; 32]),
+    });
+    let cosign_client = client.clone();
+    let cosign_address = address.clone();
+    let cosign_secret = secret.clone();
+    let cosign = tokio::spawn(async move {
+        call(
+            &cosign_client,
+            cosign_address,
+            CLAIM_OWNER_ROOT_METHOD,
+            &cosign_secret,
+            &serde_json::to_vec(&cosign_body).expect("cosign JSON"),
+        )
+        .await
+    });
+    let pending = owner_root_calls
+        .recv()
+        .await
+        .expect("co-sign reaches cmd_claim");
+    assert!(matches!(
+        pending.operation.as_ref(),
+        Some(ClaimOwnerRootOperationRef::CoSign { .. })
+    ));
+    pending.respond(Ok(ClaimOwnerRootResult::co_signed(
+        SignedOwnerKeyTransition::default(),
+    )));
+    let OwnedResponse::Success(cosigned) = cosign.await.expect("co-sign task") else {
+        panic!("owner-root co-sign must succeed");
+    };
+    let cosigned: serde_json::Value = serde_json::from_slice(&cosigned).expect("co-sign JSON");
+    assert_eq!(cosigned["kind"], "ownerRootCoSigned");
+    tokio::time::timeout(std::time::Duration::from_secs(2), completion.changed())
+        .await
+        .expect("co-sign delivery signal must not hang")
+        .expect("claim listener remains online");
+    assert!(*completion.borrow());
+
+    client.close().await;
+    router.shutdown().await.expect("router shutdown");
+}
+
+#[tokio::test]
 async fn dormant_stored_claim_state_reproduces_every_call_fail_closed() {
     let _home = IsolatedHeddleHome::new();
     let (inactive_secret, _signer) = store_production_claim_state(false);
-    let (router, client, address, _completion) = stored_endpoints().await;
+    let (router, client, address, _completion, _owner_root_calls) = stored_endpoints().await;
     let requests: [(&str, &[u8]); 3] = [
         (CLAIM_RESOLVE_METHOD, br#"{"kind":"resolve"}"#),
         (

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -3,18 +3,26 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::{
+    AuthChallengeResponse, BeginWebAuthnRegistrationRequest, CallFailure, CallFailureCode,
+};
 use config::UserConfig;
 use heddle_cli_args::{ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN};
 
 use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
     auth::resolve_server,
-    claim_authorization::validate_stored_claim_signer,
+    claim_authorization::{
+        ClaimOwnerRootCall, ClaimOwnerRootOperationRef, ClaimOwnerRootResult,
+        validate_stored_claim_signer,
+    },
     hosted::{canonical_server_authority, server_keys_match},
     identity_state::{self, ClaimIssuanceStatus, ClaimSecret, ClaimState},
 };
 
 const HEDDLE_SAAS_API: &str = "https://api.heddle.sh";
+const BEGIN_WEBAUTHN_REGISTRATION: &str =
+    "/heddle.api.v1alpha1.IdentityService/BeginWebAuthnRegistration";
 
 const CLAIM_STATUS_POLL: Duration = Duration::from_millis(200);
 
@@ -69,6 +77,10 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
         return Err(error);
     }
     let completion = client.claim_completion();
+    let mut owner_root_calls = client
+        .take_claim_owner_root_calls()
+        .await
+        .context("claim owner-root listener is already in use")?;
 
     let offer = match activate_offer(&state, args.timeout) {
         Ok(offer) => offer,
@@ -87,7 +99,14 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     drop(claim_link);
     drop(offer.secret);
 
-    let outcome = wait_for_claim(&offer.authorization_hash, args.timeout, completion).await;
+    let outcome = wait_for_claim(
+        &offer.authorization_hash,
+        args.timeout,
+        completion,
+        &mut owner_root_calls,
+        &client,
+    )
+    .await;
     let claimed = matches!(outcome, Ok(ClaimWaitOutcome::Claimed));
     let owner_root_claim = if claimed {
         super::owner_root::send_pending_register_public_key_claim(&mut client).await
@@ -168,6 +187,8 @@ async fn wait_for_claim(
     authorization_hash: &str,
     timeout: Duration,
     mut completion: tokio::sync::watch::Receiver<bool>,
+    owner_root_calls: &mut tokio::sync::mpsc::Receiver<ClaimOwnerRootCall>,
+    client: &super::hosted::HostedClient,
 ) -> Result<ClaimWaitOutcome> {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut poll = tokio::time::interval(CLAIM_STATUS_POLL);
@@ -190,6 +211,13 @@ async fn wait_for_claim(
                     }
                 }
             }
+            call = owner_root_calls.recv() => {
+                let call = call.context("claim owner-root listener stopped")?;
+                let response = handle_owner_root_call(client, &call)
+                    .await
+                    .map_err(CallFailure::from);
+                call.respond(response);
+            }
             result = tokio::signal::ctrl_c() => {
                 result.context("waiting for Ctrl-C")?;
                 return Ok(ClaimWaitOutcome::Interrupted);
@@ -208,7 +236,7 @@ async fn wait_for_claim(
                     ClaimIssuanceStatus::Active => {}
                     // ClaimState flips before the response is written. Wait
                     // for the delivery signal so shutdown cannot race the
-                    // browser's PromoteConsent response.
+                    // browser's ClaimOwnerRoot response.
                     ClaimIssuanceStatus::Claimed => {}
                     ClaimIssuanceStatus::Expired => return Ok(ClaimWaitOutcome::Expired),
                     ClaimIssuanceStatus::Replaced => return Ok(ClaimWaitOutcome::Replaced),
@@ -216,6 +244,181 @@ async fn wait_for_claim(
             }
         }
     }
+}
+
+async fn handle_owner_root_call(
+    client: &super::hosted::HostedClient,
+    call: &ClaimOwnerRootCall,
+) -> std::result::Result<ClaimOwnerRootResult, OwnerRootFailure> {
+    match call.operation.as_ref().ok_or_else(|| {
+        owner_root_failure(
+            CallFailureCode::Internal,
+            "claim owner-root operation has an invalid shape",
+        )
+    })? {
+        ClaimOwnerRootOperationRef::Resolve(handle) => {
+            let challenge = client
+                .call_unary::<_, AuthChallengeResponse>(
+                    BEGIN_WEBAUTHN_REGISTRATION,
+                    &BeginWebAuthnRegistrationRequest {
+                        username: handle.to_string(),
+                        display_name: handle.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .map_err(owner_root_internal)?;
+            if challenge.challenge_id.is_empty()
+                || challenge.challenge.is_empty()
+                || challenge.username != handle
+            {
+                return Err(owner_root_failure(
+                    CallFailureCode::FailedPrecondition,
+                    "weft returned an invalid owner-root registration challenge",
+                ));
+            }
+            let signed_owner_root = {
+                let _guard = identity_state::write_lock().map_err(owner_root_internal)?;
+                let mut state = active_owner_root_state(call)?;
+                let signed = super::owner_root::load_recorded_root(&state)
+                    .map_err(owner_root_internal)?
+                    .ok_or_else(|| {
+                        owner_root_failure(
+                            CallFailureCode::FailedPrecondition,
+                            "this device has no claimable sequence-0 owner root",
+                        )
+                    })?;
+                if !state.prepare_owner_root(handle, &challenge.challenge_id) {
+                    return Err(owner_root_failure(
+                        CallFailureCode::FailedPrecondition,
+                        "owner-root claim does not match the active ceremony",
+                    ));
+                }
+                identity_state::store_while_locked(&state).map_err(owner_root_internal)?;
+                signed
+            };
+            Ok(ClaimOwnerRootResult::resolved(signed_owner_root, challenge))
+        }
+        ClaimOwnerRootOperationRef::CoSign {
+            registration,
+            browser_claim,
+        } => {
+            if registration.challenge_id.is_empty() || registration.client_operation_id.is_empty() {
+                return Err(owner_root_failure(
+                    CallFailureCode::InvalidArgument,
+                    "owner-root registration requires challengeId and clientOperationId",
+                ));
+            }
+            let agent = client.claim_proof_signer().ok_or_else(|| {
+                owner_root_failure(
+                    CallFailureCode::FailedPrecondition,
+                    "the agent owner-root signing key is unavailable",
+                )
+            })?;
+            let signed_transition = {
+                let _guard = identity_state::write_lock().map_err(owner_root_internal)?;
+                let mut state = active_owner_root_state(call)?;
+                if !state.accepts_owner_root_challenge(&registration.challenge_id) {
+                    return Err(owner_root_failure(
+                        CallFailureCode::PermissionDenied,
+                        "owner-root registration challenge does not match this ceremony",
+                    ));
+                }
+                let signed_root = super::owner_root::load_recorded_root(&state)
+                    .map_err(owner_root_internal)?
+                    .ok_or_else(|| {
+                        owner_root_failure(
+                            CallFailureCode::FailedPrecondition,
+                            "this device has no claimable sequence-0 owner root",
+                        )
+                    })?;
+                let signed_transition = super::owner_root::build_claim_deferred_human(
+                    agent,
+                    &signed_root,
+                    browser_claim.clone(),
+                )
+                .map_err(|error| {
+                    tracing::warn!(%error, "browser owner-root proofs were rejected");
+                    owner_root_failure(
+                        CallFailureCode::PermissionDenied,
+                        "browser owner-root proofs do not match this device's sequence-0 root",
+                    )
+                })?;
+                super::owner_root::prepare_register_public_key_claim(
+                    &mut state,
+                    registration.clone(),
+                    signed_transition.clone(),
+                )
+                .map_err(|error| {
+                    tracing::warn!(%error, "owner-root RegisterPublicKey request was rejected");
+                    owner_root_failure(
+                        CallFailureCode::InvalidArgument,
+                        "invalid owner-root RegisterPublicKey request",
+                    )
+                })?;
+                if !state.claim_owner_root(&registration.challenge_id) {
+                    return Err(owner_root_failure(
+                        CallFailureCode::PermissionDenied,
+                        "owner-root registration challenge does not match this ceremony",
+                    ));
+                }
+                identity_state::store_while_locked(&state).map_err(owner_root_internal)?;
+                signed_transition
+            };
+            Ok(ClaimOwnerRootResult::co_signed(signed_transition))
+        }
+    }
+}
+
+fn active_owner_root_state(
+    call: &ClaimOwnerRootCall,
+) -> std::result::Result<ClaimState, OwnerRootFailure> {
+    let state = identity_state::load_while_locked()
+        .map_err(owner_root_internal)?
+        .ok_or_else(|| {
+            owner_root_failure(
+                CallFailureCode::Unauthenticated,
+                "claim authorization failed",
+            )
+        })?;
+    if state.owner_id.to_string() != call.principal.subject
+        || state.authorization_hash() != call.principal.authorization_hash
+        || !state.is_active(chrono::Utc::now().timestamp_millis())
+    {
+        return Err(owner_root_failure(
+            CallFailureCode::Unauthenticated,
+            "claim authorization failed",
+        ));
+    }
+    Ok(state)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OwnerRootFailure {
+    code: CallFailureCode,
+    message: &'static str,
+}
+
+impl From<OwnerRootFailure> for CallFailure {
+    fn from(failure: OwnerRootFailure) -> Self {
+        Self {
+            code: failure.code as i32,
+            message: failure.message.to_string(),
+            error: None,
+        }
+    }
+}
+
+fn owner_root_internal(error: impl std::fmt::Display) -> OwnerRootFailure {
+    tracing::warn!(%error, "claim owner-root exchange failed internally");
+    owner_root_failure(
+        CallFailureCode::Internal,
+        "claim owner-root exchange failed",
+    )
+}
+
+fn owner_root_failure(code: CallFailureCode, message: &'static str) -> OwnerRootFailure {
+    OwnerRootFailure { code, message }
 }
 
 fn deactivate_offer(authorization_hash: &str) -> Result<()> {

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -88,17 +88,24 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     drop(offer.secret);
 
     let outcome = wait_for_claim(&offer.authorization_hash, args.timeout, completion).await;
-    let cleanup = (!matches!(outcome, Ok(ClaimWaitOutcome::Claimed)))
+    let claimed = matches!(outcome, Ok(ClaimWaitOutcome::Claimed));
+    let owner_root_claim = if claimed {
+        super::owner_root::send_pending_register_public_key_claim(&mut client).await
+    } else {
+        Ok(None)
+    };
+    let cleanup = (!claimed)
         .then(|| deactivate_offer(&offer.authorization_hash))
         .transpose();
     client.close().await;
     cleanup?;
+    owner_root_claim?;
 
     match outcome? {
         ClaimWaitOutcome::Claimed => {
-            // Human promotion attaches the handle via the Iroh ceremony.
-            // Owner-root claim is ClaimDeferredHuman over the existing
-            // sequence-0 agent key — never a replacement OwnerRootInstall.
+            // Iroh promotes the handle. Owner-root claim is RegisterPublicKey
+            // plus ClaimDeferredHuman (tag 16) over the existing sequence-0
+            // agent key — never a replacement OwnerRootInstall.
             println!("Claim complete. This agent account now has a human owner.")
         }
         ClaimWaitOutcome::Expired => println!("Claim offer expired without changing the account."),

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -56,12 +56,18 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
         Some(server.clone()),
         HostedAuthMode::CredentialFallback,
     )?;
-    let client = session
+    let mut client = session
         .connect(([127, 0, 0, 1], 0).into())
         .await
         .with_context(|| {
             format!("connecting to {server} and bringing the claim listener online")
         })?;
+    // Upload the claimable seq-0 root before the Iroh ceremony so claim
+    // works even if this account never created a project spool.
+    if let Err(error) = client.ensure_claimable_owner_root().await {
+        client.close().await;
+        return Err(error);
+    }
     let completion = client.claim_completion();
 
     let offer = match activate_offer(&state, args.timeout) {
@@ -90,6 +96,9 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
 
     match outcome? {
         ClaimWaitOutcome::Claimed => {
+            // Human promotion attaches the handle via the Iroh ceremony.
+            // Owner-root claim is ClaimDeferredHuman over the existing
+            // sequence-0 agent key — never a replacement OwnerRootInstall.
             println!("Claim complete. This agent account now has a human owner.")
         }
         ClaimWaitOutcome::Expired => println!("Claim offer expired without changing the account."),

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -223,6 +223,9 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     // admits both for unclaimed agent-rooted accounts (weft#1852/#1853).
     "GetCurrentUserSpool",
     "CreateSpool",
+    // Install the claimable deferred-human owner root (heddle#1600).
+    "BootstrapOwnerRoot",
+    "GetCurrentOwnerKeyring",
     // Repository reads.
     "GetRefs",
     "ListStates",
@@ -281,6 +284,8 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
     // contributor writes for host-only auto-provision push.
     "GetCurrentUserSpool",
     "WhoAmI",
+    // Read of the installed owner keyring after BootstrapOwnerRoot (heddle#1600).
+    "GetCurrentOwnerKeyring",
 ];
 
 /// Collaboration writes a `contributor` adds on top of the read set.
@@ -295,6 +300,8 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
     "ResolveDiscussion",
     // Provision the caller's own child spool (host-only auto-provision push).
     "CreateSpool",
+    // Install the claimable deferred-human owner root (heddle#1600).
+    "BootstrapOwnerRoot",
 ];
 
 /// The push/pull/ref-move set a CI lander needs to run `ready`/`land`.

--- a/crates/hosted-client/src/hosted_runtime/hosted/claim_protocol.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/claim_protocol.rs
@@ -26,6 +26,7 @@ use iroh::{
 pub(crate) const CLAIM_ALPN_V1: &[u8] = b"heddle-claim/1";
 pub(crate) const CLAIM_RESOLVE_METHOD: &str = "/heddle.claim.v1.ClaimService/Resolve";
 pub(crate) const CLAIM_CONSENT_METHOD: &str = "/heddle.claim.v1.ClaimService/Consent";
+pub(crate) const CLAIM_OWNER_ROOT_METHOD: &str = "/heddle.claim.v1.ClaimService/ClaimOwnerRoot";
 
 const MAX_REQUEST_FRAME: usize = 6 + MAX_METHOD_PATH + MAX_CALL_CONTEXT + MAX_CONTROL_BODY;
 
@@ -172,7 +173,10 @@ where
 }
 
 fn validate_auth_shape(method: &str, context: &CallContext) -> Result<(), CallFailure> {
-    if !matches!(method, CLAIM_RESOLVE_METHOD | CLAIM_CONSENT_METHOD) {
+    if !matches!(
+        method,
+        CLAIM_RESOLVE_METHOD | CLAIM_CONSENT_METHOD | CLAIM_OWNER_ROOT_METHOD
+    ) {
         return Err(failure(
             CallFailureCode::Unimplemented,
             "unknown claim method",

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -26,6 +26,13 @@ pub(super) struct HostedConnection {
     provider_connections:
         Mutex<HashMap<EndpointId, Arc<Mutex<Option<iroh::endpoint::Connection>>>>>,
     claim_completion: tokio::sync::watch::Receiver<bool>,
+    claim_owner_root_calls: Mutex<
+        Option<
+            tokio::sync::mpsc::Receiver<
+                crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall,
+            >,
+        >,
+    >,
 }
 
 impl HostedConnection {
@@ -98,7 +105,7 @@ impl HostedConnection {
                 return Err(HostedError::transport(error));
             }
         };
-        let (router, claim_completion) = claim_router(endpoint.clone());
+        let (router, claim_completion, claim_owner_root_calls) = claim_router(endpoint.clone());
         Ok(Arc::new(Self {
             router,
             endpoint,
@@ -106,6 +113,7 @@ impl HostedConnection {
             provider_transport,
             provider_connections: Mutex::new(HashMap::new()),
             claim_completion,
+            claim_owner_root_calls: Mutex::new(Some(claim_owner_root_calls)),
         }))
     }
 
@@ -119,6 +127,14 @@ impl HostedConnection {
 
     pub(super) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
         self.claim_completion.clone()
+    }
+
+    pub(super) async fn take_claim_owner_root_calls(
+        &self,
+    ) -> Option<
+        tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
+    > {
+        self.claim_owner_root_calls.lock().await.take()
     }
 
     pub(super) async fn provider_connection(
@@ -187,8 +203,14 @@ async fn bind_endpoint(
     builder.bind().await.map_err(HostedError::transport)
 }
 
-fn claim_router(endpoint: Endpoint) -> (Router, tokio::sync::watch::Receiver<bool>) {
-    let (authorization, completion) =
+fn claim_router(
+    endpoint: Endpoint,
+) -> (
+    Router,
+    tokio::sync::watch::Receiver<bool>,
+    tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
+) {
+    let (authorization, completion, owner_root_calls) =
         crate::hosted_runtime::claim_authorization::StoredClaimAuthorization::new();
     let authorization = Arc::new(authorization);
     let router = Router::builder(endpoint)
@@ -197,7 +219,7 @@ fn claim_router(endpoint: Endpoint) -> (Router, tokio::sync::watch::Receiver<boo
             ClaimProtocol::new(Arc::clone(&authorization), authorization),
         )
         .spawn();
-    (router, completion)
+    (router, completion, owner_root_calls)
 }
 
 impl Drop for HostedConnection {

--- a/crates/hosted-client/src/hosted_runtime/hosted/context.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/context.rs
@@ -6,7 +6,7 @@ use std::{
 use api::{
     heddle::api::v1alpha1::{
         BearerProof, CallContext, HumanVerification, RepositoryRef, RequestProof,
-        StreamOpeningProof, TraceContext, repository_ref,
+        SignedSpoolOwnerGenesis, StreamOpeningProof, TraceContext, repository_ref,
     },
     signing,
 };
@@ -80,6 +80,40 @@ impl CallContextFactory {
 
     pub fn signing_identity(&self) -> Option<&str> {
         self.signing_identity.as_deref()
+    }
+
+    pub(super) fn proof_signer(&self) -> Option<&Ed25519Signer> {
+        self.signer.as_deref()
+    }
+
+    /// Mint CreateSpool genesis with the same device/proof key used for PoP.
+    ///
+    /// When a sequence-0 owner-root public key is already stored, refuse a
+    /// different genesis key so purge/claim stay bound to the account root.
+    pub(crate) fn mint_spool_owner_genesis(&self) -> Result<SignedSpoolOwnerGenesis> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        if let Some(seq0) = crate::hosted_runtime::owner_root::stored_seq0_public_key()
+            .map_err(|error| HostedError::Framing(error.to_string()))?
+            && seq0 != signer.public_key()
+        {
+            return Err(HostedError::Framing(
+                "CreateSpool genesis owner key does not match the account sequence-0 owner root"
+                    .to_owned(),
+            ));
+        }
+        let spool_uuid = uuid::Uuid::now_v7();
+        let signed = repo::sign_spool_owner_genesis(signer.as_ref(), *spool_uuid.as_bytes())
+            .map_err(HostedError::from)?;
+        if let Some(seq0) = crate::hosted_runtime::owner_root::stored_seq0_public_key()
+            .map_err(|error| HostedError::Framing(error.to_string()))?
+        {
+            repo::require_genesis_matches_seq0(&signed, &seq0)
+                .map_err(|error| HostedError::Framing(error.to_string()))?;
+        }
+        Ok(signed)
     }
 
     pub fn with_bearer_capability(mut self, capability: impl Into<Vec<u8>>) -> Self {
@@ -573,5 +607,36 @@ mod tests {
             )
             .unwrap();
         assert!(context.deadline.is_none());
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_requires_the_device_proof_key() {
+        let error = CallContextFactory::default()
+            .mint_spool_owner_genesis()
+            .expect_err("CreateSpool must not invent a throwaway owner key");
+        assert!(matches!(error, HostedError::SigningIdentityRequired));
+    }
+
+    #[test]
+    fn mint_spool_owner_genesis_uses_the_configured_proof_key_and_a_uuidv7() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let factory = CallContextFactory::default()
+            .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:test")
+            .unwrap();
+        let signed = factory.mint_spool_owner_genesis().unwrap();
+        let genesis = signed.genesis.expect("signed genesis payload");
+        let spool_uuid: [u8; 16] = genesis
+            .spool_uuid
+            .as_slice()
+            .try_into()
+            .expect("spool UUID is 16 bytes");
+        assert_eq!(uuid::Uuid::from_bytes(spool_uuid).get_version_num(), 7);
+        assert_eq!(
+            genesis
+                .owner_public_key
+                .expect("owner public key")
+                .public_key,
+            signer.public_key()
+        );
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/helpers.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/helpers.rs
@@ -427,7 +427,6 @@ fn remote_stream_failure(
     }
 }
 
-
 pub(super) fn repository_ref(path: &str) -> Option<RepositoryRef> {
     Some(RepositoryRef {
         reference: Some(Reference::CanonicalPath(path.to_string())),
@@ -534,8 +533,9 @@ pub(super) fn hosted_role_proto_to_string(role: i32) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use api::heddle::api::v1alpha1::{CallFailure, CallFailureCode, StreamFailure};
+
+    use super::*;
 
     #[test]
     fn grant_repository_targets_preserve_both_reference_variants() {
@@ -1211,9 +1211,11 @@ mod tests {
 
     #[test]
     fn stream_failure_round_trips_with_nested_resume_hints() {
-        use api::framing::{StreamFrame, decode_stream_frame, encode_stream_failure};
-        use api::heddle::api::v1alpha1::{
-            CursorFailure, ErrorDetail, ErrorReason, RetryAdvice, cursor_failure, error_detail,
+        use api::{
+            framing::{StreamFrame, decode_stream_frame, encode_stream_failure},
+            heddle::api::v1alpha1::{
+                CursorFailure, ErrorDetail, ErrorReason, RetryAdvice, cursor_failure, error_detail,
+            },
         };
 
         let hint = |context| ErrorDetail {

--- a/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
@@ -91,6 +91,20 @@ impl HostedRoutes<'_> {
         WhoAmIRequest,
         WhoAmIResponse
     );
+    unary_method!(
+        bootstrap_owner_root,
+        "OwnerAuthorizationService",
+        "BootstrapOwnerRoot",
+        BootstrapOwnerRootRequest,
+        BootstrapOwnerRootResponse
+    );
+    unary_method!(
+        get_current_owner_keyring,
+        "OwnerAuthorizationService",
+        "GetCurrentOwnerKeyring",
+        GetCurrentOwnerKeyringRequest,
+        GetCurrentOwnerKeyringResponse
+    );
 
     unary_method!(
         create_grant,

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -315,17 +315,30 @@ impl HostedClient {
         Request: Message,
         Response: Message + Default,
     {
-        let encoded = request.encode_to_vec();
+        self.call_unary_encoded(method, &request.encode_to_vec())
+            .await
+    }
+
+    /// Send a pre-encoded unary body so additive prost extensions (weft#1863
+    /// BootstrapOwnerRoot tag 5 / RegisterPublicKey tag 16) are covered by PoP.
+    pub async fn call_unary_encoded<Response>(
+        &self,
+        method: &str,
+        encoded: &[u8],
+    ) -> Result<Response>
+    where
+        Response: Message + Default,
+    {
         let descriptor = api::method_descriptor(method)
             .ok_or_else(|| HostedError::Framing(format!("unknown hosted method {method}")))?;
         let client_operation_id = descriptor
-            .client_operation_id(&encoded)?
+            .client_operation_id(encoded)?
             .unwrap_or_default();
         if descriptor.client_operation_id_required && client_operation_id.is_empty() {
             return Err(HostedError::MissingClientOperationId);
         }
-        let signed = self.context.unary(method, &encoded, client_operation_id)?;
-        match call::unary_encoded(&self.connection, method, &signed.context, &encoded).await {
+        let signed = self.context.unary(method, encoded, client_operation_id)?;
+        match call::unary_encoded(&self.connection, method, &signed.context, encoded).await {
             Ok(response) => Ok(response),
             Err(HostedError::Call {
                 code: api::heddle::api::v1alpha1::CallFailureCode::Unauthenticated,
@@ -362,7 +375,7 @@ impl HostedClient {
                         user_handle: assertion.user_handle.unwrap_or_default(),
                     },
                 )?;
-                call::unary_encoded(&self.connection, method, &context, &encoded).await
+                call::unary_encoded(&self.connection, method, &context, encoded).await
             }
             Err(error) => Err(error),
         }

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -68,8 +68,7 @@ use iroh::{Endpoint, EndpointAddr};
 pub use methods::HostedRoutes;
 use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
-pub use sync::HostedRefEntry;
-pub use sync::{decode_pull_bootstrap, decode_pull_refs};
+pub use sync::{HostedRefEntry, decode_pull_bootstrap, decode_pull_refs};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RenewableAuthorityCredential {
@@ -174,6 +173,18 @@ impl HostedClient {
 
     pub(crate) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
         self.connection.claim_completion()
+    }
+
+    pub(crate) async fn take_claim_owner_root_calls(
+        &self,
+    ) -> Option<
+        tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
+    > {
+        self.connection.take_claim_owner_root_calls().await
+    }
+
+    pub(crate) fn claim_proof_signer(&self) -> Option<&crypto::Ed25519Signer> {
+        self.context.proof_signer()
     }
 
     pub async fn connect(descriptor: &VerifiedEndpointDescriptor) -> Result<Self> {
@@ -331,9 +342,7 @@ impl HostedClient {
     {
         let descriptor = api::method_descriptor(method)
             .ok_or_else(|| HostedError::Framing(format!("unknown hosted method {method}")))?;
-        let client_operation_id = descriptor
-            .client_operation_id(encoded)?
-            .unwrap_or_default();
+        let client_operation_id = descriptor.client_operation_id(encoded)?.unwrap_or_default();
         if descriptor.client_operation_id_required && client_operation_id.is_empty() {
             return Err(HostedError::MissingClientOperationId);
         }

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -1,11 +1,12 @@
 use api::heddle::api::v1alpha1::{
-    ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, CheckMergeEligibilityRequest,
-    CheckMergeEligibilityResponse, CreateAgentAccountRequest, CreateAgentAccountResponse,
-    CreateGrantRequest, CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest,
-    DeleteGrantRequest, DeleteNamespaceRequest, DeleteRepositoryRequest,
-    GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
-    Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest, IssuedCredentialResponse,
-    ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
+    ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, BootstrapOwnerRootRequest,
+    BootstrapOwnerRootResponse, CheckMergeEligibilityRequest, CheckMergeEligibilityResponse,
+    CreateAgentAccountRequest, CreateAgentAccountResponse, CreateGrantRequest,
+    CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest, DeleteGrantRequest,
+    DeleteNamespaceRequest, DeleteRepositoryRequest, GetCurrentOwnerKeyringRequest,
+    GetCurrentOwnerKeyringResponse, GetCurrentUserSpoolRequest, GrantSupportAccessRequest,
+    GrantTargetRef, Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest,
+    IssuedCredentialResponse, ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
     ListThreadApprovalsRequest, MonorepoNode, ResolveMonorepoRequest, RevokeApprovalRequest,
     RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SupportAccessGrant,
     ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest, UpdateRepositoryRequest,
@@ -152,6 +153,50 @@ impl HostedClient {
         Ok(response.spools)
     }
 
+    pub(crate) async fn ensure_claimable_owner_root(&mut self) -> anyhow::Result<()> {
+        let Some(mut state) = crate::hosted_runtime::identity_state::load()? else {
+            return Ok(());
+        };
+        let signed = {
+            let Some(signer) = self.context.proof_signer() else {
+                return Ok(());
+            };
+            crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
+                &mut state,
+                signer,
+                chrono::Utc::now().timestamp(),
+            )?
+        };
+        crate::hosted_runtime::owner_root::persist_claimable_root(&state)?;
+        crate::hosted_runtime::owner_root::upload_claimable_root(self, signed).await
+    }
+
+    pub async fn bootstrap_owner_root(
+        &mut self,
+        request: BootstrapOwnerRootRequest,
+    ) -> Result<BootstrapOwnerRootResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            bootstrap_owner_root,
+            "/heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot",
+            request
+        ))
+    }
+
+    pub async fn get_current_owner_keyring(
+        &mut self,
+        request: GetCurrentOwnerKeyringRequest,
+    ) -> Result<GetCurrentOwnerKeyringResponse, ProtocolError> {
+        Ok(signed_call!(
+            self,
+            auth,
+            get_current_owner_keyring,
+            "/heddle.api.v1alpha1.OwnerAuthorizationService/GetCurrentOwnerKeyring",
+            request
+        ))
+    }
+
     pub async fn create_spool(
         &mut self,
         parent_path: &str,
@@ -159,8 +204,16 @@ impl HostedClient {
         kind: wire::HostedSpoolKind,
         display_name: Option<String>,
     ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
+        self.ensure_claimable_owner_root()
+            .await
+            .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
         let operation_id =
             ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/CreateSpool");
+        let owner_genesis = Some(
+            self.context
+                .mint_spool_owner_genesis()
+                .map_err(hosted_to_protocol_error)?,
+        );
         let spool = authed_call!(
             self,
             create_spool,
@@ -173,8 +226,7 @@ impl HostedClient {
                 visibility: Visibility::Private as i32,
                 client_operation_id: operation_id.to_wire(),
                 settings: None,
-                // Local genesis materialization is tracked separately by weft#1532.
-                owner_genesis: None,
+                owner_genesis,
             }
         );
         Ok(to_protocol_spool(spool))

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -157,18 +157,28 @@ impl HostedClient {
         let Some(mut state) = crate::hosted_runtime::identity_state::load()? else {
             return Ok(());
         };
-        let signed = {
+        if state.is_claimed() {
+            return Ok(());
+        }
+        if let Some(server) = self.server_key.as_deref()
+            && !crate::hosted_runtime::hosted::server_keys_match(&state.server, server)
+        {
+            return Ok(());
+        }
+        let (signed, signer_pem) = {
             let Some(signer) = self.context.proof_signer() else {
                 return Ok(());
             };
-            crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
+            let signed = crate::hosted_runtime::owner_root::mint_and_record_claimable_root(
                 &mut state,
                 signer,
                 chrono::Utc::now().timestamp(),
-            )?
+            )?;
+            (signed, signer.to_pem()?)
         };
         crate::hosted_runtime::owner_root::persist_claimable_root(&state)?;
-        crate::hosted_runtime::owner_root::upload_claimable_root(self, signed).await
+        let signer = crypto::Ed25519Signer::from_pem(&signer_pem)?;
+        crate::hosted_runtime::owner_root::upload_claimable_root(self, &signer, signed).await
     }
 
     pub async fn bootstrap_owner_root(

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -59,6 +59,12 @@ pub(crate) struct ClaimState {
     status: ClaimStatus,
     prepared_handle: Option<String>,
     prepared_nonce_hash: Option<String>,
+    /// Hex of the sequence-0 owner-root authority public key, when minted.
+    #[serde(default)]
+    pub(crate) seq0_public_key_hex: Option<String>,
+    /// Canonical protobuf hex of the claimable SignedOwnerRoot, when minted.
+    #[serde(default)]
+    pub(crate) signed_owner_root_hex: Option<String>,
 }
 
 impl ClaimState {
@@ -85,7 +91,23 @@ impl ClaimState {
             status: ClaimStatus::Dormant,
             prepared_handle: None,
             prepared_nonce_hash: None,
+            seq0_public_key_hex: None,
+            signed_owner_root_hex: None,
         }
+    }
+
+    pub(crate) fn seq0_public_key(&self) -> Option<Vec<u8>> {
+        let hex = self.seq0_public_key_hex.as_deref()?;
+        hex::decode(hex).ok()
+    }
+
+    pub(crate) fn record_claimable_owner_root(
+        &mut self,
+        seq0_public_key: &[u8],
+        signed_owner_root: &[u8],
+    ) {
+        self.seq0_public_key_hex = Some(hex::encode(seq0_public_key));
+        self.signed_owner_root_hex = Some(hex::encode(signed_owner_root));
     }
 
     /// Mint and activate a fresh one-time claim capability.

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -261,6 +261,30 @@ impl ClaimState {
         self.prepared_nonce_hash = None;
         true
     }
+
+    /// Bind the owner-root exchange to the handle and weft challenge returned
+    /// by this device's authenticated BeginWebAuthnRegistration call.
+    pub(crate) fn prepare_owner_root(&mut self, handle: &str, challenge_id: &str) -> bool {
+        self.prepare(handle, challenge_id.as_bytes())
+    }
+
+    /// Complete only the owner-root exchange opened by
+    /// [`Self::prepare_owner_root`].
+    pub(crate) fn accepts_owner_root_challenge(&self, challenge_id: &str) -> bool {
+        let challenge_hash = hex::encode(Sha256::digest(challenge_id.as_bytes()));
+        matches!(self.status, ClaimStatus::Prepared)
+            && self.prepared_handle.is_some()
+            && self.prepared_nonce_hash.as_deref() == Some(challenge_hash.as_str())
+    }
+
+    pub(crate) fn claim_owner_root(&mut self, challenge_id: &str) -> bool {
+        if !self.accepts_owner_root_challenge(challenge_id) {
+            return false;
+        }
+        self.status = ClaimStatus::Claimed;
+        self.prepared_nonce_hash = None;
+        true
+    }
 }
 
 pub(crate) fn state_path() -> PathBuf {
@@ -360,6 +384,17 @@ mod tests {
         assert!(state.reissue(b"second-secret", 2_000));
         assert!(!state.accepts(b"first-secret", 1_000));
         assert!(state.accepts(b"second-secret", 1_000));
+    }
+
+    #[test]
+    fn owner_root_completion_is_bound_to_the_exact_weft_challenge() {
+        let mut state = state();
+        assert!(state.reissue(b"claim-secret", 2_000));
+        assert!(state.prepare_owner_root("human-handle", "challenge-1"));
+        assert!(!state.accepts_owner_root_challenge("challenge-2"));
+        assert!(!state.claim_owner_root("challenge-2"));
+        assert!(state.claim_owner_root("challenge-1"));
+        assert!(state.is_claimed());
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/identity_state.rs
+++ b/crates/hosted-client/src/hosted_runtime/identity_state.rs
@@ -65,6 +65,9 @@ pub(crate) struct ClaimState {
     /// Canonical protobuf hex of the claimable SignedOwnerRoot, when minted.
     #[serde(default)]
     pub(crate) signed_owner_root_hex: Option<String>,
+    /// Encoded RegisterPublicKey + ClaimDeferredHuman (tag 16), waiting to send.
+    #[serde(default)]
+    pub(crate) pending_register_public_key_hex: Option<String>,
 }
 
 impl ClaimState {
@@ -93,6 +96,7 @@ impl ClaimState {
             prepared_nonce_hash: None,
             seq0_public_key_hex: None,
             signed_owner_root_hex: None,
+            pending_register_public_key_hex: None,
         }
     }
 
@@ -108,6 +112,19 @@ impl ClaimState {
     ) {
         self.seq0_public_key_hex = Some(hex::encode(seq0_public_key));
         self.signed_owner_root_hex = Some(hex::encode(signed_owner_root));
+    }
+
+    pub(crate) fn record_pending_register_public_key(&mut self, encoded: &[u8]) {
+        self.pending_register_public_key_hex = Some(hex::encode(encoded));
+    }
+
+    pub(crate) fn take_pending_register_public_key(&mut self) -> Result<Option<Vec<u8>>> {
+        let Some(hex) = self.pending_register_public_key_hex.take() else {
+            return Ok(None);
+        };
+        Ok(Some(
+            hex::decode(hex).context("decode pending RegisterPublicKey claim")?,
+        ))
     }
 
     /// Mint and activate a fresh one-time claim capability.

--- a/crates/hosted-client/src/hosted_runtime/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/mod.rs
@@ -21,6 +21,9 @@ pub(crate) mod credential_file;
 pub(crate) mod device_flow;
 pub mod hosted;
 mod identity_state;
+mod owner_root;
+#[cfg(test)]
+mod owner_root_tests;
 pub(crate) mod root_mint;
 #[cfg(test)]
 mod root_mint_tests;

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -2,20 +2,37 @@
 
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
-    BootstrapOwnerRootRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
+    AccessTokenResponse, BootstrapOwnerRootRequest, BootstrapOwnerRootResponse, OwnerKeyBinding,
+    RegisterPublicKeyRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
 };
 use crypto::{Ed25519Signer, Signer as _};
 use prost::Message;
 use repo::{
-    ClaimDeferredHuman, seq0_authority_public_key, sign_claim_deferred_human,
-    sign_claimable_deferred_human_root,
+    ClaimDeferredHuman, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_claim_deferred_human, sign_claimable_deferred_human_root,
 };
-use wire::ProtocolError;
-
 use super::{
-    hosted::{HostedClient, operation_id::ClientOperationId},
+    hosted::{HostedClient, HostedError, operation_id::ClientOperationId},
     identity_state::{self, ClaimState},
 };
+
+const BOOTSTRAP_OWNER_ROOT: &str =
+    "/heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot";
+const REGISTER_PUBLIC_KEY: &str = "/heddle.api.v1alpha1.IdentityService/RegisterPublicKey";
+
+/// Additive weft#1863 field on the raw BootstrapOwnerRoot request.
+#[derive(Clone, PartialEq, Message)]
+pub struct BootstrapOwnerRootExtension {
+    #[prost(message, optional, tag = "5")]
+    pub owner_key_binding: Option<OwnerKeyBinding>,
+}
+
+/// Additive weft#1863 field on the raw RegisterPublicKey request.
+#[derive(Clone, PartialEq, Message)]
+pub struct RegisterPublicKeyClaimExtension {
+    #[prost(message, optional, tag = "16")]
+    pub claim_deferred_human: Option<SignedOwnerKeyTransition>,
+}
 
 pub(crate) fn mint_and_record_claimable_root(
     state: &mut ClaimState,
@@ -62,23 +79,74 @@ pub(crate) fn stored_seq0_public_key() -> Result<Option<Vec<u8>>> {
     Ok(identity_state::load()?.and_then(|state| state.seq0_public_key()))
 }
 
+pub(crate) fn encode_bootstrap_owner_root(
+    request: &BootstrapOwnerRootRequest,
+    binding: &OwnerKeyBinding,
+) -> Vec<u8> {
+    let mut encoded = request.encode_to_vec();
+    encoded.extend_from_slice(
+        &BootstrapOwnerRootExtension {
+            owner_key_binding: Some(binding.clone()),
+        }
+        .encode_to_vec(),
+    );
+    encoded
+}
+
+pub(crate) fn encode_register_public_key_claim(
+    request: &RegisterPublicKeyRequest,
+    transition: &SignedOwnerKeyTransition,
+) -> Result<Vec<u8>> {
+    if request.owner_root.is_some()
+        || request.owner_root_proof_of_possession.is_some()
+        || request.owner_key_binding.is_some()
+    {
+        bail!(
+            "RegisterPublicKey claim must not send owner_root, owner_root_proof_of_possession, or owner_key_binding; those replace sequence-0"
+        );
+    }
+    let kind = transition
+        .transition
+        .as_ref()
+        .context("ClaimDeferredHuman has no body")?
+        .kind();
+    if kind != api::heddle::api::v1alpha1::OwnerKeyTransitionKind::ClaimDeferredHuman {
+        bail!("RegisterPublicKey claim extension must be ClaimDeferredHuman, got {kind:?}");
+    }
+    let mut encoded = request.encode_to_vec();
+    encoded.extend_from_slice(
+        &RegisterPublicKeyClaimExtension {
+            claim_deferred_human: Some(transition.clone()),
+        }
+        .encode_to_vec(),
+    );
+    Ok(encoded)
+}
+
 pub(crate) async fn upload_claimable_root(
     client: &mut HostedClient,
+    signer: &Ed25519Signer,
     signed: SignedOwnerRoot,
 ) -> Result<()> {
-    let operation_id =
-        ClientOperationId::fresh("heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot");
+    let operation_id = ClientOperationId::fresh(BOOTSTRAP_OWNER_ROOT);
+    let binding = sign_agent_claim_binding(signer, &signed, operation_id.as_str())
+        .context("signing AgentClaim owner-key binding for BootstrapOwnerRoot")?;
+    let request = BootstrapOwnerRootRequest {
+        owner_root: Some(signed),
+        approval: None,
+        client_operation_id: operation_id.to_wire(),
+    };
+    let encoded = encode_bootstrap_owner_root(&request, &binding);
     match client
-        .bootstrap_owner_root(BootstrapOwnerRootRequest {
-            owner_root: Some(signed),
-            approval: None,
-            client_operation_id: operation_id.to_wire(),
-        })
+        .call_unary_encoded::<BootstrapOwnerRootResponse>(BOOTSTRAP_OWNER_ROOT, &encoded)
         .await
     {
         Ok(_) => Ok(()),
-        Err(ProtocolError::AlreadyExists(_)) => Ok(()),
-        Err(ProtocolError::InvalidState(message)) if already_installed(&message) => Ok(()),
+        Err(HostedError::Call {
+            code: api::heddle::api::v1alpha1::CallFailureCode::AlreadyExists,
+            ..
+        }) => Ok(()),
+        Err(HostedError::Call { message, .. }) if already_installed(&message) => Ok(()),
         Err(error) => Err(error.into()),
     }
 }
@@ -104,6 +172,37 @@ pub(crate) fn build_claim_deferred_human(
         now_unix_seconds,
         nonce,
     })
+}
+
+pub(crate) fn prepare_register_public_key_claim(
+    state: &mut ClaimState,
+    request: RegisterPublicKeyRequest,
+    transition: SignedOwnerKeyTransition,
+) -> Result<()> {
+    let encoded = encode_register_public_key_claim(&request, &transition)?;
+    state.record_pending_register_public_key(&encoded);
+    Ok(())
+}
+
+pub(crate) async fn send_pending_register_public_key_claim(
+    client: &mut HostedClient,
+) -> Result<Option<AccessTokenResponse>> {
+    let encoded = {
+        let _guard = identity_state::write_lock()?;
+        let Some(mut state) = identity_state::load_while_locked()? else {
+            return Ok(None);
+        };
+        let Some(encoded) = state.take_pending_register_public_key()? else {
+            return Ok(None);
+        };
+        identity_state::store_while_locked(&state)?;
+        encoded
+    };
+    Ok(Some(
+        client
+            .call_unary_encoded(REGISTER_PUBLIC_KEY, &encoded)
+            .await?,
+    ))
 }
 
 fn already_installed(message: &str) -> bool {

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -1,0 +1,112 @@
+//! Claimable deferred-human owner-root mint for agent login / provision / claim.
+
+use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::{
+    BootstrapOwnerRootRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
+};
+use crypto::{Ed25519Signer, Signer as _};
+use prost::Message;
+use repo::{
+    ClaimDeferredHuman, seq0_authority_public_key, sign_claim_deferred_human,
+    sign_claimable_deferred_human_root,
+};
+use wire::ProtocolError;
+
+use super::{
+    hosted::{HostedClient, operation_id::ClientOperationId},
+    identity_state::{self, ClaimState},
+};
+
+pub(crate) fn mint_and_record_claimable_root(
+    state: &mut ClaimState,
+    signer: &Ed25519Signer,
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerRoot> {
+    if let Some(existing) = load_recorded_root(state)? {
+        let seq0 = seq0_authority_public_key(&existing)?;
+        if seq0 != signer.public_key() {
+            bail!(
+                "stored sequence-0 owner root is not this device/proof key; refusing to remint a different authority"
+            );
+        }
+        return Ok(existing);
+    }
+    let mut nonce = [0u8; 32];
+    getrandom::fill(&mut nonce).context("minting claimable owner-root nonce")?;
+    let signed = sign_claimable_deferred_human_root(
+        signer,
+        *state.owner_id.as_bytes(),
+        nonce,
+        now_unix_seconds,
+    )?;
+    let seq0 = seq0_authority_public_key(&signed)?.to_vec();
+    state.record_claimable_owner_root(&seq0, &signed.encode_to_vec());
+    Ok(signed)
+}
+
+pub(crate) fn persist_claimable_root(state: &ClaimState) -> Result<()> {
+    identity_state::store(state)
+}
+
+pub(crate) fn load_recorded_root(state: &ClaimState) -> Result<Option<SignedOwnerRoot>> {
+    let Some(hex) = state.signed_owner_root_hex.as_deref() else {
+        return Ok(None);
+    };
+    let bytes = hex::decode(hex).context("decode stored claimable owner root")?;
+    let signed =
+        SignedOwnerRoot::decode(bytes.as_slice()).context("parse stored claimable owner root")?;
+    Ok(Some(signed))
+}
+
+pub(crate) fn stored_seq0_public_key() -> Result<Option<Vec<u8>>> {
+    Ok(identity_state::load()?.and_then(|state| state.seq0_public_key()))
+}
+
+pub(crate) async fn upload_claimable_root(
+    client: &mut HostedClient,
+    signed: SignedOwnerRoot,
+) -> Result<()> {
+    let operation_id =
+        ClientOperationId::fresh("heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot");
+    match client
+        .bootstrap_owner_root(BootstrapOwnerRootRequest {
+            owner_root: Some(signed),
+            approval: None,
+            client_operation_id: operation_id.to_wire(),
+        })
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(ProtocolError::AlreadyExists(_)) => Ok(()),
+        Err(ProtocolError::InvalidState(message)) if already_installed(&message) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Build ClaimDeferredHuman. Do not send this as ClaimAgentOwner / a
+/// replacement sequence-0 OwnerRootInstall — those rewrite genesis.
+pub(crate) fn build_claim_deferred_human(
+    agent: &Ed25519Signer,
+    human: &Ed25519Signer,
+    signed_root: &SignedOwnerRoot,
+    next_recovery_policy: api::heddle::api::v1alpha1::RecoveryPolicy,
+    next_guardian_signers: &[Ed25519Signer],
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerKeyTransition> {
+    let mut nonce = [0u8; 32];
+    getrandom::fill(&mut nonce).context("minting ClaimDeferredHuman nonce")?;
+    sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: agent,
+        next_authority: human,
+        signed_root,
+        next_recovery_policy,
+        next_guardian_signers,
+        now_unix_seconds,
+        nonce,
+    })
+}
+
+fn already_installed(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    lowered.contains("already") && (lowered.contains("owner") || lowered.contains("root"))
+}

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -2,7 +2,8 @@
 
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
-    AccessTokenResponse, BootstrapOwnerRootRequest, BootstrapOwnerRootResponse, OwnerKeyBinding,
+    AccessTokenResponse, AuthorizationSignature, AuthorizationVerificationKey,
+    BootstrapOwnerRootRequest, BootstrapOwnerRootResponse, OwnerKeyBinding, RecoveryPolicy,
     RegisterPublicKeyRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
 };
 use crypto::{Ed25519Signer, Signer as _};
@@ -11,6 +12,7 @@ use repo::{
     ClaimDeferredHuman, seq0_authority_public_key, sign_agent_claim_binding,
     sign_claim_deferred_human, sign_claimable_deferred_human_root,
 };
+
 use super::{
     hosted::{HostedClient, HostedError, operation_id::ClientOperationId},
     identity_state::{self, ClaimState},
@@ -153,24 +155,30 @@ pub(crate) async fn upload_claimable_root(
 
 /// Build ClaimDeferredHuman. Do not send this as ClaimAgentOwner / a
 /// replacement sequence-0 OwnerRootInstall — those rewrite genesis.
+#[derive(Clone, Debug)]
+pub(crate) struct BrowserClaimDeferredHuman {
+    pub(crate) next_authority_key: AuthorizationVerificationKey,
+    pub(crate) next_authority_key_proof: AuthorizationSignature,
+    pub(crate) next_recovery_policy: RecoveryPolicy,
+    pub(crate) next_recovery_key_proofs: Vec<AuthorizationSignature>,
+    pub(crate) valid_from_unix_seconds: i64,
+    pub(crate) nonce: [u8; 32],
+}
+
 pub(crate) fn build_claim_deferred_human(
     agent: &Ed25519Signer,
-    human: &Ed25519Signer,
     signed_root: &SignedOwnerRoot,
-    next_recovery_policy: api::heddle::api::v1alpha1::RecoveryPolicy,
-    next_guardian_signers: &[Ed25519Signer],
-    now_unix_seconds: i64,
+    browser: BrowserClaimDeferredHuman,
 ) -> Result<SignedOwnerKeyTransition> {
-    let mut nonce = [0u8; 32];
-    getrandom::fill(&mut nonce).context("minting ClaimDeferredHuman nonce")?;
     sign_claim_deferred_human(ClaimDeferredHuman {
         current_authority: agent,
-        next_authority: human,
         signed_root,
-        next_recovery_policy,
-        next_guardian_signers,
-        now_unix_seconds,
-        nonce,
+        next_authority_key: browser.next_authority_key,
+        next_authority_key_proof: browser.next_authority_key_proof,
+        next_recovery_policy: browser.next_recovery_policy,
+        next_recovery_key_proofs: browser.next_recovery_key_proofs,
+        valid_from_unix_seconds: browser.valid_from_unix_seconds,
+        nonce: browser.nonce,
     })
 }
 

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{ffi::OsString, sync::MutexGuard};
+
+use api::heddle::api::v1alpha1::{
+    CreateAgentAccountResponse, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
+    RecoveryPolicy,
+};
+use config::credentials;
+use crypto::{Ed25519Signer, Signer as _};
+use repo::{authorization_key_id, ed25519_verification_key, seq0_authority_public_key};
+use tempfile::TempDir;
+
+use super::{
+    auth_login_agent::finish_invite_create_from_response,
+    hosted::{CallContextFactory, HostedError},
+    identity_state,
+    owner_root::{build_claim_deferred_human, load_recorded_root},
+};
+
+struct IsolatedHome {
+    _guard: MutexGuard<'static, ()>,
+    _temp: TempDir,
+    prev_home: Option<OsString>,
+    prev_heddle_home: Option<OsString>,
+    prev_credential: Option<OsString>,
+}
+
+impl IsolatedHome {
+    fn new() -> Self {
+        let guard = credentials::lock_test_env();
+        let temp = TempDir::new().expect("temp home");
+        let prev_home = std::env::var_os("HOME");
+        let prev_heddle_home = std::env::var_os("HEDDLE_HOME");
+        let prev_credential = std::env::var_os("HEDDLE_CREDENTIAL");
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("HEDDLE_HOME");
+            std::env::remove_var("HEDDLE_CREDENTIAL");
+        }
+        Self {
+            _guard: guard,
+            _temp: temp,
+            prev_home,
+            prev_heddle_home,
+            prev_credential,
+        }
+    }
+}
+
+impl Drop for IsolatedHome {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.prev_heddle_home {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match &self.prev_credential {
+                Some(value) => std::env::set_var("HEDDLE_CREDENTIAL", value),
+                None => std::env::remove_var("HEDDLE_CREDENTIAL"),
+            }
+        }
+    }
+}
+
+#[test]
+fn invite_create_mints_a_claimable_seq0_root_on_the_agent_proof_key() {
+    let _home = IsolatedHome::new();
+    let server = "api.owner-root.test";
+    let output = finish_invite_create_from_response(
+        server,
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("invite create");
+    let state = identity_state::load()
+        .expect("load")
+        .expect("claim state stored");
+    let signed = load_recorded_root(&state)
+        .expect("load root")
+        .expect("claimable root minted on signup");
+    let root = signed.root.as_ref().expect("body");
+    assert!(root.claimable_deferred_human);
+    assert_eq!(root.format_version, 1);
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0"),
+        hex::decode(&state.node_id).expect("node id").as_slice()
+    );
+    assert_eq!(
+        state.seq0_public_key().expect("recorded seq-0"),
+        hex::decode(&state.node_id).expect("node id")
+    );
+    assert_eq!(output.next.command, "heddle claim");
+}
+
+#[test]
+fn claim_transition_is_claim_deferred_human_not_a_replacement_seq0() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.claim-transition.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let agent_pem = credentials::get_server_credential("api.claim-transition.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&agent_pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    let body = transition.transition.as_ref().expect("body");
+    assert_eq!(body.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
+    assert_eq!(body.sequence, 1);
+    assert_eq!(
+        body.next_authority_key.as_ref().expect("next").public_key,
+        human.public_key()
+    );
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 survives claim"),
+        agent.public_key(),
+        "claim must not mint a replacement human sequence-0"
+    );
+}
+
+#[test]
+fn create_spool_genesis_refuses_a_key_that_is_not_seq0() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.seq0-mismatch.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let other = Ed25519Signer::generate().expect("other key");
+    let factory = CallContextFactory::default()
+        .with_signing_key_pem(&other.to_pem().expect("pem"), "principal:other")
+        .expect("factory");
+    let error = factory
+        .mint_spool_owner_genesis()
+        .expect_err("CreateSpool must refuse a genesis key that is not seq-0");
+    assert!(
+        matches!(error, HostedError::Framing(ref message) if message.contains("sequence-0")),
+        "{error}"
+    );
+}
+
+#[test]
+fn create_spool_genesis_matches_the_stored_seq0_proof_key() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.seq0-match.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let pem = credentials::get_server_credential("api.seq0-match.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let signer = Ed25519Signer::from_pem(&pem).expect("agent");
+    let factory = CallContextFactory::default()
+        .with_signing_key_pem(&pem, "principal:agent")
+        .expect("factory");
+    let genesis = factory
+        .mint_spool_owner_genesis()
+        .expect("same proof key as seq-0");
+    assert_eq!(
+        genesis
+            .genesis
+            .expect("body")
+            .owner_public_key
+            .expect("key")
+            .public_key,
+        signer.public_key()
+    );
+}

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -3,19 +3,28 @@
 use std::{ffi::OsString, sync::MutexGuard};
 
 use api::heddle::api::v1alpha1::{
-    CreateAgentAccountResponse, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
-    RecoveryPolicy,
+    BootstrapOwnerRootRequest, CreateAgentAccountResponse, OwnerKeyBindingKind,
+    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+    RegisterPublicKeyRequest, SignedOwnerRoot,
 };
 use config::credentials;
 use crypto::{Ed25519Signer, Signer as _};
-use repo::{authorization_key_id, ed25519_verification_key, seq0_authority_public_key};
+use prost::Message;
+use repo::{
+    authorization_key_id, ed25519_verification_key, seq0_authority_public_key,
+    sign_agent_claim_binding,
+};
 use tempfile::TempDir;
 
 use super::{
     auth_login_agent::finish_invite_create_from_response,
     hosted::{CallContextFactory, HostedError},
     identity_state,
-    owner_root::{build_claim_deferred_human, load_recorded_root},
+    owner_root::{
+        BootstrapOwnerRootExtension, RegisterPublicKeyClaimExtension, build_claim_deferred_human,
+        encode_bootstrap_owner_root, encode_register_public_key_claim, load_recorded_root,
+        prepare_register_public_key_claim,
+    },
 };
 
 struct IsolatedHome {
@@ -222,5 +231,213 @@ fn create_spool_genesis_matches_the_stored_seq0_proof_key() {
             .expect("key")
             .public_key,
         signer.public_key()
+    );
+}
+
+#[test]
+fn bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.bootstrap-binding.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.bootstrap-binding.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let operation_id = "op-bootstrap-1";
+    let binding = sign_agent_claim_binding(&agent, &signed, operation_id).expect("binding");
+    assert_eq!(binding.kind(), OwnerKeyBindingKind::AgentClaim);
+    let encoded = encode_bootstrap_owner_root(
+        &BootstrapOwnerRootRequest {
+            owner_root: Some(signed.clone()),
+            approval: None,
+            client_operation_id: operation_id.to_string(),
+        },
+        &binding,
+    );
+    let official = BootstrapOwnerRootRequest::decode(encoded.as_slice()).expect("official fields");
+    assert!(official.owner_root.is_some());
+    assert_eq!(official.client_operation_id, operation_id);
+    let extension = BootstrapOwnerRootExtension::decode(encoded.as_slice()).expect("tag 5");
+    let decoded = extension.owner_key_binding.expect("owner_key_binding");
+    assert_eq!(decoded.kind(), OwnerKeyBindingKind::AgentClaim);
+    assert_eq!(decoded.challenge_nonce, binding.challenge_nonce);
+}
+
+#[test]
+fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.register-claim.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.register-claim.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    let request = RegisterPublicKeyRequest {
+        challenge_id: "challenge-1".into(),
+        device_public_key: human.public_key().to_vec(),
+        client_operation_id: "op-claim-1".into(),
+        ..Default::default()
+    };
+    let encoded = encode_register_public_key_claim(&request, &transition).expect("wire");
+    let official = RegisterPublicKeyRequest::decode(encoded.as_slice()).expect("official");
+    assert!(official.owner_root.is_none());
+    assert!(official.owner_root_proof_of_possession.is_none());
+    assert!(official.owner_key_binding.is_none());
+    assert_eq!(official.device_public_key, human.public_key());
+    let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
+    let sent = extension.claim_deferred_human.expect("claim_deferred_human");
+    assert_eq!(
+        sent.transition.as_ref().expect("body").kind(),
+        OwnerKeyTransitionKind::ClaimDeferredHuman
+    );
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 survives claim encode"),
+        agent.public_key()
+    );
+}
+
+#[test]
+fn register_public_key_claim_refuses_a_replacement_seq0() {
+    let error = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            owner_root: Some(SignedOwnerRoot::default()),
+            client_operation_id: "op-bad".into(),
+            ..Default::default()
+        },
+        &Default::default(),
+    )
+    .expect_err("replacement seq-0 must not be encoded");
+    assert!(
+        error.to_string().contains("must not send owner_root"),
+        "{error}"
+    );
+}
+
+#[test]
+fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
+    let _home = IsolatedHome::new();
+    finish_invite_create_from_response(
+        "api.prepare-claim.test",
+        CreateAgentAccountResponse {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".into(),
+            pet_name: "quiet-otter".into(),
+            agent_capability: Vec::new(),
+            web_origin: String::new(),
+        },
+    )
+    .expect("signup");
+    let mut state = identity_state::load().expect("load").expect("state");
+    let signed = load_recorded_root(&state).expect("root").expect("minted");
+    let pem = credentials::get_server_credential("api.prepare-claim.test")
+        .expect("cred")
+        .expect("stored")
+        .private_key_pem
+        .expect("proof pem");
+    let agent = Ed25519Signer::from_pem(&pem).expect("agent");
+    let human = Ed25519Signer::generate().expect("human");
+    let g1 = Ed25519Signer::generate().expect("g1");
+    let g2 = Ed25519Signer::generate().expect("g2");
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g1.public_key()).expect("g1")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(g2.public_key()).expect("g2")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
+    let transition = build_claim_deferred_human(
+        &agent,
+        &human,
+        &signed,
+        RecoveryPolicy {
+            threshold: 2,
+            guardians,
+            window_secs: None,
+        },
+        &[g1, g2],
+        chrono::Utc::now().timestamp(),
+    )
+    .expect("ClaimDeferredHuman");
+    prepare_register_public_key_claim(
+        &mut state,
+        RegisterPublicKeyRequest {
+            challenge_id: "challenge-prepare".into(),
+            device_public_key: human.public_key().to_vec(),
+            client_operation_id: "op-prepare".into(),
+            ..Default::default()
+        },
+        transition,
+    )
+    .expect("prepare");
+    let encoded = state
+        .take_pending_register_public_key()
+        .expect("take")
+        .expect("pending");
+    let official = RegisterPublicKeyRequest::decode(encoded.as_slice()).expect("official");
+    assert!(official.owner_root.is_none());
+    assert!(official.owner_key_binding.is_none());
+    let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
+    assert_eq!(
+        extension
+            .claim_deferred_human
+            .expect("transition")
+            .transition
+            .expect("body")
+            .kind(),
+        OwnerKeyTransitionKind::ClaimDeferredHuman
     );
 }

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -5,15 +5,65 @@ use std::{ffi::OsString, sync::MutexGuard};
 use api::heddle::api::v1alpha1::{
     BootstrapOwnerRootRequest, CreateAgentAccountResponse, OwnerKeyBindingKind,
     OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
-    RegisterPublicKeyRequest, SignedOwnerRoot,
+    RegisterPublicKeyRequest, SignedOwnerKeyTransition, SignedOwnerRoot,
 };
 use config::credentials;
 use crypto::{Ed25519Signer, Signer as _};
 use prost::Message;
 use repo::{
-    authorization_key_id, ed25519_verification_key, seq0_authority_public_key,
-    sign_agent_claim_binding,
+    OWNER_TRANSITION_DOMAIN, authorization_key_id, claim_deferred_human_transition,
+    ed25519_verification_key, owner_key_transition_body, seq0_authority_public_key,
+    sign_agent_claim_binding, sign_canonical,
 };
+
+fn build_with_browser_proofs(
+    agent: &Ed25519Signer,
+    human: &Ed25519Signer,
+    signed_root: &SignedOwnerRoot,
+    policy: RecoveryPolicy,
+    guardian_signers: &[Ed25519Signer],
+    valid_from_unix_seconds: i64,
+) -> SignedOwnerKeyTransition {
+    let next_authority_key =
+        ed25519_verification_key(human.public_key()).expect("human public key");
+    let nonce = [0x91; 32];
+    let unsigned = claim_deferred_human_transition(
+        signed_root,
+        next_authority_key.clone(),
+        policy.clone(),
+        valid_from_unix_seconds,
+        nonce,
+    )
+    .expect("browser transition");
+    let body = owner_key_transition_body(&unsigned).expect("browser canonical body");
+    let next_authority_key_proof =
+        sign_canonical(human, OWNER_TRANSITION_DOMAIN, &body).expect("human proof");
+    let next_recovery_key_proofs = policy
+        .guardians
+        .iter()
+        .map(|guardian| {
+            let public_key = &guardian.key.as_ref().expect("guardian key").public_key;
+            let signer = guardian_signers
+                .iter()
+                .find(|signer| signer.public_key() == public_key)
+                .expect("guardian signer");
+            sign_canonical(signer, OWNER_TRANSITION_DOMAIN, &body).expect("guardian proof")
+        })
+        .collect();
+    build_claim_deferred_human(
+        agent,
+        signed_root,
+        BrowserClaimDeferredHuman {
+            next_authority_key,
+            next_authority_key_proof,
+            next_recovery_policy: policy,
+            next_recovery_key_proofs,
+            valid_from_unix_seconds,
+            nonce,
+        },
+    )
+    .expect("device co-signs ClaimDeferredHuman")
+}
 use tempfile::TempDir;
 
 use super::{
@@ -21,9 +71,9 @@ use super::{
     hosted::{CallContextFactory, HostedError},
     identity_state,
     owner_root::{
-        BootstrapOwnerRootExtension, RegisterPublicKeyClaimExtension, build_claim_deferred_human,
-        encode_bootstrap_owner_root, encode_register_public_key_claim, load_recorded_root,
-        prepare_register_public_key_claim,
+        BootstrapOwnerRootExtension, BrowserClaimDeferredHuman, RegisterPublicKeyClaimExtension,
+        build_claim_deferred_human, encode_bootstrap_owner_root, encode_register_public_key_claim,
+        load_recorded_root, prepare_register_public_key_claim,
     },
 };
 
@@ -145,7 +195,7 @@ fn claim_transition_is_claim_deferred_human_not_a_replacement_seq0() {
         },
     ];
     guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
-    let transition = build_claim_deferred_human(
+    let transition = build_with_browser_proofs(
         &agent,
         &human,
         &signed,
@@ -156,8 +206,7 @@ fn claim_transition_is_claim_deferred_human_not_a_replacement_seq0() {
         },
         &[g1, g2],
         chrono::Utc::now().timestamp(),
-    )
-    .expect("ClaimDeferredHuman");
+    );
     let body = transition.transition.as_ref().expect("body");
     assert_eq!(body.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
     assert_eq!(body.sequence, 1);
@@ -310,7 +359,7 @@ fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
         },
     ];
     guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
-    let transition = build_claim_deferred_human(
+    let transition = build_with_browser_proofs(
         &agent,
         &human,
         &signed,
@@ -321,8 +370,7 @@ fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
         },
         &[g1, g2],
         chrono::Utc::now().timestamp(),
-    )
-    .expect("ClaimDeferredHuman");
+    );
     let request = RegisterPublicKeyRequest {
         challenge_id: "challenge-1".into(),
         device_public_key: human.public_key().to_vec(),
@@ -336,7 +384,9 @@ fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
     assert!(official.owner_key_binding.is_none());
     assert_eq!(official.device_public_key, human.public_key());
     let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
-    let sent = extension.claim_deferred_human.expect("claim_deferred_human");
+    let sent = extension
+        .claim_deferred_human
+        .expect("claim_deferred_human");
     assert_eq!(
         sent.transition.as_ref().expect("body").kind(),
         OwnerKeyTransitionKind::ClaimDeferredHuman
@@ -399,7 +449,7 @@ fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
         },
     ];
     guardians.sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("key")));
-    let transition = build_claim_deferred_human(
+    let transition = build_with_browser_proofs(
         &agent,
         &human,
         &signed,
@@ -410,8 +460,7 @@ fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
         },
         &[g1, g2],
         chrono::Utc::now().timestamp(),
-    )
-    .expect("ClaimDeferredHuman");
+    );
     prepare_register_public_key_claim(
         &mut state,
         RegisterPublicKeyRequest {

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -214,10 +214,15 @@ fn restricted_agent_capability_keeps_the_deny_floor() {
 /// both server-side for unclaimed agent-rooted accounts (weft#1852/#1853).
 #[test]
 fn safe_ceiling_allows_host_only_spool_provisioning() {
-    for op in ["GetCurrentUserSpool", "CreateSpool"] {
+    for op in [
+        "GetCurrentUserSpool",
+        "CreateSpool",
+        "BootstrapOwnerRoot",
+        "GetCurrentOwnerKeyring",
+    ] {
         assert!(
             SAFE_AGENT_OPERATIONS.contains(&op),
-            "agent ceiling missing {op}: host-only auto-provision push cannot fire it"
+            "agent ceiling missing {op}: host-only auto-provision / claimable owner-root cannot fire it"
         );
     }
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -46,6 +46,15 @@ pub mod operation_dedup;
 mod owner_authorization;
 #[cfg(test)]
 mod owner_authorization_tests;
+mod owner_root;
+#[cfg(test)]
+mod owner_root_tests;
+pub use owner_root::{
+    CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, authorization_key_id,
+    ed25519_verification_key, genesis_owner_public_key, require_genesis_matches_seq0,
+    seq0_authority_public_key, sign_canonical, sign_claim_deferred_human,
+    sign_claimable_deferred_human_root, sign_spool_owner_genesis,
+};
 mod repository;
 mod repository_key_binding;
 mod repository_redaction;

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -50,8 +50,9 @@ mod owner_root;
 #[cfg(test)]
 mod owner_root_tests;
 pub use owner_root::{
-    CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, authorization_key_id,
-    ed25519_verification_key, genesis_owner_public_key, registration_binding_nonce,
+    CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, OWNER_TRANSITION_DOMAIN,
+    authorization_key_id, claim_deferred_human_transition, ed25519_verification_key,
+    genesis_owner_public_key, owner_key_transition_body, registration_binding_nonce,
     require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
     sign_canonical, sign_claim_deferred_human, sign_claimable_deferred_human_root,
     sign_spool_owner_genesis,
@@ -140,12 +141,6 @@ pub mod visibility;
 
 #[path = "worktree/mod.rs"]
 pub mod worktree;
-pub(crate) use worktree::{
-    fsmonitor, stat_signature, status_tracked_refresh, status_untracked_scan, worktree_ignore,
-    worktree_state,
-};
-pub use worktree::{git_worktree_status, worktree_index, worktree_status_options, worktree_walk};
-
 // Re-export commonly used types from underlying crates.
 pub use actor_presence::{
     ActorChainNode, ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary,
@@ -178,12 +173,12 @@ pub use git_ref_name::{
 pub use grant_audience::{GrantRole, audience_tier_for_grant};
 pub use hooks::{Hook, HookContext, HookManager, HookResponse};
 pub use merge_state::{MergeState, MergeStateManager};
-pub use objects::blame::{
-    BlameFrontierGroup, BlameFrontierRecord, BlameLineMap, BlamePreparation, BlameSliceAdvance,
-    BlameSliceError, BlameSliceLimits, OriginRange, advance_file_blame_slice, blame_file,
-    finalize_file_provenance, origin_from_state, prepare_file_blame,
-};
 pub use objects::{
+    blame::{
+        BlameFrontierGroup, BlameFrontierRecord, BlameLineMap, BlamePreparation, BlameSliceAdvance,
+        BlameSliceError, BlameSliceLimits, OriginRange, advance_file_blame_slice, blame_file,
+        finalize_file_provenance, origin_from_state, prepare_file_blame,
+    },
     error::{HeddleError as StoreError, HeddleError, Result},
     object::{
         BranchCreatedV1, CursorMovedV1, NativeToolCallRefV1, TIMELINE_OPERATION_SCHEMA_VERSION,
@@ -278,6 +273,11 @@ pub use visibility::{
     AudienceParseError, AudienceTier, ScopeDropCounts, filter_for_audience,
     filter_for_audience_with_drops, visible,
 };
+pub(crate) use worktree::{
+    fsmonitor, stat_signature, status_tracked_refresh, status_untracked_scan, worktree_ignore,
+    worktree_state,
+};
+pub use worktree::{git_worktree_status, worktree_index, worktree_status_options, worktree_walk};
 pub use worktree_index::{DirectoryCacheEntry, IndexEntry, WorktreeIndex};
 pub use worktree_state::WorktreeState;
 pub use worktree_status_options::{

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -51,9 +51,10 @@ mod owner_root;
 mod owner_root_tests;
 pub use owner_root::{
     CLAIMABLE_DEFERRED_HUMAN_TTL_SECS, ClaimDeferredHuman, authorization_key_id,
-    ed25519_verification_key, genesis_owner_public_key, require_genesis_matches_seq0,
-    seq0_authority_public_key, sign_canonical, sign_claim_deferred_human,
-    sign_claimable_deferred_human_root, sign_spool_owner_genesis,
+    ed25519_verification_key, genesis_owner_public_key, registration_binding_nonce,
+    require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_canonical, sign_claim_deferred_human, sign_claimable_deferred_human_root,
+    sign_spool_owner_genesis,
 };
 mod repository;
 mod repository_key_binding;

--- a/crates/repo/src/owner_root.rs
+++ b/crates/repo/src/owner_root.rs
@@ -13,7 +13,7 @@ use api::heddle::api::v1alpha1::{
     RecoveryPolicy, SignedOwnerKeyTransition, SignedOwnerRoot, SignedSpoolOwnerGenesis,
     SpoolOwnerGenesis,
 };
-use crypto::{Signer, SignerError};
+use crypto::{Signer, SignerError, verify_payload_signature};
 use heddleco_capability_verifier::{
     VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
     verify_spool_owner_genesis,
@@ -22,7 +22,8 @@ use sha2::{Digest, Sha256};
 
 const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
 const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
-const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+/// Domain separator shared by Heddle, tapestry, and weft for owner transitions.
+pub const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
 const OWNER_BINDING_DOMAIN: &[u8] = b"heddle-owner-key-binding-v1";
 const REGISTRATION_BINDING_NONCE_DOMAIN: &[u8] = b"heddle-owner-registration-binding-nonce-v1";
 const OWNER_ROOT_FORMAT_VERSION: u32 = 1;
@@ -101,28 +102,34 @@ pub fn sign_claimable_deferred_human_root(
     Ok(signed)
 }
 
-/// Inputs for a ClaimDeferredHuman transition. Sequence-0 stays the agent key.
-pub struct ClaimDeferredHuman<'a, C, N, G> {
+/// Browser proof material for a ClaimDeferredHuman transition.
+///
+/// Sequence-0 stays the agent key. The browser owns the next authority and
+/// guardian private keys; this device receives only their public material and
+/// signatures over the canonical transition body.
+pub struct ClaimDeferredHuman<'a, C> {
     pub current_authority: &'a C,
-    pub next_authority: &'a N,
     pub signed_root: &'a SignedOwnerRoot,
+    pub next_authority_key: AuthorizationVerificationKey,
+    pub next_authority_key_proof: AuthorizationSignature,
     pub next_recovery_policy: RecoveryPolicy,
-    pub next_guardian_signers: &'a [G],
-    pub now_unix_seconds: i64,
+    pub next_recovery_key_proofs: Vec<AuthorizationSignature>,
+    pub valid_from_unix_seconds: i64,
     pub nonce: [u8; 32],
 }
 
-/// Build ClaimDeferredHuman signed by the agent proof key and the human root.
+/// Co-sign ClaimDeferredHuman with the sequence-0 agent proof key.
 ///
-/// Does not mint a replacement sequence-0 OwnerRoot. The agent key remains
-/// genesis; the human key becomes current authority at sequence 1.
-pub fn sign_claim_deferred_human<C, N, G>(
-    claim: ClaimDeferredHuman<'_, C, N, G>,
+/// The human authority and every next guardian proof are verified before the
+/// agent key signs. The transition is rebuilt from the verified sequence-0
+/// root, so browser-supplied owner ids, state hashes, or sequences never cross
+/// this seam. The complete co-signed transition is then applied locally with
+/// the shared verifier before it may be sent to weft.
+pub fn sign_claim_deferred_human<C>(
+    claim: ClaimDeferredHuman<'_, C>,
 ) -> Result<SignedOwnerKeyTransition>
 where
     C: Signer,
-    N: Signer,
-    G: Signer,
 {
     let state = verify_owner_root(claim.signed_root).context("verify claimable sequence-0 root")?;
     let root = claim
@@ -137,46 +144,83 @@ where
     if current_key.public_key != claim.current_authority.public_key() {
         bail!("claim current authority is not the sequence-0 device/proof key");
     }
-    if claim.next_authority.public_key() == claim.current_authority.public_key() {
+    if claim.next_authority_key.public_key == claim.current_authority.public_key() {
         bail!("claim next authority must be the human device root, not the agent key");
     }
-    if claim.now_unix_seconds <= 0 {
+    let transition = claim_deferred_human_transition(
+        claim.signed_root,
+        claim.next_authority_key,
+        claim.next_recovery_policy,
+        claim.valid_from_unix_seconds,
+        claim.nonce,
+    )?;
+    let body = owner_key_transition_body(&transition)?;
+    verify_browser_claim_proofs(
+        &transition,
+        &claim.next_authority_key_proof,
+        &claim.next_recovery_key_proofs,
+        &body,
+    )?;
+    let current_proof = sign_canonical(claim.current_authority, OWNER_TRANSITION_DOMAIN, &body)?;
+    let signed = SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: vec![current_proof],
+        next_authority_key_proof: Some(claim.next_authority_key_proof),
+        next_recovery_key_proofs: claim.next_recovery_key_proofs,
+    };
+    let limits = VerificationLimits::new(MAX_CAPABILITY_TTL_SECONDS)
+        .context("construct claim transition verifier limits")?;
+    apply_transition(&state, &signed, claim.valid_from_unix_seconds, limits)
+        .context("minted ClaimDeferredHuman failed local verify")?;
+    Ok(signed)
+}
+
+/// Assemble the canonical sequence-0-to-human transition a browser signs.
+///
+/// The device calls the same builder again while co-signing; any browser body
+/// that substituted the owner id, previous state hash, or sequence therefore
+/// produces proofs that fail verification.
+pub fn claim_deferred_human_transition(
+    signed_root: &SignedOwnerRoot,
+    next_authority_key: AuthorizationVerificationKey,
+    next_recovery_policy: RecoveryPolicy,
+    valid_from_unix_seconds: i64,
+    nonce: [u8; 32],
+) -> Result<OwnerKeyTransition> {
+    let state = verify_owner_root(signed_root).context("verify claimable sequence-0 root")?;
+    let root = signed_root
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
+    if state.sequence() != 0 || !root.claimable_deferred_human {
+        bail!("claim must bind to a claimable sequence-0 owner root");
+    }
+    if valid_from_unix_seconds <= 0 {
         bail!("claim clock must be a positive unix timestamp");
     }
-    let next_authority_key = ed25519_verification_key(claim.next_authority.public_key())?;
-    let transition = OwnerKeyTransition {
+    if valid_from_unix_seconds > root.claimable_until_unix_seconds {
+        bail!("claim valid_from exceeds the sequence-0 claimable deadline");
+    }
+    Ok(OwnerKeyTransition {
         format_version: OWNER_ROOT_FORMAT_VERSION,
         owner_id: state.owner_id().to_vec(),
         previous_state_hash: state.state_hash().to_vec(),
         sequence: 1,
         kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
         next_authority_key: Some(next_authority_key),
-        next_recovery_policy: Some(claim.next_recovery_policy),
-        valid_from_unix_seconds: claim.now_unix_seconds,
+        next_recovery_policy: Some(next_recovery_policy),
+        valid_from_unix_seconds,
         previous_key_valid_until_unix_seconds: 0,
-        nonce: claim.nonce.to_vec(),
-    };
-    let body = transition_body(&transition)?;
-    let current_proof = sign_canonical(claim.current_authority, OWNER_TRANSITION_DOMAIN, &body)?;
-    let next_proof = sign_canonical(claim.next_authority, OWNER_TRANSITION_DOMAIN, &body)?;
-    let next_recovery_key_proofs =
-        guardian_proofs_in_policy_order(&transition, claim.next_guardian_signers, &body)?;
-    let signed = SignedOwnerKeyTransition {
-        transition: Some(transition),
-        authorizations: vec![current_proof],
-        next_authority_key_proof: Some(next_proof),
-        next_recovery_key_proofs,
-    };
-    let limits = VerificationLimits::new(MAX_CAPABILITY_TTL_SECONDS)
-        .context("construct claim transition verifier limits")?;
-    apply_transition(&state, &signed, claim.now_unix_seconds, limits)
-        .context("minted ClaimDeferredHuman failed local verify")?;
-    Ok(signed)
+        nonce: nonce.to_vec(),
+    })
 }
 
 /// Sequence-0 authority public key from a verified owner root.
 pub fn seq0_authority_public_key(signed: &SignedOwnerRoot) -> Result<&[u8]> {
-    let root = signed.root.as_ref().context("signed owner root has no body")?;
+    let root = signed
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
     let key = root
         .authority_key
         .as_ref()
@@ -303,43 +347,67 @@ pub fn sign_canonical(
 
 const MAX_CAPABILITY_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
 
-fn guardian_proofs_in_policy_order<G: Signer>(
+fn verify_browser_claim_proofs(
     transition: &OwnerKeyTransition,
-    signers: &[G],
+    next_authority_key_proof: &AuthorizationSignature,
+    next_recovery_key_proofs: &[AuthorizationSignature],
     body: &[u8],
-) -> Result<Vec<AuthorizationSignature>> {
+) -> Result<()> {
+    verify_canonical_signature(
+        transition
+            .next_authority_key
+            .as_ref()
+            .context("transition has no next authority key")?,
+        next_authority_key_proof,
+        OWNER_TRANSITION_DOMAIN,
+        body,
+    )
+    .context("verify browser human authority proof")?;
     let policy = transition
         .next_recovery_policy
         .as_ref()
         .context("transition has no next recovery policy")?;
-    if signers.len() != policy.guardians.len() {
+    if next_recovery_key_proofs.len() != policy.guardians.len() {
         bail!(
-            "claim guardian signer count {} does not match next recovery policy {}",
-            signers.len(),
+            "claim guardian proof count {} does not match next recovery policy {}",
+            next_recovery_key_proofs.len(),
             policy.guardians.len()
         );
     }
-    let mut unused: Vec<&G> = signers.iter().collect();
-    let mut proofs = Vec::with_capacity(policy.guardians.len());
-    for guardian in &policy.guardians {
-        let expected = authorization_key_id(
+    for (guardian, proof) in policy.guardians.iter().zip(next_recovery_key_proofs) {
+        verify_canonical_signature(
             guardian
                 .key
                 .as_ref()
                 .context("next recovery guardian has no key")?,
-        );
-        let index = unused
-            .iter()
-            .position(|signer| {
-                ed25519_verification_key(signer.public_key())
-                    .ok()
-                    .is_some_and(|key| authorization_key_id(&key) == expected)
-            })
-            .context("claim guardian signer does not match the next recovery policy")?;
-        let signer = unused.swap_remove(index);
-        proofs.push(sign_canonical(signer, OWNER_TRANSITION_DOMAIN, body)?);
+            proof,
+            OWNER_TRANSITION_DOMAIN,
+            body,
+        )
+        .context("verify browser next guardian proof")?;
     }
-    Ok(proofs)
+    Ok(())
+}
+
+fn verify_canonical_signature(
+    key: &AuthorizationVerificationKey,
+    proof: &AuthorizationSignature,
+    domain: &[u8],
+    body: &[u8],
+) -> Result<()> {
+    if key.algorithm != AuthorizationKeyAlgorithm::Ed25519 as i32 {
+        bail!("claim proof key must use Ed25519");
+    }
+    if proof.signer_key_id != authorization_key_id(key) {
+        bail!("claim proof signer key id does not match its public key");
+    }
+    verify_payload_signature(
+        &domain_digest(domain, body),
+        "ed25519",
+        &key.public_key,
+        &proof.signature,
+    )
+    .context("claim proof signature is invalid")
 }
 
 fn domain_digest(domain: &[u8], body: &[u8]) -> [u8; 32] {
@@ -428,9 +496,8 @@ fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()>
         bail!("recovery guardians are not unique and sorted by key id");
     }
     encoder.u32(policy.threshold);
-    encoder.u32(
-        u32::try_from(policy.guardians.len()).context("guardian count exceeds u32 length")?,
-    );
+    encoder
+        .u32(u32::try_from(policy.guardians.len()).context("guardian count exceeds u32 length")?);
     for value in &policy.guardians {
         guardian(encoder, value)?;
     }
@@ -501,7 +568,11 @@ fn owner_root_body(root: &OwnerRoot) -> Result<Vec<u8>> {
     Ok(encoder.finish())
 }
 
-fn transition_body(transition: &OwnerKeyTransition) -> Result<Vec<u8>> {
+/// Canonical transition body signed by owner authorities and recovery keys.
+///
+/// The field order and counted byte encoding are shared with tapestry's
+/// `transitionBody` and weft's owner-transition verifier.
+pub fn owner_key_transition_body(transition: &OwnerKeyTransition) -> Result<Vec<u8>> {
     let mut encoder = Encoder::new();
     encoder.u32(transition.format_version);
     encoder.bytes(&transition.owner_id)?;

--- a/crates/repo/src/owner_root.rs
+++ b/crates/repo/src/owner_root.rs
@@ -9,18 +9,22 @@
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
     AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
-    OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot, RecoveryPolicy, SignedOwnerKeyTransition,
-    SignedOwnerRoot, SignedSpoolOwnerGenesis, SpoolOwnerGenesis,
+    OwnerKeyBinding, OwnerKeyBindingKind, OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot,
+    RecoveryPolicy, SignedOwnerKeyTransition, SignedOwnerRoot, SignedSpoolOwnerGenesis,
+    SpoolOwnerGenesis,
 };
 use crypto::{Signer, SignerError};
 use heddleco_capability_verifier::{
-    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+    VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
+    verify_spool_owner_genesis,
 };
 use sha2::{Digest, Sha256};
 
 const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
 const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
 const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+const OWNER_BINDING_DOMAIN: &[u8] = b"heddle-owner-key-binding-v1";
+const REGISTRATION_BINDING_NONCE_DOMAIN: &[u8] = b"heddle-owner-registration-binding-nonce-v1";
 const OWNER_ROOT_FORMAT_VERSION: u32 = 1;
 const DEFAULT_RECOVERY_WINDOW_SECS: u64 = 604_800;
 
@@ -191,6 +195,58 @@ pub fn genesis_owner_public_key(signed: &SignedSpoolOwnerGenesis) -> Result<&[u8
         .as_ref()
         .context("signed spool genesis has no owner key")?;
     Ok(key.public_key.as_slice())
+}
+
+/// Nonce weft hashes as `registration_binding_nonce(client_operation_id)`.
+pub fn registration_binding_nonce(client_operation_id: &str) -> [u8; 32] {
+    Sha256::new()
+        .chain_update(REGISTRATION_BINDING_NONCE_DOMAIN)
+        .chain_update(client_operation_id.as_bytes())
+        .finalize()
+        .into()
+}
+
+/// Self-asserted AgentClaim binding of the claimable seq-0 root to the account UUID.
+///
+/// `challenge_nonce` is [`registration_binding_nonce`]. The proof must verify
+/// with `verify_owner_key_binding` against the same root.
+pub fn sign_agent_claim_binding(
+    signer: &impl Signer,
+    signed_root: &SignedOwnerRoot,
+    client_operation_id: &str,
+) -> Result<OwnerKeyBinding> {
+    let state = verify_owner_root(signed_root).context("verify claimable sequence-0 root")?;
+    let root = signed_root
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
+    let account_uuid: [u8; 16] = root
+        .account_uuid
+        .as_slice()
+        .try_into()
+        .context("owner root account_uuid must be 16 bytes")?;
+    if root
+        .authority_key
+        .as_ref()
+        .is_none_or(|key| key.public_key != signer.public_key())
+    {
+        bail!("owner-key binding signer is not the sequence-0 device/proof key");
+    }
+    let mut binding = OwnerKeyBinding {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        stable_owner_uuid: account_uuid.to_vec(),
+        root_public_key: Some(ed25519_verification_key(signer.public_key())?),
+        root_state_hash: state.state_hash().to_vec(),
+        kind: OwnerKeyBindingKind::AgentClaim as i32,
+        binding_epoch: 1,
+        challenge_nonce: registration_binding_nonce(client_operation_id).to_vec(),
+        root_proof_of_possession: None,
+    };
+    let body = owner_binding_body(&binding)?;
+    binding.root_proof_of_possession = Some(sign_canonical(signer, OWNER_BINDING_DOMAIN, &body)?);
+    verify_owner_key_binding(&binding, &state, &account_uuid)
+        .context("minted AgentClaim binding failed local verify")?;
+    Ok(binding)
 }
 
 /// Refuse CreateSpool genesis whose owner key is not the stored sequence-0 key.
@@ -380,6 +436,24 @@ fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()>
     }
     encoder.u64(policy.window_secs.unwrap_or(DEFAULT_RECOVERY_WINDOW_SECS));
     Ok(())
+}
+
+fn owner_binding_body(binding: &OwnerKeyBinding) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(binding.format_version);
+    encoder.bytes(&binding.stable_owner_uuid)?;
+    verification_key(
+        &mut encoder,
+        binding
+            .root_public_key
+            .as_ref()
+            .context("OwnerKeyBinding.root_public_key")?,
+    )?;
+    encoder.bytes(&binding.root_state_hash)?;
+    encoder.i32(binding.kind);
+    encoder.u64(binding.binding_epoch);
+    encoder.bytes(&binding.challenge_nonce)?;
+    Ok(encoder.finish())
 }
 
 fn owner_root_without_id(root: &OwnerRoot) -> Result<Vec<u8>> {

--- a/crates/repo/src/owner_root.rs
+++ b/crates/repo/src/owner_root.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Client mint for protocol-1 owner roots and ClaimDeferredHuman.
+//!
+//! Weft verifies; it does not hold the owner private key. Sequence-0 of a
+//! claimable deferred-human root is the same device/proof key CreateSpool
+//! pins as spool genesis. Claim advances authority with ClaimDeferredHuman
+//! and must not mint a replacement human sequence-0.
+
+use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::{
+    AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey,
+    OwnerKeyTransition, OwnerKeyTransitionKind, OwnerRoot, RecoveryPolicy, SignedOwnerKeyTransition,
+    SignedOwnerRoot, SignedSpoolOwnerGenesis, SpoolOwnerGenesis,
+};
+use crypto::{Signer, SignerError};
+use heddleco_capability_verifier::{
+    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+};
+use sha2::{Digest, Sha256};
+
+const OWNER_KEY_ID_DOMAIN: &[u8] = b"heddle-key-v1";
+const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
+const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+const OWNER_ROOT_FORMAT_VERSION: u32 = 1;
+const DEFAULT_RECOVERY_WINDOW_SECS: u64 = 604_800;
+
+/// Claim window for an agent-rooted deferred human root.
+pub const CLAIMABLE_DEFERRED_HUMAN_TTL_SECS: i64 = 90 * 24 * 60 * 60;
+
+/// Protocol-2 self-signature: the owner key signs `SHA-256(public_key || uuid)`.
+///
+/// CreateSpool callers mint this locally. Use a UUIDv7 — weft checks the version.
+pub fn sign_spool_owner_genesis(
+    signer: &impl Signer,
+    spool_uuid: [u8; 16],
+) -> Result<SignedSpoolOwnerGenesis, SignerError> {
+    let owner_public_key = ed25519_verification_key(signer.public_key())?;
+    let signer_key_id = authorization_key_id(&owner_public_key).to_vec();
+    let digest = Sha256::new()
+        .chain_update(&owner_public_key.public_key)
+        .chain_update(spool_uuid)
+        .finalize();
+    Ok(SignedSpoolOwnerGenesis {
+        genesis: Some(SpoolOwnerGenesis {
+            spool_uuid: spool_uuid.to_vec(),
+            owner_public_key: Some(owner_public_key),
+        }),
+        owner_signature: Some(AuthorizationSignature {
+            signer_key_id,
+            signature: signer.sign(&digest)?,
+        }),
+    })
+}
+
+/// Protocol-1 claimable deferred-human owner root.
+///
+/// Authority is the caller's device/proof key. Recovery is empty: the verifier
+/// allows that only while `claimable_deferred_human` is set. `nonce` must be
+/// 32 random bytes. `now_unix_seconds` plus [`CLAIMABLE_DEFERRED_HUMAN_TTL_SECS`]
+/// is the claim deadline.
+pub fn sign_claimable_deferred_human_root(
+    signer: &impl Signer,
+    account_uuid: [u8; 16],
+    nonce: [u8; 32],
+    now_unix_seconds: i64,
+) -> Result<SignedOwnerRoot> {
+    if now_unix_seconds <= 0 {
+        bail!("claimable owner-root clock must be a positive unix timestamp");
+    }
+    let claimable_until_unix_seconds = now_unix_seconds
+        .checked_add(CLAIMABLE_DEFERRED_HUMAN_TTL_SECS)
+        .context("claimable owner-root deadline overflows")?;
+    let authority_key = ed25519_verification_key(signer.public_key())?;
+    let mut root = OwnerRoot {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        owner_id: Vec::new(),
+        account_uuid: account_uuid.to_vec(),
+        authority_key: Some(authority_key),
+        recovery_policy: Some(RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        }),
+        claimable_deferred_human: true,
+        nonce: nonce.to_vec(),
+        claimable_until_unix_seconds,
+    };
+    root.owner_id = domain_digest(OWNER_ROOT_DOMAIN, &owner_root_without_id(&root)?).to_vec();
+    let body = owner_root_body(&root)?;
+    let authority_proof = sign_canonical(signer, OWNER_ROOT_DOMAIN, &body)?;
+    let signed = SignedOwnerRoot {
+        root: Some(root),
+        authority_proof: Some(authority_proof),
+        recovery_key_proofs: Vec::new(),
+    };
+    verify_owner_root(&signed).context("minted claimable owner root failed local verify")?;
+    Ok(signed)
+}
+
+/// Inputs for a ClaimDeferredHuman transition. Sequence-0 stays the agent key.
+pub struct ClaimDeferredHuman<'a, C, N, G> {
+    pub current_authority: &'a C,
+    pub next_authority: &'a N,
+    pub signed_root: &'a SignedOwnerRoot,
+    pub next_recovery_policy: RecoveryPolicy,
+    pub next_guardian_signers: &'a [G],
+    pub now_unix_seconds: i64,
+    pub nonce: [u8; 32],
+}
+
+/// Build ClaimDeferredHuman signed by the agent proof key and the human root.
+///
+/// Does not mint a replacement sequence-0 OwnerRoot. The agent key remains
+/// genesis; the human key becomes current authority at sequence 1.
+pub fn sign_claim_deferred_human<C, N, G>(
+    claim: ClaimDeferredHuman<'_, C, N, G>,
+) -> Result<SignedOwnerKeyTransition>
+where
+    C: Signer,
+    N: Signer,
+    G: Signer,
+{
+    let state = verify_owner_root(claim.signed_root).context("verify claimable sequence-0 root")?;
+    let root = claim
+        .signed_root
+        .root
+        .as_ref()
+        .context("signed owner root has no body")?;
+    let current_key = root
+        .authority_key
+        .as_ref()
+        .context("signed owner root has no authority")?;
+    if current_key.public_key != claim.current_authority.public_key() {
+        bail!("claim current authority is not the sequence-0 device/proof key");
+    }
+    if claim.next_authority.public_key() == claim.current_authority.public_key() {
+        bail!("claim next authority must be the human device root, not the agent key");
+    }
+    if claim.now_unix_seconds <= 0 {
+        bail!("claim clock must be a positive unix timestamp");
+    }
+    let next_authority_key = ed25519_verification_key(claim.next_authority.public_key())?;
+    let transition = OwnerKeyTransition {
+        format_version: OWNER_ROOT_FORMAT_VERSION,
+        owner_id: state.owner_id().to_vec(),
+        previous_state_hash: state.state_hash().to_vec(),
+        sequence: 1,
+        kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
+        next_authority_key: Some(next_authority_key),
+        next_recovery_policy: Some(claim.next_recovery_policy),
+        valid_from_unix_seconds: claim.now_unix_seconds,
+        previous_key_valid_until_unix_seconds: 0,
+        nonce: claim.nonce.to_vec(),
+    };
+    let body = transition_body(&transition)?;
+    let current_proof = sign_canonical(claim.current_authority, OWNER_TRANSITION_DOMAIN, &body)?;
+    let next_proof = sign_canonical(claim.next_authority, OWNER_TRANSITION_DOMAIN, &body)?;
+    let next_recovery_key_proofs =
+        guardian_proofs_in_policy_order(&transition, claim.next_guardian_signers, &body)?;
+    let signed = SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: vec![current_proof],
+        next_authority_key_proof: Some(next_proof),
+        next_recovery_key_proofs,
+    };
+    let limits = VerificationLimits::new(MAX_CAPABILITY_TTL_SECONDS)
+        .context("construct claim transition verifier limits")?;
+    apply_transition(&state, &signed, claim.now_unix_seconds, limits)
+        .context("minted ClaimDeferredHuman failed local verify")?;
+    Ok(signed)
+}
+
+/// Sequence-0 authority public key from a verified owner root.
+pub fn seq0_authority_public_key(signed: &SignedOwnerRoot) -> Result<&[u8]> {
+    let root = signed.root.as_ref().context("signed owner root has no body")?;
+    let key = root
+        .authority_key
+        .as_ref()
+        .context("signed owner root has no authority")?;
+    Ok(key.public_key.as_slice())
+}
+
+/// CreateSpool genesis owner public key.
+pub fn genesis_owner_public_key(signed: &SignedSpoolOwnerGenesis) -> Result<&[u8]> {
+    let genesis = signed
+        .genesis
+        .as_ref()
+        .context("signed spool genesis has no body")?;
+    let key = genesis
+        .owner_public_key
+        .as_ref()
+        .context("signed spool genesis has no owner key")?;
+    Ok(key.public_key.as_slice())
+}
+
+/// Refuse CreateSpool genesis whose owner key is not the stored sequence-0 key.
+pub fn require_genesis_matches_seq0(
+    genesis: &SignedSpoolOwnerGenesis,
+    seq0_public_key: &[u8],
+) -> Result<()> {
+    let verified =
+        verify_spool_owner_genesis(genesis).context("verify CreateSpool owner genesis")?;
+    if verified.owner_public_key().public_key != seq0_public_key {
+        bail!(
+            "CreateSpool genesis owner key does not match the account sequence-0 owner root; refusing to pin a different key"
+        );
+    }
+    Ok(())
+}
+
+/// Ed25519 verification key for a 32-byte public key.
+pub fn ed25519_verification_key(
+    public_key: &[u8],
+) -> Result<AuthorizationVerificationKey, SignerError> {
+    if public_key.len() != 32 {
+        return Err(SignerError::InvalidKey(format!(
+            "authorization public key must be 32 bytes, got {}",
+            public_key.len()
+        )));
+    }
+    Ok(AuthorizationVerificationKey {
+        algorithm: AuthorizationKeyAlgorithm::Ed25519 as i32,
+        public_key: public_key.to_vec(),
+    })
+}
+
+/// SHA-256("heddle-key-v1" || algorithm || public_key).
+pub fn authorization_key_id(key: &AuthorizationVerificationKey) -> [u8; 32] {
+    let mut body = Vec::with_capacity(4 + key.public_key.len());
+    body.extend_from_slice(&key.algorithm.to_be_bytes());
+    body.extend_from_slice(&key.public_key);
+    domain_digest(OWNER_KEY_ID_DOMAIN, &body)
+}
+
+/// Sign a domain-separated canonical body the way the verifier checks it.
+pub fn sign_canonical(
+    signer: &impl Signer,
+    domain: &[u8],
+    body: &[u8],
+) -> Result<AuthorizationSignature, SignerError> {
+    let key = ed25519_verification_key(signer.public_key())?;
+    Ok(AuthorizationSignature {
+        signer_key_id: authorization_key_id(&key).to_vec(),
+        signature: signer.sign(&domain_digest(domain, body))?,
+    })
+}
+
+const MAX_CAPABILITY_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
+
+fn guardian_proofs_in_policy_order<G: Signer>(
+    transition: &OwnerKeyTransition,
+    signers: &[G],
+    body: &[u8],
+) -> Result<Vec<AuthorizationSignature>> {
+    let policy = transition
+        .next_recovery_policy
+        .as_ref()
+        .context("transition has no next recovery policy")?;
+    if signers.len() != policy.guardians.len() {
+        bail!(
+            "claim guardian signer count {} does not match next recovery policy {}",
+            signers.len(),
+            policy.guardians.len()
+        );
+    }
+    let mut unused: Vec<&G> = signers.iter().collect();
+    let mut proofs = Vec::with_capacity(policy.guardians.len());
+    for guardian in &policy.guardians {
+        let expected = authorization_key_id(
+            guardian
+                .key
+                .as_ref()
+                .context("next recovery guardian has no key")?,
+        );
+        let index = unused
+            .iter()
+            .position(|signer| {
+                ed25519_verification_key(signer.public_key())
+                    .ok()
+                    .is_some_and(|key| authorization_key_id(&key) == expected)
+            })
+            .context("claim guardian signer does not match the next recovery policy")?;
+        let signer = unused.swap_remove(index);
+        proofs.push(sign_canonical(signer, OWNER_TRANSITION_DOMAIN, body)?);
+    }
+    Ok(proofs)
+}
+
+fn domain_digest(domain: &[u8], body: &[u8]) -> [u8; 32] {
+    Sha256::new()
+        .chain_update(domain)
+        .chain_update(body)
+        .finalize()
+        .into()
+}
+
+struct Encoder {
+    bytes: Vec<u8>,
+}
+
+impl Encoder {
+    const fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn raw(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn bool(&mut self, value: bool) {
+        self.bytes.push(u8::from(value));
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn i32(&mut self, value: i32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn i64(&mut self, value: i64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn bytes(&mut self, value: &[u8]) -> Result<()> {
+        let len = u32::try_from(value.len()).context("canonical collection exceeds u32 length")?;
+        self.u32(len);
+        self.raw(value);
+        Ok(())
+    }
+}
+
+fn verification_key(encoder: &mut Encoder, key: &AuthorizationVerificationKey) -> Result<()> {
+    encoder.i32(key.algorithm);
+    encoder.bytes(&key.public_key)
+}
+
+fn guardian(
+    encoder: &mut Encoder,
+    guardian: &api::heddle::api::v1alpha1::RecoveryGuardian,
+) -> Result<()> {
+    encoder.i32(guardian.kind);
+    let key = guardian
+        .key
+        .as_ref()
+        .context("recovery guardian has no key")?;
+    verification_key(encoder, key)
+}
+
+fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()> {
+    let ids = policy
+        .guardians
+        .iter()
+        .map(|value| {
+            value
+                .key
+                .as_ref()
+                .map(authorization_key_id)
+                .unwrap_or([0; 32])
+        })
+        .collect::<Vec<_>>();
+    if ids.windows(2).any(|pair| pair[0] >= pair[1]) {
+        bail!("recovery guardians are not unique and sorted by key id");
+    }
+    encoder.u32(policy.threshold);
+    encoder.u32(
+        u32::try_from(policy.guardians.len()).context("guardian count exceeds u32 length")?,
+    );
+    for value in &policy.guardians {
+        guardian(encoder, value)?;
+    }
+    encoder.u64(policy.window_secs.unwrap_or(DEFAULT_RECOVERY_WINDOW_SECS));
+    Ok(())
+}
+
+fn owner_root_without_id(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        root.authority_key
+            .as_ref()
+            .context("OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        root.recovery_policy
+            .as_ref()
+            .context("OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+fn owner_root_body(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.owner_id)?;
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        root.authority_key
+            .as_ref()
+            .context("OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        root.recovery_policy
+            .as_ref()
+            .context("OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+fn transition_body(transition: &OwnerKeyTransition) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(transition.format_version);
+    encoder.bytes(&transition.owner_id)?;
+    encoder.bytes(&transition.previous_state_hash)?;
+    encoder.u64(transition.sequence);
+    encoder.i32(transition.kind);
+    verification_key(
+        &mut encoder,
+        transition
+            .next_authority_key
+            .as_ref()
+            .context("OwnerKeyTransition.next_authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        transition
+            .next_recovery_policy
+            .as_ref()
+            .context("OwnerKeyTransition.next_recovery_policy")?,
+    )?;
+    encoder.i64(transition.valid_from_unix_seconds);
+    encoder.i64(transition.previous_key_valid_until_unix_seconds);
+    encoder.bytes(&transition.nonce)?;
+    Ok(encoder.finish())
+}

--- a/crates/repo/src/owner_root_tests.rs
+++ b/crates/repo/src/owner_root_tests.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use api::heddle::api::v1alpha1::{
+    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+};
+use crypto::Signer;
+use heddleco_capability_verifier::{
+    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+};
+
+use crate::{
+    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, require_genesis_matches_seq0,
+    seq0_authority_public_key, sign_claim_deferred_human, sign_claimable_deferred_human_root,
+    sign_spool_owner_genesis,
+};
+
+const NOW: i64 = 1_700_000_000;
+const ACCOUNT: [u8; 16] = [0x11; 16];
+
+fn paper_policy(left: &impl Signer, right: &impl Signer) -> RecoveryPolicy {
+    let mut guardians = vec![
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(left.public_key()).expect("left guardian")),
+        },
+        RecoveryGuardian {
+            kind: RecoveryGuardianKind::Paper as i32,
+            key: Some(ed25519_verification_key(right.public_key()).expect("right guardian")),
+        },
+    ];
+    guardians.sort_by_key(|guardian| {
+        authorization_key_id(guardian.key.as_ref().expect("guardian key"))
+    });
+    RecoveryPolicy {
+        threshold: 2,
+        guardians,
+        window_secs: None,
+    }
+}
+
+#[test]
+fn claimable_deferred_human_root_is_protocol_1_with_the_device_key() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x42; 32], NOW)
+        .expect("mint claimable root");
+    let state = verify_owner_root(&signed).expect("verifier accepts the minted root");
+    let root = signed.root.as_ref().expect("root body");
+
+    assert_eq!(root.format_version, 1);
+    assert!(root.claimable_deferred_human);
+    assert_eq!(
+        root.claimable_until_unix_seconds,
+        NOW + crate::CLAIMABLE_DEFERRED_HUMAN_TTL_SECS
+    );
+    assert_eq!(root.account_uuid, ACCOUNT);
+    assert_eq!(
+        root.authority_key.as_ref().expect("authority").public_key,
+        agent.public_key()
+    );
+    assert_eq!(state.sequence(), 0);
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 key"),
+        agent.public_key()
+    );
+    let policy = root
+        .recovery_policy
+        .as_ref()
+        .expect("empty recovery while claimable");
+    assert_eq!(policy.threshold, 0);
+    assert!(policy.guardians.is_empty());
+}
+
+#[test]
+fn claim_deferred_human_advances_authority_without_replacing_sequence_0() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let human = crypto::Ed25519Signer::generate().expect("human device root");
+    let g1 = crypto::Ed25519Signer::generate().expect("guardian 1");
+    let g2 = crypto::Ed25519Signer::generate().expect("guardian 2");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x7; 32], NOW)
+        .expect("mint claimable root");
+    let seq0 = seq0_authority_public_key(&signed)
+        .expect("seq-0")
+        .to_vec();
+    let policy = paper_policy(&g1, &g2);
+
+    let signed_transition = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &agent,
+        next_authority: &human,
+        signed_root: &signed,
+        next_recovery_policy: policy,
+        next_guardian_signers: &[g1, g2],
+        now_unix_seconds: NOW + 60,
+        nonce: [0x9; 32],
+    })
+    .expect("claim transition");
+
+    let transition = signed_transition.transition.as_ref().expect("transition");
+    assert_eq!(transition.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
+    assert_eq!(transition.sequence, 1);
+    assert_eq!(
+        transition
+            .next_authority_key
+            .as_ref()
+            .expect("next")
+            .public_key,
+        human.public_key()
+    );
+
+    let limits = VerificationLimits::new(30 * 24 * 60 * 60).expect("limits");
+    let claimed = apply_transition(
+        &verify_owner_root(&signed).expect("root"),
+        &signed_transition,
+        NOW + 60,
+        limits,
+    )
+    .expect("verifier applies ClaimDeferredHuman");
+    assert_eq!(claimed.sequence(), 1);
+    assert_eq!(claimed.authority_key().public_key, human.public_key());
+    assert_eq!(
+        seq0_authority_public_key(&signed).expect("seq-0 after claim"),
+        seq0.as_slice(),
+        "claim must not rewrite sequence-0"
+    );
+    assert_eq!(seq0, agent.public_key());
+}
+
+#[test]
+fn create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0() {
+    let agent = crypto::Ed25519Signer::generate().expect("device proof key");
+    let other = crypto::Ed25519Signer::generate().expect("throwaway key");
+    let spool_uuid = uuid::Uuid::now_v7();
+    assert_eq!(spool_uuid.get_version_num(), 7);
+
+    let matched = sign_spool_owner_genesis(&agent, *spool_uuid.as_bytes()).expect("genesis");
+    verify_spool_owner_genesis(&matched).expect("genesis verifies");
+    require_genesis_matches_seq0(&matched, agent.public_key()).expect("same key as seq-0");
+
+    let mismatched = sign_spool_owner_genesis(&other, *spool_uuid.as_bytes()).expect("other genesis");
+    let error = require_genesis_matches_seq0(&mismatched, agent.public_key())
+        .expect_err("throwaway per-spool key must not pass the seq-0 check");
+    assert!(
+        error.to_string().contains("sequence-0"),
+        "mismatch must name the seq-0 pin: {error}"
+    );
+}
+
+#[test]
+fn claim_refuses_to_install_the_agent_key_as_the_human_next_authority() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent");
+    let signed =
+        sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x3; 32], NOW).expect("root");
+    let error = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &agent,
+        next_authority: &agent,
+        signed_root: &signed,
+        next_recovery_policy: RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        },
+        next_guardian_signers: &[] as &[crypto::Ed25519Signer],
+        now_unix_seconds: NOW + 1,
+        nonce: [0x4; 32],
+    })
+    .expect_err("human next authority is required");
+    assert!(error.to_string().contains("human device root"), "{error}");
+}

--- a/crates/repo/src/owner_root_tests.rs
+++ b/crates/repo/src/owner_root_tests.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use api::heddle::api::v1alpha1::{
-    OwnerKeyBindingKind, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
-    RecoveryPolicy,
+    AuthorizationSignature, AuthorizationVerificationKey, OwnerKeyBindingKind, OwnerKeyTransition,
+    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+    SignedOwnerRoot,
 };
-use crypto::Signer;
+use crypto::{Signer, SignerError};
 use heddleco_capability_verifier::{
     VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
     verify_spool_owner_genesis,
@@ -13,7 +14,8 @@ use heddleco_capability_verifier::{
 use crate::{
     ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, registration_binding_nonce,
     require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
-    sign_claim_deferred_human, sign_claimable_deferred_human_root, sign_spool_owner_genesis,
+    sign_canonical, sign_claim_deferred_human, sign_claimable_deferred_human_root,
+    sign_spool_owner_genesis,
 };
 
 const NOW: i64 = 1_700_000_000;
@@ -30,14 +32,57 @@ fn paper_policy(left: &impl Signer, right: &impl Signer) -> RecoveryPolicy {
             key: Some(ed25519_verification_key(right.public_key()).expect("right guardian")),
         },
     ];
-    guardians.sort_by_key(|guardian| {
-        authorization_key_id(guardian.key.as_ref().expect("guardian key"))
-    });
+    guardians
+        .sort_by_key(|guardian| authorization_key_id(guardian.key.as_ref().expect("guardian key")));
     RecoveryPolicy {
         threshold: 2,
         guardians,
         window_secs: None,
     }
+}
+
+fn browser_claim_proofs(
+    signed_root: &SignedOwnerRoot,
+    human: &crypto::Ed25519Signer,
+    policy: &RecoveryPolicy,
+    guardian_signers: &[crypto::Ed25519Signer],
+    valid_from_unix_seconds: i64,
+    nonce: [u8; 32],
+) -> (
+    AuthorizationVerificationKey,
+    AuthorizationSignature,
+    Vec<AuthorizationSignature>,
+) {
+    let next_authority_key =
+        ed25519_verification_key(human.public_key()).expect("browser human public key");
+    let transition = crate::claim_deferred_human_transition(
+        signed_root,
+        next_authority_key.clone(),
+        policy.clone(),
+        valid_from_unix_seconds,
+        nonce,
+    )
+    .expect("browser claim transition");
+    let body = crate::owner_key_transition_body(&transition).expect("browser canonical body");
+    let next_authority_key_proof =
+        sign_canonical(human, crate::OWNER_TRANSITION_DOMAIN, &body).expect("human proof");
+    let next_recovery_key_proofs = policy
+        .guardians
+        .iter()
+        .map(|guardian| {
+            let public_key = &guardian.key.as_ref().expect("guardian key").public_key;
+            let signer = guardian_signers
+                .iter()
+                .find(|signer| signer.public_key() == public_key)
+                .expect("browser owns guardian key");
+            sign_canonical(signer, crate::OWNER_TRANSITION_DOMAIN, &body).expect("guardian proof")
+        })
+        .collect();
+    (
+        next_authority_key,
+        next_authority_key_proof,
+        next_recovery_key_proofs,
+    )
 }
 
 #[test]
@@ -73,31 +118,52 @@ fn claimable_deferred_human_root_is_protocol_1_with_the_device_key() {
 }
 
 #[test]
-fn claim_deferred_human_advances_authority_without_replacing_sequence_0() {
+fn agent_cosign_accepts_separately_produced_browser_proofs_without_human_signer() {
     let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
-    let human = crypto::Ed25519Signer::generate().expect("human device root");
-    let g1 = crypto::Ed25519Signer::generate().expect("guardian 1");
-    let g2 = crypto::Ed25519Signer::generate().expect("guardian 2");
     let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x7; 32], NOW)
         .expect("mint claimable root");
-    let seq0 = seq0_authority_public_key(&signed)
-        .expect("seq-0")
-        .to_vec();
-    let policy = paper_policy(&g1, &g2);
+    let seq0 = seq0_authority_public_key(&signed).expect("seq-0").to_vec();
+    let valid_from = NOW + 60;
+    let nonce = [0x9; 32];
+    let (
+        human_public_key,
+        policy,
+        next_authority_key,
+        next_authority_key_proof,
+        next_recovery_key_proofs,
+    ) = {
+        let human = crypto::Ed25519Signer::generate().expect("browser human device root");
+        let g1 = crypto::Ed25519Signer::generate().expect("browser guardian 1");
+        let g2 = crypto::Ed25519Signer::generate().expect("browser guardian 2");
+        let policy = paper_policy(&g1, &g2);
+        let (next_authority_key, next_authority_key_proof, next_recovery_key_proofs) =
+            browser_claim_proofs(&signed, &human, &policy, &[g1, g2], valid_from, nonce);
+        (
+            human.public_key().to_vec(),
+            policy,
+            next_authority_key,
+            next_authority_key_proof,
+            next_recovery_key_proofs,
+        )
+    };
 
     let signed_transition = sign_claim_deferred_human(ClaimDeferredHuman {
         current_authority: &agent,
-        next_authority: &human,
         signed_root: &signed,
+        next_authority_key,
+        next_authority_key_proof,
         next_recovery_policy: policy,
-        next_guardian_signers: &[g1, g2],
-        now_unix_seconds: NOW + 60,
-        nonce: [0x9; 32],
+        next_recovery_key_proofs,
+        valid_from_unix_seconds: valid_from,
+        nonce,
     })
     .expect("claim transition");
 
     let transition = signed_transition.transition.as_ref().expect("transition");
-    assert_eq!(transition.kind(), OwnerKeyTransitionKind::ClaimDeferredHuman);
+    assert_eq!(
+        transition.kind(),
+        OwnerKeyTransitionKind::ClaimDeferredHuman
+    );
     assert_eq!(transition.sequence, 1);
     assert_eq!(
         transition
@@ -105,7 +171,7 @@ fn claim_deferred_human_advances_authority_without_replacing_sequence_0() {
             .as_ref()
             .expect("next")
             .public_key,
-        human.public_key()
+        human_public_key
     );
 
     let limits = VerificationLimits::new(30 * 24 * 60 * 60).expect("limits");
@@ -117,7 +183,7 @@ fn claim_deferred_human_advances_authority_without_replacing_sequence_0() {
     )
     .expect("verifier applies ClaimDeferredHuman");
     assert_eq!(claimed.sequence(), 1);
-    assert_eq!(claimed.authority_key().public_key, human.public_key());
+    assert_eq!(claimed.authority_key().public_key, human_public_key);
     assert_eq!(
         seq0_authority_public_key(&signed).expect("seq-0 after claim"),
         seq0.as_slice(),
@@ -137,7 +203,8 @@ fn create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0() {
     verify_spool_owner_genesis(&matched).expect("genesis verifies");
     require_genesis_matches_seq0(&matched, agent.public_key()).expect("same key as seq-0");
 
-    let mismatched = sign_spool_owner_genesis(&other, *spool_uuid.as_bytes()).expect("other genesis");
+    let mismatched =
+        sign_spool_owner_genesis(&other, *spool_uuid.as_bytes()).expect("other genesis");
     let error = require_genesis_matches_seq0(&mismatched, agent.public_key())
         .expect_err("throwaway per-spool key must not pass the seq-0 check");
     assert!(
@@ -149,23 +216,174 @@ fn create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0() {
 #[test]
 fn claim_refuses_to_install_the_agent_key_as_the_human_next_authority() {
     let agent = crypto::Ed25519Signer::generate().expect("agent");
-    let signed =
-        sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x3; 32], NOW).expect("root");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x3; 32], NOW).expect("root");
     let error = sign_claim_deferred_human(ClaimDeferredHuman {
         current_authority: &agent,
-        next_authority: &agent,
         signed_root: &signed,
+        next_authority_key: ed25519_verification_key(agent.public_key()).expect("agent public"),
+        next_authority_key_proof: AuthorizationSignature::default(),
         next_recovery_policy: RecoveryPolicy {
             threshold: 0,
             guardians: Vec::new(),
             window_secs: None,
         },
-        next_guardian_signers: &[] as &[crypto::Ed25519Signer],
-        now_unix_seconds: NOW + 1,
+        next_recovery_key_proofs: Vec::new(),
+        valid_from_unix_seconds: NOW + 1,
         nonce: [0x4; 32],
     })
     .expect_err("human next authority is required");
     assert!(error.to_string().contains("human device root"), "{error}");
+}
+
+#[test]
+fn claim_deferred_human_canonical_body_matches_shared_field_order_vector() {
+    let transition = OwnerKeyTransition {
+        format_version: 1,
+        owner_id: vec![0x11; 32],
+        previous_state_hash: vec![0x22; 32],
+        sequence: 1,
+        kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
+        next_authority_key: Some(AuthorizationVerificationKey {
+            algorithm: 1,
+            public_key: vec![0x33; 32],
+        }),
+        next_recovery_policy: Some(RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        }),
+        valid_from_unix_seconds: 1,
+        previous_key_valid_until_unix_seconds: 0,
+        nonce: vec![0x44; 32],
+    };
+
+    assert_eq!(
+        crate::OWNER_TRANSITION_DOMAIN,
+        b"heddle-owner-key-transition-v1"
+    );
+    assert_eq!(
+        hex::encode(crate::owner_key_transition_body(&transition).expect("canonical body")),
+        concat!(
+            "00000001",
+            "00000020",
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "00000020",
+            "2222222222222222222222222222222222222222222222222222222222222222",
+            "0000000000000001",
+            "00000004",
+            "00000001",
+            "00000020",
+            "3333333333333333333333333333333333333333333333333333333333333333",
+            "00000000",
+            "00000000",
+            "0000000000093a80",
+            "0000000000000001",
+            "0000000000000000",
+            "00000020",
+            "4444444444444444444444444444444444444444444444444444444444444444",
+        ),
+        "must match tapestry transitionBody and weft transition_body byte-for-byte"
+    );
+}
+
+struct PanicOnSignAgent {
+    public_key: Vec<u8>,
+}
+
+impl Signer for PanicOnSignAgent {
+    fn algorithm(&self) -> &'static str {
+        "ed25519"
+    }
+
+    fn public_key(&self) -> &[u8] {
+        &self.public_key
+    }
+
+    fn sign(&self, _data: &[u8]) -> Result<Vec<u8>, SignerError> {
+        panic!("the agent must not sign before browser proofs verify")
+    }
+
+    fn verify(&self, _data: &[u8], _signature: &[u8]) -> Result<(), SignerError> {
+        Err(SignerError::VerificationFailed)
+    }
+}
+
+#[test]
+fn forged_owner_state_binding_is_rejected_before_the_device_signs() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent");
+    let human = crypto::Ed25519Signer::generate().expect("browser human key");
+    let signed_root =
+        sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x51; 32], NOW).expect("root");
+    let policy = RecoveryPolicy {
+        threshold: 0,
+        guardians: Vec::new(),
+        window_secs: None,
+    };
+    let next_authority_key =
+        ed25519_verification_key(human.public_key()).expect("human public key");
+    let mut forged_transition = crate::claim_deferred_human_transition(
+        &signed_root,
+        next_authority_key.clone(),
+        policy.clone(),
+        NOW + 1,
+        [0x52; 32],
+    )
+    .expect("browser transition");
+    forged_transition.owner_id[0] ^= 0xff;
+    forged_transition.previous_state_hash[0] ^= 0xff;
+    forged_transition.sequence = 2;
+    let forged_body =
+        crate::owner_key_transition_body(&forged_transition).expect("forged body encodes");
+    let next_authority_key_proof =
+        sign_canonical(&human, crate::OWNER_TRANSITION_DOMAIN, &forged_body)
+            .expect("browser signs forged body");
+    let public_only_agent = PanicOnSignAgent {
+        public_key: agent.public_key().to_vec(),
+    };
+
+    let error = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &public_only_agent,
+        signed_root: &signed_root,
+        next_authority_key,
+        next_authority_key_proof,
+        next_recovery_policy: policy,
+        next_recovery_key_proofs: Vec::new(),
+        valid_from_unix_seconds: NOW + 1,
+        nonce: [0x52; 32],
+    })
+    .expect_err("proof over a different canonical body must fail closed");
+    assert!(
+        error.to_string().contains("human authority proof"),
+        "{error}"
+    );
+}
+
+#[test]
+fn claim_after_sequence_zero_deadline_is_rejected_before_the_device_signs() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent");
+    let human = crypto::Ed25519Signer::generate().expect("browser human key");
+    let signed_root =
+        sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x61; 32], NOW).expect("root");
+    let public_only_agent = PanicOnSignAgent {
+        public_key: agent.public_key().to_vec(),
+    };
+
+    let error = sign_claim_deferred_human(ClaimDeferredHuman {
+        current_authority: &public_only_agent,
+        signed_root: &signed_root,
+        next_authority_key: ed25519_verification_key(human.public_key()).expect("human public key"),
+        next_authority_key_proof: AuthorizationSignature::default(),
+        next_recovery_policy: RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+            window_secs: None,
+        },
+        next_recovery_key_proofs: Vec::new(),
+        valid_from_unix_seconds: NOW + crate::CLAIMABLE_DEFERRED_HUMAN_TTL_SECS + 1,
+        nonce: [0x62; 32],
+    })
+    .expect_err("expired claimable sequence-0 root must fail closed");
+    assert!(error.to_string().contains("claimable deadline"), "{error}");
 }
 
 #[test]

--- a/crates/repo/src/owner_root_tests.rs
+++ b/crates/repo/src/owner_root_tests.rs
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use api::heddle::api::v1alpha1::{
-    OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy,
+    OwnerKeyBindingKind, OwnerKeyTransitionKind, RecoveryGuardian, RecoveryGuardianKind,
+    RecoveryPolicy,
 };
 use crypto::Signer;
 use heddleco_capability_verifier::{
-    VerificationLimits, apply_transition, verify_owner_root, verify_spool_owner_genesis,
+    VerificationLimits, apply_transition, verify_owner_key_binding, verify_owner_root,
+    verify_spool_owner_genesis,
 };
 
 use crate::{
-    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, require_genesis_matches_seq0,
-    seq0_authority_public_key, sign_claim_deferred_human, sign_claimable_deferred_human_root,
-    sign_spool_owner_genesis,
+    ClaimDeferredHuman, authorization_key_id, ed25519_verification_key, registration_binding_nonce,
+    require_genesis_matches_seq0, seq0_authority_public_key, sign_agent_claim_binding,
+    sign_claim_deferred_human, sign_claimable_deferred_human_root, sign_spool_owner_genesis,
 };
 
 const NOW: i64 = 1_700_000_000;
@@ -164,4 +166,21 @@ fn claim_refuses_to_install_the_agent_key_as_the_human_next_authority() {
     })
     .expect_err("human next authority is required");
     assert!(error.to_string().contains("human device root"), "{error}");
+}
+
+#[test]
+fn agent_claim_binding_uses_registration_nonce_and_verifies_against_the_root() {
+    let agent = crypto::Ed25519Signer::generate().expect("agent proof key");
+    let signed = sign_claimable_deferred_human_root(&agent, ACCOUNT, [0x5; 32], NOW)
+        .expect("mint claimable root");
+    let operation_id = "op-bind-1";
+    let binding = sign_agent_claim_binding(&agent, &signed, operation_id).expect("binding");
+    assert_eq!(binding.kind(), OwnerKeyBindingKind::AgentClaim);
+    assert_eq!(binding.binding_epoch, 1);
+    assert_eq!(
+        binding.challenge_nonce.as_slice(),
+        registration_binding_nonce(operation_id).as_slice()
+    );
+    let state = verify_owner_root(&signed).expect("root");
+    verify_owner_key_binding(&binding, &state, &ACCOUNT).expect("weft verifies the binding");
 }


### PR DESCRIPTION
Closes #1603. Supersedes #1601 (this branch contains #1601's encoders and wires them live).

Implements the **device half** of the two-party co-signed `ClaimDeferredHuman` owner-root claim (epic weft#1861, MODEL B; server arm merged as weft#1863).

## What
- Splits `sign_claim_deferred_human` into an **agent-only** co-sign: recomputes the transition body, verifies the browser-produced human + guardian proofs against it, and signs **only** `authorizations[0]`. The device never holds the human key.
- Extends `heddle-claim/1` with `ClaimOwnerRoot` and wires `cmd_claim` through `prepare/send_pending_register_public_key_claim`, making the `owner_root` encoders **live** (clears the `-D dead-code` gate #1601 fails).
- Fail-closed device gate before signing: `next_authority_key != agent key`; recomputed body binds to this device's stored seq-0 root (`sequence == 1`, `previous_state_hash`/`owner_id`); `valid_from <= claimable_until`; human + guardian proofs verify.

## Silent-failure guards
- Domain separator pinned to `heddle-owner-key-transition-v1` (matches weft `owner_registration.rs` + tapestry `canonical.ts`).
- Counted-statement field order pinned by a shared vector test `claim_deferred_human_canonical_body_matches_shared_field_order_vector`, so heddle-sign / weft-verify / browser-sign cannot diverge.

## Merge note
Reconciled with main's #1599 (`SignedSpoolOwnerGenesis`): deduped the now-duplicate `sign_spool_owner_genesis` to the canonical `owner_authorization` copy (byte-identical: same `Sha256(b"heddle-key-v1"‖alg_be32‖pubkey)` key-id and `Sha256(pubkey‖uuid)` digest), and kept #1603's seq0-binding guard in `mint_spool_owner_genesis`.

## Verification (box)
- `clippy --all-targets -- -D warnings -D dead-code` clean (repo + hosted-client).
- owner_root 8/0 incl. field-order vector + `create_spool_genesis_uses_the_device_key_and_refuses_a_different_seq0`; owner_authorization 5/0.
- The device→weft `RegisterPublicKey` e2e is now unblocked (weft#1863 merged) and the browser↔device transport lands with tapestry#467 / iroh-web#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790620828&installation_model_id=21489&pr_number=1605&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1605&signature=45d07853694acb639e6244b778bf28653fa94b09ea148df08ac31f86cc8e291c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->