### PR TITLE
feat(claim): mount heddle-claim/1 router on the net daemon + foreground co-sign bridge (heddle#1620)

### DIFF
--- a/crates/cli/src/cli/commands/netdaemon/server.rs
+++ b/crates/cli/src/cli/commands/netdaemon/server.rs
@@ -81,18 +81,23 @@ pub async fn run_network_daemon() -> Result<()> {
     .context("binding persistent device endpoint")?;
     let node_id = endpoint.id().to_string();
 
-    // ---- PIECE 3 (heddle#1620) MOUNT SEAM ----
-    // The endpoint is live, relay-reachable, and pinned to the
-    // persisted node id. Piece 3 mounts the claim protocol here,
-    // without tearing this daemon down:
+    // ---- PIECE 3 (heddle#1620): mount the claim-ALPN router ----
+    // The endpoint is live, relay-reachable, and pinned to the persisted
+    // node id. Mount the persistent `heddle-claim/1` router on it and
+    // serve its owner-root co-sign bridge for the daemon's lifetime.
     //
-    //     use hosted_client::network::Router;
-    //     let router = Router::builder(endpoint.clone())
-    //         .accept(CLAIM_ALPN_V1, claim_protocol)
-    //         .spawn();
-    //
-    // Hold the returned `router` alongside `endpoint` for the daemon's
-    // lifetime and shut it down in the cleanup block below.
+    // The daemon drives Resolve / preConsent / promoteConsent inline
+    // against the file-backed claim state, but it deliberately holds no
+    // agent owner-root signer (decision D3): when a browser reaches the
+    // owner-root co-sign, the router forwards it over `claim_socket` to a
+    // foreground `heddle claim` process, which holds the signer and a live
+    // HostedClient and completes the co-sign. The bridge task is aborted
+    // and its socket removed in the cleanup block below; because the
+    // router re-mounts on the persisted node id, a daemon restart mid-
+    // window keeps outstanding claim links resolving.
+    let claim_socket = hosted_client::network::claim_bridge_socket_path(&heddle_home);
+    let claim_router = hosted_client::network::mount_claim_router(endpoint.clone());
+    let claim_bridge = tokio::spawn(claim_router.serve_owner_root_bridge(claim_socket.clone()));
 
     let advertised = EndpointState {
         version: NETWORK_DAEMON_PROTOCOL_VERSION,
@@ -129,12 +134,15 @@ pub async fn run_network_daemon() -> Result<()> {
 
     let loop_result = control.await;
 
-    // Cleanup ordering: close the endpoint first, then unlink our own
-    // discovery file (only if it still advertises us) and the socket.
-    // `remove_endpoint_if_owned` makes the unlink single-writer safe —
-    // a successor that raced in keeps its file.
+    // Cleanup ordering: stop the claim bridge, close the endpoint (which
+    // tears the router down), then unlink our own discovery file (only if
+    // it still advertises us) and the sockets. `remove_endpoint_if_owned`
+    // makes the unlink single-writer safe — a successor that raced in
+    // keeps its file.
+    claim_bridge.abort();
     endpoint.close().await;
     remove_endpoint_if_owned(&endpoint_path, &advertised);
+    let _ = std::fs::remove_file(&claim_socket);
     let _ = std::fs::remove_file(&socket_path);
     info!("heddle network daemon exiting");
 

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization.rs
@@ -160,15 +160,30 @@ impl ClaimOwnerRootResult {
     }
 }
 
+/// One owner-root call the daemon-hosted router forwards to a foreground
+/// signer. It carries only the verified principal and the raw request
+/// body — never a parsed operation and never a signer — so the daemon can
+/// relay it across the co-sign bridge without interpreting it. The
+/// `response` oneshot is daemon-local and never crosses the socket.
 #[derive(Debug)]
 pub(crate) struct ClaimOwnerRootCall {
-    pub(crate) principal: VerifiedClaimPrincipal,
-    pub(crate) operation: ClaimOwnerRootOperation,
-    response: tokio::sync::oneshot::Sender<Result<ClaimOwnerRootResult, CallFailure>>,
+    principal: VerifiedClaimPrincipal,
+    body: Vec<u8>,
+    response: tokio::sync::oneshot::Sender<Result<Vec<u8>, CallFailure>>,
 }
 
 impl ClaimOwnerRootCall {
-    pub(crate) fn respond(self, response: Result<ClaimOwnerRootResult, CallFailure>) {
+    pub(crate) fn principal(&self) -> &VerifiedClaimPrincipal {
+        &self.principal
+    }
+
+    pub(crate) fn body(&self) -> &[u8] {
+        &self.body
+    }
+
+    /// Relay the foreground worker's reply bytes (or a failure) back to
+    /// the browser call awaiting on the daemon.
+    pub(crate) fn respond(self, response: Result<Vec<u8>, CallFailure>) {
         let _ = self.response.send(response);
     }
 }
@@ -252,54 +267,67 @@ impl ClaimHandler for StoredClaimAuthorization {
 }
 
 impl StoredClaimAuthorization {
+    /// Forward an owner-root call to the foreground signer over the
+    /// co-sign bridge and relay its reply back to the browser.
+    ///
+    /// The daemon performs a fail-fast active-state gate for this
+    /// principal, then hands the raw body to a foreground `heddle claim`
+    /// worker (which holds the signer and re-checks the state under the
+    /// write lock before signing). The reply bytes come back verbatim —
+    /// the daemon neither parses the body nor encodes the reply, and so
+    /// never touches the agent owner-root signer.
     async fn owner_root_reply(
         &self,
         principal: VerifiedClaimPrincipal,
         body: &[u8],
     ) -> Result<Vec<u8>, CallFailure> {
-        let operation = {
-            let _guard = identity_state::write_lock().map_err(internal_failure)?;
-            let state = identity_state::load_while_locked()
-                .map_err(internal_failure)?
-                .ok_or_else(auth_failure)?;
-            let now = chrono::Utc::now().timestamp_millis();
-            if state.owner_id.to_string() != principal.subject
-                || state.authorization_hash() != principal.authorization_hash
-                || !state.is_active(now)
-            {
-                return Err(auth_failure());
-            }
-            owner_root_operation(body)?
-        };
+        let state = identity_state::load()
+            .map_err(internal_failure)?
+            .ok_or_else(auth_failure)?;
+        let now = chrono::Utc::now().timestamp_millis();
+        if state.owner_id.to_string() != principal.subject
+            || state.authorization_hash() != principal.authorization_hash
+            || !state.is_active(now)
+        {
+            return Err(auth_failure());
+        }
         let (response, receive) = tokio::sync::oneshot::channel();
         self.owner_root_calls
             .send(ClaimOwnerRootCall {
                 principal,
-                operation,
+                body: body.to_vec(),
                 response,
             })
             .await
             .map_err(|_| internal_failure("claim owner-root session is unavailable"))?;
-        let result = receive
+        receive
             .await
-            .map_err(|_| internal_failure("claim owner-root session stopped"))??;
-        let reply = match result
-            .as_ref()
-            .ok_or_else(|| internal_failure("claim owner-root result has an invalid shape"))?
-        {
-            ClaimOwnerRootResultRef::Resolved {
-                signed_owner_root,
-                webauthn_challenge,
-            } => ClaimReply::OwnerRootResolved {
-                signed_owner_root: encode_message(signed_owner_root),
-                webauthn_challenge: encode_message(webauthn_challenge),
-            },
-            ClaimOwnerRootResultRef::CoSigned(signed_transition) => ClaimReply::OwnerRootCoSigned {
-                signed_transition: encode_message(signed_transition),
-            },
-        };
-        serde_json::to_vec(&reply).map_err(internal_failure)
+            .map_err(|_| internal_failure("claim owner-root session stopped"))?
     }
+}
+
+/// Encode an owner-root result into the exact `heddle-claim/1` reply the
+/// browser consumes. Runs in the foreground worker (which produced the
+/// result), never in the daemon.
+pub(crate) fn encode_owner_root_reply(
+    result: &ClaimOwnerRootResult,
+) -> Result<Vec<u8>, CallFailure> {
+    let reply = match result
+        .as_ref()
+        .ok_or_else(|| internal_failure("claim owner-root result has an invalid shape"))?
+    {
+        ClaimOwnerRootResultRef::Resolved {
+            signed_owner_root,
+            webauthn_challenge,
+        } => ClaimReply::OwnerRootResolved {
+            signed_owner_root: encode_message(signed_owner_root),
+            webauthn_challenge: encode_message(webauthn_challenge),
+        },
+        ClaimOwnerRootResultRef::CoSigned(signed_transition) => ClaimReply::OwnerRootCoSigned {
+            signed_transition: encode_message(signed_transition),
+        },
+    };
+    serde_json::to_vec(&reply).map_err(internal_failure)
 }
 
 #[derive(Deserialize)]
@@ -460,7 +488,7 @@ pub(crate) fn consent_reply(
     }
 }
 
-fn owner_root_operation(body: &[u8]) -> Result<ClaimOwnerRootOperation, CallFailure> {
+pub(crate) fn owner_root_operation(body: &[u8]) -> Result<ClaimOwnerRootOperation, CallFailure> {
     match parse_request(body)? {
         ClaimRequest::ResolveOwnerRoot { handle } => {
             validate_handle(&handle)?;

--- a/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_authorization_tests.rs
@@ -1,3 +1,7 @@
+// The canned owner-root worker returns `Result<_, CallFailure>` by value,
+// mirroring the production co-sign seam.
+#![allow(clippy::result_large_err)]
+
 use std::{
     ffi::OsString,
     net::Ipv4Addr,
@@ -22,11 +26,12 @@ use super::{
     agent_node_identity,
     auth_login::store_agent_root,
     claim_authorization::{
-        AgentConsent, ClaimOwnerRootOperationRef, ClaimOwnerRootResult, StoredClaimAuthorization,
-        consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
+        AgentConsent, ClaimOwnerRootResult, StoredClaimAuthorization, consent_reply,
+        encode_owner_root_reply, pre_consent_message, promote_consent_message, resolved_reply,
         signed_pre_consent, signed_promote_consent, validate_credential_id, validate_handle,
         verify_promotion_consents,
     },
+    claim_bridge::{ClaimBridgeWorker, claim_bridge_socket_path, mount_claim_router},
     device_flow::restrict_agent_account_root,
     hosted::claim_protocol::{
         CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_OWNER_ROOT_METHOD, CLAIM_RESOLVE_METHOD,
@@ -683,12 +688,14 @@ async fn claim_owner_root_routes_resolve_and_cosign_over_the_authenticated_chann
     let pending = owner_root_calls
         .recv()
         .await
-        .expect("resolve reaches cmd_claim");
-    assert!(matches!(
-        pending.operation.as_ref(),
-        Some(ClaimOwnerRootOperationRef::Resolve("human-handle"))
-    ));
-    pending.respond(Ok(ClaimOwnerRootResult::resolved(
+        .expect("resolve reaches the foreground signer");
+    // The daemon forwards the raw request body — never a parsed operation
+    // and never a signer — so a foreground worker parses and co-signs it.
+    let forwarded: serde_json::Value =
+        serde_json::from_slice(pending.body()).expect("forwarded owner-root body");
+    assert_eq!(forwarded["kind"], "resolveOwnerRoot");
+    assert_eq!(forwarded["handle"], "human-handle");
+    let resolved_reply = encode_owner_root_reply(&ClaimOwnerRootResult::resolved(
         SignedOwnerRoot::default(),
         AuthChallengeResponse {
             challenge_id: "challenge-1".to_string(),
@@ -696,7 +703,9 @@ async fn claim_owner_root_routes_resolve_and_cosign_over_the_authenticated_chann
             username: "human-handle".to_string(),
             ..Default::default()
         },
-    )));
+    ))
+    .expect("encode owner-root resolved reply");
+    pending.respond(Ok(resolved_reply));
     let OwnedResponse::Success(resolved) = resolve.await.expect("resolve task") else {
         panic!("owner-root resolve must succeed");
     };
@@ -736,14 +745,15 @@ async fn claim_owner_root_routes_resolve_and_cosign_over_the_authenticated_chann
     let pending = owner_root_calls
         .recv()
         .await
-        .expect("co-sign reaches cmd_claim");
-    assert!(matches!(
-        pending.operation.as_ref(),
-        Some(ClaimOwnerRootOperationRef::CoSign { .. })
-    ));
-    pending.respond(Ok(ClaimOwnerRootResult::co_signed(
+        .expect("co-sign reaches the foreground signer");
+    let forwarded: serde_json::Value =
+        serde_json::from_slice(pending.body()).expect("forwarded co-sign body");
+    assert_eq!(forwarded["kind"], "claimOwnerRoot");
+    let cosign_reply = encode_owner_root_reply(&ClaimOwnerRootResult::co_signed(
         SignedOwnerKeyTransition::default(),
-    )));
+    ))
+    .expect("encode owner-root co-signed reply");
+    pending.respond(Ok(cosign_reply));
     let OwnedResponse::Success(cosigned) = cosign.await.expect("co-sign task") else {
         panic!("owner-root co-sign must succeed");
     };
@@ -1024,4 +1034,297 @@ async fn expired_claim_state_is_rejected_before_resolve() {
 
     client.close().await;
     router.shutdown().await.unwrap();
+}
+
+// ---- Piece 3 (heddle#1620): daemon-hosted router + foreground co-sign bridge ----
+
+async fn device_endpoint() -> Endpoint {
+    let identity = agent_node_identity::load_or_create().expect("persisted device identity");
+    Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .secret_key(identity.secret_key())
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .expect("device bind addr")
+        .bind()
+        .await
+        .expect("device endpoint")
+}
+
+async fn browser_endpoint() -> Endpoint {
+    Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .expect("browser bind addr")
+        .bind()
+        .await
+        .expect("browser endpoint")
+}
+
+/// The co-sign bridge socket is bound asynchronously inside the daemon's
+/// serve task, so a freshly-spawned daemon (or one just restarted) may not
+/// be listening yet. Mirror the foreground's real re-arm retry.
+async fn arm_worker(socket: &std::path::Path) -> ClaimBridgeWorker {
+    for _ in 0..100 {
+        if let Ok(worker) = ClaimBridgeWorker::arm(socket).await {
+            return worker;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("could not arm the owner-root co-sign bridge worker");
+}
+
+fn resolved_owner_root_reply() -> Vec<u8> {
+    encode_owner_root_reply(&ClaimOwnerRootResult::resolved(
+        SignedOwnerRoot::default(),
+        AuthChallengeResponse {
+            challenge_id: "challenge-1".to_string(),
+            challenge: "challenge".to_string(),
+            username: "human-handle".to_string(),
+            ..Default::default()
+        },
+    ))
+    .expect("encode owner-root resolved reply")
+}
+
+fn cosigned_owner_root_reply() -> Vec<u8> {
+    encode_owner_root_reply(&ClaimOwnerRootResult::co_signed(
+        SignedOwnerKeyTransition::default(),
+    ))
+    .expect("encode owner-root co-signed reply")
+}
+
+fn cosign_owner_root_body() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "kind": "claimOwnerRoot",
+        "registration": URL_SAFE_NO_PAD.encode(RegisterPublicKeyRequest::default().encode_to_vec()),
+        "nextAuthorityKey": URL_SAFE_NO_PAD.encode(AuthorizationVerificationKey::default().encode_to_vec()),
+        "nextAuthorityKeyProof": URL_SAFE_NO_PAD.encode(AuthorizationSignature::default().encode_to_vec()),
+        "nextRecoveryPolicy": URL_SAFE_NO_PAD.encode(RecoveryPolicy::default().encode_to_vec()),
+        "nextRecoveryKeyProofs": [],
+        "validFromUnixSeconds": 1,
+        "nonce": URL_SAFE_NO_PAD.encode([0x42; 32]),
+    }))
+    .expect("cosign body json")
+}
+
+/// Dial one owner-root call at the daemon's node id and serve it through
+/// the foreground worker with a canned reply, recording the exact body the
+/// daemon forwarded so the test can prove the co-sign left the daemon.
+async fn bridged_owner_root(
+    browser: &Endpoint,
+    address: &iroh::EndpointAddr,
+    secret: &[u8],
+    request_body: &[u8],
+    worker: &mut ClaimBridgeWorker,
+    observed: &std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+    reply: Vec<u8>,
+) -> serde_json::Value {
+    let dial = {
+        let browser = browser.clone();
+        let address = address.clone();
+        let secret = secret.to_vec();
+        let body = request_body.to_vec();
+        tokio::spawn(async move {
+            call(&browser, address, CLAIM_OWNER_ROOT_METHOD, &secret, &body).await
+        })
+    };
+    let observed = std::sync::Arc::clone(observed);
+    let served = worker
+        .serve_next_canned(move |_subject, _authorization_hash, forwarded_body| {
+            observed.lock().expect("observed lock").push(forwarded_body.to_vec());
+            Ok(reply)
+        })
+        .await
+        .expect("foreground worker serves one owner-root call");
+    assert!(served, "the daemon forwarded one owner-root call to co-sign");
+    let OwnedResponse::Success(reply_bytes) = dial.await.expect("owner-root dial task") else {
+        panic!("bridged owner-root call must succeed");
+    };
+    serde_json::from_slice(&reply_bytes).expect("owner-root reply json")
+}
+
+#[tokio::test]
+async fn daemon_router_forwards_owner_root_cosign_to_the_foreground_signer() {
+    let _home = IsolatedHeddleHome::new();
+    let (secret, _signer) = store_production_claim_state(true);
+
+    let endpoint = device_endpoint().await;
+    let address = endpoint.addr();
+    let node_id = endpoint.id();
+
+    let socket = claim_bridge_socket_path(&repo::identity::heddle_home_dir());
+    let daemon = mount_claim_router(endpoint.clone());
+    let bridge = tokio::spawn(daemon.serve_owner_root_bridge(socket.clone()));
+
+    // Resolve is served inline by the daemon-hosted router — no foreground
+    // process is involved for it.
+    let browser = browser_endpoint().await;
+    let OwnedResponse::Success(resolved) = call(
+        &browser,
+        address.clone(),
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("the daemon-hosted router must resolve");
+    };
+    let resolved: serde_json::Value = serde_json::from_slice(&resolved).unwrap();
+    assert_eq!(resolved["agent"]["petName"], "steady-heron");
+
+    // Owner-root resolve + co-sign are forwarded across the UDS bridge to a
+    // foreground worker that holds the signer; the daemon relays the reply.
+    let mut worker = arm_worker(&socket).await;
+    let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    let resolve_reply = bridged_owner_root(
+        &browser,
+        &address,
+        &secret,
+        br#"{"kind":"resolveOwnerRoot","handle":"human-handle"}"#,
+        &mut worker,
+        &observed,
+        resolved_owner_root_reply(),
+    )
+    .await;
+    assert_eq!(resolve_reply["kind"], "ownerRootResolved");
+
+    let cosign_reply = bridged_owner_root(
+        &browser,
+        &address,
+        &secret,
+        &cosign_owner_root_body(),
+        &mut worker,
+        &observed,
+        cosigned_owner_root_reply(),
+    )
+    .await;
+    assert_eq!(cosign_reply["kind"], "ownerRootCoSigned");
+
+    // The foreground worker — not the daemon — received both owner-root
+    // bodies. The daemon holds no signer and never co-signs itself.
+    let bodies = observed.lock().unwrap().clone();
+    assert_eq!(bodies.len(), 2, "both owner-root calls crossed the bridge");
+    let first: serde_json::Value = serde_json::from_slice(&bodies[0]).unwrap();
+    assert_eq!(first["kind"], "resolveOwnerRoot");
+    let second: serde_json::Value = serde_json::from_slice(&bodies[1]).unwrap();
+    assert_eq!(second["kind"], "claimOwnerRoot");
+
+    assert_eq!(
+        node_id,
+        agent_node_identity::load().unwrap().unwrap().node_id(),
+        "the advertised claim node id is the persisted device node id"
+    );
+
+    drop(worker);
+    browser.close().await;
+    bridge.abort();
+    let _ = bridge.await;
+    endpoint.close().await;
+}
+
+#[tokio::test]
+async fn owner_root_cosign_fails_closed_when_no_foreground_signer_is_armed() {
+    let _home = IsolatedHeddleHome::new();
+    let (secret, _signer) = store_production_claim_state(true);
+
+    let endpoint = device_endpoint().await;
+    let address = endpoint.addr();
+    let socket = claim_bridge_socket_path(&repo::identity::heddle_home_dir());
+    let daemon = mount_claim_router(endpoint.clone());
+    let bridge = tokio::spawn(daemon.serve_owner_root_bridge(socket.clone()));
+
+    // No foreground `heddle claim` is armed. The daemon must never co-sign
+    // the owner root itself — it holds no signer — so the call fails closed.
+    let browser = browser_endpoint().await;
+    let OwnedResponse::Failure(failure) = call(
+        &browser,
+        address,
+        CLAIM_OWNER_ROOT_METHOD,
+        &secret,
+        br#"{"kind":"resolveOwnerRoot","handle":"human-handle"}"#,
+    )
+    .await
+    else {
+        panic!("owner-root co-sign without a foreground signer must fail closed");
+    };
+    assert_eq!(failure.code, CallFailureCode::FailedPrecondition as i32);
+
+    browser.close().await;
+    bridge.abort();
+    let _ = bridge.await;
+    endpoint.close().await;
+}
+
+#[tokio::test]
+async fn daemon_claim_router_re_mounts_on_the_persisted_node_id_after_restart() {
+    let _home = IsolatedHeddleHome::new();
+    let (secret, _signer) = store_production_claim_state(true);
+    let socket = claim_bridge_socket_path(&repo::identity::heddle_home_dir());
+    let observed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let browser = browser_endpoint().await;
+
+    // First daemon incarnation serves one owner-root call over the bridge.
+    let endpoint_a = device_endpoint().await;
+    let address_a = endpoint_a.addr();
+    let node_id_a = endpoint_a.id();
+    let daemon_a = mount_claim_router(endpoint_a.clone());
+    let bridge_a = tokio::spawn(daemon_a.serve_owner_root_bridge(socket.clone()));
+    let mut worker_a = arm_worker(&socket).await;
+    let before = bridged_owner_root(
+        &browser,
+        &address_a,
+        &secret,
+        br#"{"kind":"resolveOwnerRoot","handle":"human-handle"}"#,
+        &mut worker_a,
+        &observed,
+        resolved_owner_root_reply(),
+    )
+    .await;
+    assert_eq!(before["kind"], "ownerRootResolved");
+
+    // Restart mid-window: stop the bridge, tear the endpoint down, drop the
+    // foreground worker's connection.
+    bridge_a.abort();
+    let _ = bridge_a.await;
+    drop(worker_a);
+    endpoint_a.close().await;
+
+    // Second incarnation rebinds the SAME persisted device node id.
+    let endpoint_b = device_endpoint().await;
+    let node_id_b = endpoint_b.id();
+    assert_eq!(
+        node_id_a, node_id_b,
+        "the claim link node id must survive the daemon restart"
+    );
+    let address_b = endpoint_b.addr();
+    let daemon_b = mount_claim_router(endpoint_b.clone());
+    let bridge_b = tokio::spawn(daemon_b.serve_owner_root_bridge(socket.clone()));
+
+    // Re-dial the same node id and re-arm the foreground signer; the
+    // ceremony completes again against the re-mounted router.
+    let mut worker_b = arm_worker(&socket).await;
+    let after = bridged_owner_root(
+        &browser,
+        &address_b,
+        &secret,
+        br#"{"kind":"resolveOwnerRoot","handle":"human-handle"}"#,
+        &mut worker_b,
+        &observed,
+        resolved_owner_root_reply(),
+    )
+    .await;
+    assert_eq!(after["kind"], "ownerRootResolved");
+    assert_eq!(
+        observed.lock().unwrap().len(),
+        2,
+        "both daemon incarnations forwarded the co-sign to a foreground signer"
+    );
+
+    drop(worker_b);
+    browser.close().await;
+    bridge_b.abort();
+    let _ = bridge_b.await;
+    endpoint_b.close().await;
 }

--- a/crates/hosted-client/src/hosted_runtime/claim_bridge.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_bridge.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-process bridge for the owner-root co-sign step of the browser
+//! claim ceremony (heddle#1620, decision D3).
+//!
+//! The persistent box network daemon (`heddle netd`) hosts the
+//! `heddle-claim/1` router (see [`mount_claim_router`]). It drives the
+//! browser's `Resolve` + `preConsent` + `promoteConsent` calls itself,
+//! but it deliberately **does not hold the agent owner-root signer**.
+//! When a browser reaches the owner-root co-sign (`ClaimOwnerRoot`), the
+//! daemon forwards the call — subject, authorization hash, and the raw
+//! request body — over a same-uid Unix socket to a foreground
+//! `heddle claim` process, which holds `claim_proof_signer()` and a live
+//! [`HostedClient`], completes the co-sign, and returns the reply the
+//! daemon relays back to the browser verbatim.
+//!
+//! The in-process `mpsc` between the router handler and the daemon stays
+//! inside the daemon; only the serialized request/reply cross the socket,
+//! on a connection the foreground worker holds open for the ceremony
+//! window. This keeps the mpsc's oneshot responder daemon-local (it can
+//! never cross the socket) while the signer stays foreground-only.
+
+use anyhow::{Context, Result};
+use api::heddle::api::v1alpha1::{CallFailure, CallFailureCode};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use iroh::{Endpoint, protocol::Router};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{UnixListener, UnixStream},
+};
+
+use super::{
+    claim_authorization::{ClaimOwnerRootCall, StoredClaimAuthorization},
+    claim_offer::handle_owner_root_body,
+    hosted::{
+        HostedClient,
+        claim_protocol::{CLAIM_ALPN_V1, ClaimProtocol, VerifiedClaimPrincipal},
+    },
+};
+
+/// Ceiling on a single bridge frame. Owner-root bodies carry a handful of
+/// small protobuf messages; a few hundred KiB is comfortably above the
+/// real payloads and well below anything that could pressure memory.
+const MAX_BRIDGE_FRAME: usize = 1024 * 1024;
+
+/// Serialized daemon→worker request: the verified principal plus the raw
+/// `ClaimOwnerRoot` body. The daemon never interprets the body — parsing,
+/// signing, and reply encoding all happen in the foreground worker.
+#[derive(Serialize, Deserialize)]
+struct BridgeRequest {
+    subject: String,
+    authorization_hash: String,
+    body_b64: String,
+}
+
+/// Serialized worker→daemon reply: either the exact reply bytes the
+/// browser consumes, or a structured failure to relay back.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum BridgeReply {
+    Ok { reply_b64: String },
+    Err { code: i32, message: String },
+}
+
+fn failure(code: CallFailureCode, message: impl Into<String>) -> CallFailure {
+    CallFailure {
+        code: code as i32,
+        message: message.into(),
+        error: None,
+    }
+}
+
+/// Box-scoped path of the owner-root co-sign bridge socket:
+/// `<heddle_home>/state/heddle-netd-claim.sock`.
+///
+/// The single source of truth for both the daemon (which binds it) and a
+/// foreground `heddle claim` (which connects to it).
+pub fn claim_bridge_socket_path(heddle_home: &Path) -> PathBuf {
+    repo::daemon::box_state_dir_in(heddle_home).join("heddle-netd-claim.sock")
+}
+
+/// The claim router mounted on the daemon's persistent endpoint, plus the
+/// channel of owner-root calls the daemon must forward to a foreground
+/// signer. Held for the daemon's lifetime; dropping it (or completing
+/// [`Self::serve_owner_root_bridge`]) shuts the router down.
+pub struct DaemonClaimRouter {
+    router: Router,
+    owner_root_calls: tokio::sync::mpsc::Receiver<ClaimOwnerRootCall>,
+}
+
+/// Mount the `heddle-claim/1` router on a live daemon endpoint.
+///
+/// The router serves `Resolve` / `preConsent` / `promoteConsent` inline
+/// against the file-backed, lock-serialized claim state (so it works
+/// across daemon restarts on the persisted node id), and routes the
+/// owner-root co-sign out through [`DaemonClaimRouter::serve_owner_root_bridge`].
+#[must_use]
+pub fn mount_claim_router(endpoint: Endpoint) -> DaemonClaimRouter {
+    let (authorization, _completion, owner_root_calls) = StoredClaimAuthorization::new();
+    let authorization = std::sync::Arc::new(authorization);
+    let router = Router::builder(endpoint)
+        .accept(
+            CLAIM_ALPN_V1,
+            ClaimProtocol::new(std::sync::Arc::clone(&authorization), authorization),
+        )
+        .spawn();
+    DaemonClaimRouter {
+        router,
+        owner_root_calls,
+    }
+}
+
+impl DaemonClaimRouter {
+    /// Serve the owner-root co-sign bridge on `socket_path` until the
+    /// router's endpoint closes (its owner-root sender drops).
+    ///
+    /// A single foreground worker is armed at a time; a newer connection
+    /// replaces an older one. When no worker is armed, or the armed
+    /// worker's connection has failed, an owner-root call fails closed
+    /// with a `FailedPrecondition` the browser can surface — never a
+    /// hang, and never a co-sign the daemon performed itself.
+    pub async fn serve_owner_root_bridge(mut self, socket_path: PathBuf) -> Result<()> {
+        let listener = bind_bridge_listener(&socket_path)
+            .with_context(|| format!("binding claim co-sign bridge socket {}", socket_path.display()))?;
+        let mut worker: Option<UnixStream> = None;
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((stream, _)) if peer_is_same_uid(&stream) => {
+                            // A newer foreground `heddle claim` takes over the
+                            // co-sign role from any earlier one.
+                            worker = Some(stream);
+                        }
+                        Ok((stream, _)) => {
+                            tracing::warn!("rejecting claim co-sign worker: peer uid mismatch");
+                            drop(stream);
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, "claim co-sign bridge accept failed");
+                        }
+                    }
+                }
+                call = self.owner_root_calls.recv() => {
+                    let Some(call) = call else {
+                        // The router endpoint closed; stop serving.
+                        break;
+                    };
+                    let bridge = OwnerRootBridgeCall::new(call);
+                    match worker.as_mut() {
+                        Some(stream) => match exchange(stream, bridge.request_bytes()).await {
+                            Ok(reply) => bridge.respond(&reply),
+                            Err(error) => {
+                                tracing::warn!(%error, "claim co-sign worker exchange failed");
+                                worker = None;
+                                bridge.respond_unavailable();
+                            }
+                        },
+                        None => bridge.respond_unavailable(),
+                    }
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&socket_path);
+        if let Err(error) = self.router.shutdown().await {
+            tracing::warn!(%error, "claim router shutdown failed");
+        }
+        Ok(())
+    }
+}
+
+/// One owner-root call captured from the router, pre-serialized for the
+/// worker. Owns the daemon-local oneshot responder; the reply the worker
+/// returns (or its absence) is relayed back through it.
+struct OwnerRootBridgeCall {
+    call: ClaimOwnerRootCall,
+    request: Vec<u8>,
+}
+
+impl OwnerRootBridgeCall {
+    fn new(call: ClaimOwnerRootCall) -> Self {
+        let request = serde_json::to_vec(&BridgeRequest {
+            subject: call.principal().subject.clone(),
+            authorization_hash: call.principal().authorization_hash.clone(),
+            body_b64: URL_SAFE_NO_PAD.encode(call.body()),
+        })
+        .unwrap_or_default();
+        Self { call, request }
+    }
+
+    fn request_bytes(&self) -> &[u8] {
+        &self.request
+    }
+
+    fn respond(self, reply_frame: &[u8]) {
+        let response = match serde_json::from_slice::<BridgeReply>(reply_frame) {
+            Ok(BridgeReply::Ok { reply_b64 }) => match URL_SAFE_NO_PAD.decode(reply_b64) {
+                Ok(reply) => Ok(reply),
+                Err(_) => Err(failure(
+                    CallFailureCode::Internal,
+                    "claim co-sign worker returned a malformed reply",
+                )),
+            },
+            Ok(BridgeReply::Err { code, message }) => Err(CallFailure {
+                code,
+                message,
+                error: None,
+            }),
+            Err(_) => Err(failure(
+                CallFailureCode::Internal,
+                "claim co-sign worker returned an unparseable reply",
+            )),
+        };
+        self.call.respond(response);
+    }
+
+    fn respond_unavailable(self) {
+        self.call.respond(Err(failure(
+            CallFailureCode::FailedPrecondition,
+            "no foreground `heddle claim` process is armed to co-sign the owner root",
+        )));
+    }
+}
+
+/// A foreground worker's held-open connection to the daemon's co-sign
+/// bridge. The worker reads one owner-root request at a time, co-signs it
+/// with its local signer, and writes the reply.
+pub(crate) struct ClaimBridgeWorker {
+    stream: UnixStream,
+}
+
+impl ClaimBridgeWorker {
+    /// Connect to the daemon's co-sign bridge socket and arm as the
+    /// foreground signer for the claim window.
+    pub(crate) async fn arm(socket_path: &Path) -> Result<Self> {
+        let stream = UnixStream::connect(socket_path).await.with_context(|| {
+            format!(
+                "connecting to the claim co-sign bridge at {}; is `heddle netd serve` running?",
+                socket_path.display()
+            )
+        })?;
+        Ok(Self { stream })
+    }
+
+    /// Await the next owner-root request the daemon forwards, co-sign it
+    /// with `client`, and return the reply. Returns `Ok(false)` when the
+    /// daemon closed the bridge (window over or daemon stopped).
+    pub(crate) async fn serve_next(&mut self, client: &HostedClient) -> Result<bool> {
+        let Some(request) = read_frame(&mut self.stream).await? else {
+            return Ok(false);
+        };
+        let reply = cosign_owner_root_request(&request, client).await;
+        write_frame(&mut self.stream, &reply).await?;
+        Ok(true)
+    }
+
+    /// Await one forwarded owner-root request and answer it with a
+    /// caller-supplied reply, decoding the forwarded principal and body.
+    /// Test-only stand-in for [`Self::serve_next`] that does not need a
+    /// live [`HostedClient`].
+    #[cfg(test)]
+    pub(crate) async fn serve_next_canned<F>(&mut self, respond: F) -> Result<bool>
+    where
+        F: FnOnce(&str, &str, &[u8]) -> std::result::Result<Vec<u8>, CallFailure>,
+    {
+        let Some(request) = read_frame(&mut self.stream).await? else {
+            return Ok(false);
+        };
+        let request: BridgeRequest =
+            serde_json::from_slice(&request).context("decoding forwarded owner-root request")?;
+        let body = URL_SAFE_NO_PAD
+            .decode(&request.body_b64)
+            .context("decoding forwarded owner-root body")?;
+        let reply = match respond(&request.subject, &request.authorization_hash, &body) {
+            Ok(reply) => BridgeReply::Ok {
+                reply_b64: URL_SAFE_NO_PAD.encode(reply),
+            },
+            Err(failure) => BridgeReply::Err {
+                code: failure.code,
+                message: failure.message,
+            },
+        };
+        write_frame(&mut self.stream, &serde_json::to_vec(&reply)?).await?;
+        Ok(true)
+    }
+}
+
+/// Foreground co-sign: parse a forwarded request, run the owner-root
+/// exchange with the local signer + `client`, and serialize the reply.
+///
+/// This is the only place the agent owner-root signer is used, and it is
+/// only ever reached in the foreground `heddle claim` process — never in
+/// the daemon.
+async fn cosign_owner_root_request(request_frame: &[u8], client: &HostedClient) -> Vec<u8> {
+    let reply = match serde_json::from_slice::<BridgeRequest>(request_frame) {
+        Ok(request) => match URL_SAFE_NO_PAD.decode(&request.body_b64) {
+            Ok(body) => {
+                let principal = VerifiedClaimPrincipal {
+                    subject: request.subject,
+                    authorization_hash: request.authorization_hash,
+                };
+                match handle_owner_root_body(client, &principal, &body).await {
+                    Ok(reply) => BridgeReply::Ok {
+                        reply_b64: URL_SAFE_NO_PAD.encode(reply),
+                    },
+                    Err(failure) => BridgeReply::Err {
+                        code: failure.code,
+                        message: failure.message,
+                    },
+                }
+            }
+            Err(_) => BridgeReply::Err {
+                code: CallFailureCode::Internal as i32,
+                message: "claim co-sign request body was malformed".to_string(),
+            },
+        },
+        Err(_) => BridgeReply::Err {
+            code: CallFailureCode::Internal as i32,
+            message: "claim co-sign request was unparseable".to_string(),
+        },
+    };
+    serde_json::to_vec(&reply).unwrap_or_default()
+}
+
+/// Bind the co-sign bridge socket, reusing the mount daemon's mode-0600,
+/// fail-closed, same-uid binder so a live worker socket is never stolen.
+fn bind_bridge_listener(socket_path: &Path) -> Result<UnixListener> {
+    let listener = repo::daemon::bind_unix_socket(socket_path)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    listener
+        .set_nonblocking(true)
+        .context("marking claim bridge socket non-blocking")?;
+    UnixListener::from_std(listener).context("adopting claim bridge socket into the async runtime")
+}
+
+fn peer_is_same_uid(stream: &UnixStream) -> bool {
+    match stream.peer_cred() {
+        Ok(peer) => peer.uid() == unsafe { libc::getuid() },
+        Err(error) => {
+            tracing::warn!(%error, "could not read claim co-sign peer credentials");
+            false
+        }
+    }
+}
+
+/// Daemon side of one request/reply: write the request frame, read the
+/// reply frame. A closed connection surfaces as an error so the caller
+/// can fail the call closed and disarm the worker.
+async fn exchange(stream: &mut UnixStream, request: &[u8]) -> Result<Vec<u8>> {
+    write_frame(stream, request).await?;
+    read_frame(stream)
+        .await?
+        .context("claim co-sign worker closed the connection before replying")
+}
+
+async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> Result<()> {
+    let length = u32::try_from(payload.len()).context("claim bridge frame is too large")?;
+    stream.write_all(&length.to_be_bytes()).await?;
+    stream.write_all(payload).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn read_frame(stream: &mut UnixStream) -> Result<Option<Vec<u8>>> {
+    let mut length = [0u8; 4];
+    match stream.read_exact(&mut length).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error).context("reading claim bridge frame length"),
+    }
+    let length = u32::from_be_bytes(length) as usize;
+    if length > MAX_BRIDGE_FRAME {
+        anyhow::bail!("claim bridge frame of {length} bytes exceeds the {MAX_BRIDGE_FRAME} limit");
+    }
+    let mut payload = vec![0u8; length];
+    stream
+        .read_exact(&mut payload)
+        .await
+        .context("reading claim bridge frame body")?;
+    Ok(Some(payload))
+}

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -1,5 +1,10 @@
 //! Resident agent side of the human claim ceremony.
 
+// The transport contract owns `CallFailure` by value at the owner-root
+// seam (`handle_owner_root_body`), matching `claim_authorization` and
+// `claim_protocol`; boxing it would only fragment that seam's error type.
+#![allow(clippy::result_large_err)]
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -13,10 +18,11 @@ use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
     auth::resolve_server,
     claim_authorization::{
-        ClaimOwnerRootCall, ClaimOwnerRootOperationRef, ClaimOwnerRootResult,
-        validate_stored_claim_signer,
+        ClaimOwnerRootOperation, ClaimOwnerRootOperationRef, ClaimOwnerRootResult,
+        encode_owner_root_reply, owner_root_operation, validate_stored_claim_signer,
     },
-    hosted::{canonical_server_authority, server_keys_match},
+    claim_bridge::ClaimBridgeWorker,
+    hosted::{canonical_server_authority, claim_protocol::VerifiedClaimPrincipal, server_keys_match},
     identity_state::{self, ClaimIssuanceStatus, ClaimSecret, ClaimState},
 };
 
@@ -58,29 +64,32 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
         bail!("agent-node-identity.toml does not match the account waiting to be claimed");
     }
 
+    // The persistent box network daemon serves the `heddle-claim/1`
+    // router on this device node id (heddle#1620). A foreground
+    // `heddle claim` does not host the endpoint or the router; it arms
+    // itself as the owner-root co-sign signer over the daemon's UDS
+    // bridge and observes the shared, file-backed claim state.
+    let heddle_home = repo::identity::heddle_home_dir();
+    let claim_socket = crate::hosted_runtime::claim_bridge::claim_bridge_socket_path(&heddle_home);
+
     let user_config = UserConfig::load_default()?;
     let session = HostedSession::build(
         &user_config,
         Some(server.clone()),
         HostedAuthMode::CredentialFallback,
     )?;
+    // Outbound only: an ephemeral endpoint that does not bind the device
+    // node id the daemon serves the claim router on.
     let mut client = session
-        .connect(([127, 0, 0, 1], 0).into())
+        .connect_outbound(([127, 0, 0, 1], 0).into())
         .await
-        .with_context(|| {
-            format!("connecting to {server} and bringing the claim listener online")
-        })?;
+        .with_context(|| format!("connecting to {server} for the claim ceremony"))?;
     // Upload the claimable seq-0 root before the Iroh ceremony so claim
     // works even if this account never created a project spool.
     if let Err(error) = client.ensure_claimable_owner_root().await {
         client.close().await;
         return Err(error);
     }
-    let completion = client.claim_completion();
-    let mut owner_root_calls = client
-        .take_claim_owner_root_calls()
-        .await
-        .context("claim owner-root listener is already in use")?;
 
     let offer = match activate_offer(&state, args.timeout) {
         Ok(offer) => offer,
@@ -99,14 +108,8 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     drop(claim_link);
     drop(offer.secret);
 
-    let outcome = wait_for_claim(
-        &offer.authorization_hash,
-        args.timeout,
-        completion,
-        &mut owner_root_calls,
-        &client,
-    )
-    .await;
+    let outcome =
+        wait_for_claim(&offer.authorization_hash, args.timeout, &claim_socket, &client).await;
     let claimed = matches!(outcome, Ok(ClaimWaitOutcome::Claimed));
     let owner_root_claim = if claimed {
         super::owner_root::send_pending_register_public_key_claim(&mut client).await
@@ -186,37 +189,36 @@ fn activate_offer(expected: &ClaimState, timeout: Duration) -> Result<ActiveClai
 async fn wait_for_claim(
     authorization_hash: &str,
     timeout: Duration,
-    mut completion: tokio::sync::watch::Receiver<bool>,
-    owner_root_calls: &mut tokio::sync::mpsc::Receiver<ClaimOwnerRootCall>,
+    claim_socket: &std::path::Path,
     client: &super::hosted::HostedClient,
 ) -> Result<ClaimWaitOutcome> {
     let deadline = tokio::time::Instant::now() + timeout;
     let mut poll = tokio::time::interval(CLAIM_STATUS_POLL);
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // Arm as the daemon-hosted router's owner-root co-sign signer for this
+    // window. The daemon drives resolve/preConsent/promoteConsent itself
+    // and forwards only the owner-root co-sign here, where the signer lives.
+    let mut worker = ClaimBridgeWorker::arm(claim_socket).await.context(
+        "arming the owner-root co-sign bridge; is `heddle netd serve` running on this machine?",
+    )?;
     loop {
         tokio::select! {
             biased;
 
-            delivered = completion.changed() => {
-                delivered.context("claim listener stopped before promotion was delivered")?;
-                if *completion.borrow() {
-                    let state = identity_state::load()?
-                        .context("agent claim state disappeared after promotion")?;
-                    if state.issuance_status(
-                        authorization_hash,
-                        chrono::Utc::now().timestamp_millis(),
-                    ) == ClaimIssuanceStatus::Claimed
-                    {
-                        return Ok(ClaimWaitOutcome::Claimed);
+            served = worker.serve_next(client) => {
+                let alive = served.unwrap_or_else(|error| {
+                    tracing::warn!(%error, "owner-root co-sign bridge failed; will re-arm");
+                    false
+                });
+                if !alive {
+                    // The daemon closed the bridge — it may be restarting
+                    // mid-window. Re-arm so a re-dial after the router
+                    // re-mounts still reaches this foreground signer.
+                    match rearm(claim_socket, authorization_hash, deadline).await? {
+                        RearmOutcome::Rearmed(next) => worker = next,
+                        RearmOutcome::Terminal(outcome) => return Ok(outcome),
                     }
                 }
-            }
-            call = owner_root_calls.recv() => {
-                let call = call.context("claim owner-root listener stopped")?;
-                let response = handle_owner_root_call(client, &call)
-                    .await
-                    .map_err(CallFailure::from);
-                call.respond(response);
             }
             result = tokio::signal::ctrl_c() => {
                 result.context("waiting for Ctrl-C")?;
@@ -226,18 +228,9 @@ async fn wait_for_claim(
                 return Ok(ClaimWaitOutcome::Expired);
             }
             _ = poll.tick() => {
-                let Some(state) = identity_state::load()? else {
-                    return Ok(ClaimWaitOutcome::Replaced);
-                };
-                match state.issuance_status(
-                    authorization_hash,
-                    chrono::Utc::now().timestamp_millis(),
-                ) {
+                match observe_issuance(authorization_hash)? {
                     ClaimIssuanceStatus::Active => {}
-                    // ClaimState flips before the response is written. Wait
-                    // for the delivery signal so shutdown cannot race the
-                    // browser's ClaimOwnerRoot response.
-                    ClaimIssuanceStatus::Claimed => {}
+                    ClaimIssuanceStatus::Claimed => return Ok(ClaimWaitOutcome::Claimed),
                     ClaimIssuanceStatus::Expired => return Ok(ClaimWaitOutcome::Expired),
                     ClaimIssuanceStatus::Replaced => return Ok(ClaimWaitOutcome::Replaced),
                 }
@@ -246,11 +239,74 @@ async fn wait_for_claim(
     }
 }
 
+enum RearmOutcome {
+    Rearmed(ClaimBridgeWorker),
+    Terminal(ClaimWaitOutcome),
+}
+
+/// Re-establish the co-sign bridge after the daemon closed it (a
+/// mid-window restart), or report a terminal outcome if the ceremony
+/// resolved or the deadline passed while the daemon was away.
+async fn rearm(
+    claim_socket: &std::path::Path,
+    authorization_hash: &str,
+    deadline: tokio::time::Instant,
+) -> Result<RearmOutcome> {
+    loop {
+        match observe_issuance(authorization_hash)? {
+            ClaimIssuanceStatus::Active => {}
+            ClaimIssuanceStatus::Claimed => {
+                return Ok(RearmOutcome::Terminal(ClaimWaitOutcome::Claimed));
+            }
+            ClaimIssuanceStatus::Expired => {
+                return Ok(RearmOutcome::Terminal(ClaimWaitOutcome::Expired));
+            }
+            ClaimIssuanceStatus::Replaced => {
+                return Ok(RearmOutcome::Terminal(ClaimWaitOutcome::Replaced));
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(RearmOutcome::Terminal(ClaimWaitOutcome::Expired));
+        }
+        match ClaimBridgeWorker::arm(claim_socket).await {
+            Ok(worker) => return Ok(RearmOutcome::Rearmed(worker)),
+            Err(_) => tokio::time::sleep(CLAIM_STATUS_POLL).await,
+        }
+    }
+}
+
+fn observe_issuance(authorization_hash: &str) -> Result<ClaimIssuanceStatus> {
+    let Some(state) = identity_state::load()? else {
+        return Ok(ClaimIssuanceStatus::Replaced);
+    };
+    Ok(state.issuance_status(authorization_hash, chrono::Utc::now().timestamp_millis()))
+}
+
+/// Complete one forwarded owner-root call from the daemon-hosted router.
+///
+/// The daemon relays only the verified principal and the raw request
+/// body; parsing, the weft `BeginWebAuthnRegistration` round trip, the
+/// owner-root co-sign with the agent signer, and reply encoding all
+/// happen here in the foreground process. The daemon never holds the
+/// agent signer.
+pub(crate) async fn handle_owner_root_body(
+    client: &super::hosted::HostedClient,
+    principal: &VerifiedClaimPrincipal,
+    body: &[u8],
+) -> std::result::Result<Vec<u8>, CallFailure> {
+    let operation = owner_root_operation(body)?;
+    let result = handle_owner_root_call(client, principal, &operation)
+        .await
+        .map_err(CallFailure::from)?;
+    encode_owner_root_reply(&result)
+}
+
 async fn handle_owner_root_call(
     client: &super::hosted::HostedClient,
-    call: &ClaimOwnerRootCall,
+    principal: &VerifiedClaimPrincipal,
+    operation: &ClaimOwnerRootOperation,
 ) -> std::result::Result<ClaimOwnerRootResult, OwnerRootFailure> {
-    match call.operation.as_ref().ok_or_else(|| {
+    match operation.as_ref().ok_or_else(|| {
         owner_root_failure(
             CallFailureCode::Internal,
             "claim owner-root operation has an invalid shape",
@@ -279,7 +335,7 @@ async fn handle_owner_root_call(
             }
             let signed_owner_root = {
                 let _guard = identity_state::write_lock().map_err(owner_root_internal)?;
-                let mut state = active_owner_root_state(call)?;
+                let mut state = active_owner_root_state(principal)?;
                 let signed = super::owner_root::load_recorded_root(&state)
                     .map_err(owner_root_internal)?
                     .ok_or_else(|| {
@@ -317,7 +373,7 @@ async fn handle_owner_root_call(
             })?;
             let signed_transition = {
                 let _guard = identity_state::write_lock().map_err(owner_root_internal)?;
-                let mut state = active_owner_root_state(call)?;
+                let mut state = active_owner_root_state(principal)?;
                 if !state.accepts_owner_root_challenge(&registration.challenge_id) {
                     return Err(owner_root_failure(
                         CallFailureCode::PermissionDenied,
@@ -371,7 +427,7 @@ async fn handle_owner_root_call(
 }
 
 fn active_owner_root_state(
-    call: &ClaimOwnerRootCall,
+    principal: &VerifiedClaimPrincipal,
 ) -> std::result::Result<ClaimState, OwnerRootFailure> {
     let state = identity_state::load_while_locked()
         .map_err(owner_root_internal)?
@@ -381,8 +437,8 @@ fn active_owner_root_state(
                 "claim authorization failed",
             )
         })?;
-    if state.owner_id.to_string() != call.principal.subject
-        || state.authorization_hash() != call.principal.authorization_hash
+    if state.owner_id.to_string() != principal.subject
+        || state.authorization_hash() != principal.authorization_hash
         || !state.is_active(chrono::Utc::now().timestamp_millis())
     {
         return Err(owner_root_failure(

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -19,26 +19,49 @@ const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub(super) struct HostedConnection {
+    // A transient inbound claim listener on this connection's endpoint.
+    // It serves resolve/consent for a browser that reaches this process's
+    // endpoint, but it holds no owner-root co-sign consumer: the persisted
+    // box network daemon owns that, and the owner-root co-sign is bridged
+    // to a foreground signer (heddle#1620). A co-sign dialed here therefore
+    // fails closed rather than being performed without a foreground owner.
     router: Router,
     pub(super) endpoint: Endpoint,
     pub(super) connection: iroh::endpoint::Connection,
     provider_transport: Option<ProviderWebSocketTransport>,
     provider_connections:
         Mutex<HashMap<EndpointId, Arc<Mutex<Option<iroh::endpoint::Connection>>>>>,
-    claim_completion: tokio::sync::watch::Receiver<bool>,
-    claim_owner_root_calls: Mutex<
-        Option<
-            tokio::sync::mpsc::Receiver<
-                crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall,
-            >,
-        >,
-    >,
 }
 
 impl HostedConnection {
     pub(super) async fn connect_verified(
         descriptor: &VerifiedEndpointDescriptor,
         config: &ClientConfig,
+    ) -> Result<Arc<Self>> {
+        Self::connect_verified_inner(descriptor, config, EndpointIdentity::Device).await
+    }
+
+    /// Connect for outbound calls only, on an *ephemeral* endpoint node id.
+    ///
+    /// The persistent box network daemon owns the device node id and the
+    /// inbound `heddle-claim/1` router (heddle#1620). A foreground
+    /// `heddle claim` that also bound the device node id would fight the
+    /// daemon for the relay's home registration and strand browsers
+    /// dialing the advertised node id. Its weft auth is carried entirely
+    /// by the credential proof key (bearer + PoP + request proof), which
+    /// is independent of the endpoint node id, so an ephemeral endpoint
+    /// makes the same authenticated calls without the collision.
+    pub(super) async fn connect_verified_outbound(
+        descriptor: &VerifiedEndpointDescriptor,
+        config: &ClientConfig,
+    ) -> Result<Arc<Self>> {
+        Self::connect_verified_inner(descriptor, config, EndpointIdentity::Ephemeral).await
+    }
+
+    async fn connect_verified_inner(
+        descriptor: &VerifiedEndpointDescriptor,
+        config: &ClientConfig,
+        identity: EndpointIdentity,
     ) -> Result<Arc<Self>> {
         heddle_perf_contract::record_network_client_initialization();
         let relays = descriptor.relay_urls()?;
@@ -56,7 +79,8 @@ impl HostedConnection {
             } else {
                 RelayMode::custom(relays.clone())
             };
-            let endpoint = bind_endpoint(relay_mode, Some(provider_transport.clone())).await?;
+            let endpoint =
+                bind_endpoint(relay_mode, Some(provider_transport.clone()), identity).await?;
             if relays.is_empty() {
                 return Self::connect_inner(endpoint, direct_address, Some(provider_transport))
                     .await;
@@ -84,7 +108,8 @@ impl HostedConnection {
             RelayMode::custom(relays)
         };
         let provider_transport = ProviderWebSocketTransport::new(config.clone());
-        let endpoint = bind_endpoint(relay_mode, Some(provider_transport.clone())).await?;
+        let endpoint =
+            bind_endpoint(relay_mode, Some(provider_transport.clone()), identity).await?;
         Self::connect_inner(endpoint, address, Some(provider_transport)).await
     }
 
@@ -105,15 +130,13 @@ impl HostedConnection {
                 return Err(HostedError::transport(error));
             }
         };
-        let (router, claim_completion, claim_owner_root_calls) = claim_router(endpoint.clone());
+        let router = claim_router(endpoint.clone());
         Ok(Arc::new(Self {
             router,
             endpoint,
             connection,
             provider_transport,
             provider_connections: Mutex::new(HashMap::new()),
-            claim_completion,
-            claim_owner_root_calls: Mutex::new(Some(claim_owner_root_calls)),
         }))
     }
 
@@ -123,18 +146,6 @@ impl HostedConnection {
 
     pub(super) fn supports_provider_transport(&self) -> bool {
         self.provider_transport.is_some()
-    }
-
-    pub(super) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
-        self.claim_completion.clone()
-    }
-
-    pub(super) async fn take_claim_owner_root_calls(
-        &self,
-    ) -> Option<
-        tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
-    > {
-        self.claim_owner_root_calls.lock().await.take()
     }
 
     pub(super) async fn provider_connection(
@@ -187,39 +198,54 @@ impl HostedConnection {
     }
 }
 
+/// Which node identity a hosted endpoint binds.
+#[derive(Clone, Copy, Debug)]
+enum EndpointIdentity {
+    /// The persisted device node id — the machine's single stable
+    /// address, also served by the box network daemon.
+    Device,
+    /// A fresh per-process node id, for outbound-only connections that
+    /// must not contend with the daemon for the device node id.
+    Ephemeral,
+}
+
 async fn bind_endpoint(
     relay_mode: RelayMode,
     provider_transport: Option<ProviderWebSocketTransport>,
+    identity: EndpointIdentity,
 ) -> Result<Endpoint> {
-    let identity = crate::hosted_runtime::agent_node_identity::load_or_create()
-        .map_err(HostedError::transport)?;
     let mut builder = Endpoint::builder(presets::Minimal)
         .transport_config(transport_config())
-        .relay_mode(relay_mode)
-        .secret_key(identity.secret_key());
+        .relay_mode(relay_mode);
+    if let EndpointIdentity::Device = identity {
+        let device = crate::hosted_runtime::agent_node_identity::load_or_create()
+            .map_err(HostedError::transport)?;
+        builder = builder.secret_key(device.secret_key());
+    }
     if let Some(provider_transport) = provider_transport {
         builder = builder.add_custom_transport(Arc::new(provider_transport));
     }
     builder.bind().await.map_err(HostedError::transport)
 }
 
-fn claim_router(
-    endpoint: Endpoint,
-) -> (
-    Router,
-    tokio::sync::watch::Receiver<bool>,
-    tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
-) {
-    let (authorization, completion, owner_root_calls) =
+/// Mount a transient claim listener on this connection's endpoint.
+///
+/// The completion watcher and owner-root call receiver are dropped here
+/// on purpose: this endpoint has no foreground signer arming it, so an
+/// owner-root co-sign dialed against it fails closed at
+/// `StoredClaimAuthorization` (the send finds no receiver) rather than
+/// being co-signed without a foreground owner. Persistent, foreground-
+/// bridged co-sign is the box network daemon's job (heddle#1620).
+fn claim_router(endpoint: Endpoint) -> Router {
+    let (authorization, _completion, _owner_root_calls) =
         crate::hosted_runtime::claim_authorization::StoredClaimAuthorization::new();
     let authorization = Arc::new(authorization);
-    let router = Router::builder(endpoint)
+    Router::builder(endpoint)
         .accept(
             CLAIM_ALPN_V1,
             ClaimProtocol::new(Arc::clone(&authorization), authorization),
         )
-        .spawn();
-    (router, completion, owner_root_calls)
+        .spawn()
 }
 
 impl Drop for HostedConnection {

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -171,18 +171,6 @@ impl HostedClient {
         HostedRoutes::new(self)
     }
 
-    pub(crate) fn claim_completion(&self) -> tokio::sync::watch::Receiver<bool> {
-        self.connection.claim_completion()
-    }
-
-    pub(crate) async fn take_claim_owner_root_calls(
-        &self,
-    ) -> Option<
-        tokio::sync::mpsc::Receiver<crate::hosted_runtime::claim_authorization::ClaimOwnerRootCall>,
-    > {
-        self.connection.take_claim_owner_root_calls().await
-    }
-
     pub(crate) fn claim_proof_signer(&self) -> Option<&crypto::Ed25519Signer> {
         self.context.proof_signer()
     }
@@ -205,6 +193,25 @@ impl HostedClient {
         let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
             connection: HostedConnection::connect_verified(descriptor, config).await?,
+            context,
+            transport: helpers::HostedTransportPolicy::from_client_config(config),
+            on_human_signature: None,
+            server_key: config.server_key.clone(),
+        })
+    }
+
+    /// Connect for outbound calls only, on an ephemeral endpoint node id
+    /// that does not contend with the box network daemon for the device
+    /// node id. Used by `heddle claim`, whose inbound claim serving is the
+    /// daemon's job while this client only makes authenticated weft calls
+    /// (BeginWebAuthnRegistration, BootstrapOwnerRoot, RegisterPublicKey).
+    pub(crate) async fn connect_outbound_with_config(
+        descriptor: &VerifiedEndpointDescriptor,
+        config: &ClientConfig,
+    ) -> Result<Self> {
+        let context = CallContextFactory::from_client_config(config)?;
+        Ok(Self {
+            connection: HostedConnection::connect_verified_outbound(descriptor, config).await?,
             context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,

--- a/crates/hosted-client/src/hosted_runtime/hosted/session.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/session.rs
@@ -151,6 +151,28 @@ impl HostedSession {
             .await;
         Ok(client)
     }
+
+    /// Connect for outbound calls only, on an ephemeral endpoint node id.
+    ///
+    /// `heddle claim` uses this so its authenticated weft calls never bind
+    /// the device node id the box network daemon serves the claim router
+    /// on (heddle#1620).
+    pub async fn connect_outbound(
+        &self,
+        fallback_addr: SocketAddr,
+    ) -> Result<HostedClient, ProtocolError> {
+        let descriptor = self
+            .discover_endpoint(fallback_addr)
+            .await
+            .map_err(|error| ProtocolError::Remote(error.to_string()))?;
+        let mut client = HostedClient::connect_outbound_with_config(&descriptor, &self.config)
+            .await
+            .map_err(|error| ProtocolError::Remote(error.to_string()))?;
+        client
+            .auto_rotate_if_needed(self.renewable_authority_credential.as_ref())
+            .await;
+        Ok(client)
+    }
 }
 
 impl HostedClient {

--- a/crates/hosted-client/src/hosted_runtime/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod auth_requests;
 mod claim_authorization;
 #[cfg(test)]
 mod claim_authorization_tests;
+pub(crate) mod claim_bridge;
 pub(crate) mod claim_offer;
 pub(crate) mod credential_file;
 pub(crate) mod device_flow;

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -34,6 +34,14 @@ pub use iroh::protocol::Router;
 #[cfg(feature = "client")]
 pub use iroh::{Endpoint, EndpointId, RelayMode};
 
+/// Owner-root claim router hosted on the daemon endpoint, and the socket
+/// convention for bridging its co-sign step to a foreground signer
+/// (heddle#1620, piece 3). See [`crate::hosted_runtime::claim_bridge`].
+#[cfg(feature = "client")]
+pub use crate::hosted_runtime::claim_bridge::{
+    DaemonClaimRouter, claim_bridge_socket_path, mount_claim_router,
+};
+
 /// Relay mode that keeps the endpoint reachable through the default
 /// (number-0) relay servers.
 ///


### PR DESCRIPTION
## What

Piece 3 of the owner-root claim ceremony (heddle#1620). The persistent box network daemon (heddle#1533, piece 1) now hosts the `heddle-claim/1` router on its persisted device endpoint, at the exact mount seam piece 1 left. An outstanding claim link keeps resolving across `heddle claim` restarts and even when no `heddle claim` process is running.

## Owner decision D3 — the daemon never holds the agent signer

The daemon router drives `Resolve` / `preConsent` / `promoteConsent` inline against the file-backed, lock-serialized claim state. But the **owner-root co-sign stays in a foreground `heddle claim` process**: when a browser reaches `ClaimOwnerRoot`, the router forwards the verified principal + raw request body over a same-uid UDS bridge (`<heddle_home>/state/heddle-netd-claim.sock`) to a foreground worker, which holds `claim_proof_signer()` + a live `HostedClient`, completes the co-sign, and returns the reply the daemon relays back verbatim.

The in-daemon mpsc's oneshot responder never crosses the socket (it can't) — only the serialized request/reply do, over a connection the foreground worker holds open for the window. This is the standard worker-registration pattern, so the mpsc-across-UDS concern flagged in the brief is a non-blocker.

## Mechanics

- **`hosted_client::network`**: `mount_claim_router(endpoint) -> DaemonClaimRouter`; `DaemonClaimRouter::serve_owner_root_bridge(socket_path)` runs the same-uid accept + dispatch loop; `claim_bridge_socket_path()` is the single source of truth both sides use.
- **`heddle netd serve`**: mounts the router at the piece-1 seam and spawns the bridge; the bridge socket + task are torn down on `netd stop`.
- **`heddle claim`**: refactored to *arm/observe* the daemon-hosted router over the UDS bridge and render the link, rather than owning the endpoint/router. It connects outbound on an **ephemeral** endpoint so it never binds the device node id the daemon serves (weft auth is carried by the credential proof key, independent of the endpoint node id). Cross-process claim state is the existing lock-serialized `identity_state`.
- The transient per-connection claim listener no longer carries an owner-root consumer, so a co-sign dialed against a plain command endpoint **fails closed** rather than being signed without a foreground owner.

## Proofs (all green)

- `daemon_router_forwards_owner_root_cosign_to_the_foreground_signer` — real loopback Endpoint+Router via `mount_claim_router`; Resolve served inline; owner-root Resolve+CoSign forwarded over a **real UDS** to a foreground worker; asserts the daemon (no signer) forwarded both bodies.
- `daemon_claim_router_re_mounts_on_the_persisted_node_id_after_restart` — restart mid-window (drop router+endpoint, rebind on the persisted device id, re-mount, re-arm), re-dial completes; node id identical across restart. Complements the binary-level `node_id_survives_kill_and_restart`.
- `owner_root_cosign_fails_closed_when_no_foreground_signer_is_armed` — negative case: co-sign with no foreground armed returns `FailedPrecondition`, never a daemon-side co-sign.
- `heddle-claim/1` golden/contract vectors unchanged and green.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `heddle-hosted-client` suite (isolated `HEDDLE_HOME`): 330 passed, 0 failed.
- `heddle-cli --test netd_daemon` (spawns the real daemon binary): 4 passed.

## Notes for review

- Client-side pilot browser transport is tapestry#467; this PR is the agent/daemon side.
- Pre-existing: `hosted::user::tests::{create_spool_…, administration_facade_…}` read the box's real `~/.heddle/agent-claim.toml` (no `HEDDLE_HOME` isolation) and fail on the dev box only; both pass with an isolated home. Not touched here.
- Follow-up (piece-1/2 scope, not this issue): normal hosted commands still bind the device node id via `connect_verified`, so they can transiently contend with the daemon for the relay home registration; routing them ephemeral or through the daemon is separate.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790794591&installation_model_id=21489&pr_number=1623&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1623&signature=984efae86c19230d568bd6044b6ad10ca6f2a542af96b5cc4c4146e9e39b4d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->