### PR TITLE
ci: prevent published-crate API version drift

### DIFF
--- a/.github/workflows/crate-publish-integrity.yml
+++ b/.github/workflows/crate-publish-integrity.yml
@@ -1,0 +1,82 @@
+name: Crate publish integrity
+
+# The workspace graph is always self-consistent because path dependencies win.
+# These checks cover the two boundaries that workspace-only CI cannot see:
+# dependency changes that need fresh crate versions, and the artifacts that are
+# already published on crates.io.
+on:
+  pull_request:
+    branches:
+      - main
+  # Re-check the registry after the main-branch publisher completes. This is a
+  # separate workflow so the read-only tripwire does not alter or weaken the
+  # credentialed publish trust gate.
+  workflow_run:
+    workflows:
+      - Publish crates
+    branches:
+      - main
+    types:
+      - completed
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crate-publish-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PYTHONDONTWRITEBYTECODE: '1'
+
+jobs:
+  dependency-version-bump:
+    name: Dependency change requires version bump
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # NOTE: release-plz should eventually own the automatic version bump.
+    # This manual-bump gate is the concrete stopgap, not the auto-bump half.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          # The gate reads both immutable PR endpoint commits with `git show`.
+          fetch-depth: 0
+
+      - name: Prove the gate passes and fails in the intended cases
+        run: >-
+          python3 -m unittest
+          scripts.tests.test_crate_publish_integrity.DependencyVersionGateTests -v
+
+      - name: Compare publishable dependency contracts
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/check-dependency-version-bump.py "$BASE_SHA" "$HEAD_SHA"
+
+  published-api-graph:
+    name: Published crates use one heddle-api line
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Prove a synthetic published split is rejected
+        run: >-
+          python3 -m unittest
+          scripts.tests.test_crate_publish_integrity.PublishedGraphTests -v
+
+      - name: Resolve the current crates.io sparse-index graph
+        run: python3 scripts/check-published-api-graph.py

--- a/scripts/check-dependency-version-bump.py
+++ b/scripts/check-dependency-version-bump.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Require a workspace version bump when public dependency contracts change."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from functools import total_ordering
+
+import tomllib
+
+PUBLISH_WORKFLOW = ".github/workflows/publish-crates.yml"
+
+
+class CheckError(Exception):
+    """A configuration or repository error that must fail the gate."""
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CheckError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def read_at(revision: str, path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{revision}:{path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return result.stdout
+    if result.returncode == 128 and "does not exist" in result.stderr:
+        return None
+    detail = result.stderr.strip() or result.stdout.strip()
+    raise CheckError(f"git show {revision}:{path} failed: {detail}")
+
+
+def parse_toml(contents: str, source: str) -> dict:
+    try:
+        return tomllib.loads(contents)
+    except tomllib.TOMLDecodeError as error:
+        raise CheckError(f"could not parse {source}: {error}") from error
+
+
+def publishable_crates(contents: str, source: str) -> list[str]:
+    crates: list[str] = []
+    in_list = False
+    for line in contents.splitlines():
+        if line == "  PUBLISHABLE_CRATES: |":
+            in_list = True
+            continue
+        if in_list:
+            if line.startswith("    "):
+                name = line.strip()
+                if name:
+                    crates.append(name)
+                continue
+            break
+    if not crates:
+        raise CheckError(f"could not parse PUBLISHABLE_CRATES from {source}")
+    if len(crates) != len(set(crates)):
+        raise CheckError(f"PUBLISHABLE_CRATES contains duplicates in {source}")
+    return crates
+
+
+def manifests_at(revision: str) -> dict[str, tuple[str, dict]]:
+    paths = git("ls-tree", "-r", "--name-only", revision, "--", "crates")
+    manifests: dict[str, tuple[str, dict]] = {}
+    for path in paths.splitlines():
+        if not path.endswith("/Cargo.toml"):
+            continue
+        contents = read_at(revision, path)
+        if contents is None:
+            continue
+        parsed = parse_toml(contents, f"{revision}:{path}")
+        name = parsed.get("package", {}).get("name")
+        if not isinstance(name, str):
+            continue
+        if name in manifests:
+            raise CheckError(f"duplicate package name {name!r} at {revision}")
+        manifests[name] = (path, parsed)
+    return manifests
+
+
+@total_ordering
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+
+    _PATTERN = re.compile(
+        r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+        r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+        r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+    )
+
+    @classmethod
+    def parse(cls, value: object, source: str) -> SemVer:
+        if not isinstance(value, str):
+            raise CheckError(f"{source} must be a semantic version string")
+        match = cls._PATTERN.fullmatch(value)
+        if match is None:
+            raise CheckError(f"{source} is not a valid semantic version: {value!r}")
+        prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+        return cls(*(int(match.group(i)) for i in range(1, 4)), prerelease)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        left_core = (self.major, self.minor, self.patch)
+        right_core = (other.major, other.minor, other.patch)
+        if left_core != right_core:
+            return left_core < right_core
+        if not self.prerelease:
+            return False
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease):
+            if left == right:
+                continue
+            if left.isdigit() and right.isdigit():
+                return int(left) < int(right)
+            if left.isdigit() != right.isdigit():
+                return left.isdigit()
+            return left < right
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def revision_state(
+    revision: str,
+) -> tuple[dict, list[str], dict[str, tuple[str, dict]]]:
+    root_contents = read_at(revision, "Cargo.toml")
+    if root_contents is None:
+        raise CheckError(f"Cargo.toml does not exist at {revision}")
+    workflow_contents = read_at(revision, PUBLISH_WORKFLOW)
+    if workflow_contents is None:
+        raise CheckError(f"{PUBLISH_WORKFLOW} does not exist at {revision}")
+    return (
+        parse_toml(root_contents, f"{revision}:Cargo.toml"),
+        publishable_crates(workflow_contents, f"{revision}:{PUBLISH_WORKFLOW}"),
+        manifests_at(revision),
+    )
+
+
+def dependency_changes(base: str, head: str) -> tuple[list[str], str, str]:
+    # CI passes the immutable PR endpoint SHAs. Use their diff as the change
+    # boundary, then compare the affected TOML tables semantically so comments
+    # and formatting alone do not force a release.
+    changed_paths = set(
+        git(
+            "diff",
+            "--name-only",
+            base,
+            head,
+            "--",
+            "Cargo.toml",
+            "crates/*/Cargo.toml",
+            PUBLISH_WORKFLOW,
+        ).splitlines()
+    )
+    base_root, base_publishable, base_manifests = revision_state(base)
+    head_root, head_publishable, head_manifests = revision_state(head)
+
+    changes: list[str] = []
+    base_workspace = base_root.get("workspace", {})
+    head_workspace = head_root.get("workspace", {})
+    if "Cargo.toml" in changed_paths and base_workspace.get(
+        "dependencies", {}
+    ) != head_workspace.get("dependencies", {}):
+        changes.append("Cargo.toml [workspace.dependencies]")
+
+    names = dict.fromkeys([*base_publishable, *head_publishable])
+    for name in names:
+        base_entry = base_manifests.get(name)
+        head_entry = head_manifests.get(name)
+        base_deps = base_entry[1].get("dependencies", {}) if base_entry else {}
+        head_deps = head_entry[1].get("dependencies", {}) if head_entry else {}
+        paths = {entry[0] for entry in (base_entry, head_entry) if entry is not None}
+        if paths.intersection(changed_paths) and base_deps != head_deps:
+            path = head_entry[0] if head_entry else base_entry[0]  # type: ignore[index]
+            changes.append(f"{path} [dependencies] ({name})")
+
+    base_version_value = base_workspace.get("package", {}).get("version")
+    head_version_value = head_workspace.get("package", {}).get("version")
+    SemVer.parse(base_version_value, f"{base}:workspace.package.version")
+    SemVer.parse(head_version_value, f"{head}:workspace.package.version")
+    return changes, str(base_version_value), str(head_version_value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", help="PR base commit")
+    parser.add_argument("head", nargs="?", default="HEAD", help="PR head commit")
+    args = parser.parse_args()
+
+    try:
+        changes, base_version_text, head_version_text = dependency_changes(
+            args.base, args.head
+        )
+        base_version = SemVer.parse(base_version_text, "base workspace version")
+        head_version = SemVer.parse(head_version_text, "head workspace version")
+    except CheckError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    if not changes:
+        print("ok: no publishable dependency contracts changed")
+        return 0
+
+    print("changed publishable dependency contracts:")
+    for change in changes:
+        print(f"  - {change}")
+    sys.stdout.flush()
+
+    if head_version <= base_version:
+        print(
+            "error: dependency changes require an increased "
+            "[workspace.package] version in Cargo.toml "
+            f"(base {base_version_text}, head {head_version_text})",
+            file=sys.stderr,
+        )
+        print(
+            "note: release-plz auto-bump wiring is the fuller fix; until then "
+            "this bump is manual",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "ok: workspace version increased "
+        f"from {base_version_text} to {head_version_text}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-published-api-graph.py
+++ b/scripts/check-published-api-graph.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Check latest published Heddle crates resolve one heddle-api major/minor."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from functools import total_ordering
+from pathlib import Path
+
+DEFAULT_WORKFLOW = ".github/workflows/publish-crates.yml"
+DEFAULT_INDEX_URL = "https://index.crates.io"
+USER_AGENT = "heddle-published-graph-check/1.0 (https://github.com/HeddleCo/heddle)"
+
+
+class CheckError(Exception):
+    """An index, configuration, or resolution error that must fail the check."""
+
+
+def publishable_crates(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise CheckError(f"could not read {path}: {error}") from error
+
+    crates: list[str] = []
+    in_list = False
+    for line in lines:
+        if line == "  PUBLISHABLE_CRATES: |":
+            in_list = True
+            continue
+        if in_list:
+            if line.startswith("    "):
+                name = line.strip()
+                if name:
+                    crates.append(name)
+                continue
+            break
+    if not crates:
+        raise CheckError(f"could not parse PUBLISHABLE_CRATES from {path}")
+    if len(crates) != len(set(crates)):
+        raise CheckError(f"PUBLISHABLE_CRATES contains duplicates in {path}")
+    return crates
+
+
+def sparse_index_path(crate: str) -> str:
+    name = crate.lower()
+    if len(name) == 1:
+        return f"1/{name}"
+    if len(name) == 2:
+        return f"2/{name}"
+    if len(name) == 3:
+        return f"3/{name[0]}/{name}"
+    return f"{name[:2]}/{name[2:4]}/{name}"
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    _PATTERN = re.compile(
+        r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+        r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+        r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+    )
+
+    @classmethod
+    def parse(cls, value: object, source: str) -> Version:
+        if not isinstance(value, str):
+            raise CheckError(f"{source} has a non-string version")
+        match = cls._PATTERN.fullmatch(value)
+        if match is None:
+            raise CheckError(f"{source} has invalid semantic version {value!r}")
+        prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+        return cls(*(int(match.group(i)) for i in range(1, 4)), prerelease)
+
+    def __str__(self) -> str:
+        value = f"{self.major}.{self.minor}.{self.patch}"
+        if self.prerelease:
+            value += "-" + ".".join(self.prerelease)
+        return value
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        left_core = (self.major, self.minor, self.patch)
+        right_core = (other.major, other.minor, other.patch)
+        if left_core != right_core:
+            return left_core < right_core
+        if not self.prerelease:
+            return False
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease):
+            if left == right:
+                continue
+            if left.isdigit() and right.isdigit():
+                return int(left) < int(right)
+            if left.isdigit() != right.isdigit():
+                return left.isdigit()
+            return left < right
+        return len(self.prerelease) < len(other.prerelease)
+
+
+class Index:
+    def __init__(self, base_url: str, directory: Path | None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.directory = directory
+
+    def records(self, crate: str) -> list[dict] | None:
+        relative = sparse_index_path(crate)
+        if self.directory is not None:
+            path = self.directory / relative
+            if not path.exists():
+                return None
+            try:
+                contents = path.read_text(encoding="utf-8")
+            except OSError as error:
+                raise CheckError(
+                    f"could not read sparse index entry {path}: {error}"
+                ) from error
+        else:
+            contents = self._download(crate, relative)
+            if contents is None:
+                return None
+
+        records: list[dict] = []
+        for line_number, line in enumerate(contents.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise CheckError(
+                    f"invalid JSON in sparse index entry for {crate}, line {line_number}: {error}"
+                ) from error
+            if not isinstance(record, dict):
+                raise CheckError(
+                    f"non-object sparse index record for {crate}, line {line_number}"
+                )
+            records.append(record)
+        if not records:
+            raise CheckError(f"sparse index entry for {crate} is empty")
+        return records
+
+    def _download(self, crate: str, relative: str) -> str | None:
+        url = f"{self.base_url}/{relative}"
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        for attempt in range(1, 4):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    return response.read().decode("utf-8")
+            except urllib.error.HTTPError as error:
+                if error.code == 404:
+                    return None
+                last_error: Exception = error
+            except (urllib.error.URLError, TimeoutError, UnicodeDecodeError) as error:
+                last_error = error
+            if attempt < 3:
+                time.sleep(attempt)
+        raise CheckError(
+            f"could not fetch sparse index entry for {crate}: {last_error}"
+        )
+
+
+@dataclass(frozen=True)
+class LatestCrate:
+    name: str
+    version: Version
+    record: dict
+
+
+@dataclass(frozen=True)
+class ApiResolution:
+    crate: str
+    crate_version: Version
+    requirement: str
+    compatible_versions: tuple[Version, ...]
+
+    def latest_on(self, line: tuple[int, int] | None = None) -> Version:
+        if line is None:
+            return self.compatible_versions[0]
+        return next(
+            version
+            for version in self.compatible_versions
+            if (version.major, version.minor) == line
+        )
+
+
+def latest_stable(crate: str, records: list[dict]) -> LatestCrate:
+    candidates: list[tuple[Version, dict]] = []
+    for line_number, record in enumerate(records, start=1):
+        version = Version.parse(record.get("vers"), f"{crate} index line {line_number}")
+        if record.get("yanked") is True or version.prerelease:
+            continue
+        candidates.append((version, record))
+    if not candidates:
+        raise CheckError(
+            f"{crate} has no non-yanked stable version in the sparse index"
+        )
+    version, record = max(candidates, key=lambda candidate: candidate[0])
+    return LatestCrate(crate, version, record)
+
+
+def parse_partial(value: str, requirement: str) -> tuple[list[int], bool]:
+    if "-" in value or "+" in value:
+        raise CheckError(
+            f"pre-release/build metadata is unsupported in heddle-api requirement {requirement!r}"
+        )
+    parts = value.split(".")
+    if len(parts) > 3:
+        raise CheckError(f"invalid heddle-api requirement {requirement!r}")
+    numbers: list[int] = []
+    wildcard = False
+    for index, part in enumerate(parts):
+        if part in ("*", "x", "X"):
+            wildcard = True
+            if index != len(parts) - 1:
+                raise CheckError(
+                    f"invalid heddle-api wildcard requirement {requirement!r}"
+                )
+            break
+        if not part.isdigit() or (len(part) > 1 and part.startswith("0")):
+            raise CheckError(f"invalid heddle-api requirement {requirement!r}")
+        numbers.append(int(part))
+    return numbers, wildcard
+
+
+def padded(numbers: list[int]) -> Version:
+    values = [*numbers, 0, 0, 0]
+    return Version(values[0], values[1], values[2])
+
+
+def caret_upper(numbers: list[int]) -> Version:
+    values = [*numbers, 0, 0, 0]
+    if not numbers or values[0] != 0 or len(numbers) == 1:
+        return Version(values[0] + 1, 0, 0)
+    if values[1] != 0 or len(numbers) == 2:
+        return Version(0, values[1] + 1, 0)
+    return Version(0, 0, values[2] + 1)
+
+
+def comparator_matches(comparator: str, version: Version, requirement: str) -> bool:
+    match = re.fullmatch(r"(\^|~|>=|<=|>|<|=)?\s*(.+)", comparator)
+    if match is None:
+        raise CheckError(f"invalid heddle-api requirement {requirement!r}")
+    operator = match.group(1) or "^"
+    value = match.group(2).strip()
+    numbers, wildcard = parse_partial(value, requirement)
+
+    if wildcard:
+        return (version.major, version.minor, version.patch)[: len(numbers)] == tuple(
+            numbers
+        )
+    if not numbers:
+        raise CheckError(f"invalid heddle-api requirement {requirement!r}")
+
+    lower = padded(numbers)
+    if operator == ">=":
+        return version >= lower
+    if operator == ">":
+        return version > lower
+    if operator == "<=":
+        return version <= lower
+    if operator == "<":
+        return version < lower
+    if operator == "=":
+        if len(numbers) < 3:
+            return (version.major, version.minor, version.patch)[
+                : len(numbers)
+            ] == tuple(numbers)
+        return version == lower
+    if operator == "~":
+        if len(numbers) == 1:
+            upper = Version(numbers[0] + 1, 0, 0)
+        else:
+            upper = Version(numbers[0], numbers[1] + 1, 0)
+        return lower <= version < upper
+    return lower <= version < caret_upper(numbers)
+
+
+def requirement_matches(requirement: str, version: Version) -> bool:
+    if requirement.strip() == "*":
+        return True
+    comparators = [part.strip() for part in requirement.split(",") if part.strip()]
+    if not comparators:
+        raise CheckError("empty heddle-api version requirement")
+    return all(
+        comparator_matches(comparator, version, requirement)
+        for comparator in comparators
+    )
+
+
+def api_requirements(latest: LatestCrate) -> list[str]:
+    deps = latest.record.get("deps")
+    if not isinstance(deps, list):
+        raise CheckError(f"{latest.name}@{latest.version} has no dependency list")
+    requirements: list[str] = []
+    for dependency in deps:
+        if not isinstance(dependency, dict):
+            raise CheckError(
+                f"{latest.name}@{latest.version} has a malformed dependency"
+            )
+        actual_name = dependency.get("package") or dependency.get("name")
+        if actual_name != "heddle-api" or dependency.get("kind") == "dev":
+            continue
+        requirement = dependency.get("req")
+        if not isinstance(requirement, str):
+            raise CheckError(
+                f"{latest.name}@{latest.version} has a non-string heddle-api requirement"
+            )
+        requirements.append(requirement)
+    return requirements
+
+
+def run(workflow: Path, index: Index) -> int:
+    crates = publishable_crates(workflow)
+    print(f"ok: read {len(crates)} publishable crates from {workflow}")
+
+    all_names = [*crates, "heddle-api"]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {name: executor.submit(index.records, name) for name in all_names}
+        records_by_name = {name: future.result() for name, future in futures.items()}
+
+    api_records = records_by_name["heddle-api"]
+    if api_records is None:
+        raise CheckError("heddle-api is not present in the sparse index")
+    api_version_set: set[Version] = set()
+    for line_number, record in enumerate(api_records, start=1):
+        version = Version.parse(
+            record.get("vers"), f"heddle-api index line {line_number}"
+        )
+        if record.get("yanked") is not True and not version.prerelease:
+            api_version_set.add(version)
+    if not api_version_set:
+        raise CheckError(
+            "heddle-api has no non-yanked stable version in the sparse index"
+        )
+    api_versions = sorted(api_version_set, reverse=True)
+
+    resolutions: list[ApiResolution] = []
+    unpublished: list[str] = []
+    published_count = 0
+    for crate in crates:
+        records = records_by_name[crate]
+        if records is None:
+            unpublished.append(crate)
+            continue
+        latest = latest_stable(crate, records)
+        published_count += 1
+        for requirement in api_requirements(latest):
+            compatible = tuple(
+                version
+                for version in api_versions
+                if requirement_matches(requirement, version)
+            )
+            if not compatible:
+                raise CheckError(
+                    f"{crate}@{latest.version} requires heddle-api {requirement}, "
+                    "but no published non-yanked stable version satisfies it"
+                )
+            resolutions.append(
+                ApiResolution(crate, latest.version, requirement, compatible)
+            )
+
+    if unpublished:
+        print(
+            "note: not published yet (excluded from the published set): "
+            + ", ".join(unpublished)
+        )
+    print(
+        f"ok: inspected the latest non-yanked stable release of "
+        f"{published_count}/{len(crates)} publishable crates"
+    )
+    sys.stdout.flush()
+    if not resolutions:
+        raise CheckError(
+            "latest published crate set contains no heddle-api requirements"
+        )
+
+    compatible_lines = [
+        {(version.major, version.minor) for version in item.compatible_versions}
+        for item in resolutions
+    ]
+    common_lines = set.intersection(*compatible_lines)
+
+    if not common_lines:
+        lines: dict[tuple[int, int], list[ApiResolution]] = {}
+        for resolution in resolutions:
+            latest = resolution.latest_on()
+            lines.setdefault((latest.major, latest.minor), []).append(resolution)
+        print(
+            f"error: published heddle-api graph is split across {len(lines)} major/minor lines",
+            file=sys.stderr,
+        )
+        for line, entries in sorted(lines.items()):
+            print(f"  heddle-api {line[0]}.{line[1]}:", file=sys.stderr)
+            for entry in entries:
+                print(
+                    f"    - {entry.crate}@{entry.crate_version} requires "
+                    f"{entry.requirement} -> {entry.latest_on()}",
+                    file=sys.stderr,
+                )
+        return 1
+
+    line = max(common_lines)
+    resolved_versions = ", ".join(
+        str(version)
+        for version in sorted({item.latest_on(line) for item in resolutions})
+    )
+    print(
+        f"ok: {len(resolutions)} requirements from latest published crates converge "
+        f"on heddle-api {line[0]}.{line[1]} (resolved: {resolved_versions})"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", type=Path, default=Path(DEFAULT_WORKFLOW))
+    parser.add_argument("--index-url", default=DEFAULT_INDEX_URL)
+    parser.add_argument(
+        "--index-dir",
+        type=Path,
+        help="read a local sparse index fixture instead of crates.io",
+    )
+    args = parser.parse_args()
+    try:
+        return run(args.workflow, Index(args.index_url, args.index_dir))
+    except CheckError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_crate_publish_integrity.py
+++ b/scripts/tests/test_crate_publish_integrity.py
@@ -1,0 +1,211 @@
+"""Behavior tests for the published-crate drift CI checks."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERSION_GATE = REPO_ROOT / "scripts/check-dependency-version-bump.py"
+GRAPH_CHECK = REPO_ROOT / "scripts/check-published-api-graph.py"
+
+
+def run(*args: str | Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(arg) for arg in args],
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def sparse_path(crate: str) -> Path:
+    name = crate.lower()
+    if len(name) == 1:
+        return Path("1") / name
+    if len(name) == 2:
+        return Path("2") / name
+    if len(name) == 3:
+        return Path("3") / name[0] / name
+    return Path(name[:2]) / name[2:4] / name
+
+
+def index_record(name: str, version: str, api_requirement: str | None = None) -> dict:
+    deps = []
+    if api_requirement is not None:
+        deps.append(
+            {
+                "name": "api",
+                "package": "heddle-api",
+                "req": api_requirement,
+                "features": [],
+                "optional": False,
+                "default_features": True,
+                "target": None,
+                "kind": "normal",
+            }
+        )
+    return {"name": name, "vers": version, "deps": deps, "yanked": False}
+
+
+class DependencyVersionGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        (self.repo / ".github/workflows").mkdir(parents=True)
+        (self.repo / "crates/demo").mkdir(parents=True)
+        (self.repo / ".github/workflows/publish-crates.yml").write_text(
+            "env:\n  PUBLISHABLE_CRATES: |\n    heddle-demo\njobs: {}\n",
+            encoding="utf-8",
+        )
+        self.write_root("0.1.0", 'serde = "1"')
+        self.write_crate('anyhow = "1"')
+        run("git", "init", "-q", cwd=self.repo)
+        run("git", "config", "user.name", "CI Test", cwd=self.repo)
+        run("git", "config", "user.email", "ci@example.invalid", cwd=self.repo)
+        self.commit("base")
+        self.base = run("git", "rev-parse", "HEAD", cwd=self.repo).stdout.strip()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_root(self, version: str, dependency: str) -> None:
+        (self.repo / "Cargo.toml").write_text(
+            "[workspace]\n"
+            'members = ["crates/demo"]\n'
+            "\n[workspace.package]\n"
+            f'version = "{version}"\n'
+            "\n[workspace.dependencies]\n"
+            f"{dependency}\n",
+            encoding="utf-8",
+        )
+
+    def write_crate(self, dependency: str) -> None:
+        (self.repo / "crates/demo/Cargo.toml").write_text(
+            "[package]\n"
+            'name = "heddle-demo"\n'
+            "version.workspace = true\n"
+            "\n[dependencies]\n"
+            f"{dependency}\n",
+            encoding="utf-8",
+        )
+
+    def commit(self, message: str) -> None:
+        self.assertEqual(run("git", "add", ".", cwd=self.repo).returncode, 0)
+        result = run("git", "commit", "-q", "-m", message, cwd=self.repo)
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+    def gate(self, base: str) -> subprocess.CompletedProcess[str]:
+        return run("python3", VERSION_GATE, base, "HEAD", cwd=self.repo)
+
+    def test_workspace_dependency_change_requires_increased_version(self) -> None:
+        self.write_root("0.1.0", 'serde = "2"')
+        self.commit("dependency only")
+
+        failed = self.gate(self.base)
+        self.assertEqual(failed.returncode, 1, failed.stdout)
+        self.assertIn("dependency changes require an increased", failed.stdout)
+
+        self.write_root("0.1.1", 'serde = "2"')
+        self.commit("version bump")
+        passed = self.gate(self.base)
+        self.assertEqual(passed.returncode, 0, passed.stdout)
+        self.assertIn("workspace version increased from 0.1.0 to 0.1.1", passed.stdout)
+
+    def test_no_dependency_change_passes(self) -> None:
+        (self.repo / "README.md").write_text("docs only\n", encoding="utf-8")
+        self.commit("docs")
+        result = self.gate(self.base)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("no publishable dependency contracts changed", result.stdout)
+
+    def test_publishable_crate_dependency_change_is_gated(self) -> None:
+        self.write_crate('anyhow = "2"')
+        self.commit("crate dependency only")
+        result = self.gate(self.base)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("crates/demo/Cargo.toml [dependencies]", result.stdout)
+
+
+class PublishedGraphTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.index = self.root / "index"
+        self.workflow = self.root / "publish-crates.yml"
+        self.workflow.write_text(
+            "env:\n"
+            "  PUBLISHABLE_CRATES: |\n"
+            "    heddle-alpha\n"
+            "    heddle-beta\n"
+            "jobs: {}\n",
+            encoding="utf-8",
+        )
+        self.write_records(
+            "heddle-api",
+            [
+                index_record("heddle-api", "0.18.0"),
+                index_record("heddle-api", "0.19.0"),
+            ],
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_records(self, crate: str, records: list[dict]) -> None:
+        path = self.index / sparse_path(crate)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "".join(
+                json.dumps(record, separators=(",", ":")) + "\n" for record in records
+            ),
+            encoding="utf-8",
+        )
+
+    def check(self) -> subprocess.CompletedProcess[str]:
+        return run(
+            "python3",
+            GRAPH_CHECK,
+            "--workflow",
+            self.workflow,
+            "--index-dir",
+            self.index,
+            cwd=self.root,
+        )
+
+    def test_unified_graph_passes(self) -> None:
+        self.write_records(
+            "heddle-alpha",
+            [
+                index_record("heddle-alpha", "0.9.0", "^0.18.0"),
+                index_record("heddle-alpha", "1.0.0", "^0.19.0"),
+            ],
+        )
+        self.write_records(
+            "heddle-beta", [index_record("heddle-beta", "1.0.0", ">=0.19, <0.20")]
+        )
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("converge on heddle-api 0.19", result.stdout)
+
+    def test_split_graph_fails(self) -> None:
+        self.write_records(
+            "heddle-alpha", [index_record("heddle-alpha", "1.0.0", "^0.18.0")]
+        )
+        self.write_records(
+            "heddle-beta", [index_record("heddle-beta", "1.0.0", "^0.19.0")]
+        )
+        result = self.check()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("split across 2 major/minor lines", result.stdout)
+        self.assertIn("heddle-api 0.18", result.stdout)
+        self.assertIn("heddle-api 0.19", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1609.

## Summary

- add a PR gate that diffs the immutable PR base/head commits and rejects semantic changes to `[workspace.dependencies]` or a canonical publishable crate `[dependencies]` table unless `[workspace.package].version` increases
- read `PUBLISHABLE_CRATES` directly from `.github/workflows/publish-crates.yml` at both revisions; publishability is never re-derived
- add a crates.io sparse-index check that inspects the latest non-yanked stable release of every canonical publishable crate, resolves all non-dev `heddle-api` requirements against published API versions, and rejects graphs with no common API major/minor line
- run the registry tripwire on PRs, nightly, manually, and after the existing `Publish crates` workflow completes without changing its credential boundary
- keep release-plz auto-bump wiring explicitly out of scope and documented as the fuller follow-up

## Proof: dependency change gate

Synthetic repository, dependency edit without version bump:

```text
exit 1
changed publishable dependency contracts:
  - Cargo.toml [workspace.dependencies]
error: dependency changes require an increased [workspace.package] version in Cargo.toml (base 0.1.0, head 0.1.0)
note: release-plz auto-bump wiring is the fuller fix; until then this bump is manual
```

Same base and dependency edit with `0.1.0 -> 0.1.1`:

```text
exit 0
changed publishable dependency contracts:
  - Cargo.toml [workspace.dependencies]
ok: workspace version increased from 0.1.0 to 0.1.1
```

No dependency change is also covered and passes:

```text
exit 0
ok: no publishable dependency contracts changed
```

The live PR gate needs the base ref, so it runs only for `pull_request`. CI supplies `github.event.pull_request.base.sha` and `head.sha`, and checkout uses full history so both immutable endpoints are available.

## Proof: published graph

Current crates.io sparse index after 0.15.4:

```text
ok: read 29 publishable crates from .github/workflows/publish-crates.yml
ok: inspected the latest non-yanked stable release of 29/29 publishable crates
ok: 4 requirements from latest published crates converge on heddle-api 0.19 (resolved: 0.19.0)
```

Synthetic 0.18/0.19 split:

```text
exit 1
ok: read 2 publishable crates from <fixture>/publish-crates.yml
ok: inspected the latest non-yanked stable release of 2/2 publishable crates
error: published heddle-api graph is split across 2 major/minor lines
  heddle-api 0.18:
    - heddle-alpha@1.0.0 requires ^0.18.0 -> 0.18.0
  heddle-api 0.19:
    - heddle-beta@1.0.0 requires ^0.19.0 -> 0.19.0
```

## Validation

```text
python3 -m unittest scripts.tests.test_crate_publish_integrity -v
Ran 5 tests in 0.368s
OK

black --check ...
3 files would be left unchanged.

ruff check ...
All checks passed!

yamllint .github/workflows/crate-publish-integrity.yml
# clean

git diff --cached --check
# clean
```

`rustfmt` and `shellcheck` are not applicable: this change adds no Rust or shell files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790649747&installation_model_id=21489&pr_number=1612&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1612&signature=cd38590cebb0f7cceb4e627429038a881bb42f282e4e4a5a128a4f95a22faa8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->