### PR TITLE
feat(claim): publish heddle-claim/1 two-phase JSON contract for browser clients (heddle#1564)

### DIFF
--- a/crates/hosted-client/contracts/README.md
+++ b/crates/hosted-client/contracts/README.md
@@ -1,0 +1,53 @@
+# heddle-claim/1 — published JSON contract
+
+Consumable contract for the **two-phase browser claim protocol**. Browser/TS
+clients (tapestry, iroh-web) should generate their types and test fixtures from
+the files here instead of hand-mirroring the private Rust enums in
+`crates/hosted-client/src/hosted_runtime/claim_authorization.rs`.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `heddle-claim-v1.schema.json` | JSON Schema (draft 2020-12) for every request/reply shape. Feed it to `json-schema-to-typescript`, `ajv`, `quicktype`, etc. |
+| `heddle-claim-v1.golden.json` | Golden vectors — one concrete example per request and reply variant, plus the protocol/method routing. Use these as cross-language test fixtures. |
+
+## Divergence guard
+
+`claim_authorization.rs` contains a `#[cfg(test)] mod contract` test that
+serializes every `ClaimReply` variant and parses every `ClaimRequest` variant
+through the **real serde enums**, asserting they match `heddle-claim-v1.golden.json`
+byte-for-value. If the Rust enums change a field name, a `#[serde(rename)]`, the
+`kind` tag, or the camelCase casing, that test goes red. Regenerate/adjust the
+golden file only alongside the Rust change. The schema is maintained by hand
+alongside the golden vectors and the same test asserts every golden vector is
+one of the schema's declared variants.
+
+## Transport
+
+- **ALPN:** `heddle-claim/1` (iroh)
+- **Service:** `heddle.claim.v1.ClaimService`
+- **Encoding:** `serde_json` — **not** protobuf. Request bodies are
+  `serde_json::from_slice`; reply bodies are `#[derive(Serialize)]`.
+- **Enum representation:** internally tagged on the `kind` discriminant; variant
+  names and all fields are `camelCase`; requests reject unknown fields.
+- **Claim secret:** the one-time claim secret rides in
+  `CallContext.bearer_capability` on the transport frame — **never** in a JSON body.
+
+## Two-phase flow
+
+| Method | Request `kind` | Reply `kind` |
+|---|---|---|
+| `/heddle.claim.v1.ClaimService/Resolve` | `resolve` | `resolved` (or `refused` when already claimed) |
+| `/heddle.claim.v1.ClaimService/Consent` | `preConsent` `{ handle, nonce }` | `preConsented` `{ consent }` |
+| `/heddle.claim.v1.ClaimService/Consent` | `promoteConsent` `{ handle, credentialId }` | `promoteConsented` `{ consent }` |
+| `/heddle.claim.v1.ClaimService/ClaimOwnerRoot` | `resolveOwnerRoot` `{ handle }` | `ownerRootResolved` `{ signedOwnerRoot, webauthnChallenge }` |
+| `/heddle.claim.v1.ClaimService/ClaimOwnerRoot` | `claimOwnerRoot` `{ ... }` | `ownerRootCoSigned` `{ signedTransition }` |
+
+`preConsent` binds the ceremony (`state.prepare(handle, nonce)`); `promoteConsent`
+must match its own pre-consent (`state.claim(handle)`). Both consent replies carry
+a signed `AgentConsent` tuple; a browser must present the matching pre/promote pair
+to weft to attach the passkey root.
+
+> Values in the golden vectors are representative examples. Only the **shape**
+> (keys, casing, `kind` tag) is contractual — not the specific string values.

--- a/crates/hosted-client/contracts/heddle-claim-v1.golden.json
+++ b/crates/hosted-client/contracts/heddle-claim-v1.golden.json
@@ -1,0 +1,101 @@
+{
+  "$comment": "Published golden vectors for the heddle-claim/1 two-phase claim protocol. These are the SOURCE OF TRUTH for browser/TS clients: do not hand-mirror the private Rust enums in crates/hosted-client/src/hosted_runtime/claim_authorization.rs. A Rust test (mod contract in that file) serializes each request/reply variant through the real serde enums and asserts equality with these vectors, so any drift in a field name, serde rename, or enum tagging turns the build red. Regenerate/adjust here only alongside the Rust change. Values below are representative examples; only the SHAPE (keys, casing, tag) is contractual, not the specific string values.",
+  "protocol": {
+    "alpn": "heddle-claim/1",
+    "service": "heddle.claim.v1.ClaimService",
+    "encoding": "serde_json (NOT protobuf); request bodies are serde_json::from_slice, reply bodies are #[derive(Serialize)]",
+    "enumRepresentation": "internally tagged on the \"kind\" discriminant; variant names and all fields are camelCase; requests deny unknown fields",
+    "bearerCapability": "The one-time claim secret rides in CallContext.bearer_capability (the transport frame), NOT in any JSON body.",
+    "methods": {
+      "/heddle.claim.v1.ClaimService/Resolve": {
+        "requestKinds": ["resolve"],
+        "replyKinds": ["resolved", "refused"]
+      },
+      "/heddle.claim.v1.ClaimService/Consent": {
+        "requestKinds": ["preConsent", "promoteConsent"],
+        "replyKinds": ["preConsented", "promoteConsented"]
+      },
+      "/heddle.claim.v1.ClaimService/ClaimOwnerRoot": {
+        "requestKinds": ["resolveOwnerRoot", "claimOwnerRoot"],
+        "replyKinds": ["ownerRootResolved", "ownerRootCoSigned"]
+      }
+    }
+  },
+  "requests": {
+    "resolve": {
+      "kind": "resolve"
+    },
+    "resolveOwnerRoot": {
+      "kind": "resolveOwnerRoot",
+      "handle": "human-handle"
+    },
+    "preConsent": {
+      "kind": "preConsent",
+      "handle": "human-handle",
+      "nonce": "MDEyMzQ1Njc4OWFiY2RlZg"
+    },
+    "promoteConsent": {
+      "kind": "promoteConsent",
+      "handle": "human-handle",
+      "credentialId": "Y3JlZGVudGlhbA"
+    },
+    "claimOwnerRoot": {
+      "kind": "claimOwnerRoot",
+      "registration": "cmVnaXN0cmF0aW9u",
+      "nextAuthorityKey": "bmV4dC1hdXRob3JpdHkta2V5",
+      "nextAuthorityKeyProof": "bmV4dC1hdXRob3JpdHkta2V5LXByb29m",
+      "nextRecoveryPolicy": "bmV4dC1yZWNvdmVyeS1wb2xpY3k",
+      "nextRecoveryKeyProofs": ["cmVjb3Zlcnkta2V5LXByb29m"],
+      "validFromUnixSeconds": 1,
+      "nonce": "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI"
+    }
+  },
+  "replies": {
+    "resolved": {
+      "kind": "resolved",
+      "agent": {
+        "accountId": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+        "petName": "steady-heron",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "lastActiveAt": null,
+        "spools": [],
+        "repos": [],
+        "changeCount": null,
+        "agentLabel": null
+      }
+    },
+    "preConsented": {
+      "kind": "preConsented",
+      "consent": {
+        "accountId": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+        "nodeId": "1111111111111111111111111111111111111111111111111111111111111111",
+        "signature": "cHJlLWNvbnNlbnQtc2lnbmF0dXJl",
+        "authorizationHash": "authorization-hash-abc123",
+        "expiresAt": 1700000000000
+      }
+    },
+    "promoteConsented": {
+      "kind": "promoteConsented",
+      "consent": {
+        "accountId": "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28",
+        "nodeId": "1111111111111111111111111111111111111111111111111111111111111111",
+        "signature": "cHJvbW90ZS1jb25zZW50LXNpZ25hdHVyZQ",
+        "authorizationHash": "authorization-hash-abc123",
+        "expiresAt": 1700000000000
+      }
+    },
+    "ownerRootResolved": {
+      "kind": "ownerRootResolved",
+      "signedOwnerRoot": "c2lnbmVkLW93bmVyLXJvb3Q",
+      "webauthnChallenge": "d2ViYXV0aG4tY2hhbGxlbmdl"
+    },
+    "ownerRootCoSigned": {
+      "kind": "ownerRootCoSigned",
+      "signedTransition": "c2lnbmVkLXRyYW5zaXRpb24"
+    },
+    "refused": {
+      "kind": "refused",
+      "refusal": "claimed"
+    }
+  }
+}

--- a/crates/hosted-client/contracts/heddle-claim-v1.schema.json
+++ b/crates/hosted-client/contracts/heddle-claim-v1.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heddle.co/contracts/heddle-claim-v1.schema.json",
+  "title": "heddle-claim/1",
+  "description": "JSON contract for the heddle-claim/1 two-phase browser claim protocol. Request and reply bodies are serde_json over the iroh ALPN 'heddle-claim/1', methods /heddle.claim.v1.ClaimService/{Resolve,Consent,ClaimOwnerRoot}. Both enums are internally tagged on 'kind'; variant names and fields are camelCase; requests reject unknown fields. The one-time claim secret travels in CallContext.bearer_capability on the transport frame, never in these bodies. Source of truth: crates/hosted-client/src/hosted_runtime/claim_authorization.rs (private Rust enums ClaimRequest/ClaimReply); a Rust divergence test pins this schema's golden vectors to those enums.",
+  "$defs": {
+    "ClaimRequest": {
+      "description": "A request body sent by the browser claim client.",
+      "oneOf": [
+        { "$ref": "#/$defs/ResolveRequest" },
+        { "$ref": "#/$defs/ResolveOwnerRootRequest" },
+        { "$ref": "#/$defs/PreConsentRequest" },
+        { "$ref": "#/$defs/PromoteConsentRequest" },
+        { "$ref": "#/$defs/ClaimOwnerRootRequest" }
+      ]
+    },
+    "ResolveRequest": {
+      "type": "object",
+      "description": "Method /heddle.claim.v1.ClaimService/Resolve. Reply: resolved or refused.",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "const": "resolve" }
+      }
+    },
+    "ResolveOwnerRootRequest": {
+      "type": "object",
+      "description": "Method /heddle.claim.v1.ClaimService/ClaimOwnerRoot. Reply: ownerRootResolved.",
+      "additionalProperties": false,
+      "required": ["kind", "handle"],
+      "properties": {
+        "kind": { "const": "resolveOwnerRoot" },
+        "handle": { "type": "string" }
+      }
+    },
+    "PreConsentRequest": {
+      "type": "object",
+      "description": "Method /heddle.claim.v1.ClaimService/Consent, phase 1. Reply: preConsented.",
+      "additionalProperties": false,
+      "required": ["kind", "handle", "nonce"],
+      "properties": {
+        "kind": { "const": "preConsent" },
+        "handle": { "type": "string" },
+        "nonce": {
+          "type": "string",
+          "description": "base64url (no padding) of the ceremony nonce; 16..=1024 decoded bytes."
+        }
+      }
+    },
+    "PromoteConsentRequest": {
+      "type": "object",
+      "description": "Method /heddle.claim.v1.ClaimService/Consent, phase 2. Reply: promoteConsented.",
+      "additionalProperties": false,
+      "required": ["kind", "handle", "credentialId"],
+      "properties": {
+        "kind": { "const": "promoteConsent" },
+        "handle": { "type": "string" },
+        "credentialId": {
+          "type": "string",
+          "description": "base64url (no padding) of the WebAuthn credential id."
+        }
+      }
+    },
+    "ClaimOwnerRootRequest": {
+      "type": "object",
+      "description": "Method /heddle.claim.v1.ClaimService/ClaimOwnerRoot co-sign. Reply: ownerRootCoSigned. Each *proof/key/policy/registration field is base64url (no padding) of the corresponding protobuf message.",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "registration",
+        "nextAuthorityKey",
+        "nextAuthorityKeyProof",
+        "nextRecoveryPolicy",
+        "nextRecoveryKeyProofs",
+        "validFromUnixSeconds",
+        "nonce"
+      ],
+      "properties": {
+        "kind": { "const": "claimOwnerRoot" },
+        "registration": { "type": "string" },
+        "nextAuthorityKey": { "type": "string" },
+        "nextAuthorityKeyProof": { "type": "string" },
+        "nextRecoveryPolicy": { "type": "string" },
+        "nextRecoveryKeyProofs": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "validFromUnixSeconds": { "type": "integer" },
+        "nonce": { "type": "string" }
+      }
+    },
+    "ClaimReply": {
+      "description": "A reply body returned by heddle.",
+      "oneOf": [
+        { "$ref": "#/$defs/ResolvedReply" },
+        { "$ref": "#/$defs/PreConsentedReply" },
+        { "$ref": "#/$defs/PromoteConsentedReply" },
+        { "$ref": "#/$defs/OwnerRootResolvedReply" },
+        { "$ref": "#/$defs/OwnerRootCoSignedReply" },
+        { "$ref": "#/$defs/RefusedReply" }
+      ]
+    },
+    "ResolvedReply": {
+      "type": "object",
+      "required": ["kind", "agent"],
+      "properties": {
+        "kind": { "const": "resolved" },
+        "agent": { "$ref": "#/$defs/AgentAccountSummary" }
+      }
+    },
+    "PreConsentedReply": {
+      "type": "object",
+      "required": ["kind", "consent"],
+      "properties": {
+        "kind": { "const": "preConsented" },
+        "consent": { "$ref": "#/$defs/AgentConsent" }
+      }
+    },
+    "PromoteConsentedReply": {
+      "type": "object",
+      "required": ["kind", "consent"],
+      "properties": {
+        "kind": { "const": "promoteConsented" },
+        "consent": { "$ref": "#/$defs/AgentConsent" }
+      }
+    },
+    "OwnerRootResolvedReply": {
+      "type": "object",
+      "required": ["kind", "signedOwnerRoot", "webauthnChallenge"],
+      "properties": {
+        "kind": { "const": "ownerRootResolved" },
+        "signedOwnerRoot": {
+          "type": "string",
+          "description": "base64url (no padding) of the SignedOwnerRoot protobuf."
+        },
+        "webauthnChallenge": {
+          "type": "string",
+          "description": "base64url (no padding) of the AuthChallengeResponse protobuf."
+        }
+      }
+    },
+    "OwnerRootCoSignedReply": {
+      "type": "object",
+      "required": ["kind", "signedTransition"],
+      "properties": {
+        "kind": { "const": "ownerRootCoSigned" },
+        "signedTransition": {
+          "type": "string",
+          "description": "base64url (no padding) of the SignedOwnerKeyTransition protobuf."
+        }
+      }
+    },
+    "RefusedReply": {
+      "type": "object",
+      "required": ["kind", "refusal"],
+      "properties": {
+        "kind": { "const": "refused" },
+        "refusal": {
+          "type": "string",
+          "description": "Terminal refusal reason, e.g. \"claimed\" when the account is already claimed."
+        }
+      }
+    },
+    "AgentAccountSummary": {
+      "type": "object",
+      "description": "The resolved agent account. lastActiveAt, changeCount and agentLabel are always present but may be null (serde emits None as null).",
+      "required": [
+        "accountId",
+        "petName",
+        "createdAt",
+        "lastActiveAt",
+        "spools",
+        "repos",
+        "changeCount",
+        "agentLabel"
+      ],
+      "properties": {
+        "accountId": { "type": "string" },
+        "petName": { "type": "string" },
+        "createdAt": { "type": "string" },
+        "lastActiveAt": { "type": ["string", "null"] },
+        "spools": { "type": "array", "items": true },
+        "repos": { "type": "array", "items": true },
+        "changeCount": { "type": ["integer", "null"], "minimum": 0 },
+        "agentLabel": { "type": ["string", "null"] }
+      }
+    },
+    "AgentConsent": {
+      "type": "object",
+      "description": "A signed consent tuple. signature is base64url (no padding) over weft's exact counted-tuple statement; expiresAt is Unix milliseconds.",
+      "required": [
+        "accountId",
+        "nodeId",
+        "signature",
+        "authorizationHash",
+        "expiresAt"
+      ],
+      "properties": {
+        "accountId": { "type": "string" },
+        "nodeId": { "type": "string" },
+        "signature": { "type": "string" },
+        "authorizationHash": { "type": "string" },
+        "expiresAt": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
@@ -796,3 +796,236 @@ fn failure(code: CallFailureCode, message: impl Into<String>) -> CallFailure {
         error: None,
     }
 }
+
+/// Pins the published `heddle-claim/1` JSON contract to these private serde
+/// enums. The golden vectors and JSON Schema under `contracts/` are the source
+/// of truth browser/TS clients consume; if a field name, `#[serde(rename)]`,
+/// the `kind` tag, or the camelCase casing here ever drifts from what is
+/// published, one of these assertions fails and the build goes red.
+///
+/// See `crates/hosted-client/contracts/README.md`.
+#[cfg(test)]
+mod contract {
+    use super::{
+        AgentAccountSummary, AgentConsent, ClaimReply, ClaimRequest, parse_request,
+    };
+    use serde_json::{Value, json};
+
+    const GOLDEN: &str = include_str!("../../contracts/heddle-claim-v1.golden.json");
+    const SCHEMA: &str = include_str!("../../contracts/heddle-claim-v1.schema.json");
+
+    fn golden() -> Value {
+        serde_json::from_str(GOLDEN).expect("golden vectors parse as JSON")
+    }
+
+    fn sample_consent(signature: &str) -> AgentConsent {
+        AgentConsent {
+            account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".to_string(),
+            node_id: "11".repeat(32),
+            signature: signature.to_string(),
+            authorization_hash: "authorization-hash-abc123".to_string(),
+            expires_at: 1_700_000_000_000,
+        }
+    }
+
+    /// Every reply variant, serialized through the real enum, must equal its
+    /// published golden vector — this is what catches a rename/casing/tag drift
+    /// on the reply side that a hand-mirror would silently diverge on.
+    #[test]
+    fn reply_variants_match_published_golden() {
+        let golden = golden();
+        let replies = &golden["replies"];
+
+        let cases: Vec<(&str, ClaimReply)> = vec![
+            (
+                "resolved",
+                ClaimReply::Resolved {
+                    agent: AgentAccountSummary {
+                        account_id: "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28".to_string(),
+                        pet_name: "steady-heron".to_string(),
+                        created_at: "2026-01-01T00:00:00Z".to_string(),
+                        last_active_at: None,
+                        spools: Vec::new(),
+                        repos: Vec::new(),
+                        change_count: None,
+                        agent_label: None,
+                    },
+                },
+            ),
+            (
+                "preConsented",
+                ClaimReply::PreConsented {
+                    consent: sample_consent("cHJlLWNvbnNlbnQtc2lnbmF0dXJl"),
+                },
+            ),
+            (
+                "promoteConsented",
+                ClaimReply::PromoteConsented {
+                    consent: sample_consent("cHJvbW90ZS1jb25zZW50LXNpZ25hdHVyZQ"),
+                },
+            ),
+            (
+                "ownerRootResolved",
+                ClaimReply::OwnerRootResolved {
+                    signed_owner_root: "c2lnbmVkLW93bmVyLXJvb3Q".to_string(),
+                    webauthn_challenge: "d2ViYXV0aG4tY2hhbGxlbmdl".to_string(),
+                },
+            ),
+            (
+                "ownerRootCoSigned",
+                ClaimReply::OwnerRootCoSigned {
+                    signed_transition: "c2lnbmVkLXRyYW5zaXRpb24".to_string(),
+                },
+            ),
+            ("refused", ClaimReply::Refused { refusal: "claimed" }),
+        ];
+
+        for (kind, reply) in cases {
+            let produced = serde_json::to_value(&reply).expect("reply serializes");
+            assert_eq!(
+                produced["kind"], kind,
+                "{kind} reply must carry its own internal tag"
+            );
+            assert_eq!(
+                produced, replies[kind],
+                "{kind} reply diverged from the published golden vector"
+            );
+        }
+
+        // Every published reply vector is covered by a case above.
+        let published: std::collections::BTreeSet<String> = replies
+            .as_object()
+            .expect("replies is an object")
+            .keys()
+            .cloned()
+            .collect();
+        let covered: std::collections::BTreeSet<String> = [
+            "resolved",
+            "preConsented",
+            "promoteConsented",
+            "ownerRootResolved",
+            "ownerRootCoSigned",
+            "refused",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        assert_eq!(
+            published, covered,
+            "published reply vectors and the pinned cases must be the same set"
+        );
+    }
+
+    /// Every request variant's published golden vector must parse through the
+    /// real deserialize enum with the expected fields. `deny_unknown_fields`
+    /// plus the internal tag mean a rename/casing drift makes the published
+    /// vector fail to parse — turning this red.
+    #[test]
+    fn request_variants_match_published_golden() {
+        let golden = golden();
+        let requests = &golden["requests"];
+
+        let bytes = |kind: &str| serde_json::to_vec(&requests[kind]).expect("request re-serializes");
+
+        assert!(matches!(
+            parse_request(&bytes("resolve")).expect("resolve parses"),
+            ClaimRequest::Resolve
+        ));
+
+        match parse_request(&bytes("resolveOwnerRoot")).expect("resolveOwnerRoot parses") {
+            ClaimRequest::ResolveOwnerRoot { handle } => assert_eq!(handle, "human-handle"),
+            _ => panic!("resolveOwnerRoot parsed as the wrong variant"),
+        }
+
+        match parse_request(&bytes("preConsent")).expect("preConsent parses") {
+            ClaimRequest::PreConsent { handle, nonce } => {
+                assert_eq!(handle, "human-handle");
+                assert_eq!(nonce, "MDEyMzQ1Njc4OWFiY2RlZg");
+            }
+            _ => panic!("preConsent parsed as the wrong variant"),
+        }
+
+        match parse_request(&bytes("promoteConsent")).expect("promoteConsent parses") {
+            ClaimRequest::PromoteConsent {
+                handle,
+                credential_id,
+            } => {
+                assert_eq!(handle, "human-handle");
+                assert_eq!(credential_id, "Y3JlZGVudGlhbA");
+            }
+            _ => panic!("promoteConsent parsed as the wrong variant"),
+        }
+
+        match parse_request(&bytes("claimOwnerRoot")).expect("claimOwnerRoot parses") {
+            ClaimRequest::ClaimOwnerRoot {
+                registration,
+                next_authority_key,
+                next_authority_key_proof,
+                next_recovery_policy,
+                next_recovery_key_proofs,
+                valid_from_unix_seconds,
+                nonce,
+            } => {
+                assert_eq!(registration, "cmVnaXN0cmF0aW9u");
+                assert_eq!(next_authority_key, "bmV4dC1hdXRob3JpdHkta2V5");
+                assert_eq!(next_authority_key_proof, "bmV4dC1hdXRob3JpdHkta2V5LXByb29m");
+                assert_eq!(next_recovery_policy, "bmV4dC1yZWNvdmVyeS1wb2xpY3k");
+                assert_eq!(next_recovery_key_proofs, vec!["cmVjb3Zlcnkta2V5LXByb29m"]);
+                assert_eq!(valid_from_unix_seconds, 1);
+                assert_eq!(nonce, "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI");
+            }
+            _ => panic!("claimOwnerRoot parsed as the wrong variant"),
+        }
+
+        // An unknown field must be rejected — proves the published vectors are
+        // exhaustive, not merely a permissive subset.
+        let mut poisoned = requests["preConsent"].clone();
+        poisoned["unexpected"] = json!(true);
+        assert!(
+            parse_request(&serde_json::to_vec(&poisoned).unwrap()).is_err(),
+            "requests must deny unknown fields"
+        );
+    }
+
+    /// The hand-maintained JSON Schema must declare exactly the `kind`
+    /// discriminants the golden vectors (and therefore the enums) carry, so a
+    /// new/removed variant cannot land in the golden without the schema
+    /// following.
+    #[test]
+    fn schema_declares_the_same_variants_as_the_golden() {
+        let golden = golden();
+        let schema: Value = serde_json::from_str(SCHEMA).expect("schema parses as JSON");
+
+        let mut schema_kinds = std::collections::BTreeSet::new();
+        for def in schema["$defs"]
+            .as_object()
+            .expect("schema $defs is an object")
+            .values()
+        {
+            if let Some(kind) = def
+                .get("properties")
+                .and_then(|properties| properties.get("kind"))
+                .and_then(|kind| kind.get("const"))
+                .and_then(Value::as_str)
+            {
+                schema_kinds.insert(kind.to_string());
+            }
+        }
+
+        let mut golden_kinds = std::collections::BTreeSet::new();
+        for group in ["requests", "replies"] {
+            for kind in golden[group]
+                .as_object()
+                .expect("golden group is an object")
+                .keys()
+            {
+                golden_kinds.insert(kind.clone());
+            }
+        }
+
+        assert_eq!(
+            schema_kinds, golden_kinds,
+            "the JSON Schema and golden vectors must declare the same variants"
+        );
+    }
+}


### PR DESCRIPTION
## What

Publishes a consumable JSON contract for the **claim protocol's two-phase flow** so browser/TS clients (tapestry, iroh-web#2) stop hand-mirroring it from the private Rust enums in `crates/hosted-client/src/hosted_runtime/claim_authorization.rs`. The tapestry stub was already wrong — it modeled a single `consent`; heddle implements a two-phase `preConsent`/`promoteConsent`.

Closes heddle#1564.

## Published artifacts (`crates/hosted-client/contracts/`)

- `heddle-claim-v1.schema.json` — JSON Schema (draft 2020-12) for every request/reply variant; feed to `json-schema-to-typescript` / `ajv` / `quicktype`.
- `heddle-claim-v1.golden.json` — golden vectors (one concrete example per variant) + the ALPN/method routing.
- `README.md` — transport (ALPN `heddle-claim/1`, methods, bearer-in-`CallContext`), the two-phase flow, and the divergence guard.

## Contract, pinned from the real serde enums

Enums are **serde_json** (not protobuf), **internally tagged** on `kind`, variant names and fields **camelCase**, requests **deny unknown fields**. Correction to the issue's summary: there is a **third method** (`ClaimOwnerRoot`) and its `resolveOwnerRoot`/`claimOwnerRoot` requests + `ownerRootResolved`/`ownerRootCoSigned` replies — the published contract covers all of it.

| Method | Request `kind` | Reply `kind` |
|---|---|---|
| `…/Resolve` | `resolve` | `resolved` \| `refused` |
| `…/Consent` | `preConsent {handle,nonce}` | `preConsented {consent}` |
| `…/Consent` | `promoteConsent {handle,credentialId}` | `promoteConsented {consent}` |
| `…/ClaimOwnerRoot` | `resolveOwnerRoot {handle}` | `ownerRootResolved {signedOwnerRoot,webauthnChallenge}` |
| `…/ClaimOwnerRoot` | `claimOwnerRoot {…}` | `ownerRootCoSigned {signedTransition}` |

`AgentAccountSummary` emits `lastActiveAt`/`changeCount`/`agentLabel` as present-but-`null` (no `skip_serializing_if`). The claim secret rides in `CallContext.bearer_capability`, never in a body.

## Divergence guard

`#[cfg(test)] mod contract` in `claim_authorization.rs` serializes every `ClaimReply` variant and parses every `ClaimRequest` variant through the **real enums**, asserting equality with the golden vectors, plus that the schema declares the same variant set. Any field rename, `#[serde(rename)]`, tag, or casing drift turns the build red.

**Perturbation proof:** renamed `petName`→`petName2` and `credentialId`→`credential_id` in the golden → `reply_variants_match_published_golden` FAILED ("resolved reply diverged…") and `request_variants_match_published_golden` FAILED ("promoteConsent parses: invalid claim request body"); restored → all 3 green.

## Verification

`cargo test -p heddle-hosted-client --features client contract::` → `3 passed`. `cargo clippy -p heddle-hosted-client --features client --tests` clean (isolated target). No generated-schema freshness gate touches this path.

## Consumability / release

The contract is checked-in JSON + a Rust test — **no heddle release is required** for a consumer to read the files from this repo. If tapestry/iroh-web prefer to vendor them via a published heddle crate rather than a repo reference, that would need a `heddle-hosted-client` release; flagging for orchestrator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790782371&installation_model_id=21489&pr_number=1621&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1621&signature=0dc2ee4df25d01e93843ba1a61125056e7ce1de8cfd665366965e2e6a4bc0c08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->