### PR TITLE
Connect remint enrollment through hosted hostname authority

### DIFF
--- a/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth_login_agent.rs
@@ -33,7 +33,7 @@ pub(crate) async fn remint(server: &str) -> Result<()> {
                 signing_identity: format!("principal:{}", stored.subject),
             },
         )?;
-        let mut client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+        let mut client = session.connect(server).await?;
         let upload = upload_reminted_owner_root(&mut client, &stored.private_key_pem, root).await;
         client.close().await;
         upload?;

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -737,6 +737,7 @@ mod tests {
 
     #[tokio::test]
     async fn administration_facade_builds_and_dispatches_every_native_request() {
+        let _home = IsolatedHeddleHome::new();
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
 
         client.who_am_i().await.unwrap();
@@ -949,6 +950,7 @@ mod tests {
         use crypto::Ed25519Signer;
         use sha2::{Digest, Sha256};
 
+        let _home = IsolatedHeddleHome::new();
         let (mut client, server, captured) =
             crate::hosted_runtime::hosted::test_server::start_recording_create_spool().await;
         let created = client


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `HostedSession::connect` takes a hosted hostname after #1631; remint enrollment still passed a dummy loopback `SocketAddr` leftover from before that change
- once #1632 landed, `cargo build --release -p heddle-cli` (and any `heddle-hosted-client` build) failed with `the trait bound \`&str: From<([{integer}; 4], {integer})>\` is not satisfied`
- remint now calls `session.connect(server)` — the same hostname authority already used by invite-create — so owner-root upload goes to the real hosted server (Cloudflare SNI / hostname bootstrap)
- searched for other leftover dummy-addr `connect(([127, 0, 0, 1], 0).into())` sites; remint was the only one
- CreateSpool tests that mint genesis now take `IsolatedHeddleHome` so they cannot race remint enrollment tests that persist a sequence-0 owner root (the enrollment vs CreateSpool split is unchanged)

## Closes

Refs #1631
Refs #1632

## Red commit
`9455f8df7eadecbfffb4e814e44f96ffcca80f6d` (#1632 on main). Remint still used `session.connect(([127, 0, 0, 1], 0).into())` against `connect(&str)`:

```
error[E0277]: the trait bound `&str: From<([{integer}; 4], {integer})>` is not satisfied
  --> crates/hosted-client/src/hosted_runtime/auth_login_agent.rs:36:62
```

## Test evidence

Re-run on HEAD `d42e432d2d4b99359c310b4f25b315fc3b42c568`:

```
$ cargo build --release -p heddle-cli
   Compiling heddle-hosted-client v0.15.8 (/workspace/crates/hosted-client)
   Compiling heddle-cli v0.15.8 (/workspace/crates/cli)
    Finished `release` profile [optimized] target(s) in 10m 55s

$ cargo test -p heddle-hosted-client --all-features --lib
test result: ok. 336 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 16.34s

$ cargo test -p heddle-hosted-client --all-features --lib -- \
    remint_uses_claim_state_and_uploads_owner_root_at_enrollment \
    login_remints_an_expired_node_key_account_without_an_invite \
    create_spool_provision_sequence_excludes_owner_root_ceremony \
    create_spool_sends_device_key_signed_uuidv7_owner_genesis
test hosted_runtime::hosted::user::tests::create_spool_provision_sequence_excludes_owner_root_ceremony ... ok
test hosted_runtime::auth_login_tests::login_remints_an_expired_node_key_account_without_an_invite ... ok
test hosted_runtime::auth_login_tests::remint_uses_claim_state_and_uploads_owner_root_at_enrollment ... ok
test hosted_runtime::hosted::user::tests::create_spool_sends_device_key_signed_uuidv7_owner_genesis ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 333 filtered out; finished in 0.20s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d06a4c24-4bbd-4372-890c-51222fdad4e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d06a4c24-4bbd-4372-890c-51222fdad4e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790857360&installation_model_id=21489&pr_number=1633&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1633&signature=a433f8ae680ca08ca054bf60e470cfecdef476e33737004dd97af58930c99eec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->