### PR TITLE
chore(release): heddle 0.15.4 — republish full crate set on api 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "libc",
@@ -2314,11 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.3"
+version = "0.15.4"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "blake3",
  "bytes",
@@ -2576,11 +2576,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.3"
+version = "0.15.4"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.3"
+version = "0.15.4"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.3", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.3", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.3", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.3" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.3" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.3", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.3" }
-heddle-pack = { path = "crates/pack", version = "0.15.3" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.3" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.3", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.3" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.3" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.3" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.3" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.3", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.3", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.3" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.3" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.3" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.3", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.3" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.3", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.3" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.3" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.3" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.3", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.3", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.4", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.4", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.4", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.4" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.4" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.4", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.4" }
+heddle-pack = { path = "crates/pack", version = "0.15.4" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.4" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.4", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.4" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.4" }
+config = { path = "crates/config", package = "heddle-config", version = "0.15.4" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.4" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.4", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.4", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.4" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.4" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.4" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.4", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.4" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.4", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.4" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.4" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.4" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.4", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.4", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.3",
+  "schemaVersion": "0.15.4",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.3" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.4" as const;
 
 export interface AbortSchema {
   action: OperatorAction;


### PR DESCRIPTION
Republishes heddle's full crate set at 0.15.4, uniformly on `heddle-api` 0.19 (from main, post-#1607).

**Why:** the currently-published 0.15.x set is inconsistent on api version — `heddle-repo` pins api 0.18 (tight req) while `heddle-objects` resolves 0.19 — which leaves consumers (weft) on a **split graph** with two heddle-api versions. Bumping all 28 workspace + internal-dep version reqs 0.15.3→0.15.4 and letting `publish-crates.yml` republish from main gives a consistent api-0.19 set, so weft can unify onto a single heddle graph.

Version-only change (code is identical to #1607, which built + full-ci'd green); client schemas regenerated for the version pin; llms-full regenerated (no content change).

On merge, `publish-crates.yml` publishes the full crate set at 0.15.4. Then weft bumps all `heddle-*` deps to 0.15.4 (the graph-unification follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790638761&installation_model_id=21489&pr_number=1608&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1608&signature=79ec052132ce7c2e4e142a184ecea7a01fdabf0e4e40593b73b1013ef730e486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->