### PR TITLE
deps: bump to heddle-api 0.20.0 and cv 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93c3df670c6e27e4e7757af0887daf410bdbbc3a19961ff7c3de2877835b20c"
+checksum = "184dae4d574220a294850876b6f400864b6e6e75def89e53b1efc272d44cc0c8"
 dependencies = [
  "blake3",
  "bytes",
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186f0766c7abae31cc5591f75c79abfe0d39fc9455c4ac047e152204a2d717ea"
+checksum = "fcab89b5d2c914c0d3250a4df0c7d04a72d734a5920eaabcd0d39bee61406806"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "heddle-object-model",
  "regex",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "libc",
@@ -2314,11 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.4"
+version = "0.15.5"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "base32",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "base32",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "chrono",
  "criterion",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "blake3",
  "bytes",
@@ -2576,11 +2576,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.4"
+version = "0.15.5"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "chrono",
  "fs2",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "base32",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.19.0" }
+api = { package = "heddle-api", version = "0.20.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.4"
+version = "0.15.5"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.4", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.4", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.4", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.4" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.4" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.4", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.4" }
-heddle-pack = { path = "crates/pack", version = "0.15.4" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.4" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.4", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.4" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.4" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.4" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.4" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.4", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.4", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.4" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.4" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.4" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.4", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.4" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.4", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.4" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.4" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.4" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.4", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.4", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.5", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.5", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.5", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.5" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.5" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.5", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.5" }
+heddle-pack = { path = "crates/pack", version = "0.15.5" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.5" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.5", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.5" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.5" }
+config = { path = "crates/config", package = "heddle-config", version = "0.15.5" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.5" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.5", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.5", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.5" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.5" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.5" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.5", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.5" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.5", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.5" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.5" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.5" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.5", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.5", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.4",
+  "schemaVersion": "0.15.5",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.4" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.5" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.8"
+heddleco-capability-verifier = "0.9"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
Closes #1614.

Summary:
- bump heddle-api from 0.19.0 to 0.20.0
- bump heddleco-capability-verifier from 0.8.0 to 0.9.0
- update Cargo.lock for the paired releases
- regenerate llms and npm schema/TypeScript artifacts (already byte-for-byte current)

Verification:
- cargo run --locked -p heddle-docsgen -- --check
- cargo test --locked -p heddle-cli --test ts_types_in_sync
- cargo build --locked --workspace --all-targets
- cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
- cargo test --locked --workspace --lib --bins (HEDDLE_HOME set to a writable temporary directory for this sandbox)

No workspace version bump, release tag, or publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790660043&installation_model_id=21489&pr_number=1615&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1615&signature=a9518d6d35a46dd6870571b5b58bc5614ce29e3ab66f0dc08cac3e3f87886eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->