### PR TITLE
chore(deps): bump to api 0.21.0 (+ cv 0.10.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "libc",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.5"
+version = "0.15.6"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "base32",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "base32",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "chrono",
  "criterion",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "blake3",
  "bytes",
@@ -2578,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.5"
+version = "0.15.6"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "chrono",
  "fs2",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "base32",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184dae4d574220a294850876b6f400864b6e6e75def89e53b1efc272d44cc0c8"
+checksum = "afb287405dd5ebd1a5ce2c6424ac8cbb47d2c03b6d5bc68b6da8e16afa82a589"
 dependencies = [
  "blake3",
  "bytes",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcab89b5d2c914c0d3250a4df0c7d04a72d734a5920eaabcd0d39bee61406806"
+checksum = "b4bc19b683ad966d72dbb46f949e33cea0766c581cafc12b904a443708b6033e"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.5"
+version = "0.15.6"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.20.0" }
+api = { package = "heddle-api", version = "0.21.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -146,12 +146,6 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
     // Consumes a human invite to open an unclaimed placeholder account;
     // provisioning stays parent-only even though the RPC is public.
     ("CreateAgentAccount", AgentAuthOperationDisposition::Denied),
-    // Legacy generated-handle variant of create-on-behalf. It remains in the
-    // shared contract but is not the pet-name claim path used by this CLI.
-    (
-        "ProvisionAgentRootedAccount",
-        AgentAuthOperationDisposition::Denied,
-    ),
     // Claim promotion is authorized by the browser's verified passkey and the
     // agent's dedicated Iroh consent, never by an attached derived bearer.
     ("PromoteAgentAccount", AgentAuthOperationDisposition::Denied),

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -137,6 +137,11 @@ pub(crate) async fn upload_claimable_root(
         owner_root: Some(signed),
         approval: None,
         client_operation_id: operation_id.to_wire(),
+        // Additive api 0.21.0 field (tag 5). This client carries its
+        // UUID-to-key binding in the appended AgentClaim extension
+        // (`encode_bootstrap_owner_root`), so the inline binding stays empty,
+        // which preserves prior bootstrap behavior.
+        owner_key_binding: None,
     };
     let encoded = encode_bootstrap_owner_root(&request, &binding);
     match client

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -312,6 +312,7 @@ fn bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5() {
             owner_root: Some(signed.clone()),
             approval: None,
             client_operation_id: operation_id.to_string(),
+            owner_key_binding: None,
         },
         &binding,
     );

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.9"
+heddleco-capability-verifier = "0.10"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
Bumps `heddle-api` 0.20.0 → 0.21.0 and `heddleco-capability-verifier` 0.9 → 0.10, adapting to the api 0.21.0 breaking changes.

## Dep bumps
- `Cargo.toml`: `api = { package = "heddle-api", version = "0.20.0" → "0.21.0" }`
- `crates/repo/Cargo.toml`: `heddleco-capability-verifier = "0.9" → "0.10"`
- `Cargo.lock` updated to `heddle-api 0.21.0`, `heddleco-capability-verifier 0.10.0`

## Breaking adaptations
- **`IdentityService/ProvisionAgentRootedAccount` deleted in 0.21.0** → removed its entry from `AUTH_SERVICE_AGENT_POLICY` in `crates/hosted-client/src/hosted_runtime/device_flow.rs`. That policy is asserted to match the shared proto descriptor's `IdentityService` method set exactly (`identity_service_agent_policy_exactly_matches_the_shared_descriptor`), so leaving a stale entry for the removed RPC would fail the test.
- **`BootstrapOwnerRootRequest.owner_key_binding` (additive, tag 5)** → set to `None` at both construction sites (`owner_root.rs` and its test). This client carries its UUID-to-key binding in the appended `AgentClaim` extension (`encode_bootstrap_owner_root`), so the inline field stays empty, preserving prior bootstrap behavior.

No code change needed for the other additive api changes (`DiscussionKind::IMPORTED`, `FeedItemKind::IMPORTED_DISCUSSION`, `WhoAmIResponse.root_status`, `RegisterPublicKeyRequest.claim_deferred_human`): heddle only casts `DiscussionKind` to `i32` and constructs the affected messages via `..Default::default()`. The 8 Shipped→Planned maturity demotions are metadata-only.

`heddleco-capability-verifier` 0.10 is API-compatible with heddle's usage in `crates/repo` (owner_root / owner_authorization) — `heddle-repo` compiles unchanged.

## Regenerated artifacts (no drift)
- `docs/llms-full.txt` — `heddle-docsgen --check`: up to date.
- `clients/npm/generated/*` — `gen-ts-types.sh`: no drift.

## Public surface
Unaffected. The only api types heddle re-exports (`RepoEvent`, `SubscribeRepoEventsRequest`, in `crates/hosted-client`) are unchanged in 0.21.0.

## Verification (isolated `CARGO_TARGET_DIR`, `TMPDIR=/home/scratch`)
- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Freshness gates (docsgen `--check`, gen-ts-types drift) — pass.
- `cargo test --workspace` — **1799 passed, 35 ignored**. One e2e test (`multi_agent_worktrees::e2e::agent_capture_and_ready_require_authenticated_writer_authority`) fails **only because the suite ran as a child of the `claude` harness process**: the agent-relay probe walks the parent-process argv and stamps `anthropic`, overriding the test's file-based `openai` provider. Re-run orphaned from the harness process tree (reparented to init), the same test passes — matching clean CI, which has no harness parent. Orthogonal to this dep bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790720459&installation_model_id=21489&pr_number=1617&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1617&signature=b0e041f1cba2f7e366b2038b140b91a35db7e9b4d9075d173c4033debf14dba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->