### PR TITLE
Preserve hosted remote hostname for TLS bootstrap

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -17,9 +17,19 @@ use std::{
 #[cfg(feature = "client")]
 use anyhow::Context;
 use anyhow::{Result, anyhow};
+/// `output_kind` value carried by the final `heddle clone --output json`
+/// payload. Referenced by the command catalog and the catalog/runtime
+/// invariant test to keep the runtime emission and the advertised
+/// discriminator from drifting apart.
+// The wire payload lives in cli-contract so the schema registry registers
+// the real serialization type.
+pub use heddle_cli_contract::cli::commands::wire::remote::CloneOutput;
 use heddle_git_projection::git_core::{
     clone_url_to_bare, copy_local_repo_to_bare, open_repo, set_reference, write_head_symref,
 };
+use hosted_client::client::LocalSync;
+#[cfg(feature = "client")]
+use hosted_client::hosted_runtime::hosted::{HostedClient, HostedRefEntry, PullMaterialization};
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
 use objects::fs_atomic::CloneDurabilityBatch;
@@ -72,17 +82,6 @@ use crate::{
     perf::{ProfileField, emit_profile},
     remote::{Remote, RemoteConfig, RemoteTarget},
 };
-use hosted_client::client::LocalSync;
-#[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{HostedClient, HostedRefEntry, PullMaterialization};
-
-/// `output_kind` value carried by the final `heddle clone --output json`
-/// payload. Referenced by the command catalog and the catalog/runtime
-/// invariant test to keep the runtime emission and the advertised
-/// discriminator from drifting apart.
-// The wire payload lives in cli-contract so the schema registry registers
-// the real serialization type.
-pub use heddle_cli_contract::cli::commands::wire::remote::CloneOutput;
 
 pub const CLONE_OUTPUT_KIND: &str = "clone";
 
@@ -239,8 +238,11 @@ pub async fn cmd_clone(
             clone_git_overlay_url(cli, &remote, &plan.destination, &options)?;
         }
         CloneMode::NetworkHosted { recursive } => {
-            let (addr, repo_path) = match parse_result {
-                Ok(RemoteTarget::Network { addr, repo_path }) => (addr, repo_path),
+            let (authority, repo_path) = match parse_result {
+                Ok(RemoteTarget::Network {
+                    authority,
+                    repo_path,
+                }) => (authority, repo_path),
                 _ => {
                     return Err(anyhow!(clone_invalid_remote_url_advice(&remote)));
                 }
@@ -254,7 +256,7 @@ pub async fn cmd_clone(
                 if recursive {
                     clone_monorepo(
                         cli,
-                        addr,
+                        &authority,
                         repo_path.as_deref(),
                         &plan.destination,
                         &options,
@@ -265,7 +267,7 @@ pub async fn cmd_clone(
                 } else {
                     clone_network(
                         cli,
-                        addr,
+                        &authority,
                         repo_path.as_deref(),
                         &plan.destination,
                         &options,
@@ -277,7 +279,7 @@ pub async fn cmd_clone(
             }
             #[cfg(not(feature = "client"))]
             {
-                let _ = (addr, repo_path, recursive, &plan.security);
+                let _ = (authority, repo_path, recursive, &plan.security);
                 return Err(anyhow!(network_clone_unavailable_advice()));
             }
         }
@@ -1395,9 +1397,9 @@ fn clone_remote_thread_not_found_advice(track_name: &str, remote_path: &Path) ->
 }
 
 /// Extract the `host:port` substring from a raw remote URL so the lazy
-/// hydrator config can persist it instead of the post-DNS `SocketAddr`.
+/// hydrator config can persist it as the descriptor-trust authority.
 /// Keeping the hostname matters when the upstream service rotates IPs
-/// (e.g. behind a load balancer): a SocketAddr baked into the marker at
+/// (e.g. behind a load balancer): an IP baked into the marker at
 /// clone time would pin to a stale IP and break later hydrate calls even
 /// though the original URL still resolves. The hydrator re-resolves DNS
 /// on every process start when given a hostname spec.
@@ -1536,15 +1538,16 @@ impl Drop for CloneDestinationCleanup<'_> {
 #[cfg(feature = "client")]
 async fn clone_network(
     cli: &Cli,
-    addr: std::net::SocketAddr,
+    authority: &str,
     repo_path: Option<&str>,
     local_path: &Path,
     options: &CloneOptions,
     server_key: Option<String>,
     endpoint_spec: String,
 ) -> Result<()> {
-    use crate::config::UserConfig;
     use hosted_client::client::{HostedAuthMode, HostedSession};
+
+    use crate::config::UserConfig;
 
     let user_config = UserConfig::load_default()?;
     // On every network-connecting command, TLS/auth config validation
@@ -1557,10 +1560,10 @@ async fn clone_network(
             .with_allow_insecure(options.insecure);
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
 
-    let mut client = session.connect(addr).await?;
+    let mut client = session.connect(authority).await?;
     let result = clone_network_connected(
         cli,
-        addr,
+        authority,
         repo_path,
         local_path,
         options,
@@ -1575,7 +1578,7 @@ async fn clone_network(
 #[cfg(feature = "client")]
 async fn clone_network_connected(
     cli: &Cli,
-    addr: std::net::SocketAddr,
+    authority: &str,
     repo_path: &str,
     local_path: &Path,
     options: &CloneOptions,
@@ -1601,11 +1604,11 @@ async fn clone_network_connected(
             serde_json::json!({
                 "output_kind": CLONE_CONNECTION_OUTPUT_KIND,
                 "status": "connected",
-                "address": addr.to_string(),
+                "address": authority,
             })
         );
     } else {
-        println!("Connected to {}", addr);
+        println!("Connected to {authority}");
     }
 
     let mut cleanup = CloneDestinationCleanup::new(local_path);
@@ -1877,8 +1880,9 @@ async fn clone_network_connected(
 
 #[cfg(feature = "client")]
 pub async fn recover_interrupted_clone(cli: &Cli, start: &Path) -> Result<bool> {
-    use crate::config::UserConfig;
     use hosted_client::client::{HostedAuthMode, HostedSession};
+
+    use crate::config::UserConfig;
 
     let Some(root) = repo::clone_intent::find_clone_intent_root(start) else {
         return Ok(false);
@@ -1886,7 +1890,7 @@ pub async fn recover_interrupted_clone(cli: &Cli, start: &Path) -> Result<bool> 
     let intent = CloneIntent::load(&root)?
         .context("clone intent disappeared while recovery was starting")?;
     let target = RemoteTarget::parse(&intent.origin).map_err(anyhow::Error::msg)?;
-    let RemoteTarget::Network { addr, .. } = target else {
+    let RemoteTarget::Network { authority, .. } = target else {
         anyhow::bail!(
             "clone intent origin is not a hosted remote: {}",
             intent.origin
@@ -1896,7 +1900,7 @@ pub async fn recover_interrupted_clone(cli: &Cli, start: &Path) -> Result<bool> 
     let server_key = credential_key_from_remote_url(&intent.origin);
     let session =
         HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?;
-    let mut client = session.connect(addr).await?;
+    let mut client = session.connect(&authority).await?;
     let recovered = recover_interrupted_clone_connected(cli, &root, &intent, &mut client).await;
     client.close().await;
     recovered?;
@@ -2100,15 +2104,16 @@ fn verify_hosted_clone(
 #[cfg(feature = "client")]
 async fn clone_monorepo(
     cli: &Cli,
-    addr: std::net::SocketAddr,
+    authority: &str,
     repo_path: Option<&str>,
     local_path: &Path,
     options: &CloneOptions,
     server_key: Option<String>,
     endpoint_spec: String,
 ) -> Result<()> {
-    use crate::config::UserConfig;
     use hosted_client::client::{HostedAuthMode, HostedSession};
+
+    use crate::config::UserConfig;
 
     // Monorepo clone materializes each node at a resolved state; the shallow /
     // lazy / partial knobs don't compose with the multi-spool walk in this
@@ -2125,10 +2130,16 @@ async fn clone_monorepo(
         HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
             .with_allow_insecure(options.insecure);
 
-    let mut client = session.connect(addr).await?;
-    let result =
-        clone_monorepo_connected(cli, addr, root_path, local_path, endpoint_spec, &mut client)
-            .await;
+    let mut client = session.connect(authority).await?;
+    let result = clone_monorepo_connected(
+        cli,
+        authority,
+        root_path,
+        local_path,
+        endpoint_spec,
+        &mut client,
+    )
+    .await;
     client.close().await;
     result
 }
@@ -2136,7 +2147,7 @@ async fn clone_monorepo(
 #[cfg(feature = "client")]
 async fn clone_monorepo_connected(
     cli: &Cli,
-    addr: std::net::SocketAddr,
+    authority: &str,
     root_path: &str,
     local_path: &Path,
     endpoint_spec: String,
@@ -2149,11 +2160,11 @@ async fn clone_monorepo_connected(
             serde_json::json!({
                 "output_kind": CLONE_CONNECTION_OUTPUT_KIND,
                 "status": "connected",
-                "address": addr.to_string(),
+                "address": authority,
             })
         );
     } else {
-        println!("Connected to {}", addr);
+        println!("Connected to {authority}");
     }
 
     // Resolve the whole child tree into the caller's coherent visible slice,

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -2079,6 +2079,27 @@ mod tests {
 
     #[cfg(feature = "client")]
     #[test]
+    fn auto_provision_persists_hostname_authority() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured =
+            persist_auto_provisioned_remote(&repo, None, "api-staging.heddle.sh", "org/repo")
+                .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "heddle://api-staging.heddle.sh/org/repo");
+        let RemoteTarget::Network { authority, .. } = RemoteTarget::parse(&remote.url).unwrap()
+        else {
+            panic!("persisted hosted remote must remain a network target");
+        };
+        assert_eq!(authority, "api-staging.heddle.sh");
+        assert!(authority.parse::<std::net::IpAddr>().is_err());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
     fn auto_provision_reuses_create_spool_already_exists() {
         let typed_already_exists = ProtocolError::AlreadyExists("luke/demo-repo".to_string());
         assert!(auto_provision_create_already_exists(&typed_already_exists));

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Remote operations (push, pull, remote management).
 
-#[cfg(feature = "client")]
-use std::net::SocketAddr;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
@@ -14,6 +12,11 @@ use heddle_git_projection::{
         AuthoritativeGitPushOptions, GitPushScope, push_authoritative_git_refs, set_reference,
     },
 };
+#[cfg(feature = "client")]
+use hosted_client::client::HostedClient;
+use hosted_client::client::LocalSync;
+#[cfg(feature = "client")]
+use hosted_client::client::{HostedAuthMode, HostedSession};
 use objects::object::ThreadName;
 use repo::{Repository, RepositoryCapability};
 use sley::{
@@ -67,18 +70,12 @@ use crate::{
     config::UserConfig,
     remote::{RemoteConfig, RemoteTarget, resolve_remote_with_key},
 };
-#[cfg(feature = "client")]
-use hosted_client::client::HostedClient;
-use hosted_client::client::LocalSync;
-#[cfg(feature = "client")]
-use hosted_client::client::{HostedAuthMode, HostedSession};
 
 mod remote_ops;
 
 // The wire payload lives in cli-contract so the schema registry registers
 // the real serialization type.
 pub(crate) use heddle_cli_contract::cli::commands::wire::remote::PushOutput;
-
 pub use remote_ops::{cmd_pull, cmd_remote};
 pub(crate) use remote_ops::{
     pull_current_git_overlay_authoritative, resolve_default_remote_name,
@@ -411,12 +408,15 @@ pub async fn cmd_push(
                 push_local(&repo, &path, state_id, track_name, &plan, cli).await?;
             }
         }
-        RemoteTarget::Network { addr, repo_path } => {
+        RemoteTarget::Network {
+            authority,
+            repo_path,
+        } => {
             #[cfg(feature = "client")]
             push_network(
                 &repo,
                 PushNetworkOptions {
-                    addr,
+                    authority: &authority,
                     repo_path: repo_path.as_deref(),
                     remote_arg: remote.as_deref(),
                     session: network_session
@@ -431,7 +431,7 @@ pub async fn cmd_push(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, single_state_id, insecure);
+            let _ = (authority, repo_path, single_state_id, insecure);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("push"));
         }
@@ -922,7 +922,7 @@ pub(super) fn admit_git_overlay_remote_url(url: &str) -> Result<()> {
 
 #[cfg(feature = "client")]
 async fn discover_native_https_remote(spec: &str, action: &str) -> Result<()> {
-    let RemoteTarget::Network { addr, .. } =
+    let RemoteTarget::Network { authority, .. } =
         RemoteTarget::parse_native(spec).map_err(anyhow::Error::msg)?
     else {
         anyhow::bail!("native HTTPS discovery requires a network remote");
@@ -933,7 +933,7 @@ async fn discover_native_https_remote(spec: &str, action: &str) -> Result<()> {
         server_key,
         HostedAuthMode::Unauthenticated,
     )?;
-    match session.discover_endpoint(addr).await {
+    match session.discover_endpoint(&authority).await {
         Ok(_) => Ok(()),
         Err(hosted_client::hosted_runtime::hosted::HostedError::EndpointDescriptorUnavailable) => {
             Err(RecoveryAdvice::native_https_iroh_endpoint_missing(action, spec).into())
@@ -1383,7 +1383,7 @@ async fn push_local_all_threads(
 async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Result<()> {
     let mut client = options
         .session
-        .connect(options.addr)
+        .connect(options.authority)
         .await?
         .with_human_signature_callback(hosted_client::client::cli_human_signature_callback());
     let result = push_network_connected(repo, &mut client, options).await;
@@ -1398,7 +1398,7 @@ async fn push_network_connected(
     options: PushNetworkOptions<'_>,
 ) -> Result<()> {
     if !should_output_json(options.cli, Some(repo.config())) {
-        let line = format_connected_to(&options.addr.to_string());
+        let line = format_connected_to(options.authority);
         if let Some(addr) = line.strip_prefix("connected to ") {
             println!("{} connected to {}", style::ok_marker(), style::dim(addr));
         } else {
@@ -1765,7 +1765,7 @@ async fn auto_provision_hosted_repo(
     let configured_remote = persist_auto_provisioned_remote(
         repo,
         options.remote_arg,
-        options.addr,
+        options.authority,
         provisioned_repo.full_path(),
     )?;
 
@@ -1789,14 +1789,17 @@ async fn auto_provision_hosted_repo(
                     &format!(
                         "{} -> {}",
                         style::bold(&remote_name),
-                        style::dim(&format!("heddle://{}/{}", options.addr, display_full_path))
+                        style::dim(&format!(
+                            "heddle://{}/{}",
+                            options.authority, display_full_path
+                        ))
                     )
                 )
             );
         } else {
             print_next(&format!(
                 "heddle remote add origin heddle://{}/{}",
-                options.addr, display_full_path
+                options.authority, display_full_path
             ));
         }
     }
@@ -1856,7 +1859,7 @@ fn auto_provision_create_error_message(slug: &str, err: &ProtocolError) -> Strin
 fn persist_auto_provisioned_remote(
     repo: &Repository,
     remote_arg: Option<&str>,
-    addr: SocketAddr,
+    authority: &str,
     full_path: &str,
 ) -> Result<Option<String>> {
     let Some(remote_name) = auto_provision_remote_name(repo, remote_arg)? else {
@@ -1866,7 +1869,7 @@ fn persist_auto_provisioned_remote(
     cfg.add(
         &remote_name,
         Remote {
-            url: format!("heddle://{addr}/{full_path}"),
+            url: format!("heddle://{authority}/{full_path}"),
             insecure: false,
         },
     )
@@ -1941,7 +1944,7 @@ fn spool_slug_from_local_name(name: &str) -> String {
 
 #[cfg(feature = "client")]
 struct PushNetworkOptions<'a> {
-    addr: SocketAddr,
+    authority: &'a str,
     repo_path: Option<&'a str>,
     remote_arg: Option<&'a str>,
     session: &'a HostedSession,
@@ -2019,7 +2022,7 @@ mod tests {
         );
         assert_eq!(
             classify_push_remote_spec(&native, Some("heddle://api.heddle.sh/luke/tiny-notes")),
-            Some(RemoteTransportKind::Unknown)
+            Some(RemoteTransportKind::NetworkHeddle)
         );
 
         let overlay_dir = tempfile::TempDir::new().unwrap();
@@ -2089,8 +2092,7 @@ mod tests {
         let permission = ProtocolError::AuthorizationFailed("missing grant".to_string());
         assert!(!auto_provision_create_already_exists(&permission));
 
-        let missing_genesis =
-            ProtocolError::InvalidState("owner_genesis is required".to_string());
+        let missing_genesis = ProtocolError::InvalidState("owner_genesis is required".to_string());
         assert!(
             !auto_provision_create_already_exists(&missing_genesis),
             "weft's CreateSpool genesis require is a hard failure, not AlreadyExists"

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1,25 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pull, remote management, and serve commands.
 
-#[cfg(feature = "client")]
-use std::net::SocketAddr;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-#[cfg(feature = "client")]
-use verbs::{
-    HostedPullResult, HostedPullResultFields, format_connected_to,
-    heddle_pull_execution_facts_from_hosted, parse_hosted_pull_result, pull_tip_changed,
-};
-use verbs::{
-    LocalTransferSummary, PullFailure, PullOutcome, PullPlan, PullPlanRequest, RemoteInfo,
-    RemoteListReport, build_pull_outcome, format_pull_outcome_text, format_pulling_from,
-    git_overlay_pull_execution_facts, heddle_pull_execution_facts_from_local,
-    is_native_transport_mismatch, list_plain_git_remotes, list_remotes, local_pull_changed,
-    plan_pull, pull_should_materialize, show_plain_git_remote, show_remote,
+/// CLI machine envelope: domain [`PullOutcome`] plus repository verification.
+// The wire payload lives in cli-contract so the schema registry registers
+// the real serialization type.
+pub(crate) use heddle_cli_contract::cli::commands::wire::remote::{
+    PullOutput, RemoteMutationOutput,
 };
 // Re-export under the historical crate-local names for sibling modules.
 use heddle_git_projection::credential::EmbeddingSafeCredentialProvider;
+#[cfg(feature = "client")]
+use hosted_client::client::HostedClient;
+use hosted_client::client::LocalSync;
+#[cfg(feature = "client")]
+use hosted_client::hosted_runtime::hosted::{HostedAuthMode, PullMaterialization};
 use objects::{
     object::{StateId, ThreadName, Tree},
     store::ObjectStore,
@@ -32,6 +29,18 @@ use sley::{
     remote::{
         FetchOptions, PackGenerationProgress, ProgressSink as SleyProgressSink, TransferProgress,
     },
+};
+#[cfg(feature = "client")]
+use verbs::{
+    HostedPullResult, HostedPullResultFields, format_connected_to,
+    heddle_pull_execution_facts_from_hosted, parse_hosted_pull_result, pull_tip_changed,
+};
+use verbs::{
+    LocalTransferSummary, PullFailure, PullOutcome, PullPlan, PullPlanRequest, RemoteInfo,
+    RemoteListReport, build_pull_outcome, format_pull_outcome_text, format_pulling_from,
+    git_overlay_pull_execution_facts, heddle_pull_execution_facts_from_local,
+    is_native_transport_mismatch, list_plain_git_remotes, list_remotes, local_pull_changed,
+    plan_pull, pull_should_materialize, show_plain_git_remote, show_remote,
 };
 pub(crate) use verbs::{resolve_default_remote_name, resolved_default_remote_name};
 
@@ -54,18 +63,6 @@ use crate::{
     },
     config::UserConfig,
     remote::{Remote, RemoteConfig, RemoteTarget, resolve_remote_with_key},
-};
-#[cfg(feature = "client")]
-use hosted_client::client::HostedClient;
-use hosted_client::client::LocalSync;
-#[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{HostedAuthMode, PullMaterialization};
-
-/// CLI machine envelope: domain [`PullOutcome`] plus repository verification.
-// The wire payload lives in cli-contract so the schema registry registers
-// the real serialization type.
-pub(crate) use heddle_cli_contract::cli::commands::wire::remote::{
-    PullOutput, RemoteMutationOutput,
 };
 
 fn heddle_pull_output_from_local(
@@ -275,12 +272,15 @@ pub async fn cmd_pull(
             )
             .await?;
         }
-        RemoteTarget::Network { addr, repo_path } => {
+        RemoteTarget::Network {
+            authority,
+            repo_path,
+        } => {
             #[cfg(feature = "client")]
             pull_network(
                 &repo,
                 PullNetworkOptions {
-                    addr,
+                    authority: &authority,
                     repo_path: repo_path.as_deref(),
                     user_config: &user_config,
                     server_key,
@@ -295,7 +295,7 @@ pub async fn cmd_pull(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, insecure);
+            let _ = (authority, repo_path, insecure);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("pull"));
         }
@@ -1085,7 +1085,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
         .repo_path
         .context("network remotes must include a hosted repository path")?;
     let mut client = HostedClient::open_session_with_insecure(
-        options.addr,
+        options.authority,
         options.user_config,
         options.server_key.clone(),
         HostedAuthMode::CredentialFallback,
@@ -1106,7 +1106,7 @@ async fn pull_network_connected(
     options: PullNetworkOptions<'_>,
 ) -> Result<()> {
     if !should_output_json(options.cli, Some(repo.config())) {
-        let line = format_connected_to(&options.addr.to_string());
+        let line = format_connected_to(options.authority);
         if let Some(addr) = line.strip_prefix("connected to ") {
             println!("{} connected to {}", style::ok_marker(), style::dim(addr));
         } else {
@@ -1723,7 +1723,7 @@ fn render_remote_info(output: &RemoteInfo, json: bool) -> Result<()> {
 
 #[cfg(feature = "client")]
 struct PullNetworkOptions<'a> {
-    addr: SocketAddr,
+    authority: &'a str,
     repo_path: Option<&'a str>,
     user_config: &'a UserConfig,
     server_key: Option<String>,

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -17,6 +17,12 @@
 use anyhow::{Context, Result, anyhow};
 use api::heddle::api::v1alpha1::{RepositoryRef, StateId as ApiStateId, repository_ref::Reference};
 use heddle_cli_args::CliContext as _;
+// The approval wire payloads live in cli-contract so the schema registry
+// registers the real serialization types.
+pub(crate) use heddle_cli_contract::cli::commands::wire::thread::{
+    ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, UnmetOutput,
+};
+use hosted_client::client::{HostedAuthMode, HostedClient};
 use objects::object::ThreadName;
 use repo::Repository;
 use verbs::approval_plan::{
@@ -27,8 +33,10 @@ use verbs::approval_plan::{
     timestamp_secs_u64, unmet_requirement_line,
 };
 
-use super::RecoveryAdvice;
-use super::next_action::{NextActionValidationContext, write_full_command_json};
+use super::{
+    RecoveryAdvice,
+    next_action::{NextActionValidationContext, write_full_command_json},
+};
 use crate::{
     cli::{
         Cli,
@@ -39,13 +47,6 @@ use crate::{
     },
     config::UserConfig,
     remote::{RemoteTarget, resolve_remote_with_key},
-};
-use hosted_client::client::{HostedAuthMode, HostedClient};
-
-// The approval wire payloads live in cli-contract so the schema registry
-// registers the real serialization types.
-pub(crate) use heddle_cli_contract::cli::commands::wire::thread::{
-    ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, UnmetOutput,
 };
 
 fn ts_secs(ts: &Option<prost_types::Timestamp>) -> u64 {
@@ -73,9 +74,12 @@ async fn open_hosted_session(
     remote_name: &str,
 ) -> Result<(HostedClient, String)> {
     let (target, server_key) = resolve_remote_with_key(repo, Some(remote_name))?;
-    let (addr, repo_path) = match target {
-        RemoteTarget::Network { addr, repo_path } => (
-            addr,
+    let (authority, repo_path) = match target {
+        RemoteTarget::Network {
+            authority,
+            repo_path,
+        } => (
+            authority,
             repo_path.context("hosted remote must include a repository path")?,
         ),
         RemoteTarget::Local(_) => {
@@ -97,7 +101,7 @@ async fn open_hosted_session(
     // CredentialFallback (resolves the credential store's proof key) rather
     // than a token-only ConfigToken session.
     let client = HostedClient::open_session(
-        addr,
+        &authority,
         &user_config,
         server_key,
         HostedAuthMode::CredentialFallback,

--- a/crates/hosted-client/src/client/repo_events.rs
+++ b/crates/hosted-client/src/client/repo_events.rs
@@ -87,7 +87,7 @@ impl RepoEventClient {
     pub async fn connect(server: &str) -> Result<Self, RepoEventError> {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let target = RemoteTarget::parse_native(server).map_err(RepoEventError::InvalidServer)?;
-        let RemoteTarget::Network { addr, .. } = target else {
+        let RemoteTarget::Network { authority, .. } = target else {
             return Err(RepoEventError::LocalServer);
         };
         let server_key = repo::remote::credential_key_from_remote_url(server);
@@ -97,7 +97,7 @@ impl RepoEventClient {
             HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)
                 .map_err(|error| RepoEventError::Configuration(error.to_string()))?;
         let client = session
-            .connect(addr)
+            .connect(&authority)
             .await
             .map_err(|error| RepoEventError::Connection(error.to_string()))?;
         Ok(Self { client })

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -123,10 +123,10 @@ async fn cmd_auth_invite(
     // chokepoint used by the other durable identity writes under `auth`.
     let session = HostedSession::build(
         &user_config,
-        Some(server),
+        Some(server.clone()),
         HostedAuthMode::CredentialFallback,
     )?;
-    let mut auth_client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let mut auth_client = session.connect(&server).await?;
     let result = if list {
         list_signup_invites_connected(ctx, &mut auth_client).await
     } else {
@@ -1098,7 +1098,7 @@ async fn cmd_create_service_token(
         Some(server.clone()),
         HostedAuthMode::CredentialFallback,
     )?;
-    let mut auth_client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let mut auth_client = session.connect(&server).await?;
     let result = create_service_token_connected(
         ctx,
         &mut auth_client,
@@ -1342,7 +1342,7 @@ async fn connect_auth_client(server: &str) -> Result<HostedClient> {
         Some(server.to_string()),
         HostedAuthMode::Unauthenticated,
     )?
-    .connect(([127, 0, 0, 1], 0).into())
+    .connect(server)
     .await
     .map_err(hosted_bootstrap_connect_error)
 }

--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -67,7 +67,7 @@ pub(crate) async fn create_with_invite(
             signing_identity: format!("principal:{}", minted.subject),
         },
     )?;
-    let mut client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let mut client = session.connect(server).await?;
     let operation_id = match ctx.operation_id_wire() {
         value if value.is_empty() => uuid::Uuid::new_v4().to_string(),
         value => value,

--- a/crates/hosted-client/src/hosted_runtime/claim_offer.rs
+++ b/crates/hosted-client/src/hosted_runtime/claim_offer.rs
@@ -22,7 +22,9 @@ use super::{
         encode_owner_root_reply, owner_root_operation, validate_stored_claim_signer,
     },
     claim_bridge::ClaimBridgeWorker,
-    hosted::{canonical_server_authority, claim_protocol::VerifiedClaimPrincipal, server_keys_match},
+    hosted::{
+        canonical_server_authority, claim_protocol::VerifiedClaimPrincipal, server_keys_match,
+    },
     identity_state::{self, ClaimIssuanceStatus, ClaimSecret, ClaimState},
 };
 
@@ -81,7 +83,7 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     // Outbound only: an ephemeral endpoint that does not bind the device
     // node id the daemon serves the claim router on.
     let mut client = session
-        .connect_outbound(([127, 0, 0, 1], 0).into())
+        .connect_outbound(&server)
         .await
         .with_context(|| format!("connecting to {server} for the claim ceremony"))?;
     // Upload the claimable seq-0 root before the Iroh ceremony so claim
@@ -108,8 +110,13 @@ pub(crate) async fn cmd_claim(args: ClaimArgs) -> Result<()> {
     drop(claim_link);
     drop(offer.secret);
 
-    let outcome =
-        wait_for_claim(&offer.authorization_hash, args.timeout, &claim_socket, &client).await;
+    let outcome = wait_for_claim(
+        &offer.authorization_hash,
+        args.timeout,
+        &claim_socket,
+        &client,
+    )
+    .await;
     let claimed = matches!(outcome, Ok(ClaimWaitOutcome::Claimed));
     let owner_root_claim = if claimed {
         super::owner_root::send_pending_register_public_key_claim(&mut client).await

--- a/crates/hosted-client/src/hosted_runtime/hosted/hydration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/hydration.rs
@@ -1,5 +1,4 @@
 use std::{
-    net::ToSocketAddrs,
     sync::{Arc, Mutex, OnceLock, mpsc},
     thread,
     time::Duration,
@@ -187,22 +186,6 @@ enum HydrateMessage {
 
 impl HydrationBridge {
     fn connect(endpoint: &str) -> objects::error::Result<Self> {
-        // Resolve DNS at connect time so a hostname that's persisted
-        // (rather than a frozen IP) re-resolves on every process start.
-        let addr = endpoint
-            .to_socket_addrs()
-            .map_err(|err| {
-                HeddleError::Config(format!(
-                    "lazy hosted hydrator: resolve endpoint '{endpoint}': {err}",
-                ))
-            })?
-            .next()
-            .ok_or_else(|| {
-                HeddleError::Config(format!(
-                    "lazy hosted hydrator: DNS returned no addresses for '{endpoint}'",
-                ))
-            })?;
-
         let user_config = config::UserConfig::load_default().map_err(|err| {
             HeddleError::Config(format!("lazy hosted hydrator: load user config: {err}"))
         })?;
@@ -260,12 +243,13 @@ impl HydrationBridge {
                     // before its async close can run. The caller still times
                     // out below; this private worker finishes the dial and
                     // closes the client if the caller has gone away.
-                    let client = session.connect(addr).await.map_err(|err: ProtocolError| {
-                        HeddleError::Config(format!(
-                            "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
-                                     (resolved to {addr}): {err}",
-                        ))
-                    })?;
+                    let client = session.connect(&endpoint_for_thread).await.map_err(
+                        |err: ProtocolError| {
+                            HeddleError::Config(format!(
+                                "lazy hosted hydrator: connect to '{endpoint_for_thread}': {err}",
+                            ))
+                        },
+                    )?;
                     Ok::<_, HeddleError>(client)
                 });
                 let mut client = match connect_result {
@@ -1045,7 +1029,7 @@ mod connect_path_tests {
             "hydration.rs must build its session through the shared HostedSession seam",
         );
         assert!(
-            source.contains("session.connect(addr)"),
+            source.contains("session.connect(&endpoint_for_thread)"),
             "hydration.rs must connect via HostedSession::connect, which owns rotation",
         );
     }

--- a/crates/hosted-client/src/hosted_runtime/hosted/resolver.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/resolver.rs
@@ -119,7 +119,7 @@ fn now_unix_millis() -> Result<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{descriptor_key_url, descriptor_url};
+    use super::{canonical_server_authority, descriptor_key_url, descriptor_url};
 
     #[test]
     fn descriptor_bootstrap_is_https_and_well_known() {
@@ -131,6 +131,20 @@ mod tests {
             descriptor_key_url("https://weft.example:8421"),
             "https://weft.example:8421/.well-known/heddle/iroh-descriptor-key"
         );
+    }
+
+    #[test]
+    fn descriptor_bootstrap_urls_preserve_hostname_authority() {
+        let canonical = canonical_server_authority("api-staging.heddle.sh").unwrap();
+        assert_eq!(
+            descriptor_url(&canonical),
+            "https://api-staging.heddle.sh/.well-known/heddle/iroh-endpoint"
+        );
+        assert_eq!(
+            descriptor_key_url(&canonical),
+            "https://api-staging.heddle.sh/.well-known/heddle/iroh-descriptor-key"
+        );
+        assert!(!descriptor_key_url(&canonical).contains("104.18."));
     }
 
     #[tokio::test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/session.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/session.rs
@@ -1,7 +1,5 @@
 //! Validated native hosted-session assembly and signed descriptor bootstrap.
 
-use std::net::SocketAddr;
-
 use anyhow::{Context, Result};
 use biscuit_auth::builder::BlockBuilder;
 use config::{ClientConfig, UserConfig};
@@ -127,20 +125,14 @@ impl HostedSession {
 
     pub async fn discover_endpoint(
         &self,
-        fallback_addr: SocketAddr,
+        server: &str,
     ) -> super::Result<super::VerifiedEndpointDescriptor> {
-        let server = self
-            .config
-            .server_key
-            .as_deref()
-            .map(str::to_string)
-            .unwrap_or_else(|| fallback_addr.to_string());
-        resolve_and_verify_endpoint_descriptor(&server, &self.config).await
+        resolve_and_verify_endpoint_descriptor(server, &self.config).await
     }
 
-    pub async fn connect(&self, fallback_addr: SocketAddr) -> Result<HostedClient, ProtocolError> {
+    pub async fn connect(&self, server: &str) -> Result<HostedClient, ProtocolError> {
         let descriptor = self
-            .discover_endpoint(fallback_addr)
+            .discover_endpoint(server)
             .await
             .map_err(|error| ProtocolError::Remote(error.to_string()))?;
         let mut client = HostedClient::connect_with_config(&descriptor, &self.config)
@@ -157,12 +149,9 @@ impl HostedSession {
     /// `heddle claim` uses this so its authenticated weft calls never bind
     /// the device node id the box network daemon serves the claim router
     /// on (heddle#1620).
-    pub async fn connect_outbound(
-        &self,
-        fallback_addr: SocketAddr,
-    ) -> Result<HostedClient, ProtocolError> {
+    pub async fn connect_outbound(&self, server: &str) -> Result<HostedClient, ProtocolError> {
         let descriptor = self
-            .discover_endpoint(fallback_addr)
+            .discover_endpoint(server)
             .await
             .map_err(|error| ProtocolError::Remote(error.to_string()))?;
         let mut client = HostedClient::connect_outbound_with_config(&descriptor, &self.config)
@@ -188,16 +177,16 @@ impl HostedClient {
     }
 
     pub async fn open_session(
-        addr: SocketAddr,
+        server: &str,
         user_config: &UserConfig,
         server_key: Option<String>,
         mode: HostedAuthMode,
     ) -> Result<Self> {
-        Self::open_session_with_insecure(addr, user_config, server_key, mode, false).await
+        Self::open_session_with_insecure(server, user_config, server_key, mode, false).await
     }
 
     pub async fn open_session_with_insecure(
-        addr: SocketAddr,
+        server: &str,
         user_config: &UserConfig,
         server_key: Option<String>,
         mode: HostedAuthMode,
@@ -205,7 +194,7 @@ impl HostedClient {
     ) -> Result<Self> {
         Ok(HostedSession::build(user_config, server_key, mode)?
             .with_allow_insecure(allow_insecure)
-            .connect(addr)
+            .connect(server)
             .await?)
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/whoami.rs
+++ b/crates/hosted-client/src/hosted_runtime/whoami.rs
@@ -185,7 +185,7 @@ async fn fetch_identity(server: &str) -> Result<WhoamiIdentity> {
     )
     .map_err(|error| anyhow::anyhow!(error))?;
     let mut client = session
-        .connect(([127, 0, 0, 1], 0).into())
+        .connect(server)
         .await
         .map_err(|error| anyhow::anyhow!(error))?;
     let response = client

--- a/crates/repo/src/remote/mod.rs
+++ b/crates/repo/src/remote/mod.rs
@@ -256,9 +256,8 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use crate::Repository;
-
     use super::*;
+    use crate::Repository;
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -350,8 +349,11 @@ mod tests {
             resolve_remote_with_key_and_insecure(&repo, Some("127.0.0.1:8421"))
                 .expect("resolve host:port-named remote");
         match target {
-            RemoteTarget::Network { addr, repo_path } => {
-                assert_eq!(addr.port(), 9999);
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
+                assert_eq!(authority, "127.0.0.1:9999");
                 assert_eq!(repo_path.as_deref(), Some("acme/repo"));
             }
             other => panic!("expected network target, got {other:?}"),

--- a/crates/repo/src/remote/target.rs
+++ b/crates/repo/src/remote/target.rs
@@ -180,6 +180,23 @@ mod tests {
     use super::RemoteTarget;
 
     #[test]
+    fn heddle_url_preserves_hostname_authority() {
+        let target = RemoteTarget::parse("heddle://api-staging.heddle.sh/org/repo")
+            .expect("parse hosted hostname");
+        match target {
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
+                assert_eq!(authority, "api-staging.heddle.sh");
+                assert_eq!(repo_path.as_deref(), Some("org/repo"));
+                assert!(authority.parse::<std::net::IpAddr>().is_err());
+            }
+            other => panic!("expected network target, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parses_hostname_without_repo_path() {
         let target = RemoteTarget::parse("localhost:8421").expect("parse localhost");
         match target {

--- a/crates/repo/src/remote/target.rs
+++ b/crates/repo/src/remote/target.rs
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Remote target resolution.
 
-use std::{
-    net::{SocketAddr, ToSocketAddrs},
-    path::PathBuf,
-};
+use std::{net::Ipv6Addr, path::PathBuf};
 
 /// A remote target - either a network address or a local path.
 #[derive(Debug, Clone)]
 pub enum RemoteTarget {
-    /// Network address (host:port).
+    /// Network authority (host or host:port).
     Network {
-        addr: SocketAddr,
+        authority: String,
         repo_path: Option<String>,
     },
     /// Local filesystem path (file:// URL).
@@ -24,6 +21,7 @@ impl RemoteTarget {
     /// Accepts:
     /// - `file:///path/to/repo` or `file://path/to/repo`
     /// - `/path/to/repo` (raw path, if it exists as a directory)
+    /// - `heddle://host[:port]/repo` (port defaults to HTTPS 443)
     /// - `host:port` (network address)
     pub fn parse(s: &str) -> Result<Self, String> {
         // Check for file:// protocol
@@ -37,20 +35,17 @@ impl RemoteTarget {
             ));
         }
 
-        if let Some((addr, repo_path)) = parse_network_with_repo_path(s) {
-            return Ok(RemoteTarget::Network { addr, repo_path });
+        if let Some((authority, repo_path)) = parse_network_with_repo_path(s) {
+            return Ok(RemoteTarget::Network {
+                authority,
+                repo_path,
+            });
         }
 
         // Check if it's a raw path (exists as a directory)
         let path = PathBuf::from(s);
         if path.exists() && path.is_dir() {
             return Ok(RemoteTarget::Local(path));
-        }
-
-        if s.starts_with("heddle://") {
-            return Err(format!(
-                "invalid remote url: {s} (`heddle://` carries no addressing that push can use; use https://<host>/<repo> or host:port/repo)"
-            ));
         }
 
         if looks_like_unresolved_local_path(s) {
@@ -73,9 +68,12 @@ impl RemoteTarget {
     /// retain their existing transport classification.
     pub fn parse_native(s: &str) -> Result<Self, String> {
         if let Some(rest) = s.strip_prefix("https://") {
-            let (addr, repo_path) = parse_https_network_with_repo_path(rest)
+            let (authority, repo_path) = parse_https_network_with_repo_path(rest)
                 .ok_or_else(|| format!("invalid native HTTPS remote url: {s}"))?;
-            return Ok(RemoteTarget::Network { addr, repo_path });
+            return Ok(RemoteTarget::Network {
+                authority,
+                repo_path,
+            });
         }
         Self::parse(s)
     }
@@ -94,11 +92,14 @@ impl RemoteTarget {
 impl std::fmt::Display for RemoteTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RemoteTarget::Network { addr, repo_path } => {
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
                 if let Some(repo_path) = repo_path {
-                    write!(f, "heddle://{}/{}", addr, repo_path)
+                    write!(f, "heddle://{authority}/{repo_path}")
                 } else {
-                    write!(f, "{}", addr)
+                    write!(f, "{authority}")
                 }
             }
             RemoteTarget::Local(path) => write!(f, "file://{}", path.display()),
@@ -106,30 +107,21 @@ impl std::fmt::Display for RemoteTarget {
     }
 }
 
-fn parse_network_with_repo_path(s: &str) -> Option<(SocketAddr, Option<String>)> {
+fn parse_network_with_repo_path(s: &str) -> Option<(String, Option<String>)> {
     if let Some(rest) = s.strip_prefix("heddle://") {
-        return parse_network_with_repo_path(rest);
+        return parse_authority_with_repo_path(rest, true);
     }
-
-    if let Ok(addr) = s.parse::<SocketAddr>() {
-        return Some((addr, None));
-    }
-
-    if let Some(addr) = resolve_socket_addr(s) {
-        return Some((addr, None));
-    }
-
-    let slash = s.find('/')?;
-    let (addr_part, repo_part) = s.split_at(slash);
-    let addr = resolve_socket_addr(addr_part)?;
-    let repo_path = repo_part.trim_start_matches('/');
-    if repo_path.is_empty() {
-        return Some((addr, None));
-    }
-    Some((addr, Some(repo_path.to_string())))
+    parse_authority_with_repo_path(s, false)
 }
 
-fn parse_https_network_with_repo_path(s: &str) -> Option<(SocketAddr, Option<String>)> {
+fn parse_https_network_with_repo_path(s: &str) -> Option<(String, Option<String>)> {
+    parse_authority_with_repo_path(s, true)
+}
+
+fn parse_authority_with_repo_path(
+    s: &str,
+    allow_default_https_port: bool,
+) -> Option<(String, Option<String>)> {
     if s.is_empty() || s.contains(['?', '#', '@']) {
         return None;
     }
@@ -140,25 +132,38 @@ fn parse_https_network_with_repo_path(s: &str) -> Option<(SocketAddr, Option<Str
     if authority.is_empty() {
         return None;
     }
-    let addr = resolve_socket_addr(authority).or_else(|| {
-        let host = authority
-            .strip_prefix('[')
-            .and_then(|host| host.strip_suffix(']'))
-            .unwrap_or(authority);
-        (host, 443).to_socket_addrs().ok()?.next()
-    })?;
+    validate_authority(authority, allow_default_https_port)?;
     let repo_path = repo_path
         .filter(|path| !path.is_empty())
         .map(str::to_string);
-    Some((addr, repo_path))
+    Some((authority.to_string(), repo_path))
 }
 
-fn resolve_socket_addr(addr: &str) -> Option<SocketAddr> {
-    if let Ok(parsed) = addr.parse::<SocketAddr>() {
-        return Some(parsed);
+fn validate_authority(authority: &str, allow_default_https_port: bool) -> Option<()> {
+    if authority.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return None;
     }
+    if let Some(bracketed) = authority.strip_prefix('[') {
+        let (host, suffix) = bracketed.split_once(']')?;
+        host.parse::<Ipv6Addr>().ok()?;
+        return match suffix {
+            "" if allow_default_https_port => Some(()),
+            suffix if suffix.starts_with(':') => validate_port(&suffix[1..]),
+            _ => None,
+        };
+    }
+    if authority.contains(['[', ']']) {
+        return None;
+    }
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() && !host.contains(':') => validate_port(port),
+        None if allow_default_https_port && !authority.is_empty() => Some(()),
+        _ => None,
+    }
+}
 
-    addr.to_socket_addrs().ok()?.next()
+fn validate_port(port: &str) -> Option<()> {
+    port.parse::<u16>().ok().map(|_| ())
 }
 
 fn looks_like_unresolved_local_path(value: &str) -> bool {
@@ -178,9 +183,11 @@ mod tests {
     fn parses_hostname_without_repo_path() {
         let target = RemoteTarget::parse("localhost:8421").expect("parse localhost");
         match target {
-            RemoteTarget::Network { addr, repo_path } => {
-                assert_eq!(addr.port(), 8421);
-                assert!(addr.ip().is_loopback());
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
+                assert_eq!(authority, "localhost:8421");
                 assert!(repo_path.is_none());
             }
             other => panic!("expected network target, got {other:?}"),
@@ -192,9 +199,11 @@ mod tests {
         let target =
             RemoteTarget::parse("localhost:8421/acme/heddle").expect("parse localhost repo path");
         match target {
-            RemoteTarget::Network { addr, repo_path } => {
-                assert_eq!(addr.port(), 8421);
-                assert!(addr.ip().is_loopback());
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
+                assert_eq!(authority, "localhost:8421");
                 assert_eq!(repo_path.as_deref(), Some("acme/heddle"));
             }
             other => panic!("expected network target, got {other:?}"),
@@ -208,8 +217,11 @@ mod tests {
         let target = RemoteTarget::parse_native("https://127.0.0.1:8431/acme/heddle")
             .expect("parse native HTTPS URL");
         match target {
-            RemoteTarget::Network { addr, repo_path } => {
-                assert_eq!(addr, "127.0.0.1:8431".parse().unwrap());
+            RemoteTarget::Network {
+                authority,
+                repo_path,
+            } => {
+                assert_eq!(authority, "127.0.0.1:8431");
                 assert_eq!(repo_path.as_deref(), Some("acme/heddle"));
             }
             other => panic!("expected network target, got {other:?}"),
@@ -221,20 +233,15 @@ mod tests {
         let target =
             RemoteTarget::parse_native("https://127.0.0.1/acme/heddle").expect("parse HTTPS URL");
         match target {
-            RemoteTarget::Network { addr, .. } => assert_eq!(addr.port(), 443),
+            RemoteTarget::Network { authority, .. } => assert_eq!(authority, "127.0.0.1"),
             other => panic!("expected network target, got {other:?}"),
         }
     }
 
     #[test]
-    fn heddle_scheme_without_port_is_not_a_push_url() {
-        let error = RemoteTarget::parse("heddle://api.heddle.sh/luke/tiny-notes")
-            .expect_err("schemeless heddle:// host has no addressing");
-        assert!(
-            error.contains("heddle://") && error.contains("no addressing"),
-            "refusal must name the scheme gap: {error}"
-        );
-        assert!(RemoteTarget::parse_native("heddle://api.heddle.sh/luke/tiny-notes").is_err());
+    fn heddle_scheme_without_port_uses_default_https_port() {
+        assert!(RemoteTarget::parse("heddle://api.heddle.sh/luke/tiny-notes").is_ok());
+        assert!(RemoteTarget::parse_native("heddle://api.heddle.sh/luke/tiny-notes").is_ok());
         assert!(RemoteTarget::parse("heddle://127.0.0.1:8421/luke/tiny-notes").is_ok());
     }
 


### PR DESCRIPTION
Closes #1629

## Summary

- replace the lossy resolved SocketAddr in RemoteTarget::Network with the original host authority
- carry that authority through clone, push, pull, approvals, auth, recovery, and lazy hydration
- persist auto-provisioned remotes and user advice as heddle://<hostname>/<path>
- build descriptor-trust and endpoint discovery URLs from the hostname so HTTPS uses the correct Cloudflare SNI

## Verification

- pre-fix hostname-preservation regression failed because heddle://api-staging.heddle.sh/org/repo was rejected after the parser discarded hostname authority
- post-fix hostname-preservation, auto-provision persistence, and both .well-known URL tests pass
- cargo test -p heddle-repo --lib: 738 passed, 3 ignored
- cargo test -p heddle-cli --lib: 439 passed
- HEDDLE_HOME=<isolated> cargo test -p heddle-hosted-client --all-features --lib: 335 passed, 1 ignored
- cargo build --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Live TLS verification against staging Cloudflare remains a manual staging check; no live result is claimed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790837005&installation_model_id=21489&pr_number=1631&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1631&signature=643f558fe22afe93fee52d992bbd9cd06ab168e038efc9eb2c7a391d84d3f11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->