### PR TITLE
chore(deps): heddle 0.15.8 onto api 0.23.0 + cv 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4fd525384a6423262222817aaedf7b79035cd32751b69348f6e3139ba183f4"
+checksum = "e082bd2ce66eaf172ada9e6e44910c4ac69a507914121a03ab9f6b6e03c5b3ac"
 dependencies = [
  "blake3",
  "bytes",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "libc",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.7"
+version = "0.15.8"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "base32",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "base32",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "chrono",
  "criterion",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "blake3",
  "bytes",
@@ -2578,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.7"
+version = "0.15.8"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "chrono",
  "fs2",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "base32",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b7310b15ef26f6ee77ea2cc6ab8f48228996860b60ea15629d209a3adb7ff2"
+checksum = "a57b537ef09cee99f292bd1a43640c3a1cdaeacb9e9eeed553c4b3355f81f057"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.7"
+version = "0.15.8"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.22.0" }
+api = { package = "heddle-api", version = "0.23.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.7",
+  "schemaVersion": "0.15.8",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.7" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.15.8" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.11"
+heddleco-capability-verifier = "0.12"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
Leg 3 of the NotificationService maturity-promotion cascade — a maturity-only api change (5 NotificationService RPCs promoted PLANNED→SHIPPED; no proto shape change, no new fields).

## Dep + version bumps
- `heddle-api` 0.22.0 → **0.23.0** (`Cargo.toml` `[workspace.dependencies]`)
- `heddleco-capability-verifier` 0.11 → **0.12** (`crates/repo/Cargo.toml`)
- `[workspace.package].version` 0.15.7 → **0.15.8** (the 30-crate publish set; required by the `check-dependency-version-bump.py` gate when publishable dep contracts change)
- `Cargo.lock` updated via `cargo update --precise` (real checksums)

## Regenerated freshness artifacts (not hand-edited)
- `clients/npm/generated/heddle-schemas.ts` / `.json` via `scripts/gen-ts-types.sh` — only change is the embedded version pin (`HEDDLE_SCHEMA_VERSION` / `schemaVersion` `0.15.7` → `0.15.8`), which follows the workspace version.
- `docs/llms.txt` / `docs/llms-full.txt` regenerated via `heddle-docsgen` — byte-identical (no version string in the docs corpus), so no diff.

## Capability / maturity surface
No shift. heddle does not consume NotificationService (0 references in `api-capabilities/heddle.json`), and the `shipped_native_inventory_is_36_unary_seven_server_streams_and_two_bidi` test filters by an explicit `ROUTES` allow-list that excludes NotificationService, so its counts are unaffected. `api-capabilities/verify_sync.py`'s pinned `API_REVISION` and the local declaration are unchanged (no consumed surface moved).

## Verification (isolated CARGO_TARGET_DIR, api 0.23.0 + cv 0.12.0)
- `cargo build --workspace` — green (clean additive bump; no API break)
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo test --workspace` — green on a clean environment. Three tests fail only on this dev box due to pre-existing environmental pollution, **not** this change — verified identical failures on pristine `main` (api 0.22 / cv 0.11 / v0.15.7):
  - 2× `heddle-hosted-client` CreateSpool tests read a real stored owner-root from `$HOME/.heddle/agent-claim.toml`; pass with an isolated `HEDDLE_HOME`.
  - 1× `agent_capture...` picks up the ambient Claude Code harness (provider stamped `anthropic/`); the identity file's model survives.
- Freshness gates: `ts_types_in_sync` ✓, `agent_api_schema` ✓, `doctor schemas` (no drift) ✓, `doctor docs --all` (no drift, 197 files) ✓, `heddle-docsgen --check` (up to date) ✓
- `check-dependency-version-bump.py` ✓ (workspace 0.15.7 → 0.15.8 satisfies the changed-contract gate)
- `cargo publish --dry-run` on leaf crates `heddle-perf-contract` and `heddle-format` — package + verify clean at 0.15.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790755294&installation_model_id=21489&pr_number=1619&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1619&signature=a506bf0f6bbe3c19726c6e415a1f8047d1fb690a0e1c47492d98f65a79bb2306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->