### PR TITLE
chore(deps): bump to api 0.22.0 (+ cv 0.11.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb287405dd5ebd1a5ce2c6424ac8cbb47d2c03b6d5bc68b6da8e16afa82a589"
+checksum = "2a4fd525384a6423262222817aaedf7b79035cd32751b69348f6e3139ba183f4"
 dependencies = [
  "blake3",
  "bytes",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "libc",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.6"
+version = "0.15.7"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "base32",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "base32",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "chrono",
  "criterion",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "blake3",
  "bytes",
@@ -2578,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.6"
+version = "0.15.7"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "chrono",
  "fs2",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "base32",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "blake3",
  "chrono",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bc19b683ad966d72dbb46f949e33cea0766c581cafc12b904a443708b6033e"
+checksum = "c2b7310b15ef26f6ee77ea2cc6ab8f48228996860b60ea15629d209a3adb7ff2"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.6"
+version = "0.15.7"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.21.0" }
+api = { package = "heddle-api", version = "0.22.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.5",
+  "schemaVersion": "0.15.7",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.5" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.7" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -407,6 +407,7 @@ mod tests {
                     seconds: 42,
                     nanos: 0,
                 }),
+                ..Default::default()
             }],
             ..Default::default()
         };

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.10"
+heddleco-capability-verifier = "0.11"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
## What

Additive dependency bump to consume the newly published ecosystem releases:

- `heddle-api` **0.21.0 → 0.22.0** (`Cargo.toml` `[workspace.dependencies]`)
- `heddleco-capability-verifier` **0.10 → 0.11** (`crates/repo/Cargo.toml`)
- Workspace `[workspace.package].version` **0.15.6 → 0.15.7** (required by the `check-dependency-version-bump.py` gate when public dependency contracts change), with `Cargo.lock` refreshed so every workspace crate resolves at 0.15.7.

api 0.22.0 is **additive**: it adds a PLANNED `NotificationService` plus additive `RepoEventKind` / `DiscussionTurn` proto fields. Nothing breaking.

## Code adaptation

One test-only touch. A unit test in `crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs` constructs the proto `DiscussionTurn` by struct literal, which now misses the six new additive fields. Fixed minimally by spreading `..Default::default()` — the same pattern already used on the enclosing `ProtoDiscussion` literal. No non-test code required changes.

## Regenerated artifacts

- `clients/npm/generated/heddle-schemas.{ts,json}` — version pin refreshed to 0.15.7 (`scripts/gen-ts-types.sh`).
- `docs/llms-full.txt` / `docs/llms.txt` — regenerated (`cargo run -p heddle-docsgen`); no diff since docs are unchanged. `--check` passes.

## Verification (shared target, TMPDIR=/home/scratch)

- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — passes except two failures that are **not caused by this change**:
  - `multi_agent_worktrees::e2e::agent_capture_and_ready_require_authenticated_writer_authority` — known claude-harness parent-argv false positive (stamps `anthropic` over `openai`); passes in clean CI.
  - `hosted_runtime::hosted::user::tests::administration_facade_builds_and_dispatches_every_native_request` — **verified pre-existing on base `62999c10`**: reverting to the old deps (api 0.21.0 / cv 0.10.0) reproduces the identical `InvalidState("stored sequence-0 owner root is not this device/proof key; refusing to remint a different authority")`. Environmental owner-root/authority harness issue, independent of the bump.
- `check-dependency-version-bump.py` gate — passes (0.15.6 → 0.15.7).
- docsgen freshness gate (`--check`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790732331&installation_model_id=21489&pr_number=1618&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1618&signature=a8bae2f61872a6718f780ac58a2171c2922b1a33bca96c7b3e5f5bc859ada994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->