### PR TITLE
feat(auth): derive human-delegated CI runner credentials

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -160,11 +160,11 @@ pub enum AuthCommands {
         #[arg(long = "ttl", default_value_t = 3600)]
         ttl_secs: u64,
 
-        /// Forward-compatible resource scope (`repo:org/name`, `namespace:org`, or a bare repo path).
+        /// Resource scope (`repo:org/name`, `namespace:org`, `spool:org/name`, or a bare repo path).
         #[arg(long = "scope")]
         scopes: Vec<String>,
 
-        /// Narrow the safe operation set (repeatable, using hosted method names such as `Push`).
+        /// Narrow the safe operation set (repeatable, using hosted operation names such as `Push`).
         #[arg(long = "allow")]
         allowed_operations: Vec<String>,
 
@@ -174,6 +174,11 @@ pub enum AuthCommands {
         /// A combined `--allow` may only narrow the template.
         #[arg(long, value_enum)]
         template: Option<AgentTemplateArg>,
+
+        /// Derive a CI-verdict runner: `ci-verdict:write` on the required
+        /// `spool:` scope(s), without Push, UpdateRef, or other source writes.
+        #[arg(long, conflicts_with_all = ["template", "allowed_operations"])]
+        runner: bool,
 
         /// Write a single self-verifying `<name>.hcred` credential file to this
         /// path instead of installing the child into the keystore.
@@ -508,5 +513,46 @@ mod tests {
             .is_err(),
             "token-only child export is unsafe because it cannot carry its proof key"
         );
+    }
+
+    #[test]
+    fn derive_agent_parses_the_runner_persona_and_rejects_wider_overrides() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "derive-agent",
+            "--server",
+            "api.heddle.test",
+            "--runner",
+            "--scope",
+            "spool:acme/api",
+        ])
+        .expect("runner flags parse");
+
+        let Commands::Auth {
+            command: AuthCommands::DeriveAgent { runner, scopes, .. },
+        } = cli.command
+        else {
+            panic!("expected auth derive-agent");
+        };
+        assert!(runner);
+        assert_eq!(scopes, ["spool:acme/api"]);
+
+        for conflicting in [["--allow", "Push"], ["--template", "ci-landing"]] {
+            assert!(
+                Cli::try_parse_from([
+                    "heddle",
+                    "auth",
+                    "derive-agent",
+                    "--server",
+                    "api.heddle.test",
+                    "--runner",
+                    conflicting[0],
+                    conflicting[1],
+                ])
+                .is_err(),
+                "runner persona must reject authority-changing overrides"
+            );
+        }
     }
 }

--- a/crates/hosted-client/src/extensions.rs
+++ b/crates/hosted-client/src/extensions.rs
@@ -96,6 +96,7 @@ fn auth_command(command: AuthCommands) -> AuthCommand {
             scopes,
             allowed_operations,
             template,
+            runner,
             out,
         } => AuthCommand::DeriveAgent {
             server,
@@ -103,7 +104,11 @@ fn auth_command(command: AuthCommands) -> AuthCommand {
             ttl_secs,
             scopes,
             allowed_operations,
-            template: template.map(agent_template),
+            template: if runner {
+                Some(AgentTemplate::Runner)
+            } else {
+                template.map(agent_template)
+            },
             out,
         },
         AuthCommands::CreateServiceToken {

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -25,8 +25,8 @@ use super::{
     auth_requests::{AuthCommand, AuthTrustCommand},
     credential_file::{self, CredentialKind, CredentialProvenance, VerifiedCredential},
     device_flow::{
-        AgentAttenuation, AgentTemplate, SAFE_AGENT_OPERATIONS, attenuate_for_agent,
-        effective_pop_public_key_hex,
+        AgentAttenuation, AgentTemplate, CI_VERDICT_WRITE_ACTION, SAFE_AGENT_OPERATIONS,
+        attenuate_for_agent, effective_pop_public_key_hex,
     },
     hosted::{
         HostedAuthMode, HostedClient, HostedError, HostedSession, ResolvedHostedCredential,
@@ -407,6 +407,7 @@ pub(crate) fn cmd_auth_derive_agent(
     let agent_id = agent_id.unwrap_or_else(|| format!("agent-{}", uuid::Uuid::new_v4()));
     let allowed_operations = resolve_agent_operations(template, requested_operations)?;
     let declared_scopes = parse_agent_scopes(scopes)?;
+    validate_runner_scopes(template, &declared_scopes)?;
     validate_scope_narrowing(&parent_token.id, &declared_scopes)?;
     let child_signer = Ed25519Signer::generate()
         .map_err(|error| anyhow::anyhow!("failed to generate child proof key: {error}"))?;
@@ -462,6 +463,9 @@ pub(crate) fn cmd_auth_derive_agent(
             println!("Template: {} ceiling", template.as_str());
         }
         println!("Allowed operations: {}", allowed_operations.join(", "));
+        if let Some(scope) = rendered_agent_scope(template, &declared_scopes) {
+            println!("Scope: {scope}");
+        }
         println!("{DERIVED_TOKEN_SECURITY_NOTE}");
         return Ok(());
     }
@@ -492,6 +496,8 @@ pub(crate) fn cmd_auth_derive_agent(
         println!("Allowed operations: {}", allowed_operations.join(", "));
         if declared_scopes.is_empty() {
             println!("Scopes: none (full resource authority inherited from parent)");
+        } else if let Some(scope) = rendered_agent_scope(template, &declared_scopes) {
+            println!("Scope: {scope} (enforced server-side per request)");
         } else {
             println!(
                 "Scopes: {} (enforced server-side per request)",
@@ -505,6 +511,21 @@ pub(crate) fn cmd_auth_derive_agent(
         println!("{DERIVED_TOKEN_SECURITY_NOTE}");
     }
     Ok(())
+}
+
+fn rendered_agent_scope(
+    template: Option<AgentTemplate>,
+    scopes: &[(String, String)],
+) -> Option<String> {
+    if template != Some(AgentTemplate::Runner) || scopes.is_empty() {
+        return None;
+    }
+    let mut tokens = scopes
+        .iter()
+        .map(|(kind, path)| format!("{kind}:{path}"))
+        .collect::<Vec<_>>();
+    tokens.push(CI_VERDICT_WRITE_ACTION.to_string());
+    Some(tokens.join(" "))
 }
 
 /// Resolve the final operation ceiling for a derived agent.
@@ -557,8 +578,9 @@ fn parse_agent_scopes(scopes: Vec<String>) -> Result<Vec<(String, String)>> {
         let (kind, path) = match scope.split_once(':') {
             Some(("repo", path)) => ("repo", path),
             Some(("namespace" | "ns", path)) => ("namespace", path),
+            Some(("spool", path)) => ("spool", path),
             Some((kind, _)) => bail!(
-                "unsupported scope kind {kind:?}; use repo:<path>, namespace:<path>, or a bare repo path"
+                "unsupported scope kind {kind:?}; use repo:<path>, namespace:<path>, spool:<path>, or a bare repo path"
             ),
             None => ("repo", scope.as_str()),
         };
@@ -569,6 +591,25 @@ fn parse_agent_scopes(scopes: Vec<String>) -> Result<Vec<(String, String)>> {
         parsed.insert((kind.to_string(), path.to_string()));
     }
     Ok(parsed.into_iter().collect())
+}
+
+fn validate_runner_scopes(
+    template: Option<AgentTemplate>,
+    scopes: &[(String, String)],
+) -> Result<()> {
+    if template != Some(AgentTemplate::Runner) {
+        return Ok(());
+    }
+    if scopes.is_empty() {
+        bail!("--runner requires at least one --scope spool:<path>");
+    }
+    if let Some((kind, path)) = scopes.iter().find(|(kind, _)| kind != "spool") {
+        bail!("--runner scope {kind}:{path} is not a spool; use --scope spool:<path>");
+    }
+    if let Some((_, path)) = scopes.iter().find(|(_, path)| path.contains('*')) {
+        bail!("--runner scope spool:{path} must name a concrete spool path");
+    }
+    Ok(())
 }
 
 fn validate_scope_narrowing(parent_token: &str, child: &[(String, String)]) -> Result<()> {
@@ -638,6 +679,7 @@ fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool 
         ("repo", "repo") => path_is_within,
         ("namespace", "namespace") => path_is_within,
         ("namespace", "repo") => child.1 != parent.1 && path_is_within,
+        ("spool", "spool") => path_is_within,
         _ => false,
     }
 }
@@ -1620,6 +1662,7 @@ fn open_url(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hosted_runtime::device_flow::CI_VERDICT_WRITE_OPERATION;
 
     #[test]
     fn signup_invite_commands_construct_the_declared_requests() {
@@ -1994,22 +2037,25 @@ mod tests {
         }
     }
 
-    fn stored_device_parent() -> (ServerCredential, String) {
+    fn stored_device_parent() -> (ServerCredential, String, biscuit_auth::KeyPair) {
         let signer = Ed25519Signer::generate().expect("device key");
         let private_key_pem = signer.to_pem().expect("device PEM");
         let expires_at = chrono::Utc::now() + chrono::Duration::hours(2);
+        let root = biscuit_auth::KeyPair::new();
         let token = biscuit_auth::Biscuit::builder()
             .fact(r#"user("alice")"#)
             .expect("user fact")
             .fact(r#"credential_id("root-credential")"#)
             .expect("credential fact")
+            .fact(format!("right(\"spool\", \"org/acme\", \"{CI_VERDICT_WRITE_ACTION}\")").as_str())
+            .expect("CI-verdict authority right")
             .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
             .expect("device PoP fact")
             .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
             .expect("expiry fact")
             .check(format!("check if time($now), $now < {}", expires_at.to_rfc3339()).as_str())
             .expect("expiry check")
-            .build(&biscuit_auth::KeyPair::new())
+            .build(&root)
             .expect("build parent")
             .to_base64()
             .expect("encode parent");
@@ -2023,14 +2069,56 @@ mod tests {
                 expires_at: Some(expires_at.to_rfc3339()),
             },
             private_key_pem,
+            root,
         )
+    }
+
+    fn runner_request_is_authorized(
+        token: &str,
+        root: &biscuit_auth::KeyPair,
+        operation: &str,
+        spool: &str,
+    ) -> bool {
+        use biscuit_auth::{builder::AuthorizerBuilder, datalog::RunLimits};
+
+        let root_public = root.public();
+        let biscuit = biscuit_auth::Biscuit::from_base64(token, move |_| Ok(root_public))
+            .expect("verify runner Biscuit");
+        let mut builder = AuthorizerBuilder::new()
+            .set_limits(RunLimits {
+                max_facts: 1000,
+                max_iterations: 100,
+                max_time: std::time::Duration::from_secs(1),
+            })
+            .fact(format!("time({})", chrono::Utc::now().to_rfc3339()).as_str())
+            .expect("request time fact")
+            .fact(format!("operation(\"{operation}\")").as_str())
+            .expect("request operation fact")
+            .fact(format!("resource(\"spool\", \"{spool}\")").as_str())
+            .expect("request spool fact");
+        if operation == CI_VERDICT_WRITE_OPERATION {
+            builder = builder
+                .check(
+                format!(
+                    "check if resource(\"spool\", $path), right(\"spool\", $path, \"{CI_VERDICT_WRITE_ACTION}\") trusting authority"
+                )
+                .as_str(),
+            )
+                .expect("CI-verdict authority check");
+        }
+        let mut authorizer = builder
+            .policy("allow if true")
+            .expect("allow policy")
+            .build(&biscuit)
+            .expect("build runner authorizer");
+        authorizer.authorize().is_ok()
     }
 
     #[test]
     fn derive_agent_installs_fresh_pop_child_and_supports_narrower_subderivation() {
         with_isolated_home(|| {
             let server = "api.S";
-            let (parent, private_key_pem) = stored_device_parent();
+            let (parent, private_key_pem, _root) = stored_device_parent();
             credentials::store_server_credential(server, parent).expect("store parent");
 
             cmd_auth_derive_agent(
@@ -2140,7 +2228,7 @@ mod tests {
     fn derive_agent_out_writes_one_verifiable_hcred_with_a_fresh_child_key() {
         with_isolated_home(|| {
             let server = "api.S";
-            let (parent, private_key_pem) = stored_device_parent();
+            let (parent, private_key_pem, _root) = stored_device_parent();
             credentials::store_server_credential(server, parent).expect("store parent");
             let out = repo::identity::heddle_home_dir().join("agent-export.hcred");
 
@@ -2208,6 +2296,105 @@ mod tests {
     }
 
     #[test]
+    fn derive_agent_runner_hcred_is_human_delegated_and_least_privileged() {
+        with_isolated_home(|| {
+            let server = "api.S";
+            let (parent, parent_private_key_pem, root) = stored_device_parent();
+            credentials::store_server_credential(server, parent).expect("store human parent");
+            let out = repo::identity::heddle_home_dir().join("runner.hcred");
+
+            cmd_auth_derive_agent(
+                server,
+                Some("ci-runner".to_string()),
+                900,
+                vec!["spool:org/acme".to_string()],
+                Vec::new(),
+                Some(AgentTemplate::Runner),
+                Some(&out),
+                false,
+            )
+            .expect("derive portable runner credential offline");
+
+            let loaded = credential_file::load_credential_file(&out).expect("load runner .hcred");
+            assert_eq!(loaded.subject, "alice");
+            assert_ne!(
+                loaded.proof_key_pem, parent_private_key_pem,
+                "runner must carry a fresh PoP key, never the human device key"
+            );
+            let child_signer =
+                Ed25519Signer::from_pem(&loaded.proof_key_pem).expect("parse runner PoP key");
+            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(loaded.token.as_bytes())
+                .expect("runner token is a Biscuit");
+            let authority = parsed.print_block_source(0).expect("authority block");
+            let attenuation = parsed.print_block_source(1).expect("runner block");
+            assert!(
+                authority.contains("user(\"alice\")"),
+                "runner must retain the human subject in the authority block: {authority}"
+            );
+            assert!(
+                authority.contains("right(\"spool\", \"org/acme\", \"ci-verdict:write\")"),
+                "runner must retain the human's exact CI-verdict authority right: {authority}"
+            );
+            assert!(
+                attenuation.contains(&hex::encode(child_signer.public_key())),
+                "runner attenuation must bind its fresh PoP public key"
+            );
+            assert!(
+                attenuation.contains("agent_scope(\"spool\", \"org/acme\")"),
+                "runner must declare the exact spool scope: {attenuation}"
+            );
+            assert!(
+                attenuation.contains(format!("$op == \"{CI_VERDICT_WRITE_OPERATION}\"").as_str()),
+                "runner must carry weft's exact verdict request operation: {attenuation}"
+            );
+
+            let provenance = loaded.provenance.expect("runner provenance");
+            assert_eq!(provenance.template.as_deref(), Some("runner"));
+            assert_eq!(
+                provenance.scopes.as_deref(),
+                Some(["spool:org/acme".to_string()].as_slice())
+            );
+            let operations = provenance
+                .allowed_operations
+                .expect("runner operation ceiling");
+            assert_eq!(operations, [CI_VERDICT_WRITE_OPERATION.to_string()]);
+            assert_eq!(
+                rendered_agent_scope(
+                    Some(AgentTemplate::Runner),
+                    &[("spool".to_string(), "org/acme".to_string())]
+                )
+                .as_deref(),
+                Some("spool:org/acme ci-verdict:write")
+            );
+            for forbidden in ["Push", "UpdateRef", "CreateSpool", "spool:write"] {
+                assert!(
+                    !operations.iter().any(|operation| operation == forbidden),
+                    "runner .hcred must not carry source-write operation {forbidden}"
+                );
+                assert!(
+                    !runner_request_is_authorized(&loaded.token, &root, forbidden, "org/acme"),
+                    "runner Biscuit must deny source-write operation {forbidden}"
+                );
+            }
+            assert!(runner_request_is_authorized(
+                &loaded.token,
+                &root,
+                CI_VERDICT_WRITE_OPERATION,
+                "org/acme"
+            ));
+            assert!(
+                !runner_request_is_authorized(
+                    &loaded.token,
+                    &root,
+                    CI_VERDICT_WRITE_OPERATION,
+                    "org/other"
+                ),
+                "runner verdict authority must not escape its spool scope"
+            );
+        });
+    }
+
+    #[test]
     fn derive_agent_allow_flag_cannot_select_unsafe_operations() {
         for operation in [
             "CreateServiceAccount",
@@ -2224,6 +2411,36 @@ mod tests {
                     .contains("outside the safe agent operation ceiling")
             );
         }
+    }
+
+    #[test]
+    fn runner_requires_concrete_spool_scopes() {
+        let missing = validate_runner_scopes(Some(AgentTemplate::Runner), &[])
+            .expect_err("an unscoped runner must be rejected");
+        assert!(missing.to_string().contains("requires at least one"));
+
+        let wrong_kind = validate_runner_scopes(
+            Some(AgentTemplate::Runner),
+            &[("repo".to_string(), "org/acme".to_string())],
+        )
+        .expect_err("a repo-scoped runner must be rejected");
+        assert!(wrong_kind.to_string().contains("is not a spool"));
+
+        let wildcard = validate_runner_scopes(
+            Some(AgentTemplate::Runner),
+            &[("spool".to_string(), "*".to_string())],
+        )
+        .expect_err("a wildcard runner must be rejected");
+        assert!(wildcard.to_string().contains("concrete spool path"));
+
+        validate_runner_scopes(
+            Some(AgentTemplate::Runner),
+            &[
+                ("spool".to_string(), "org/acme".to_string()),
+                ("spool".to_string(), "org/docs".to_string()),
+            ],
+        )
+        .expect("one or more concrete spool scopes are valid");
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/auth_requests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_requests.rs
@@ -32,7 +32,8 @@ pub enum AuthCommand {
         ttl_secs: u64,
         scopes: Vec<String>,
         allowed_operations: Vec<String>,
-        /// Preset operation ceiling (`reviewer` | `contributor` | `ci-landing`).
+        /// Preset operation ceiling (`reviewer` | `contributor` | `ci-landing`
+        /// or the internal `--runner` persona).
         /// Expands to a curated `--allow` set; a combined explicit `--allow`
         /// may only narrow it.
         template: Option<crate::hosted_runtime::device_flow::AgentTemplate>,

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -202,6 +202,11 @@ fn mandatory_agent_denied_operations() -> impl Iterator<Item = &'static str> {
     )
 }
 
+/// Scope token and authority-right action parsed by weft-authz.
+pub const CI_VERDICT_WRITE_ACTION: &str = "ci-verdict:write";
+/// Request-time operation injected by weft's CI-verdict authorization gate.
+pub const CI_VERDICT_WRITE_OPERATION: &str = "CiVerdictWrite";
+
 /// Curated W1 operation ceiling for `heddle auth derive-agent`.
 ///
 /// This is the derive-agent child ceiling only. The unclaimed agent-rooted
@@ -212,6 +217,10 @@ fn mandatory_agent_denied_operations() -> impl Iterator<Item = &'static str> {
 /// both evaluated by the server, so sub-derivation computes an intersection
 /// and cannot widen an ancestor's selection.
 pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
+    // CI runners submit signed verdicts without receiving source-write
+    // authority. Weft gates this operation on the distinct authority action
+    // `ci-verdict:write` for the request's spool.
+    CI_VERDICT_WRITE_OPERATION,
     // Hosted push and pull.
     "Push",
     "Pull",
@@ -292,6 +301,7 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
 
 /// Collaboration writes a `contributor` adds on top of the read set.
 const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
+    CI_VERDICT_WRITE_OPERATION,
     "Push",
     "UpdateRef",
     "SetContext",
@@ -308,6 +318,9 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
 
 /// The push/pull/ref-move set a CI lander needs to run `ready`/`land`.
 const TEMPLATE_CI_LANDING_WRITES: &[&str] = &["Push", "UpdateRef"];
+
+/// The sole write capability a human delegates to a CI runner.
+const TEMPLATE_RUNNER_WRITES: &[&str] = &[CI_VERDICT_WRITE_OPERATION];
 
 /// Preset operation ceilings for `heddle auth derive-agent --template`.
 ///
@@ -334,16 +347,19 @@ pub enum AgentTemplate {
     /// Read + `Pull` + the `Push`/`UpdateRef` a CI lander needs to run
     /// `ready`/`land`. No context or discussion writes.
     CiLanding,
+    /// CI verdict submission only. No source reads, writes, or ref moves.
+    Runner,
 }
 
 impl AgentTemplate {
-    /// Every template variant, in privilege order. A new variant added to the
-    /// enum must be added here too — the `operations()` match already forces
-    /// handling it, and the template invariant tests iterate `ALL` so a new
-    /// variant is automatically held to the safe-ceiling and ordering checks.
+    /// Every template variant. A new variant added to the enum must be added
+    /// here too — the `operations()` match already forces handling it, and the
+    /// template invariant tests iterate `ALL` so a new variant is
+    /// automatically held to the safe-ceiling checks.
     #[cfg(test)]
-    pub const ALL: [AgentTemplate; 3] = [
+    pub const ALL: [AgentTemplate; 4] = [
         AgentTemplate::Reviewer,
+        AgentTemplate::Runner,
         AgentTemplate::CiLanding,
         AgentTemplate::Contributor,
     ];
@@ -354,6 +370,7 @@ impl AgentTemplate {
             AgentTemplate::Reviewer => "reviewer",
             AgentTemplate::Contributor => "contributor",
             AgentTemplate::CiLanding => "ci-landing",
+            AgentTemplate::Runner => "runner",
         }
     }
 
@@ -371,6 +388,10 @@ impl AgentTemplate {
             }
             AgentTemplate::CiLanding => {
                 set.extend(TEMPLATE_CI_LANDING_WRITES.iter().copied());
+            }
+            AgentTemplate::Runner => {
+                set.clear();
+                set.extend(TEMPLATE_RUNNER_WRITES.iter().copied());
             }
         }
         set.into_iter().map(str::to_string).collect()
@@ -397,16 +418,16 @@ pub struct AgentAttenuation {
     /// `expires_at`, the chain rejects regardless of the parent's
     /// own expiry.
     pub expires_at: DateTime<Utc>,
-    /// When `Some`, the agent is restricted to the listed hosted
-    /// operations. Each entry is the bare method name (e.g.
-    /// `"GetState"`, `"ListRefs"`).
+    /// When `Some`, the agent is restricted to the listed hosted operations.
+    /// Each entry is a bare method name (e.g. `"GetState"`, `"ListRefs"`) or
+    /// a verifier operation such as `"CiVerdictWrite"`.
     pub allowed_operations: Option<Vec<String>>,
     /// When `Some`, the agent is restricted to resources whose path matches
     /// one of the entries. Format: `(kind, path)` where
-    /// `kind ∈ {"repo", "namespace"}`. Emits an ENFORCEABLE
-    /// `check if resource($k, $p), …` caveat against the `resource("repo", …)`
-    /// fact the server injects per request (weft#644): a `repo` entry matches
-    /// that exact repo or any subtree path, a `namespace` entry matches the
+    /// `kind ∈ {"repo", "namespace", "spool"}`. Emits an ENFORCEABLE
+    /// `check if resource($k, $p), …` caveat against the resource fact the
+    /// server injects per request (weft#644). A `repo` or `spool` entry matches
+    /// that exact path or any subtree path; a `namespace` entry matches the
     /// whole `<namespace>/` repo subtree. An entry rejects a request whose
     /// target the caveat does not cover; a full-authority token (`None`) is
     /// unaffected because facts never reject, only caveats do.
@@ -920,7 +941,8 @@ mod tests {
             .into_iter()
             .collect();
         let ci: BTreeSet<String> = AgentTemplate::CiLanding.operations().into_iter().collect();
-        // Reviewer is the read-only floor; both write templates are supersets.
+        let runner: BTreeSet<String> = AgentTemplate::Runner.operations().into_iter().collect();
+        // Reviewer is the read-only floor for contributor and CI landing.
         assert!(reviewer.is_subset(&contributor));
         assert!(reviewer.is_subset(&ci));
         // CI landing sits between reviewer and contributor: it adds only
@@ -929,6 +951,23 @@ mod tests {
         // Contributor carries collaboration writes CI landing does not.
         assert!(contributor.contains("OpenDiscussion"));
         assert!(!ci.contains("OpenDiscussion"));
+        assert!(runner.is_subset(&contributor));
+    }
+
+    #[test]
+    fn runner_template_can_write_verdicts_but_cannot_write_source() {
+        let runner: BTreeSet<String> = AgentTemplate::Runner.operations().into_iter().collect();
+
+        assert_eq!(
+            runner,
+            BTreeSet::from([CI_VERDICT_WRITE_OPERATION.to_string()])
+        );
+        for forbidden in ["Push", "UpdateRef", "spool:write", "spool-write"] {
+            assert!(
+                !runner.contains(forbidden),
+                "runner operation ceiling must deny source-write operation {forbidden}"
+            );
+        }
     }
 
     /// Mint a parent Biscuit using biscuit-auth directly. We avoid

--- a/docs/SELF_SOVEREIGN_AUTH.md
+++ b/docs/SELF_SOVEREIGN_AUTH.md
@@ -132,6 +132,22 @@ heddle auth derive-agent \
   --allow GetState
 ```
 
+For a human-delegated CI verdict runner, use a concrete spool scope and the
+fixed runner persona:
+
+```bash
+heddle auth derive-agent \
+  --server grpc.heddle.sh \
+  --agent-id ci-main \
+  --runner \
+  --scope spool:org/acme \
+  --out ci-main.hcred
+```
+
+The canonical weft scope is `spool:org/acme ci-verdict:write`. The Biscuit's
+request-operation fence uses weft's corresponding `CiVerdictWrite` operation;
+it does not admit `Push`, `UpdateRef`, or ordinary spool write.
+
 ## What gets emitted in the attenuation block
 
 Each restriction translates to a Biscuit Datalog clause that the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1804,6 +1804,22 @@ heddle auth derive-agent \
   --allow GetState
 ```
 
+For a human-delegated CI verdict runner, use a concrete spool scope and the
+fixed runner persona:
+
+```bash
+heddle auth derive-agent \
+  --server grpc.heddle.sh \
+  --agent-id ci-main \
+  --runner \
+  --scope spool:org/acme \
+  --out ci-main.hcred
+```
+
+The canonical weft scope is `spool:org/acme ci-verdict:write`. The Biscuit's
+request-operation fence uses weft's corresponding `CiVerdictWrite` operation;
+it does not admit `Push`, `UpdateRef`, or ordinary spool write.
+
 ## What gets emitted in the attenuation block
 
 Each restriction translates to a Biscuit Datalog clause that the


### PR DESCRIPTION
Closes #1624

## Summary
- add `heddle auth derive-agent --runner` as a purely offline, human-delegated persona
- require concrete `spool:<path>` scopes and a fresh child PoP key
- use weft's exact `CiVerdictWrite` request operation and `ci-verdict:write` authority action/scope token
- deny Push, UpdateRef, CreateSpool, ordinary spool write, and out-of-scope verdicts

## Verification
- `cargo test -p heddle-cli-args --features client`
- `HEDDLE_HOME=<temp> cargo test -p heddle-hosted-client --features client -- --test-threads=1` (333 passed, 1 ignored)
- `cargo build -p heddle-cli`
- `cargo clippy -p heddle-cli -- -D warnings`
- `rustfmt +nightly --edition 2024 <touched Rust files>`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790813232&installation_model_id=21489&pr_number=1625&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1625&signature=32fd6906eafb3c75a15438f3445bf9ed62ae15c203ef4fbdc18ef9d206f21267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->