### PR TITLE
Move owner-root installation from push to enrollment

### DIFF
--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -1,7 +1,9 @@
 //! Node-key remint and invite-create for `heddle auth login`.
 
 use anyhow::{Context, Result, bail};
-use api::heddle::api::v1alpha1::{CreateAgentAccountRequest, CreateAgentAccountResponse};
+use api::heddle::api::v1alpha1::{
+    CreateAgentAccountRequest, CreateAgentAccountResponse, SignedOwnerRoot,
+};
 use config::UserConfig;
 use crypto::{Ed25519Signer, Signer as _};
 use heddle_cli_args::CliContext;
@@ -20,7 +22,22 @@ use super::{
 
 pub(crate) async fn remint(server: &str) -> Result<()> {
     let stored = mint_restricted_agent_root()?;
-    record_claimable_root_for_stored_account(server, &stored.private_key_pem)?;
+    let claimable_root = claimable_root_for_stored_account(server, &stored.private_key_pem)?;
+    if let Some(root) = claimable_root {
+        let user_config = UserConfig::load_default()?;
+        let session = HostedSession::build(
+            &user_config,
+            Some(server.to_string()),
+            HostedAuthMode::ProofOnly {
+                proof_key_pem: stored.private_key_pem.clone(),
+                signing_identity: format!("principal:{}", stored.subject),
+            },
+        )?;
+        let mut client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+        let upload = upload_reminted_owner_root(&mut client, &stored.private_key_pem, root).await;
+        client.close().await;
+        upload?;
+    }
     store_agent_root(
         server,
         stored.token,
@@ -36,20 +53,56 @@ pub(crate) fn record_claimable_root_for_stored_account(
     server: &str,
     private_key_pem: &str,
 ) -> Result<()> {
+    claimable_root_for_stored_account(server, private_key_pem).map(|_| ())
+}
+
+fn claimable_root_for_stored_account(
+    server: &str,
+    private_key_pem: &str,
+) -> Result<Option<SignedOwnerRoot>> {
     let Some(mut state) = identity_state::load()? else {
-        return Ok(());
+        return Ok(None);
     };
     if !super::hosted::server_keys_match(&state.server, server) || state.is_claimed() {
-        return Ok(());
+        return Ok(None);
     }
     let signer = Ed25519Signer::from_pem(private_key_pem)
         .context("loading the agent proof key for the claimable owner root")?;
-    super::owner_root::mint_and_record_claimable_root(
+    let root = super::owner_root::mint_and_record_claimable_root(
         &mut state,
         &signer,
         chrono::Utc::now().timestamp(),
     )?;
-    identity_state::store(&state)
+    identity_state::store(&state)?;
+    Ok(Some(root))
+}
+
+async fn upload_reminted_owner_root(
+    client: &mut super::HostedClient,
+    private_key_pem: &str,
+    root: SignedOwnerRoot,
+) -> Result<()> {
+    let signer = Ed25519Signer::from_pem(private_key_pem)
+        .context("loading the agent proof key for BootstrapOwnerRoot")?;
+    super::owner_root::upload_claimable_root(client, &signer, root).await
+}
+
+#[cfg(test)]
+pub(crate) async fn remint_with_client_for_test(
+    server: &str,
+    client: &mut super::HostedClient,
+) -> Result<()> {
+    let stored = mint_restricted_agent_root()?;
+    if let Some(root) = claimable_root_for_stored_account(server, &stored.private_key_pem)? {
+        upload_reminted_owner_root(client, &stored.private_key_pem, root).await?;
+    }
+    store_agent_root(
+        server,
+        stored.token,
+        stored.subject,
+        stored.private_key_pem,
+        stored.expires_at,
+    )
 }
 
 pub(crate) async fn create_with_invite(
@@ -222,4 +275,106 @@ fn mint_restricted_agent_root() -> Result<RestrictedAgentRoot> {
         private_key_pem: root.private_key_pem,
         expires_at: root.expires_at,
     })
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::{
+        net::Ipv4Addr,
+        sync::{Arc, Mutex},
+    };
+
+    use api::{
+        framing::{decode_request_prelude, encode_success_response},
+        heddle::api::v1alpha1::HostedSpool,
+    };
+    use bytes::Bytes;
+    use crypto::Ed25519Signer;
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
+    use prost::Message;
+    use tokio::task::JoinHandle;
+
+    use crate::hosted_runtime::hosted::{CallContextFactory, HostedClient};
+
+    const CREATE_SPOOL: &str = "/heddle.api.v1alpha1.RegistryService/CreateSpool";
+
+    pub(crate) async fn start_recording_client() -> (
+        HostedClient,
+        JoinHandle<()>,
+        Arc<Mutex<Vec<String>>>,
+        String,
+    ) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let server_calls = Arc::clone(&calls);
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .expect("test server address")
+            .bind()
+            .await
+            .expect("test server endpoint");
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let connection = server
+                .accept()
+                .await
+                .expect("hosted test connection")
+                .await
+                .expect("connect hosted test client");
+            while let Ok((mut send, mut recv)) = connection.accept_bi().await {
+                let mut request = Vec::new();
+                let method = loop {
+                    let chunk = recv
+                        .read_chunk(api::framing::MAX_CONTROL_BODY + 6)
+                        .await
+                        .expect("read request")
+                        .expect("request prelude");
+                    request.extend_from_slice(&chunk);
+                    if let Some((prelude, _)) =
+                        decode_request_prelude(&request).expect("decode request prelude")
+                    {
+                        break prelude.method.to_string();
+                    }
+                };
+                server_calls
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner())
+                    .push(method.clone());
+                while recv
+                    .read_chunk(api::framing::MAX_CONTROL_BODY + 6)
+                    .await
+                    .is_ok_and(|chunk| chunk.is_some())
+                {}
+                let body = if method == CREATE_SPOOL {
+                    HostedSpool::default().encode_to_vec()
+                } else {
+                    Vec::new()
+                };
+                send.write_chunk(Bytes::from(
+                    encode_success_response(&body).expect("encode response"),
+                ))
+                .await
+                .expect("write response");
+                send.finish().expect("finish response");
+            }
+            server.close().await;
+        });
+        let endpoint = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .expect("test client address")
+            .bind()
+            .await
+            .expect("test client endpoint");
+        let signer = Ed25519Signer::generate().expect("test signer");
+        let signer_pem = signer.to_pem().expect("test signer pem");
+        let context = CallContextFactory::default()
+            .with_signing_key_pem(&signer_pem, "principal:test")
+            .expect("test call context");
+        let client = HostedClient::connect_addr_with_context(endpoint, server_addr, context)
+            .await
+            .expect("connect test client");
+        (client, server_task, calls, signer_pem)
+    }
 }

--- a/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_tests.rs
@@ -11,7 +11,10 @@ use super::{
     agent_node_identity,
     auth::headless_token_metadata,
     auth_login::{LoginInputs, LoginPath, login, login_path, store_agent_root},
-    auth_login_agent::finish_invite_create_from_response,
+    auth_login_agent::{
+        finish_invite_create_from_response, remint_with_client_for_test,
+        test_support::start_recording_client,
+    },
     device_flow::restrict_agent_account_root,
     identity_state::{self, ClaimState},
     root_mint::mint_agent_root,
@@ -327,7 +330,7 @@ fn login_invite_create_succeeds_with_a_claim_next_directive() {
 }
 
 #[tokio::test]
-async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
+async fn remint_uses_claim_state_and_uploads_owner_root_at_enrollment() {
     let _home = IsolatedHome::new();
     let server = "api.claim-state.test";
     let identity = agent_node_identity::load_or_create().expect("node identity");
@@ -340,18 +343,24 @@ async fn remint_uses_claim_state_when_the_keystore_row_is_missing() {
         None,
     ))
     .expect("store claim state");
-    login(&TextCtx, server, false, None, false)
+    let (mut client, server_task, calls, _) = start_recording_client().await;
+    remint_with_client_for_test(server, &mut client)
         .await
-        .expect("missing cred + claim state remints");
+        .expect("missing cred + claim state remints and uploads");
+    client.close().await;
+    server_task.await.expect("recording server");
     let stored = credentials::get_server_credential(server)
         .expect("load")
         .expect("reminted into the keystore");
     assert!(!stored.token.is_empty());
-    let state = identity_state::load()
-        .expect("load")
-        .expect("claim state");
+    let state = identity_state::load().expect("load").expect("claim state");
     assert!(
         state.signed_owner_root_hex.is_some(),
         "remint must lazy-mint the claimable deferred-human owner root"
+    );
+    assert_eq!(
+        *calls.lock().unwrap_or_else(|poison| poison.into_inner()),
+        ["/heddle.api.v1alpha1.OwnerAuthorizationService/BootstrapOwnerRoot"],
+        "remint must install the owner root during enrollment"
     );
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -238,9 +238,6 @@ impl HostedClient {
         kind: wire::HostedSpoolKind,
         display_name: Option<String>,
     ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
-        self.ensure_claimable_owner_root()
-            .await
-            .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
         let operation_id =
             ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/CreateSpool");
         let owner_genesis = Some(
@@ -701,9 +698,42 @@ fn parse_hosted_role_arg(
 
 #[cfg(test)]
 mod tests {
+    use std::{ffi::OsString, sync::MutexGuard};
+
     use api::heddle::api::v1alpha1::{HostedRole, grant_target_ref::Target};
 
     use super::*;
+
+    struct IsolatedHeddleHome {
+        _guard: MutexGuard<'static, ()>,
+        _temp: tempfile::TempDir,
+        previous_home: Option<OsString>,
+    }
+
+    impl IsolatedHeddleHome {
+        fn new() -> Self {
+            let guard = config::credentials::lock_test_env();
+            let temp = tempfile::TempDir::new().expect("temporary Heddle home");
+            let previous_home = std::env::var_os("HEDDLE_HOME");
+            unsafe { std::env::set_var("HEDDLE_HOME", temp.path()) };
+            Self {
+                _guard: guard,
+                _temp: temp,
+                previous_home,
+            }
+        }
+    }
+
+    impl Drop for IsolatedHeddleHome {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous_home {
+                    Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                    None => std::env::remove_var("HEDDLE_HOME"),
+                }
+            }
+        }
+    }
 
     #[tokio::test]
     async fn administration_facade_builds_and_dispatches_every_native_request() {
@@ -968,5 +998,43 @@ mod tests {
 
         client.close().await;
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_spool_provision_sequence_excludes_owner_root_ceremony() {
+        use crypto::{Ed25519Signer, Signer as _};
+
+        let _home = IsolatedHeddleHome::new();
+        let (mut client, server, calls, signer_pem) =
+            crate::hosted_runtime::auth_login_agent::test_support::start_recording_client().await;
+        let signer = Ed25519Signer::from_pem(&signer_pem).expect("test signer");
+        let mut state = crate::hosted_runtime::identity_state::ClaimState::new(
+            "api.provision.test".to_string(),
+            uuid::Uuid::parse_str("7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28").expect("account id"),
+            "subject-1".to_string(),
+            "quiet-otter".to_string(),
+            hex::encode(signer.public_key()),
+            None,
+        );
+        state.record_claimable_owner_root(signer.public_key(), b"invalid owner-root ceremony");
+        crate::hosted_runtime::identity_state::store(&state).expect("store claim state");
+
+        client
+            .create_spool(
+                "quiet-otter",
+                "spool-d",
+                wire::HostedSpoolKind::Project,
+                None,
+            )
+            .await
+            .expect("CreateSpool must not read or upload the claimable owner root");
+        client.close().await;
+        server.await.expect("recording server");
+
+        assert_eq!(
+            *calls.lock().unwrap_or_else(|poison| poison.into_inner()),
+            ["/heddle.api.v1alpha1.RegistryService/CreateSpool"],
+            "auto-provision must issue CreateSpool without BootstrapOwnerRoot"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- upload the claimable owner root from the remint enrollment path using the existing proof-authenticated session
- remove the owner-root ceremony from CreateSpool so auto-provision proceeds directly to data provisioning
- keep the sequence-0 owner-genesis consistency guard unchanged

Refs #1628

## Test evidence

```text
cargo test -p heddle-hosted-client --features client
test result: ok. 334 passed; 0 failed; 1 ignored

cargo build --workspace
Finished dev profile

cargo clippy --workspace -- -D warnings
Finished dev profile

cargo clippy -p heddle-hosted-client --features client --all-targets -- -D warnings
Finished dev profile
```

Targeted pairing tests:

- `remint_uses_claim_state_and_uploads_owner_root_at_enrollment`
- `create_spool_provision_sequence_excludes_owner_root_ceremony`

Live staging end-to-end verification remains manual and was not run from this environment.

## Deferred follow-up

`BootstrapOwnerRoot` idempotency hardening in weft remains deferred until weft#1941 lands. No weft code is included here.
