### PR TITLE
Host treadle-schema in the Heddle workspace

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -75,6 +75,7 @@ env:
   # `publish = true` in Cargo.toml is invisible at PR review time, and
   # accidentally flipping it would silently expand the public surface.
   PUBLISHABLE_CRATES: |
+    treadle-schema
     heddle-format
     heddle-object-model
     heddle-fs-prims

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -513,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +533,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1493,6 +1505,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1577,6 +1598,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastembed"
@@ -1677,6 +1709,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1896,9 +1949,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3418,7 +3473,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3553,6 +3608,42 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3723,6 +3814,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "minimal-lexical"
@@ -4197,7 +4294,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -4209,6 +4320,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -4252,6 +4369,27 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4544,6 +4682,12 @@ dependencies = [
  "lzma-rust2",
  "ureq",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -5087,7 +5231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5120,7 +5264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5454,6 +5598,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,7 +5833,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5764,7 +5925,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6639,7 +6800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6898,10 +7059,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7395,6 +7556,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "treadle-schema"
+version = "0.17.0"
+dependencies = [
+ "blake3",
+ "ed25519-dalek 3.0.0",
+ "jsonschema",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7541,6 +7715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7683,6 +7863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7699,6 +7889,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -7886,7 +8082,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2371,11 +2371,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "heddle-format"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2633,11 +2633,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -7557,7 +7557,7 @@ dependencies = [
 
 [[package]]
 name = "treadle-schema"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -160,34 +160,34 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-treadle-schema = { path = "crates/treadle-schema", version = "0.17.0" }
-heddle-cli-args = { path = "crates/cli-args", version = "0.17.0", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.17.0", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.17.0", default-features = false }
-heddle-format = { path = "crates/format", version = "0.17.0" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.17.0" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.17.0", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.17.0" }
-heddle-pack = { path = "crates/pack", version = "0.17.0" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.17.0" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.17.0", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.17.0" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.17.0" }
-config = { path = "crates/config", package = "heddle-config", version = "0.17.0" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.17.0" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.17.0", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.17.0", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.17.0" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.17.0" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.17.0" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.17.0", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.17.0" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.17.0", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.17.0" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.17.0" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.17.0" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.17.0", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.17.0", default-features = false }
+treadle-schema = { path = "crates/treadle-schema", version = "0.18.0" }
+heddle-cli-args = { path = "crates/cli-args", version = "0.18.0", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.18.0", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.18.0", default-features = false }
+heddle-format = { path = "crates/format", version = "0.18.0" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.18.0" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.18.0", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.18.0" }
+heddle-pack = { path = "crates/pack", version = "0.18.0" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.18.0" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.18.0", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.18.0" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.18.0" }
+config = { path = "crates/config", package = "heddle-config", version = "0.18.0" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.18.0" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.18.0", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.18.0", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.18.0" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.18.0" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.18.0" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.18.0", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.18.0" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.18.0", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.18.0" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.18.0" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.18.0" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.18.0", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.18.0", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/treadle-schema",
     "crates/cli",
     "crates/agent-relay",
     "crates/cli-args",
@@ -159,6 +160,7 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
+treadle-schema = { path = "crates/treadle-schema", version = "0.17.0" }
 heddle-cli-args = { path = "crates/cli-args", version = "0.17.0", default-features = false }
 heddle-cli-contract = { path = "crates/cli-contract", version = "0.17.0", default-features = false }
 heddle-cli-render = { path = "crates/cli-render", version = "0.17.0", default-features = false }

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.17.0",
+  "schemaVersion": "0.18.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.17.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.18.0" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/treadle-schema/Cargo.toml
+++ b/crates/treadle-schema/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "treadle-schema"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "The OSS heddle CI Verdict contract: signed CiVerdictBody + SignedVerdict."
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+blake3.workspace = true
+ed25519-dalek.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+jsonschema = { version = "0.46", default-features = false }
+rand.workspace = true

--- a/crates/treadle-schema/schemas/ci_verdict_body.schema.json
+++ b/crates/treadle-schema/schemas/ci_verdict_body.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heddle.co/schemas/ci/v2/ci_verdict_body.schema.json",
+  "title": "CiVerdictBody",
+  "description": "The canonical, signed body of a heddle CI verdict (treadle-schema v2). Hand-maintained to mirror crates/schema/src/body.rs; a test (schema_export.rs) asserts the invariants below. IMPORTANT: additionalProperties is intentionally TRUE everywhere — the Rust type does NOT set deny_unknown_fields, so newer producers may append fields older consumers ignore. The omit-when-absent Option rule means optional members are simply absent when unset (never null). The pre-freeze DESIGN-§3.2/D18 attestation members are present but NOT required and NOT yet gate-validated.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "repo",
+    "state",
+    "basis",
+    "check",
+    "outcome",
+    "execution",
+    "repro"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 0, "const": 2 },
+    "repo": { "type": "string" },
+    "state": { "$ref": "#/$defs/StateRef" },
+    "basis": { "$ref": "#/$defs/Basis" },
+    "check": { "$ref": "#/$defs/CheckDescriptor" },
+    "outcome": { "$ref": "#/$defs/Outcome" },
+    "execution": { "$ref": "#/$defs/Execution" },
+    "log": { "$ref": "#/$defs/LogRef" },
+    "repro": { "$ref": "#/$defs/Repro" },
+    "check_set_digest": {
+      "type": "string",
+      "description": "PRE-FREEZE (DESIGN §3.2/D18), not yet gate-validated. Canonical CheckSet digest."
+    }
+  },
+  "$defs": {
+    "StateRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["content_hash", "change_id"],
+      "properties": {
+        "content_hash": { "type": "string" },
+        "change_id": { "type": "string" },
+        "logical_change_id": { "type": "string" }
+      }
+    },
+    "Basis": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "evaluated_tree_digest"],
+      "properties": {
+        "kind": { "$ref": "#/$defs/BasisKind" },
+        "evaluated_tree_digest": { "type": "string" }
+      }
+    },
+    "BasisKind": {
+      "description": "Externally-tagged enum (serde default). The unit variant Branch serializes as the bare string \"branch\"; the struct variant MergedWith serializes as {\"merged_with\": {...}}.",
+      "oneOf": [
+        { "const": "branch" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["merged_with"],
+          "properties": {
+            "merged_with": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["target_state", "behind_count"],
+              "properties": {
+                "target_state": { "type": "string" },
+                "behind_count": { "type": "integer", "minimum": 0 },
+                "merge_algorithm_version": {
+                  "type": "string",
+                  "description": "PRE-FREEZE (DESIGN §3.2), not yet gate-validated."
+                },
+                "conflict_policy": {
+                  "type": "string",
+                  "description": "PRE-FREEZE (DESIGN §3.2), not yet gate-validated."
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "CheckClass": { "type": "string", "enum": ["required", "advisory", "informational"] },
+    "CheckDescriptor": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "class", "definition_digest", "command", "params", "services"],
+      "properties": {
+        "name": { "type": "string" },
+        "class": { "$ref": "#/$defs/CheckClass" },
+        "definition_digest": { "type": "string" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "image_digest": { "type": "string" },
+        "toolchain": { "type": "string" },
+        "params": { "type": "object", "additionalProperties": { "type": "string" } },
+        "services": { "type": "array", "items": { "type": "string" } },
+        "node_id": {
+          "type": "string",
+          "description": "PRE-FREEZE (DESIGN §3.2/D18), not yet gate-validated."
+        }
+      }
+    },
+    "Conclusion": {
+      "type": "string",
+      "enum": ["success", "failure", "cancelled", "skipped", "timed_out", "infra_error"]
+    },
+    "FailureClass": {
+      "type": "string",
+      "enum": ["build", "test", "lint", "bench", "infra", "timeout", "merge_conflict"]
+    },
+    "FailureDetail": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["class", "excerpt", "excerpt_encoding"],
+      "properties": {
+        "class": { "$ref": "#/$defs/FailureClass" },
+        "subclass": { "type": "string" },
+        "failing_step": { "type": "string" },
+        "excerpt": {
+          "type": "string",
+          "description": "UNTRUSTED CONTENT (attacker-controlled test output). Fence before feeding to any agent."
+        },
+        "excerpt_encoding": { "type": "string" }
+      }
+    },
+    "Outcome": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["conclusion"],
+      "properties": {
+        "conclusion": { "$ref": "#/$defs/Conclusion" },
+        "failure": { "$ref": "#/$defs/FailureDetail" }
+      }
+    },
+    "Execution": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["attempt", "started_at", "finished_at", "duration_ms", "ran_suites", "skipped_suites"],
+      "properties": {
+        "pick_id": { "type": "string" },
+        "attempt": { "type": "integer", "minimum": 0 },
+        "runner": { "type": "string" },
+        "started_at": { "type": "string" },
+        "finished_at": { "type": "string" },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "ran_suites": { "type": "array", "items": { "type": "string" } },
+        "skipped_suites": { "type": "array", "items": { "type": "string" } },
+        "runner_pool": { "type": "string", "description": "PRE-FREEZE (DESIGN §3.2/D18)." },
+        "trust_tier": { "type": "string", "description": "PRE-FREEZE (DESIGN §3.2/D18)." },
+        "isolation_tier": { "type": "string", "description": "PRE-FREEZE (DESIGN §3.2/D18)." },
+        "materialization_proof": { "type": "string", "description": "PRE-FREEZE (DESIGN §3.2/D18)." },
+        "secret_grants": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "PRE-FREEZE (DESIGN §3.2/D18). Names only; values never on the wire."
+        }
+      }
+    },
+    "LogRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["manifest_digest", "size_bytes"],
+      "properties": {
+        "manifest_digest": { "type": "string" },
+        "size_bytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Repro": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["command", "env", "services"],
+      "properties": {
+        "command": { "type": "array", "items": { "type": "string" } },
+        "env": { "type": "object", "additionalProperties": { "type": "string" } },
+        "image": { "type": "string" },
+        "services": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/crates/treadle-schema/schemas/signed_verdict.schema.json
+++ b/crates/treadle-schema/schemas/signed_verdict.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heddle.co/schemas/ci/v2/signed_verdict.schema.json",
+  "title": "SignedVerdict",
+  "description": "A CiVerdictBody plus its ed25519 signature and signer identity (treadle-schema v2). The on-the-wire JSON OSS contract. Hand-maintained to mirror crates/schema/src/signed.rs; schema_export.rs asserts the invariants. additionalProperties is intentionally TRUE (forward-compat: deny_unknown_fields is OFF). New signatures use the DOMAIN-SEPARATED v2 preimage (tag b'heddle-ci-verdict-v2\\x00' || body_digest || 0x00 || signer_kind || 0x00 || signed_at || 0x00), NOT the bare digest string. Verification retains the equivalent v1-tag path for schema-v1 verdicts.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["body", "body_digest", "public_key", "signature", "signed_at", "signer_kind"],
+  "properties": {
+    "body": { "$ref": "ci_verdict_body.schema.json" },
+    "body_digest": {
+      "type": "string",
+      "pattern": "^b3:[0-9a-f]+$",
+      "description": "'b3:'+hex BLAKE3-256 of the body's canonical bytes; recomputed and checked on verify."
+    },
+    "public_key": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "Signer's ed25519 public key, hex-encoded (32 bytes). Trust keys on THIS, never on an actor name."
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{128}$",
+      "description": "ed25519 signature over the domain-separated preimage, hex-encoded (64 bytes)."
+    },
+    "signed_at": {
+      "type": "string",
+      "description": "RFC3339 timestamp. Part of the signed preimage (cannot be rewritten without breaking the signature)."
+    },
+    "signer_kind": {
+      "type": "string",
+      "enum": ["service_account", "delegated", "device"],
+      "description": "Part of the signed preimage. 'delegated' and legacy 'service_account' may satisfy a required gate; 'device' is advisory-only. Authorization and trust remain the caller's responsibility."
+    }
+  }
+}

--- a/crates/treadle-schema/src/body.rs
+++ b/crates/treadle-schema/src/body.rs
@@ -1,0 +1,432 @@
+//! The [`CiVerdictBody`] — the canonical, signed body of a heddle CI verdict.
+//!
+//! # Canonical-bytes contract
+//!
+//! The canonical byte representation of a verdict body is **`serde_json` over the
+//! struct in declaration order, with every map field a [`BTreeMap`]**. There is
+//! no separate key-sorting pass: `serde_json` emits struct fields in declaration
+//! order and `BTreeMap` iterates in sorted key order, so the serialization *is*
+//! deterministic given the struct layout. The consequences are hard rules:
+//!
+//! > **Reordering any field, renaming a field, or changing a map field to a
+//! > non-sorted container changes the canonical bytes and therefore the body
+//! > digest. Any such change MUST bump [`SCHEMA_VERSION`] and regenerate the
+//! > golden vectors (`tests/fixtures/vectors.json`).**
+//!
+//! ## Option canonicalization rule (absent = omitted)
+//!
+//! Every `Option<…>` field carries `#[serde(skip_serializing_if = "Option::is_none")]`
+//! and every defaulted collection (e.g. `secret_grants`) carries the matching
+//! `skip_serializing_if = "<Type>::is_empty"`. **A `None`/empty value is omitted
+//! from the canonical bytes entirely** — it does NOT serialize as `null`/`[]`.
+//! This is the single, uniform policy across the whole body, chosen so that:
+//!
+//! - adding a new optional field later does NOT shift the canonical bytes of any
+//!   verdict that leaves it unset (a producer that never sets `check_set_digest`
+//!   emits byte-identical canonical bytes before and after the field exists), and
+//! - a cross-language re-implementation has one rule to follow: *serialize a field
+//!   iff it is present/non-empty; never emit an explicit null or empty array.*
+//!
+//! Mixing the two policies (some `None` → `null`, some omitted) would be a silent
+//! canonical-bytes footgun, so the rule is enforced uniformly and asserted by a
+//! test (`absent_options_are_omitted_not_null`).
+//!
+//! The digest ([`CiVerdictBody::body_digest`]) is `b3:<hex>` where `<hex>` is the
+//! BLAKE3-256 hash of [`CiVerdictBody::canonical_bytes`]. That digest is what the
+//! runner's ed25519 key signs (see [`crate::signed`]), binding the *content* of
+//! the verdict — check identity, evaluated-tree digest, conclusion — into the
+//! signature, per the security review's central requirement.
+//!
+//! # Pre-freeze scale-hardening fields (DESIGN.md §3.2 / D18)
+//!
+//! Per DESIGN D18, the runner-attestation fields exist as **optional schema
+//! members from day one** so that adding them does not force a post-freeze
+//! canonical-bytes break. They are present and serialized (when set) but **no gate
+//! validates them yet** — v2 enforcement reads them; v1 only carries them. The
+//! fields, mirroring `protos/ci.proto`:
+//!
+//! - body: [`CiVerdictBody::check_set_digest`] — the canonical CheckSet digest the
+//!   whole verdict binds to. The authoritative required-check match is on this
+//!   (plus `node_id` + `evaluated_tree_digest` + trust tier), not on
+//!   `definition_digest` alone (which can't distinguish a cheap check from an
+//!   expensive one sharing a `ci.toml`).
+//! - check: [`CheckDescriptor::node_id`] — the node id within that CheckSet.
+//! - execution attestation block: [`Execution::runner_pool`],
+//!   [`Execution::trust_tier`], [`Execution::isolation_tier`],
+//!   [`Execution::materialization_proof`], [`Execution::secret_grants`].
+//! - basis: [`BasisKind::MergedWith::merge_algorithm_version`] and
+//!   [`BasisKind::MergedWith::conflict_policy`] — so a cache keyed on the merged
+//!   tree records *how* the merge was computed.
+//!
+//! Because all of these follow the omit-when-absent Option rule above, a v1
+//! producer that sets none of them emits the same canonical bytes it would have
+//! before the fields existed — the day-one addition is byte-neutral for unset
+//! verdicts, which is the whole point of D18.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The current verdict-schema version. Bump on ANY field reorder/rename/add that
+/// changes canonical bytes (see module docs).
+pub const SCHEMA_VERSION: u32 = 2;
+
+/// Prefix on every BLAKE3 content digest this crate emits (`b3:<hex>`).
+pub const DIGEST_PREFIX: &str = "b3:";
+
+/// The canonical, signed body of a CI verdict.
+///
+/// One body is produced per [check](CheckDescriptor) per [pick](Execution). The
+/// signature over [`CiVerdictBody::body_digest`] is the load-bearing fact; the
+/// hosted control plane stores a denormalized copy for query, but the signed body
+/// is the truth.
+///
+/// **Forward compatibility:** this type does NOT set `#[serde(deny_unknown_fields)]`.
+/// Newer producers may append fields; older consumers ignore them. (Tests in this
+/// crate assert both that unknown fields deserialize cleanly *and* that a verdict
+/// from a strictly-newer `schema_version` is rejected by [`SignedVerdict::verify`]
+/// with a dedicated error rather than misreported as tampering — see the
+/// cross-version note on [`crate::signed::SignedVerdict::verify`].)
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CiVerdictBody {
+    /// Schema version of this body. Always [`SCHEMA_VERSION`] for current producers.
+    pub schema_version: u32,
+    /// The repository this verdict is about (e.g. `"heddle/core/heddle"`).
+    pub repo: String,
+    /// Which state was evaluated.
+    pub state: StateRef,
+    /// The tree basis the check actually ran against (branch vs merged-with-target).
+    pub basis: Basis,
+    /// The check that produced this verdict.
+    pub check: CheckDescriptor,
+    /// The outcome of running the check.
+    pub outcome: Outcome,
+    /// Execution metadata (timing, runner, suites).
+    pub execution: Execution,
+    /// Optional pointer to the finalized log blob (the appendix; never inlined).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log: Option<LogRef>,
+    /// Exact local reproduction recipe for this check.
+    pub repro: Repro,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** The canonical
+    /// CheckSet digest (`b3:…`) the whole verdict binds to. The authoritative
+    /// required-check match is on this (plus [`CheckDescriptor::node_id`],
+    /// [`Basis::evaluated_tree_digest`], and trust tier), never on
+    /// [`CheckDescriptor::definition_digest`] alone. `None` until the CheckSet
+    /// compiler lands; omitted from canonical bytes when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check_set_digest: Option<String>,
+}
+
+/// A reference to the heddle state a verdict is attached to.
+///
+/// Heddle has two state identities, and callers must not blur them:
+///
+/// - [`StateRef::change_id`] is the physical per-state `hd-...` identifier. It
+///   is the handle existing `heddle` commands resolve today, and it changes on
+///   rebase/amend.
+/// - [`StateRef::logical_change_id`] is the optional lineage identity that can
+///   survive rewrites. It is useful for correlation, not for pinning the exact
+///   state a required check verified.
+///
+/// The signed verdict also carries [`Basis::evaluated_tree_digest`], because for
+/// merge-basis checks the tree that actually ran can differ from this source
+/// state's tree.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StateRef {
+    /// The transfer-stable content hash (`b3:...`) of the source state object.
+    pub content_hash: String,
+    /// The physical per-state `hd-...` identifier. This pins one immutable state;
+    /// it is not the rewrite-stable logical identity.
+    pub change_id: String,
+    /// The optional rewrite-stable logical identity, when the producer tracks one.
+    /// Omitted from canonical bytes when `None` (see module Option rule).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_change_id: Option<String>,
+}
+
+/// The tree the check evaluated, and how it relates to a merge target.
+///
+/// This is the productized answer to "which tree failed — the branch as-pushed,
+/// or the branch merged with its target?" — the single most expensive GitHub
+/// Actions surprise per the dogfood requirements.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Basis {
+    /// Whether a plain branch tree or a speculative merge tree was evaluated.
+    pub kind: BasisKind,
+    /// The digest (`b3:…`) of the tree actually evaluated. For [`BasisKind::MergedWith`]
+    /// this is the *merged* tree digest, not the branch tree — so a cache keyed on
+    /// it cannot serve a stale-target false-green.
+    pub evaluated_tree_digest: String,
+}
+
+/// Branch-vs-merge discriminator for [`Basis`].
+///
+/// Serialized as serde's **externally tagged** enum: the unit variant
+/// [`BasisKind::Branch`] is the bare string `"branch"` (NOT `{"branch": null}`),
+/// and the struct variant [`BasisKind::MergedWith`] is `{"merged_with": {…}}`. The
+/// distinction matters for canonical bytes: a cross-language producer that emits
+/// `{"branch": null}` (which serde happens to *accept* on parse) yields different
+/// canonical bytes and a digest mismatch `verify()` would misreport as tampering.
+/// The default is [`BasisKind::Branch`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BasisKind {
+    /// The branch tree was evaluated as-pushed.
+    #[default]
+    Branch,
+    /// The branch tree merged with a target was evaluated.
+    MergedWith {
+        /// The target state (`hd-...`) the branch was merged with.
+        target_state: String,
+        /// How many commits the branch was behind that target.
+        behind_count: u32,
+        /// **Pre-freeze (DESIGN §3.2), not yet gate-validated.** The merge
+        /// algorithm version used to compute the speculative tree, so a cache
+        /// keyed on [`Basis::evaluated_tree_digest`] also pins *how* the merge was
+        /// produced. Omitted from canonical bytes when `None`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        merge_algorithm_version: Option<String>,
+        /// **Pre-freeze (DESIGN §3.2), not yet gate-validated.** The conflict
+        /// policy in effect for the merge (e.g. how the reconcile resolved or
+        /// refused). Omitted from canonical bytes when `None`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        conflict_policy: Option<String>,
+    },
+}
+
+/// Describes the check that ran, fully enough to re-derive its definition digest.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CheckDescriptor {
+    /// The check's unique name within the repo's CI definition.
+    pub name: String,
+    /// Required / advisory / informational — drives gating.
+    pub class: CheckClass,
+    /// Digest (`b3:…`) of the check's definition (the raw `.heddle/ci.toml` bytes).
+    pub definition_digest: String,
+    /// The argv the check executed.
+    pub command: Vec<String>,
+    /// Optional container image digest the check ran in.
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    /// Optional toolchain identifier (e.g. `"rustc 1.96.0"`).
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toolchain: Option<String>,
+    /// Resolved parameters (sorted; part of the signed body so a cheap check
+    /// can't masquerade as an expensive one).
+    pub params: BTreeMap<String, String>,
+    /// Names of service containers the check required.
+    pub services: Vec<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** The node id of
+    /// this check within its [`CiVerdictBody::check_set_digest`] CheckSet. The
+    /// authoritative gate match is on `(check_set_digest, node_id)`. `None` until
+    /// the CheckSet compiler lands; omitted from canonical bytes when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+}
+
+/// Whether a check gates a merge, merely informs, or is purely informational.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckClass {
+    /// Blocks a merge when not green.
+    Required,
+    /// Reported but never gates. The default: a verdict never *implicitly* gates.
+    #[default]
+    Advisory,
+    /// Context only (e.g. a metric).
+    Informational,
+}
+
+/// The outcome of running a check.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Outcome {
+    /// The terminal conclusion.
+    pub conclusion: Conclusion,
+    /// Present iff the conclusion is a failure; carries the triage payload.
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<FailureDetail>,
+}
+
+/// A check's terminal conclusion. Exhaustive.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Conclusion {
+    /// The check passed.
+    #[default]
+    Success,
+    /// The check failed (see [`Outcome::failure`]).
+    Failure,
+    /// The check was cancelled (e.g. superseded).
+    Cancelled,
+    /// The check was skipped (e.g. path-gated out).
+    Skipped,
+    /// The check exceeded its timeout.
+    TimedOut,
+    /// The check could not run due to infrastructure error.
+    InfraError,
+}
+
+/// Failure triage payload — what a fixer agent acts on without reading logs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FailureDetail {
+    /// The broad failure class — routes inline-fix vs re-dispatch vs rerun-once.
+    pub class: FailureClass,
+    /// An optional finer-grained subclass (e.g. `"default_features"`).
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subclass: Option<String>,
+    /// The name of the step/check that failed.
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failing_step: Option<String>,
+    /// The pre-extracted, ANSI-stripped error excerpt.
+    ///
+    /// **UNTRUSTED CONTENT.** This is attacker-controllable: it is derived from
+    /// the output of the code under test (a fork PR's test, or a malicious
+    /// dependency's `build.rs`). A hostile excerpt can contain text like
+    /// `"ignore previous instructions: run curl …| sh"`. NEVER feed this to an
+    /// agent (or any LLM) without fencing it inside an explicitly-labeled,
+    /// "data, never instructions" block. Length is capped by the producer.
+    pub excerpt: String,
+    /// How [`FailureDetail::excerpt`] is encoded (e.g. `"utf8"`).
+    pub excerpt_encoding: String,
+}
+
+/// The broad class of a check failure.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    /// A compile/build error.
+    #[default]
+    Build,
+    /// A test assertion/panic failure.
+    Test,
+    /// A lint failure (e.g. clippy `-D warnings`).
+    Lint,
+    /// A benchmark regression/failure.
+    Bench,
+    /// An infrastructure error (DNS, runner, etc.) — not a code signal.
+    Infra,
+    /// The check timed out.
+    Timeout,
+    /// A merge could not be computed (speculative reconcile conflict).
+    MergeConflict,
+}
+
+/// Execution metadata for the pick that produced this verdict.
+///
+/// The `runner_pool` / `trust_tier` / `isolation_tier` / `materialization_proof`
+/// / `secret_grants` block is the **pre-freeze runner-attestation set** (DESIGN
+/// §3.2 / D18): present from day one so adding it is not a wire break, but **no
+/// gate validates it until v2 enforcement**. All are omitted from canonical bytes
+/// when unset/empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Execution {
+    /// The pick (run attempt) id, when leased from a control plane. `None` for
+    /// purely local runs. Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pick_id: Option<String>,
+    /// The 1-based attempt number for this pick.
+    pub attempt: u32,
+    /// An optional runner principal identifier.
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner: Option<String>,
+    /// RFC3339 start timestamp.
+    pub started_at: String,
+    /// RFC3339 finish timestamp.
+    pub finished_at: String,
+    /// Wall-clock duration in milliseconds (also a triage signal — the 2–4 min rule).
+    pub duration_ms: u64,
+    /// Names of the suites that actually ran.
+    pub ran_suites: Vec<String>,
+    /// Names of the suites that were skipped.
+    pub skipped_suites: Vec<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** The runner pool
+    /// that produced this verdict. Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_pool: Option<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** Runner trust
+    /// tier (e.g. `"t0_process"`, `"t1_container"`, `"t2_microvm"`). A verdict from
+    /// a lower tier cannot satisfy a higher-tier protected requirement once
+    /// enforcement lands. Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_tier: Option<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** The sandbox
+    /// isolation tier actually used for this pick. Omitted from canonical bytes
+    /// when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation_tier: Option<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** Opaque proof
+    /// that the runner materialized the evaluated tree (a digest/receipt a future
+    /// gate re-checks against [`Basis::evaluated_tree_digest`], closing the
+    /// "signed a merge-basis verdict from a branch checkout" gap). Omitted from
+    /// canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization_proof: Option<String>,
+    /// **Pre-freeze (DESIGN §3.2 / D18), not yet gate-validated.** Secret grants
+    /// this pick was issued — **names only; values never appear on the wire**.
+    /// Omitted from canonical bytes when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_grants: Vec<String>,
+}
+
+/// A pointer to a finalized log blob.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LogRef {
+    /// Digest (`b3:…`) of the log manifest blob.
+    pub manifest_digest: String,
+    /// Total size of the log in bytes.
+    pub size_bytes: u64,
+}
+
+/// Exact local reproduction recipe — the gate's own command + toolchain + env.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Repro {
+    /// The argv to re-run the check.
+    pub command: Vec<String>,
+    /// Environment variables to set (sorted).
+    pub env: BTreeMap<String, String>,
+    /// Optional container image to run in.
+    /// Omitted from canonical bytes when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Service containers the repro requires.
+    pub services: Vec<String>,
+}
+
+impl CiVerdictBody {
+    /// Serialize this body to its canonical byte representation.
+    ///
+    /// See the module docs for the canonicalization rule. This never panics: the
+    /// body is a closed set of `serde`-derived types with no map keys that can
+    /// fail to serialize, so `serde_json` cannot error here.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        match serde_json::to_vec(self) {
+            Ok(bytes) => bytes,
+            Err(error) => unreachable!("CiVerdictBody is always serializable: {error}"),
+        }
+    }
+
+    /// The BLAKE3-256 content digest of [`CiVerdictBody::canonical_bytes`],
+    /// formatted as `b3:<hex>`.
+    #[must_use]
+    pub fn body_digest(&self) -> String {
+        let hash = blake3::hash(&self.canonical_bytes());
+        format!("{DIGEST_PREFIX}{}", hash.to_hex())
+    }
+}

--- a/crates/treadle-schema/src/lib.rs
+++ b/crates/treadle-schema/src/lib.rs
@@ -1,0 +1,677 @@
+//! `treadle-schema` — the OSS contract for heddle CI verdicts.
+//!
+//! A CI result is a signed [`Verdict`](SignedVerdict): an ed25519 signature over
+//! the BLAKE3-256 content digest of a canonical [`CiVerdictBody`]. The body
+//! carries everything a gate or a fixer agent needs without reading logs — the
+//! check identity and its definition digest, the evaluated-tree digest (branch vs
+//! merged-with-target), the conclusion, the failure class + ANSI-stripped excerpt,
+//! and the exact reproduction recipe.
+//!
+//! This crate is dependency-light and clock-free on purpose: it is the schema any
+//! runner or orchestrator can depend on. The hosted control plane (weft) and the
+//! runner both target these types.
+//!
+//! # Quickstart
+//!
+//! ```
+//! use treadle_schema::{fixture, sign, SignerKind};
+//! use ed25519_dalek::SigningKey;
+//!
+//! let body = fixture::passing_body();
+//! let key = SigningKey::from_bytes(&[7u8; 32]);
+//! let signed = sign(body, &key, "2026-06-11T18:05:54Z".into(), SignerKind::Delegated);
+//! assert!(signed.verify().is_ok());
+//! ```
+
+mod body;
+mod signed;
+
+pub use body::{
+    Basis, BasisKind, CheckClass, CheckDescriptor, CiVerdictBody, Conclusion, DIGEST_PREFIX,
+    Execution, FailureClass, FailureDetail, LogRef, Outcome, Repro, SCHEMA_VERSION, StateRef,
+};
+pub use signed::{
+    SIGNING_PAYLOAD_VERSION_TAG, SignedVerdict, SignerKind, VerifyError, is_content_digest, sign,
+    signed_payload,
+};
+
+/// Test/example fixtures. Public so the engine, runner, and downstream consumers
+/// can build canonical sample verdicts without hand-assembling every field.
+pub mod fixture {
+    use std::collections::BTreeMap;
+
+    use crate::body::{
+        Basis, BasisKind, CheckClass, CheckDescriptor, CiVerdictBody, Conclusion, Execution,
+        FailureClass, FailureDetail, LogRef, Outcome, Repro, SCHEMA_VERSION, StateRef,
+    };
+
+    /// A representative *passing* verdict body. Deterministic — no clock, no rng —
+    /// so its [`crate::CiVerdictBody::body_digest`] is a stable golden value.
+    #[must_use]
+    pub fn passing_body() -> CiVerdictBody {
+        let mut params = BTreeMap::new();
+        params.insert("features".to_string(), "default".to_string());
+
+        CiVerdictBody {
+            schema_version: SCHEMA_VERSION,
+            repo: "heddle/core/heddle".to_string(),
+            state: StateRef {
+                content_hash: "b3:9af2c0de".to_string(),
+                change_id: "hd-7m3k".to_string(),
+                logical_change_id: None,
+            },
+            basis: Basis {
+                kind: BasisKind::MergedWith {
+                    target_state: "b3:1c0dba5e".to_string(),
+                    behind_count: 3,
+                    merge_algorithm_version: None,
+                    conflict_policy: None,
+                },
+                evaluated_tree_digest: "b3:deadbeef".to_string(),
+            },
+            check: CheckDescriptor {
+                name: "check.test".to_string(),
+                class: CheckClass::Required,
+                definition_digest: "b3:c0ffee".to_string(),
+                command: vec!["cargo".into(), "test".into(), "--workspace".into()],
+                image_digest: None,
+                toolchain: Some("rustc 1.96.0".to_string()),
+                params,
+                services: vec![],
+                node_id: None,
+            },
+            outcome: Outcome {
+                conclusion: Conclusion::Success,
+                failure: None,
+            },
+            execution: Execution {
+                pick_id: Some("pk_01J".to_string()),
+                attempt: 1,
+                runner: Some("svc:runner-pool-a".to_string()),
+                started_at: "2026-06-11T18:02:11Z".to_string(),
+                finished_at: "2026-06-11T18:05:54Z".to_string(),
+                duration_ms: 223_000,
+                ran_suites: vec!["workspace".into()],
+                skipped_suites: vec![],
+                runner_pool: None,
+                trust_tier: None,
+                isolation_tier: None,
+                materialization_proof: None,
+                secret_grants: vec![],
+            },
+            log: None,
+            repro: Repro {
+                command: vec![
+                    "cargo".into(),
+                    "test".into(),
+                    "--locked".into(),
+                    "--workspace".into(),
+                ],
+                env: BTreeMap::new(),
+                image: None,
+                services: vec![],
+            },
+            check_set_digest: None,
+        }
+    }
+
+    /// A representative *failing* (build-class) verdict body.
+    #[must_use]
+    pub fn failing_body() -> CiVerdictBody {
+        let mut body = passing_body();
+        body.outcome = Outcome {
+            conclusion: Conclusion::Failure,
+            failure: Some(FailureDetail {
+                class: FailureClass::Build,
+                subclass: Some("default_features".to_string()),
+                failing_step: Some("check.test".to_string()),
+                excerpt: "error[E0308]: mismatched types\n  --> crates/client/src/sync.rs:412:18"
+                    .to_string(),
+                excerpt_encoding: "utf8".to_string(),
+            }),
+        };
+        body
+    }
+
+    /// A *maximal* verdict body with **every** optional field set, including the
+    /// pre-freeze D18 attestation block. Deterministic. Used to pin the canonical
+    /// bytes when the omit-when-absent Option rule has nothing to omit — the
+    /// adversarial complement to [`passing_body`] (which leaves most Options unset).
+    #[must_use]
+    pub fn maximal_body() -> CiVerdictBody {
+        let mut params = BTreeMap::new();
+        params.insert("features".to_string(), "postgres".to_string());
+        params.insert("toolchain".to_string(), "stable".to_string());
+
+        let mut env = BTreeMap::new();
+        env.insert("CARGO_TERM_COLOR".to_string(), "never".to_string());
+        env.insert("RUST_BACKTRACE".to_string(), "1".to_string());
+
+        CiVerdictBody {
+            schema_version: SCHEMA_VERSION,
+            repo: "heddle/core/weft".to_string(),
+            state: StateRef {
+                content_hash: "b3:5e11a7c0".to_string(),
+                change_id: "hd-9q2x".to_string(),
+                logical_change_id: Some("lc-weft-postgres".to_string()),
+            },
+            basis: Basis {
+                kind: BasisKind::MergedWith {
+                    target_state: "hd-main-0001".to_string(),
+                    behind_count: 7,
+                    merge_algorithm_version: Some("recursive-v2".to_string()),
+                    conflict_policy: Some("refuse-on-conflict".to_string()),
+                },
+                evaluated_tree_digest: "b3:7eaf00d5".to_string(),
+            },
+            check: CheckDescriptor {
+                name: "check.postgres".to_string(),
+                class: CheckClass::Required,
+                definition_digest: "b3:def111".to_string(),
+                command: vec![
+                    "cargo".into(),
+                    "test".into(),
+                    "--features".into(),
+                    "postgres".into(),
+                    "--".into(),
+                    "--ignored".into(),
+                ],
+                image_digest: Some("sha256:abc123".to_string()),
+                toolchain: Some("rustc 1.96.0".to_string()),
+                params,
+                services: vec!["postgres".into()],
+                node_id: Some("node-postgres-suite".to_string()),
+            },
+            outcome: Outcome {
+                conclusion: Conclusion::Failure,
+                failure: Some(FailureDetail {
+                    class: FailureClass::Test,
+                    subclass: Some("ignored_suite".to_string()),
+                    failing_step: Some("check.postgres".to_string()),
+                    excerpt: "test schema::migrations::applies ... FAILED".to_string(),
+                    excerpt_encoding: "utf8".to_string(),
+                }),
+            },
+            execution: Execution {
+                pick_id: Some("pk_02K".to_string()),
+                attempt: 2,
+                runner: Some("svc:runner-pool-b".to_string()),
+                started_at: "2026-06-11T19:00:00Z".to_string(),
+                finished_at: "2026-06-11T19:04:30Z".to_string(),
+                duration_ms: 270_000,
+                ran_suites: vec!["postgres".into(), "migrations".into()],
+                skipped_suites: vec!["unit".into()],
+                runner_pool: Some("pool-b".to_string()),
+                trust_tier: Some("t1_container".to_string()),
+                isolation_tier: Some("t1_container".to_string()),
+                materialization_proof: Some("b3:merged7eaf00d5".to_string()),
+                secret_grants: vec!["DATABASE_URL".into()],
+            },
+            log: Some(LogRef {
+                manifest_digest: "b3:109111".to_string(),
+                size_bytes: 48_122,
+            }),
+            repro: Repro {
+                command: vec![
+                    "cargo".into(),
+                    "test".into(),
+                    "--locked".into(),
+                    "--features".into(),
+                    "postgres".into(),
+                    "--".into(),
+                    "--ignored".into(),
+                ],
+                env,
+                image: Some("sha256:abc123".to_string()),
+                services: vec!["postgres".into()],
+            },
+            check_set_digest: Some("b3:cs0001".to_string()),
+        }
+    }
+
+    /// A *branch-basis* verdict body: a passing check evaluated against the branch
+    /// tree exactly as-pushed (NOT a speculative merge). This is the **only**
+    /// fixture exercising [`BasisKind::Branch`] — every other fixture is
+    /// `MergedWith` — so it pins the canonical bytes of the bare `"branch"` tag
+    /// (serde's externally-tagged unit variant). Without it, a schema/serde
+    /// mismatch on the `Branch` form passes every test silently. Deterministic.
+    #[must_use]
+    pub fn branch_basis_body() -> CiVerdictBody {
+        let mut body = passing_body();
+        body.basis = Basis {
+            kind: BasisKind::Branch,
+            evaluated_tree_digest: "b3:branchasis".to_string(),
+        };
+        body
+    }
+
+    /// A *merge-basis* verdict body: a passing check evaluated against a merged
+    /// tree (not the branch as-pushed), with the pre-freeze merge fields set. This
+    /// is the dogfood's most expensive GHA surprise (stale-target false-green) made
+    /// explicit, and a third vector shape for cross-language reproduction.
+    #[must_use]
+    pub fn merge_basis_body() -> CiVerdictBody {
+        let mut body = passing_body();
+        body.basis = Basis {
+            kind: BasisKind::MergedWith {
+                target_state: "hd-main-0042".to_string(),
+                behind_count: 2,
+                merge_algorithm_version: Some("recursive-v2".to_string()),
+                conflict_policy: None,
+            },
+            evaluated_tree_digest: "b3:merged0042".to_string(),
+        };
+        body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rng;
+    use serde_json::Value;
+
+    use super::*;
+
+    /// Golden digest snapshot for [`fixture::passing_body`]. If this value changes,
+    /// the canonical bytes changed.
+    ///
+    /// **Pre-freeze status:** the schema is not yet frozen (never published as an
+    /// authoritative wire contract), so canonical-bytes changes are permitted now
+    /// and the value below is regenerated *deliberately* rather than bumping
+    /// [`SCHEMA_VERSION`] — `v1` is still being *defined*, not revised. The most
+    /// recent regeneration folded in two deliberate pre-freeze changes:
+    /// (1) the D18 day-one attestation fields, and (2) the omit-when-absent Option
+    /// rule (every `None`/empty field now omitted from the bytes rather than
+    /// emitted as `null`/`[]`). **Once the schema freezes, any further change here
+    /// MUST bump [`SCHEMA_VERSION`] and the golden vectors together.**
+    const PASSING_BODY_GOLDEN_DIGEST: &str =
+        "b3:993b1a126b4521684ed957390f10d3445f7b3e8d5c644ccbca1f6cff88544be5";
+
+    #[test]
+    fn passing_body_digest_is_stable() {
+        // The digest must be reproducible across runs / machines.
+        let a = fixture::passing_body().body_digest();
+        let b = fixture::passing_body().body_digest();
+        assert_eq!(a, b, "digest must be deterministic");
+        assert!(
+            is_content_digest(&a),
+            "digest must be a well-formed b3: digest, got {a}"
+        );
+    }
+
+    #[test]
+    fn passing_body_matches_golden_digest() {
+        // This pins the canonicalization. A diff here means canonical bytes moved.
+        let digest = fixture::passing_body().body_digest();
+        assert_eq!(
+            digest, PASSING_BODY_GOLDEN_DIGEST,
+            "canonical bytes changed — bump SCHEMA_VERSION and update the golden \
+             digest deliberately (current: {digest})"
+        );
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let key = SigningKey::generate(&mut rng());
+        let signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        assert!(
+            signed.verify().is_ok(),
+            "freshly-signed verdict must verify"
+        );
+        assert_eq!(signed.signer_public_key(), &signed.public_key);
+    }
+
+    #[test]
+    fn tampering_with_conclusion_fails_verify() {
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        // Flip the conclusion to Failure but leave the signature + digest as-is.
+        signed.body.outcome.conclusion = Conclusion::Failure;
+        let err = signed.verify().expect_err("tampered body must fail verify");
+        assert!(
+            matches!(err, VerifyError::BodyDigestMismatch { .. }),
+            "expected digest mismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn tampering_then_recomputing_digest_still_fails_signature() {
+        // A smarter attacker also recomputes body_digest to match the tampered body.
+        // The signature (over the *original* digest) must then fail.
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        signed.body.outcome.conclusion = Conclusion::Failure;
+        signed.body_digest = signed.body.body_digest(); // re-derive to match
+        let err = signed
+            .verify()
+            .expect_err("re-digested tampered body must fail signature");
+        assert_eq!(err, VerifyError::SignatureInvalid);
+    }
+
+    #[test]
+    fn wrong_key_fails_verify() {
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        // Substitute a different, valid public key.
+        let other = SigningKey::generate(&mut rng());
+        signed.public_key = {
+            let mut s = String::new();
+            for b in other.verifying_key().as_bytes() {
+                s.push_str(&format!("{b:02x}"));
+            }
+            s
+        };
+        assert_eq!(signed.verify(), Err(VerifyError::SignatureInvalid));
+    }
+
+    #[test]
+    fn unknown_fields_deserialize_for_forward_compat() {
+        // A newer producer appends a field; an older consumer must still parse.
+        // This asserts deny_unknown_fields is NOT set on the body.
+        let mut value =
+            serde_json::to_value(fixture::passing_body()).expect("body serializes to json");
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("future_field_v2".to_string(), serde_json::json!("ignored"));
+        let parsed: CiVerdictBody =
+            serde_json::from_value(value).expect("unknown fields must be tolerated");
+        assert_eq!(parsed.repo, "heddle/core/heddle");
+    }
+
+    #[test]
+    fn deny_unknown_fields_is_off_on_every_body_struct() {
+        // Brief item 5: keep deny_unknown_fields OFF and ASSERT it. We assert it
+        // structurally — inject an unknown key into each *nested* object and prove
+        // it still deserializes (deny_unknown_fields would reject it). Covers the
+        // body + every nested struct a newer producer might extend.
+        let body = fixture::maximal_body();
+        let mut value = serde_json::to_value(&body).unwrap();
+        let root = value.as_object_mut().unwrap();
+        root.insert("future_root".into(), serde_json::json!(1));
+        for nested in ["state", "basis", "check", "outcome", "execution", "repro"] {
+            root.get_mut(nested)
+                .and_then(Value::as_object_mut)
+                .unwrap_or_else(|| panic!("{nested} is an object"))
+                .insert("future_nested".into(), serde_json::json!("x"));
+        }
+        let parsed: CiVerdictBody = serde_json::from_value(value)
+            .expect("unknown fields in body + nested structs must be tolerated");
+        assert_eq!(
+            parsed, body,
+            "unknown fields must be dropped, not alter data"
+        );
+    }
+
+    #[test]
+    fn absent_options_are_omitted_not_null() {
+        // The canonical-bytes contract: a None/empty field is OMITTED, never
+        // serialized as null/[]. passing_body leaves many Options unset.
+        let json = String::from_utf8(fixture::passing_body().canonical_bytes()).unwrap();
+        // None-valued fields must be entirely absent (no `:null`, no key at all).
+        for absent in [
+            "logical_change_id",
+            "image_digest",
+            "failure",
+            "log",
+            "check_set_digest",
+            "node_id",
+            "runner_pool",
+            "trust_tier",
+            "isolation_tier",
+            "materialization_proof",
+            "merge_algorithm_version",
+            "conflict_policy",
+        ] {
+            assert!(
+                !json.contains(absent),
+                "unset field {absent:?} must be omitted from canonical bytes, found in: {json}"
+            );
+        }
+        // And there must be no literal `null` anywhere in the canonical bytes.
+        assert!(
+            !json.contains("null"),
+            "omit-when-absent rule violated: a null leaked into canonical bytes: {json}"
+        );
+        // empty secret_grants (a Vec) is omitted too.
+        assert!(!json.contains("secret_grants"));
+    }
+
+    #[test]
+    fn present_options_do_serialize() {
+        // The flip side: when set, the fields ARE present (so omission is value-
+        // driven, not a dropped field).
+        let json = String::from_utf8(fixture::maximal_body().canonical_bytes()).unwrap();
+        for present in [
+            "logical_change_id",
+            "image_digest",
+            "node_id",
+            "check_set_digest",
+            "runner_pool",
+            "trust_tier",
+            "isolation_tier",
+            "materialization_proof",
+            "secret_grants",
+            "merge_algorithm_version",
+            "conflict_policy",
+            "failure",
+            "log",
+        ] {
+            assert!(
+                json.contains(present),
+                "set field {present:?} missing from: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn maximal_and_merge_basis_bodies_sign_and_verify() {
+        let key = SigningKey::generate(&mut rng());
+        for body in [fixture::maximal_body(), fixture::merge_basis_body()] {
+            let signed = sign(
+                body,
+                &key,
+                "2026-06-11T19:04:30Z".into(),
+                SignerKind::ServiceAccount,
+            );
+            assert!(signed.verify().is_ok(), "fixture must verify");
+        }
+    }
+
+    #[test]
+    fn newer_schema_version_is_rejected_distinctly_from_tampering() {
+        // P1-3: a verdict from a strictly-newer producer must NOT be misreported
+        // as BodyDigestMismatch (== tampering). It gets its own error.
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        signed.body.schema_version = SCHEMA_VERSION + 1;
+        let err = signed
+            .verify()
+            .expect_err("newer schema must not verify here");
+        assert_eq!(
+            err,
+            VerifyError::UnsupportedSchemaVersion {
+                found: SCHEMA_VERSION + 1,
+                supported: SCHEMA_VERSION,
+            },
+            "must be the dedicated error, not a digest mismatch"
+        );
+        assert!(
+            !matches!(err, VerifyError::BodyDigestMismatch { .. }),
+            "the whole point: distinguishable from tampering"
+        );
+    }
+
+    #[test]
+    fn signer_kind_is_bound_into_the_signature() {
+        // P1-2: flipping signer_kind without re-signing must break verify().
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::Device,
+        );
+        assert!(signed.verify().is_ok());
+        signed.signer_kind = SignerKind::ServiceAccount; // relabel device -> service
+        assert_eq!(
+            signed.verify(),
+            Err(VerifyError::SignatureInvalid),
+            "signer_kind relabel must invalidate the signature"
+        );
+    }
+
+    #[test]
+    fn signed_at_is_bound_into_the_signature() {
+        // P1-2: rewriting signed_at without re-signing must break verify().
+        let key = SigningKey::generate(&mut rng());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        assert!(signed.verify().is_ok());
+        signed.signed_at = "2026-06-11T18:05:55Z".into(); // +1s replay-presentation
+        assert_eq!(
+            signed.verify(),
+            Err(VerifyError::SignatureInvalid),
+            "signed_at rewrite must invalidate the signature"
+        );
+    }
+
+    #[test]
+    fn signature_payload_has_domain_separation() {
+        // P0-1: the preimage must begin with the domain tag and must NOT be the
+        // bare digest string (cross-protocol confusion guard).
+        let body = fixture::passing_body();
+        let digest = body.body_digest();
+        let payload = signed_payload(&digest, SignerKind::ServiceAccount, "2026-06-11T18:05:54Z");
+        assert!(
+            payload.starts_with(SIGNING_PAYLOAD_VERSION_TAG),
+            "preimage must carry the domain tag"
+        );
+        assert_ne!(
+            payload,
+            digest.as_bytes(),
+            "preimage must not be the bare digest string"
+        );
+        // A signature over the bare digest must NOT verify as a verdict signature
+        // (the exact cross-protocol confusion the tag prevents).
+        let key = SigningKey::generate(&mut rng());
+        let bare_sig = key.sign(digest.as_bytes());
+        let mut signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        signed.signature = {
+            let mut s = String::new();
+            for b in bare_sig.to_bytes() {
+                s.push_str(&format!("{b:02x}"));
+            }
+            s
+        };
+        assert_eq!(
+            signed.verify(),
+            Err(VerifyError::SignatureInvalid),
+            "a bare-digest signature must be rejected as a verdict signature"
+        );
+    }
+
+    #[test]
+    fn tampering_each_load_bearing_field_fails_verify() {
+        // P2-5: table-driven — every field an attack targets must be covered by
+        // the digest, not just outcome.conclusion. Each mutation flips the body
+        // digest, so verify() must reject with BodyDigestMismatch.
+        let key = SigningKey::generate(&mut rng());
+        type Mut = fn(&mut CiVerdictBody);
+        let mutate: Vec<(&str, Mut)> = vec![
+            ("basis.evaluated_tree_digest", |b| {
+                b.basis.evaluated_tree_digest = "b3:tampered".into();
+            }),
+            ("check.definition_digest", |b| {
+                b.check.definition_digest = "b3:tampered".into();
+            }),
+            ("check.params", |b| {
+                b.check.params.insert("features".into(), "all".into());
+            }),
+            ("check.class", |b| {
+                b.check.class = CheckClass::Advisory; // required -> advisory downgrade
+            }),
+            ("execution.attempt", |b| {
+                b.execution.attempt = 99;
+            }),
+            (
+                "check_set_digest (pre-freeze field is still digest-covered)",
+                |b| {
+                    b.check_set_digest = Some("b3:injected".into());
+                },
+            ),
+            (
+                "execution.trust_tier (pre-freeze field is still digest-covered)",
+                |b| {
+                    b.execution.trust_tier = Some("t2_microvm".into());
+                },
+            ),
+        ];
+        for (label, f) in mutate {
+            let mut signed = sign(
+                fixture::passing_body(),
+                &key,
+                "2026-06-11T18:05:54Z".into(),
+                SignerKind::ServiceAccount,
+            );
+            f(&mut signed.body);
+            let err = signed
+                .verify()
+                .expect_err(&format!("tampering {label} must fail verify"));
+            assert!(
+                matches!(err, VerifyError::BodyDigestMismatch { .. }),
+                "tampering {label}: expected digest mismatch, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_verdict_json_roundtrips() {
+        let key = SigningKey::generate(&mut rng());
+        let signed = sign(
+            fixture::failing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".into(),
+            SignerKind::ServiceAccount,
+        );
+        let json = serde_json::to_string(&signed).expect("serialize");
+        let back: SignedVerdict = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(signed, back);
+        assert!(back.verify().is_ok());
+    }
+}

--- a/crates/treadle-schema/src/signed.rs
+++ b/crates/treadle-schema/src/signed.rs
@@ -1,0 +1,719 @@
+//! Signing and verification of a [`CiVerdictBody`].
+//!
+//! A [`SignedVerdict`] binds an ed25519 signature to the body's *content digest*
+//! ([`CiVerdictBody::body_digest`]), not to a bare opaque token. Verification
+//! recomputes the digest from the embedded body and rejects any mismatch — so a
+//! tampered body (e.g. a flipped conclusion) fails even though the signature over
+//! the original digest is still cryptographically valid. This is the mechanism
+//! the security review names as mandatory: the gate must verify
+//! *signature → body digest → body fields*, keying trust on the public key, never
+//! on an actor name.
+//!
+//! # Signing payload (cross-language)
+//!
+//! The ed25519 signature is **not** over the bare `b3:<hex>` digest string. It is
+//! over a domain-separated, NUL-framed preimage that also binds the envelope
+//! metadata ([`SignedVerdict::signed_at`] and [`SignedVerdict::signer_kind`]),
+//! built by [`signed_payload`]:
+//!
+//! ```text
+//! preimage =
+//!       b"heddle-ci-verdict-v2\x00"      // 21-byte domain tag: 20 ASCII bytes + 1 NUL
+//!    || body_digest                      // ASCII of "b3:" + 64 lowercase hex chars
+//!    || 0x00                             // NUL separator
+//!    || signer_kind_str                  // "service_account" | "delegated" | "device"
+//!    || 0x00                             // NUL separator
+//!    || signed_at                        // RFC3339 timestamp, ASCII
+//!    || 0x00                             // NUL terminator
+//! ```
+//!
+//! Every framed field is ASCII with no embedded NUL (the digest is `b3:`+hex; the
+//! signer-kind token is a fixed enum string; `signed_at` is RFC3339), so the NUL
+//! framing is unambiguous and a verifier in any language can reproduce the exact
+//! bytes from the three JSON fields `body_digest`, `signer_kind`, `signed_at`.
+//!
+//! ## Why each part
+//!
+//! - **Domain tag** (`heddle-ci-verdict-v2\x00`): mirrors heddle's other signing
+//!   surfaces (`hd-rev-sig-v1\x00`, the redaction/state-visibility tags). Without
+//!   it, any other context where a runner key signs a `b3:<hex>` string (the
+//!   schema already carries `log.manifest_digest`) would yield a signature
+//!   *mutually valid* as a verdict signature — a cross-protocol confusion the
+//!   tag makes impossible. The trailing `v2` versions the preimage itself.
+//!   Verification selects v1 for schema-v1 verdicts and v2 for schema-v2
+//!   verdicts, preserving existing signatures while all new signatures use v2.
+//! - **`signer_kind`** is load-bearing: a `device`-signed verdict is advisory-only
+//!   and may never satisfy a required gate (DESIGN §7). Folding it into the
+//!   preimage means relabeling `device → delegated` breaks the signature.
+//! - **`signed_at`** is the freshness/replay-presentation field; binding it stops
+//!   silent rewrites. (It is still the caller's responsibility to range-check the
+//!   timestamp against policy — the signature only proves it wasn't altered.)
+//!
+//! The body digest itself is unchanged by this; only the signature *preimage*
+//! differs from a naive "sign the digest string" scheme. The golden signing
+//! vectors in `tests/fixtures/vectors.json` pin the exact bytes for cross-language
+//! reproduction.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::body::{CiVerdictBody, DIGEST_PREFIX, SCHEMA_VERSION};
+
+/// What kind of principal signed a verdict.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignerKind {
+    /// A legacy non-human runner service account.
+    ServiceAccount,
+    /// A CI runner acting with authority delegated by a human principal.
+    #[default]
+    Delegated,
+    /// A human device key (e.g. a local `heddle check run`).
+    Device,
+}
+
+impl SignerKind {
+    /// The stable lowercase token used both in JSON (`snake_case`) and as the
+    /// `signer_kind` field of the [signing preimage](signed_payload). Changing
+    /// these strings is a signing-payload break (bump the domain tag).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SignerKind::ServiceAccount => "service_account",
+            SignerKind::Delegated => "delegated",
+            SignerKind::Device => "device",
+        }
+    }
+
+    /// Whether this signer kind may satisfy a required gate.
+    ///
+    /// This is only the schema-level classification. The caller must separately
+    /// authorize the public key and apply its trust/policy rules.
+    #[must_use]
+    pub const fn may_satisfy_required_gate(self) -> bool {
+        matches!(self, SignerKind::ServiceAccount | SignerKind::Delegated)
+    }
+}
+
+/// A [`CiVerdictBody`] together with its signature and signer identity.
+///
+/// The on-the-wire JSON is the OSS contract any harness can produce and verify.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SignedVerdict {
+    /// The signed body.
+    pub body: CiVerdictBody,
+    /// The `b3:…` digest of [`SignedVerdict::body`], recomputed and checked on verify.
+    pub body_digest: String,
+    /// The signer's ed25519 public key, hex-encoded.
+    pub public_key: String,
+    /// The ed25519 signature over the [signing preimage](signed_payload),
+    /// hex-encoded. The preimage binds the domain tag, `body_digest`,
+    /// `signer_kind`, and `signed_at` — so none of those can be rewritten without
+    /// invalidating the signature.
+    pub signature: String,
+    /// RFC3339 timestamp the verdict was signed. **Part of the signed preimage**
+    /// (binding it stops freshness/replay-presentation rewrites); the signature
+    /// only proves it was not altered, not that it is within any policy window.
+    pub signed_at: String,
+    /// What kind of principal signed. **Part of the signed preimage** — a
+    /// `device → delegated` relabel breaks the signature.
+    pub signer_kind: SignerKind,
+}
+
+/// Errors from [`SignedVerdict::verify`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum VerifyError {
+    /// The embedded `body_digest` did not match the recomputed digest of `body`
+    /// — i.e. the body was tampered with after signing.
+    #[error("body digest mismatch: signed {signed}, recomputed {recomputed}")]
+    BodyDigestMismatch {
+        /// The digest stored in the signed verdict.
+        signed: String,
+        /// The digest recomputed from the embedded body.
+        recomputed: String,
+    },
+    /// A hex field (`public_key` or `signature`) was not valid hex.
+    #[error("malformed hex in {field}: {reason}")]
+    MalformedHex {
+        /// Which field failed to decode.
+        field: &'static str,
+        /// Why it failed.
+        reason: String,
+    },
+    /// The public key bytes were not a valid ed25519 verifying key.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+    /// The signature bytes were not a valid ed25519 signature.
+    #[error("invalid signature encoding: {0}")]
+    InvalidSignatureEncoding(String),
+    /// The signature did not verify against the public key over the digest bytes.
+    #[error("signature verification failed")]
+    SignatureInvalid,
+    /// The body's `schema_version` is not one this crate can verify. For a newer
+    /// version, canonicalize-by-reserialization cannot reproduce the producer's
+    /// exact bytes because this crate would drop any field it doesn't know.
+    ///
+    /// This is reported as its **own** error — never as
+    /// [`VerifyError::BodyDigestMismatch`] — so a forward-compat verdict from a
+    /// newer producer is distinguishable from genuine tampering. A consumer that
+    /// must verify across schema versions has to do so over the producer's raw
+    /// bytes (the proto mandates exactly this server-side: verify over the exact
+    /// `signed_verdict_json` bytes, never a reserialized struct).
+    #[error("unsupported schema_version {found}: this verifier supports up to {supported}")]
+    UnsupportedSchemaVersion {
+        /// The `schema_version` carried by the body.
+        found: u32,
+        /// The maximum `schema_version` this crate can verify by reserialization.
+        supported: u32,
+    },
+    /// The signer kind did not exist in the claimed schema version.
+    #[error("signer_kind {signer_kind:?} is not supported by schema_version {schema_version}")]
+    UnsupportedSignerKindForSchemaVersion {
+        /// The signer kind carried by the envelope.
+        signer_kind: SignerKind,
+        /// The body schema version that selects the signing domain.
+        schema_version: u32,
+    },
+}
+
+/// The domain-separation tag every CI-verdict signing preimage begins with.
+///
+/// Mirrors heddle's other signing surfaces (`hd-rev-sig-v1\x00` and friends).
+/// Bumping the trailing version versions the *preimage layout*: old signatures
+/// with the old tag continue to verify under the old code path.
+pub const SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"heddle-ci-verdict-v2\x00";
+
+const V1_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"heddle-ci-verdict-v1\x00";
+
+/// Build the exact bytes the ed25519 key signs. See the module-level
+/// "Signing payload (cross-language)" section for the full layout and rationale.
+///
+/// Layout: `TAG || body_digest || 0x00 || signer_kind.as_str() || 0x00 ||
+/// signed_at || 0x00`. Every framed field is NUL-free ASCII, so the framing is
+/// unambiguous and reproducible from the JSON fields alone.
+#[must_use]
+pub fn signed_payload(body_digest: &str, signer_kind: SignerKind, signed_at: &str) -> Vec<u8> {
+    signed_payload_with_tag(
+        SIGNING_PAYLOAD_VERSION_TAG,
+        body_digest,
+        signer_kind,
+        signed_at,
+    )
+}
+
+fn signed_payload_with_tag(
+    tag: &[u8],
+    body_digest: &str,
+    signer_kind: SignerKind,
+    signed_at: &str,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(tag.len() + body_digest.len() + signed_at.len() + 19);
+    buf.extend_from_slice(tag);
+    buf.extend_from_slice(body_digest.as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(signer_kind.as_str().as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(signed_at.as_bytes());
+    buf.push(0);
+    buf
+}
+
+/// Decode a lowercase/uppercase ASCII-hex string to bytes, **panic-free on
+/// arbitrary (attacker-controlled) input**.
+///
+/// `verify()` is the security boundary the gate calls on runner-submitted
+/// verdicts, and `public_key`/`signature` are attacker-controlled strings off the
+/// wire. This decoder therefore operates on raw bytes and never slices the `&str`
+/// at a fixed offset (`&s[i..i+2]`): a multi-byte UTF-8 codepoint with even byte
+/// length (e.g. `"€€"`, 6 bytes) passes a naive `len % 2` check yet a mid-codepoint
+/// slice panics with "byte index N is not a char boundary". We reject any non-ASCII
+/// input up front and then decode nibble-by-nibble over `as_bytes()`, so every
+/// malformed input returns [`VerifyError::MalformedHex`] — never a panic (a
+/// remotely-triggerable DoS).
+#[allow(clippy::chunks_exact_to_as_chunks, clippy::manual_is_multiple_of)]
+fn decode_hex(field: &'static str, s: &str) -> Result<Vec<u8>, VerifyError> {
+    // Reject non-ASCII before touching byte offsets: every hex char is ASCII, and
+    // this guarantees `as_bytes()` indices are also char boundaries (no panic path).
+    if !s.is_ascii() {
+        return Err(VerifyError::MalformedHex {
+            field,
+            reason: "non-ASCII input".to_string(),
+        });
+    }
+    let bytes = s.as_bytes();
+    if bytes.len() % 2 != 0 {
+        return Err(VerifyError::MalformedHex {
+            field,
+            reason: "odd length".to_string(),
+        });
+    }
+    let nibble = |b: u8| -> Result<u8, VerifyError> {
+        match b {
+            b'0'..=b'9' => Ok(b - b'0'),
+            b'a'..=b'f' => Ok(b - b'a' + 10),
+            b'A'..=b'F' => Ok(b - b'A' + 10),
+            _ => Err(VerifyError::MalformedHex {
+                field,
+                reason: format!("invalid hex digit {:?}", b as char),
+            }),
+        }
+    };
+    bytes
+        .chunks_exact(2)
+        .map(|pair| Ok((nibble(pair[0])? << 4) | nibble(pair[1])?))
+        .collect()
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Sign a verdict body with the given ed25519 key.
+///
+/// `signed_at` must be an RFC3339 timestamp; this crate does not depend on a clock
+/// so the caller supplies it (the runner uses the pick's finish time). The body is
+/// stamped with [`SCHEMA_VERSION`] so new signatures always use the v2 domain.
+#[must_use]
+pub fn sign(
+    mut body: CiVerdictBody,
+    key: &SigningKey,
+    signed_at: String,
+    signer_kind: SignerKind,
+) -> SignedVerdict {
+    // The body schema version is also the authenticated signing-format
+    // discriminator. Current producers always mint v2; only verification retains
+    // the legacy v1 path.
+    body.schema_version = SCHEMA_VERSION;
+    let body_digest = body.body_digest();
+    let signature = key.sign(&signed_payload(&body_digest, signer_kind, &signed_at));
+    let public_key = key.verifying_key();
+    SignedVerdict {
+        body,
+        public_key: encode_hex(public_key.as_bytes()),
+        signature: encode_hex(&signature.to_bytes()),
+        body_digest,
+        signed_at,
+        signer_kind,
+    }
+}
+
+impl SignedVerdict {
+    /// Sign a body, producing a [`SignedVerdict`]. Convenience over [`sign`].
+    #[must_use]
+    pub fn sign(
+        body: CiVerdictBody,
+        key: &SigningKey,
+        signed_at: String,
+        signer_kind: SignerKind,
+    ) -> Self {
+        sign(body, key, signed_at, signer_kind)
+    }
+
+    /// Verify this verdict end-to-end.
+    ///
+    /// 0. Reject a `schema_version` other than 1 or [`SCHEMA_VERSION`] with
+    ///    [`VerifyError::UnsupportedSchemaVersion`] — *before* recomputing the
+    ///    digest. This crate canonicalizes by reserializing the parsed struct, and
+    ///    serde drops unknown fields on parse, so a newer producer's verdict would
+    ///    otherwise recompute to a different digest and be misreported as
+    ///    [`VerifyError::BodyDigestMismatch`] (indistinguishable from tampering).
+    ///    Forward-compat verdicts are *parseable* (unknown fields are tolerated,
+    ///    per the body's lack of `deny_unknown_fields`) but only *verifiable* here
+    ///    up to this crate's known schema; cross-version verification must run over
+    ///    the producer's raw bytes.
+    /// 1. Recompute the body digest from the embedded body and reject any mismatch
+    ///    against `body_digest` (tamper detection).
+    /// 2. Select the v1 domain tag for a schema-v1 body or the v2 tag for a
+    ///    schema-v2 body, then verify the ed25519 signature against `public_key`
+    ///    over `tag ‖ digest ‖ signer_kind ‖ signed_at`. Thus old v1 verdicts
+    ///    remain verifiable, while [`sign`] mints only v2 verdicts.
+    ///
+    /// Trust (is `public_key` in the repo's runner trust set?) is the *caller's*
+    /// responsibility — this function proves authenticity, not authorization.
+    pub fn verify(&self) -> Result<(), VerifyError> {
+        let signing_tag = match self.body.schema_version {
+            1 => V1_SIGNING_PAYLOAD_VERSION_TAG,
+            SCHEMA_VERSION => SIGNING_PAYLOAD_VERSION_TAG,
+            found => {
+                return Err(VerifyError::UnsupportedSchemaVersion {
+                    found,
+                    supported: SCHEMA_VERSION,
+                });
+            }
+        };
+        if self.body.schema_version == 1 && self.signer_kind == SignerKind::Delegated {
+            return Err(VerifyError::UnsupportedSignerKindForSchemaVersion {
+                signer_kind: self.signer_kind,
+                schema_version: self.body.schema_version,
+            });
+        }
+
+        let recomputed = self.body.body_digest();
+        if recomputed != self.body_digest {
+            return Err(VerifyError::BodyDigestMismatch {
+                signed: self.body_digest.clone(),
+                recomputed,
+            });
+        }
+
+        let key_bytes = decode_hex("public_key", &self.public_key)?;
+        let key_arr: [u8; 32] = key_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| VerifyError::InvalidPublicKey("expected 32 bytes".to_string()))?;
+        let verifying_key = VerifyingKey::from_bytes(&key_arr)
+            .map_err(|e| VerifyError::InvalidPublicKey(e.to_string()))?;
+
+        let sig_bytes = decode_hex("signature", &self.signature)?;
+        let sig_arr: [u8; 64] = sig_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| VerifyError::InvalidSignatureEncoding("expected 64 bytes".to_string()))?;
+        let signature = Signature::from_bytes(&sig_arr);
+
+        verifying_key
+            .verify(
+                &signed_payload_with_tag(
+                    signing_tag,
+                    &self.body_digest,
+                    self.signer_kind,
+                    &self.signed_at,
+                ),
+                &signature,
+            )
+            .map_err(|_| VerifyError::SignatureInvalid)
+    }
+
+    /// The signer's public key, hex-encoded — the value a caller matches against a
+    /// trust set. (Stable accessor so callers don't reach into the field directly.)
+    #[must_use]
+    pub fn signer_public_key(&self) -> &str {
+        &self.public_key
+    }
+}
+
+/// Whether `s` looks like one of this crate's content digests (`b3:<hex>`).
+#[must_use]
+pub fn is_content_digest(s: &str) -> bool {
+    s.strip_prefix(DIGEST_PREFIX)
+        .is_some_and(|hex| !hex.is_empty() && hex.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::{Signer, SigningKey};
+
+    use super::*;
+    use crate::fixture;
+
+    #[test]
+    fn delegated_v2_roundtrip_rejects_tampering_and_forgery() {
+        let key = SigningKey::from_bytes(&[7_u8; 32]);
+        let signed = sign(
+            fixture::passing_body(),
+            &key,
+            "2026-09-01T12:00:00Z".into(),
+            SignerKind::Delegated,
+        );
+
+        assert_eq!(signed.body.schema_version, 2);
+        assert_eq!(SignerKind::default(), SignerKind::Delegated);
+        assert!(signed.signer_kind.may_satisfy_required_gate());
+        assert!(SignerKind::ServiceAccount.may_satisfy_required_gate());
+        assert!(!SignerKind::Device.may_satisfy_required_gate());
+
+        let json = serde_json::to_string(&signed).expect("serialize delegated verdict");
+        let roundtrip: SignedVerdict =
+            serde_json::from_str(&json).expect("deserialize delegated verdict");
+        assert_eq!(roundtrip, signed);
+        assert_eq!(roundtrip.verify(), Ok(()));
+
+        let mut body_tampered = signed.clone();
+        body_tampered.body.outcome.conclusion = crate::Conclusion::Failure;
+        assert!(matches!(
+            body_tampered.verify(),
+            Err(VerifyError::BodyDigestMismatch { .. })
+        ));
+
+        let mut wrong_signer_kind = signed.clone();
+        wrong_signer_kind.signer_kind = SignerKind::ServiceAccount;
+        assert_eq!(
+            wrong_signer_kind.verify(),
+            Err(VerifyError::SignatureInvalid)
+        );
+
+        let attacker_key = SigningKey::from_bytes(&[8_u8; 32]);
+        let mut forged = signed.clone();
+        forged.signature = encode_hex(
+            &attacker_key
+                .sign(&signed_payload(
+                    &forged.body_digest,
+                    forged.signer_kind,
+                    &forged.signed_at,
+                ))
+                .to_bytes(),
+        );
+        assert_eq!(forged.verify(), Err(VerifyError::SignatureInvalid));
+    }
+
+    #[test]
+    fn schema_version_selects_v1_or_v2_domain_tag_and_rejects_cross_tag_signatures() {
+        let key = SigningKey::from_bytes(&[9_u8; 32]);
+        let signed_at = "2026-09-01T12:00:00Z";
+
+        let mut v1_body = fixture::passing_body();
+        v1_body.schema_version = 1;
+        let v1_digest = v1_body.body_digest();
+        let v1_signature = key.sign(&signed_payload_with_tag(
+            V1_SIGNING_PAYLOAD_VERSION_TAG,
+            &v1_digest,
+            SignerKind::ServiceAccount,
+            signed_at,
+        ));
+        let v1 = SignedVerdict {
+            body: v1_body,
+            body_digest: v1_digest,
+            public_key: encode_hex(key.verifying_key().as_bytes()),
+            signature: encode_hex(&v1_signature.to_bytes()),
+            signed_at: signed_at.into(),
+            signer_kind: SignerKind::ServiceAccount,
+        };
+        assert_eq!(v1.verify(), Ok(()), "v1 verdict must remain verifiable");
+
+        let mut impossible_v1_delegated = v1.clone();
+        impossible_v1_delegated.signer_kind = SignerKind::Delegated;
+        impossible_v1_delegated.signature = encode_hex(
+            &key.sign(&signed_payload_with_tag(
+                V1_SIGNING_PAYLOAD_VERSION_TAG,
+                &impossible_v1_delegated.body_digest,
+                impossible_v1_delegated.signer_kind,
+                signed_at,
+            ))
+            .to_bytes(),
+        );
+        assert_eq!(
+            impossible_v1_delegated.verify(),
+            Err(VerifyError::UnsupportedSignerKindForSchemaVersion {
+                signer_kind: SignerKind::Delegated,
+                schema_version: 1,
+            })
+        );
+
+        let v2 = sign(
+            fixture::passing_body(),
+            &key,
+            signed_at.into(),
+            SignerKind::Delegated,
+        );
+        assert_eq!(v2.verify(), Ok(()));
+        assert!(
+            signed_payload(&v2.body_digest, v2.signer_kind, signed_at)
+                .starts_with(SIGNING_PAYLOAD_VERSION_TAG)
+        );
+
+        let mut v1_with_v2_tag = v1.clone();
+        v1_with_v2_tag.signature = encode_hex(
+            &key.sign(&signed_payload_with_tag(
+                SIGNING_PAYLOAD_VERSION_TAG,
+                &v1_with_v2_tag.body_digest,
+                v1_with_v2_tag.signer_kind,
+                signed_at,
+            ))
+            .to_bytes(),
+        );
+        assert_eq!(v1_with_v2_tag.verify(), Err(VerifyError::SignatureInvalid));
+
+        let mut v2_with_v1_tag = v2;
+        v2_with_v1_tag.signature = encode_hex(
+            &key.sign(&signed_payload_with_tag(
+                V1_SIGNING_PAYLOAD_VERSION_TAG,
+                &v2_with_v1_tag.body_digest,
+                v2_with_v1_tag.signer_kind,
+                signed_at,
+            ))
+            .to_bytes(),
+        );
+        assert_eq!(v2_with_v1_tag.verify(), Err(VerifyError::SignatureInvalid));
+    }
+
+    // ── decode_hex: panic-free on arbitrary input ─────────────────────────────
+
+    #[test]
+    fn decode_hex_decodes_valid_lowercase_and_uppercase() {
+        assert_eq!(decode_hex("f", "00ff").unwrap(), vec![0x00, 0xff]);
+        // Mixed case decodes to the same bytes (callers emit lowercase, but a
+        // cross-language producer might uppercase).
+        assert_eq!(
+            decode_hex("f", "DeAdBeEf").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+        assert_eq!(decode_hex("f", "").unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn decode_hex_rejects_multibyte_utf8_without_panicking() {
+        // "€€" is 6 bytes (EVEN — passes a naive `len % 2` check) but every `€` is a
+        // 3-byte codepoint, so the old `&s[i..i+2]` slice panicked mid-codepoint
+        // ("byte index 2 is not a char boundary"). Must now return MalformedHex.
+        let err = decode_hex("public_key", "\u{20AC}\u{20AC}").expect_err("must reject, not panic");
+        assert!(
+            matches!(
+                err,
+                VerifyError::MalformedHex {
+                    field: "public_key",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_hex_rejects_odd_length() {
+        let err = decode_hex("signature", "abc").expect_err("odd length must error");
+        assert!(matches!(err, VerifyError::MalformedHex { reason, .. } if reason == "odd length"));
+    }
+
+    #[test]
+    fn decode_hex_rejects_non_hex_ascii() {
+        let err = decode_hex("public_key", "zz").expect_err("non-hex ascii must error");
+        assert!(matches!(
+            err,
+            VerifyError::MalformedHex {
+                field: "public_key",
+                ..
+            }
+        ));
+        // Whitespace / punctuation are not hex either.
+        assert!(decode_hex("public_key", "  ").is_err());
+        assert!(decode_hex("public_key", "0x").is_err());
+    }
+
+    #[test]
+    fn decode_hex_rejects_a_single_multibyte_char() {
+        // A lone 2-byte codepoint (`¢` = U+00A2, bytes 0xC2 0xA2) is even-length too.
+        let err = decode_hex("public_key", "\u{00A2}").expect_err("must reject, not panic");
+        assert!(
+            matches!(err, VerifyError::MalformedHex { .. }),
+            "got {err:?}"
+        );
+    }
+
+    // ── verify(): the actual security boundary — never panics on hostile JSON ──
+
+    /// A `SignedVerdict` that verifies, as the base for hostile mutations.
+    fn good_signed() -> SignedVerdict {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        sign(
+            fixture::passing_body(),
+            &key,
+            "2026-06-11T18:05:54Z".to_string(),
+            SignerKind::ServiceAccount,
+        )
+    }
+
+    #[test]
+    fn verify_rejects_multibyte_public_key_via_json_roundtrip() {
+        // The threat model exactly: a SignedVerdict deserialized from attacker JSON
+        // whose public_key is multi-byte UTF-8 of even byte length. Must return a
+        // VerifyError (MalformedHex), never panic at the slice.
+        let mut signed = good_signed();
+        signed.public_key = "\u{20AC}\u{20AC}".to_string(); // 6 bytes, even
+        let json = serde_json::to_string(&signed).unwrap();
+        let parsed: SignedVerdict = serde_json::from_str(&json).unwrap();
+        let err = parsed
+            .verify()
+            .expect_err("hostile public_key must fail, not panic");
+        assert!(
+            matches!(
+                err,
+                VerifyError::MalformedHex {
+                    field: "public_key",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_multibyte_signature_via_json_roundtrip() {
+        let mut signed = good_signed();
+        signed.signature = "\u{20AC}\u{20AC}".to_string();
+        let json = serde_json::to_string(&signed).unwrap();
+        let parsed: SignedVerdict = serde_json::from_str(&json).unwrap();
+        // public_key is still valid here, so decode_hex on `signature` is the path.
+        let err = parsed
+            .verify()
+            .expect_err("hostile signature must fail, not panic");
+        assert!(
+            matches!(
+                err,
+                VerifyError::MalformedHex {
+                    field: "signature",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_odd_length_public_key() {
+        let mut signed = good_signed();
+        signed.public_key.pop(); // make it odd-length valid-hex-charset
+        let err = signed.verify().expect_err("odd-length must fail");
+        assert!(matches!(
+            err,
+            VerifyError::MalformedHex {
+                field: "public_key",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_non_hex_ascii_public_key() {
+        let mut signed = good_signed();
+        // 64 ascii chars but not hex (right length, wrong charset).
+        signed.public_key = "z".repeat(64);
+        let err = signed.verify().expect_err("non-hex must fail");
+        assert!(matches!(
+            err,
+            VerifyError::MalformedHex {
+                field: "public_key",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_length_valid_hex_public_key() {
+        // Valid hex, even length, but not 32 bytes ⇒ InvalidPublicKey (decode
+        // succeeds, the try_into to [u8;32] fails — still no panic).
+        let mut signed = good_signed();
+        signed.public_key = "00".repeat(31); // 31 bytes, valid hex
+        let err = signed.verify().expect_err("wrong-length key must fail");
+        assert!(
+            matches!(err, VerifyError::InvalidPublicKey(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_length_valid_hex_signature() {
+        let mut signed = good_signed();
+        signed.signature = "00".repeat(63); // 63 bytes, valid hex (sig is 64)
+        let err = signed.verify().expect_err("wrong-length sig must fail");
+        assert!(
+            matches!(err, VerifyError::InvalidSignatureEncoding(_)),
+            "got {err:?}"
+        );
+    }
+}

--- a/crates/treadle-schema/tests/fixtures/vectors.json
+++ b/crates/treadle-schema/tests/fixtures/vectors.json
@@ -1,0 +1,83 @@
+{
+  "$comment": [
+    "Golden signing vectors for treadle-schema. These pin the canonical bytes",
+    "and the ed25519 signature preimage so a re-implementation in ANY language can",
+    "reproduce them exactly. The Rust test `tests/vectors.rs` recomputes every",
+    "field below from the named fixture and asserts equality.",
+    "",
+    "How to reproduce in another language:",
+    "  1. Build the body exactly as described by `canonical_bytes_utf8` (the bytes",
+    "     are serde_json over the struct in declaration order; every map is sorted;",
+    "     every absent Option / empty `secret_grants` is OMITTED, never null/[]).",
+    "  2. body_digest = 'b3:' + lowercase_hex(BLAKE3_256(canonical_bytes)).",
+    "  3. signing_preimage =",
+    "       domain_tag                    (the 21 bytes in signing_payload_version_tag_hex)",
+    "       || body_digest (ASCII)        (the 'b3:'+hex string)",
+    "       || 0x00",
+    "       || signer_kind (ASCII)        ('service_account' | 'delegated' | 'device')",
+    "       || 0x00",
+    "       || signed_at (ASCII)          (RFC3339)",
+    "       || 0x00",
+    "     where domain_tag = the 20 ASCII bytes 'heddle-ci-verdict-v2' + one NUL (0x00).",
+    "  4. signature = ed25519_sign(private_key, signing_preimage), lowercase hex.",
+    "  5. verify recomputes (2)+(3) and checks (4) against `public_key`.",
+    "",
+    "The test private key is a FIXED seed (NEVER use it for anything real):",
+    "  ed25519 seed = 0x01 repeated 32 times.",
+    "All `*_hex` fields are lowercase, no '0x' prefix, no separators."
+  ],
+  "schema_version": 2,
+  "signing_payload_version_tag_ascii": "heddle-ci-verdict-v2",
+  "signing_payload_version_tag_hex": "686564646c652d63692d766572646963742d763200",
+  "test_key": {
+    "kind": "ed25519",
+    "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+    "seed_hex": "0101010101010101010101010101010101010101010101010101010101010101"
+  },
+  "vectors": [
+    {
+      "body_digest": "b3:993b1a126b4521684ed957390f10d3445f7b3e8d5c644ccbca1f6cff88544be5",
+      "canonical_bytes_utf8": "{\"schema_version\":2,\"repo\":\"heddle/core/heddle\",\"state\":{\"content_hash\":\"b3:9af2c0de\",\"change_id\":\"hd-7m3k\"},\"basis\":{\"kind\":{\"merged_with\":{\"target_state\":\"b3:1c0dba5e\",\"behind_count\":3}},\"evaluated_tree_digest\":\"b3:deadbeef\"},\"check\":{\"name\":\"check.test\",\"class\":\"required\",\"definition_digest\":\"b3:c0ffee\",\"command\":[\"cargo\",\"test\",\"--workspace\"],\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"default\"},\"services\":[]},\"outcome\":{\"conclusion\":\"success\"},\"execution\":{\"pick_id\":\"pk_01J\",\"attempt\":1,\"runner\":\"svc:runner-pool-a\",\"started_at\":\"2026-06-11T18:02:11Z\",\"finished_at\":\"2026-06-11T18:05:54Z\",\"duration_ms\":223000,\"ran_suites\":[\"workspace\"],\"skipped_suites\":[]},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--workspace\"],\"env\":{},\"services\":[]}}",
+      "fixture": "passing_body",
+      "name": "minimal",
+      "note": "Most Options unset — exercises the omit-when-absent rule (no logical_change_id, image_digest, failure, log, check_set_digest, no attestation block).",
+      "signature": "310017f0393a78691371c5f2cee025799772410f3938d0e75a17f7b9cb0f8bb9b6f09ecc1f7e5f7565344819149922836491a787a4cda509dfc98c0786d46001",
+      "signed_at": "2026-06-11T18:05:54Z",
+      "signer_kind": "delegated",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320062333a393933623161313236623435323136383465643935373339306631306433343435663762336538643563363434636362636131663663666638383534346265350064656c65676174656400323032362d30362d31315431383a30353a35345a00"
+    },
+    {
+      "body_digest": "b3:4e2642d513e145cf10b510a5c7fdb3d0ff6c77bcbb3cd8a78675ed5bb496c6cd",
+      "canonical_bytes_utf8": "{\"schema_version\":2,\"repo\":\"heddle/core/weft\",\"state\":{\"content_hash\":\"b3:5e11a7c0\",\"change_id\":\"hd-9q2x\",\"logical_change_id\":\"lc-weft-postgres\"},\"basis\":{\"kind\":{\"merged_with\":{\"target_state\":\"hd-main-0001\",\"behind_count\":7,\"merge_algorithm_version\":\"recursive-v2\",\"conflict_policy\":\"refuse-on-conflict\"}},\"evaluated_tree_digest\":\"b3:7eaf00d5\"},\"check\":{\"name\":\"check.postgres\",\"class\":\"required\",\"definition_digest\":\"b3:def111\",\"command\":[\"cargo\",\"test\",\"--features\",\"postgres\",\"--\",\"--ignored\"],\"image_digest\":\"sha256:abc123\",\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"postgres\",\"toolchain\":\"stable\"},\"services\":[\"postgres\"],\"node_id\":\"node-postgres-suite\"},\"outcome\":{\"conclusion\":\"failure\",\"failure\":{\"class\":\"test\",\"subclass\":\"ignored_suite\",\"failing_step\":\"check.postgres\",\"excerpt\":\"test schema::migrations::applies ... FAILED\",\"excerpt_encoding\":\"utf8\"}},\"execution\":{\"pick_id\":\"pk_02K\",\"attempt\":2,\"runner\":\"svc:runner-pool-b\",\"started_at\":\"2026-06-11T19:00:00Z\",\"finished_at\":\"2026-06-11T19:04:30Z\",\"duration_ms\":270000,\"ran_suites\":[\"postgres\",\"migrations\"],\"skipped_suites\":[\"unit\"],\"runner_pool\":\"pool-b\",\"trust_tier\":\"t1_container\",\"isolation_tier\":\"t1_container\",\"materialization_proof\":\"b3:merged7eaf00d5\",\"secret_grants\":[\"DATABASE_URL\"]},\"log\":{\"manifest_digest\":\"b3:109111\",\"size_bytes\":48122},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--features\",\"postgres\",\"--\",\"--ignored\"],\"env\":{\"CARGO_TERM_COLOR\":\"never\",\"RUST_BACKTRACE\":\"1\"},\"image\":\"sha256:abc123\",\"services\":[\"postgres\"]},\"check_set_digest\":\"b3:cs0001\"}",
+      "fixture": "maximal_body",
+      "name": "maximal",
+      "note": "Every Option set, including the D18 attestation block, log, check_set_digest, node_id, and both merge fields — the omit rule has nothing to omit.",
+      "signature": "46dc853b1e83a6d2d44a0f46166aee92a11f20b340de36c577457503eeaaed58d151906080c4af2fb24c216bd459785002d0202c14c2883b6a07c561cf370d0b",
+      "signed_at": "2026-06-11T19:04:30Z",
+      "signer_kind": "delegated",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320062333a346532363432643531336531343563663130623531306135633766646233643066663663373762636262336364386137383637356564356262343936633663640064656c65676174656400323032362d30362d31315431393a30343a33305a00"
+    },
+    {
+      "body_digest": "b3:0140b830337cc5a1b99fcd3c4d1d888e1b7bf59fc288b989920af23706e68c97",
+      "canonical_bytes_utf8": "{\"schema_version\":2,\"repo\":\"heddle/core/heddle\",\"state\":{\"content_hash\":\"b3:9af2c0de\",\"change_id\":\"hd-7m3k\"},\"basis\":{\"kind\":{\"merged_with\":{\"target_state\":\"hd-main-0042\",\"behind_count\":2,\"merge_algorithm_version\":\"recursive-v2\"}},\"evaluated_tree_digest\":\"b3:merged0042\"},\"check\":{\"name\":\"check.test\",\"class\":\"required\",\"definition_digest\":\"b3:c0ffee\",\"command\":[\"cargo\",\"test\",\"--workspace\"],\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"default\"},\"services\":[]},\"outcome\":{\"conclusion\":\"success\"},\"execution\":{\"pick_id\":\"pk_01J\",\"attempt\":1,\"runner\":\"svc:runner-pool-a\",\"started_at\":\"2026-06-11T18:02:11Z\",\"finished_at\":\"2026-06-11T18:05:54Z\",\"duration_ms\":223000,\"ran_suites\":[\"workspace\"],\"skipped_suites\":[]},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--workspace\"],\"env\":{},\"services\":[]}}",
+      "fixture": "merge_basis_body",
+      "name": "merge_basis",
+      "note": "Merge-basis (speculative merged tree, not branch-as-pushed) signed with a DEVICE key — the device path the gate treats as advisory-only. merge_algorithm_version set, conflict_policy omitted.",
+      "signature": "197e1d2d57c5916b271b63eec9b2dafe7b3984f2b6165711c5923e5a3fb9afe4cac518f39bcff63fe7200a3ef1a7ab703cdac29545c4e8efea3e423e970bce0b",
+      "signed_at": "2026-06-11T18:05:54Z",
+      "signer_kind": "device",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320062333a303134306238333033333763633561316239396663643363346431643838386531623762663539666332383862393839393230616632333730366536386339370064657669636500323032362d30362d31315431383a30353a35345a00"
+    },
+    {
+      "body_digest": "b3:8cb86ec3994b6845fdb488670d2f4aca436c6f5bf1630327d4c21f1659c9e71f",
+      "canonical_bytes_utf8": "{\"schema_version\":2,\"repo\":\"heddle/core/heddle\",\"state\":{\"content_hash\":\"b3:9af2c0de\",\"change_id\":\"hd-7m3k\"},\"basis\":{\"kind\":\"branch\",\"evaluated_tree_digest\":\"b3:branchasis\"},\"check\":{\"name\":\"check.test\",\"class\":\"required\",\"definition_digest\":\"b3:c0ffee\",\"command\":[\"cargo\",\"test\",\"--workspace\"],\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"default\"},\"services\":[]},\"outcome\":{\"conclusion\":\"success\"},\"execution\":{\"pick_id\":\"pk_01J\",\"attempt\":1,\"runner\":\"svc:runner-pool-a\",\"started_at\":\"2026-06-11T18:02:11Z\",\"finished_at\":\"2026-06-11T18:05:54Z\",\"duration_ms\":223000,\"ran_suites\":[\"workspace\"],\"skipped_suites\":[]},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--workspace\"],\"env\":{},\"services\":[]}}",
+      "fixture": "branch_basis_body",
+      "name": "branch_basis",
+      "note": "The ONLY branch-basis vector and the legacy service_account compatibility vector. BasisKind::Branch is the branch tree as-pushed, not a speculative merge. Pins the canonical bytes of serde's EXTERNALLY-TAGGED unit variant — the bare string \"kind\":\"branch\" — NOT {\"branch\":null}. Guards the schema-vs-serde mismatch that every MergedWith vector misses.",
+      "signature": "dc0d4b2df3f3b3e269d9f84af3439bfcfdbca3e3dc3dac2c64ded89d083149c2485547ca2812186d178077263831459ab5820422dc2e880d7ed156a8390a120a",
+      "signed_at": "2026-06-11T18:05:54Z",
+      "signer_kind": "service_account",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320062333a3863623836656333393934623638343566646234383836373064326634616361343336633666356266313633303332376434633231663136353963396537316600736572766963655f6163636f756e7400323032362d30362d31315431383a30353a35345a00"
+    }
+  ]
+}

--- a/crates/treadle-schema/tests/schema_export.rs
+++ b/crates/treadle-schema/tests/schema_export.rs
@@ -1,0 +1,280 @@
+//! Asserts the exported JSON Schemas in `schemas/` stay faithful to the Rust
+//! types and encode the load-bearing invariants — chiefly that they advertise
+//! the same forward-compatibility posture the code has (`deny_unknown_fields`
+//! OFF ⇒ `additionalProperties: true`) and that the pre-freeze DESIGN-§3.2/D18
+//! members are present but NOT required.
+//!
+//! These schemas are hand-written (the crate is intentionally dependency-light;
+//! see the final response notes on the schemars trade-off). This test is the
+//! mechanism that keeps a hand-written schema honest.
+
+use serde_json::Value;
+use treadle_schema::fixture;
+
+const BODY_SCHEMA: &str = include_str!("../schemas/ci_verdict_body.schema.json");
+const SIGNED_SCHEMA: &str = include_str!("../schemas/signed_verdict.schema.json");
+
+fn parse(name: &str, raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|e| panic!("{name} is not valid JSON: {e}"))
+}
+
+/// Walk every `"type": "object"` node and assert its `additionalProperties` does
+/// not *close* the object (forward-compat requires open structs). Three legal
+/// shapes:
+///   - `true`  → open struct (the forward-compat default).
+///   - a schema object (e.g. `{"type":"string"}`) → an open `map<…>` whose value
+///     type is constrained; still open to new keys.
+///   - `false` → ONLY allowed on the single-key `merged_with` BasisKind variant
+///     wrapper, which is closed by construction (an externally-tagged struct
+///     variant has exactly one key). The `branch` unit variant is now the bare
+///     string `{"const":"branch"}` — not an object — so it never reaches this arm.
+fn assert_forward_compat(node: &Value, path: &str) {
+    if let Some(obj) = node.as_object() {
+        if obj.get("type").and_then(Value::as_str) == Some("object") {
+            match obj.get("additionalProperties") {
+                Some(Value::Bool(true)) => {}
+                // A map's value-type schema — open object, fine.
+                Some(Value::Object(_)) => {}
+                Some(Value::Bool(false)) => {
+                    let is_variant_wrapper = obj
+                        .get("required")
+                        .and_then(Value::as_array)
+                        .is_some_and(|r| r.len() == 1 && r[0].as_str() == Some("merged_with"));
+                    assert!(
+                        is_variant_wrapper,
+                        "{path}: a struct object set additionalProperties:false but is not the \
+                         BasisKind merged_with variant wrapper — forward-compat requires open \
+                         structs"
+                    );
+                }
+                other => panic!(
+                    "{path}: object must declare additionalProperties (true / value-schema for \
+                     forward-compat); got {other:?}"
+                ),
+            }
+        }
+        for (k, v) in obj {
+            assert_forward_compat(v, &format!("{path}.{k}"));
+        }
+    } else if let Some(arr) = node.as_array() {
+        for (i, v) in arr.iter().enumerate() {
+            assert_forward_compat(v, &format!("{path}[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn schemas_are_valid_json() {
+    let _ = parse("ci_verdict_body.schema.json", BODY_SCHEMA);
+    let _ = parse("signed_verdict.schema.json", SIGNED_SCHEMA);
+}
+
+#[test]
+fn schemas_advertise_forward_compat_everywhere() {
+    let body = parse("body", BODY_SCHEMA);
+    let signed = parse("signed", SIGNED_SCHEMA);
+    assert_forward_compat(&body, "body");
+    assert_forward_compat(&signed, "signed");
+    // And explicitly at the two roots (the thing producers append to).
+    assert_eq!(body["additionalProperties"], Value::Bool(true));
+    assert_eq!(signed["additionalProperties"], Value::Bool(true));
+}
+
+#[test]
+fn body_required_set_matches_the_non_optional_fields() {
+    let body = parse("body", BODY_SCHEMA);
+    let required: Vec<&str> = body["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    // Exactly the fields with no skip_serializing_if in body.rs.
+    let expected = [
+        "schema_version",
+        "repo",
+        "state",
+        "basis",
+        "check",
+        "outcome",
+        "execution",
+        "repro",
+    ];
+    for f in expected {
+        assert!(required.contains(&f), "body.required must contain {f:?}");
+    }
+    // The optional members must NOT be required.
+    for opt in ["log", "check_set_digest"] {
+        assert!(
+            !required.contains(&opt),
+            "{opt:?} is optional (omit-when-absent) and must not be in body.required"
+        );
+        assert!(
+            body["properties"].get(opt).is_some(),
+            "{opt:?} must still be a declared property"
+        );
+    }
+}
+
+#[test]
+fn prefreeze_d18_members_are_present_but_not_required() {
+    let body = parse("body", BODY_SCHEMA);
+
+    // body.check_set_digest
+    assert!(body["properties"]["check_set_digest"].is_object());
+
+    // check.node_id
+    let check = &body["$defs"]["CheckDescriptor"];
+    assert!(check["properties"]["node_id"].is_object());
+    let check_required: Vec<&str> = check["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(!check_required.contains(&"node_id"));
+
+    // execution attestation block
+    let exec = &body["$defs"]["Execution"];
+    let exec_required: Vec<&str> = exec["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    for f in [
+        "runner_pool",
+        "trust_tier",
+        "isolation_tier",
+        "materialization_proof",
+        "secret_grants",
+    ] {
+        assert!(
+            exec["properties"].get(f).is_some(),
+            "Execution must declare pre-freeze member {f:?}"
+        );
+        assert!(
+            !exec_required.contains(&f),
+            "pre-freeze member {f:?} must not be required"
+        );
+    }
+
+    // basis merged_with merge_algorithm_version + conflict_policy
+    let merged = &body["$defs"]["BasisKind"]["oneOf"][1]["properties"]["merged_with"];
+    for f in ["merge_algorithm_version", "conflict_policy"] {
+        assert!(
+            merged["properties"].get(f).is_some(),
+            "merged_with must declare pre-freeze member {f:?}"
+        );
+    }
+    let merged_required: Vec<&str> = merged["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(merged_required, vec!["target_state", "behind_count"]);
+}
+
+#[test]
+fn signed_verdict_required_set_is_complete() {
+    let signed = parse("signed", SIGNED_SCHEMA);
+    let required: Vec<&str> = signed["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    for f in [
+        "body",
+        "body_digest",
+        "public_key",
+        "signature",
+        "signed_at",
+        "signer_kind",
+    ] {
+        assert!(required.contains(&f), "signed.required must contain {f:?}");
+    }
+    assert_eq!(
+        signed["properties"]["signer_kind"]["enum"],
+        serde_json::json!(["service_account", "delegated", "device"]),
+        "signed schema must expose every SignerKind token"
+    );
+}
+
+/// The honesty harness: actually *validate serialized fixture instances against
+/// the hand-written schema*. The structural-invariant tests above (required sets,
+/// forward-compat) never instantiate the schema, so they could not catch a
+/// shape mismatch like BasisKind::Branch serializing as `"branch"` while the
+/// schema demanded `{"branch": null}`. This test compiles the schema and runs
+/// every fixture (crucially `branch_basis_body`, the only `Branch` instance)
+/// through it, so the schema can no longer drift from serde's real output.
+#[test]
+fn every_fixture_validates_against_the_body_schema() {
+    let schema = parse("body", BODY_SCHEMA);
+    let validator =
+        jsonschema::validator_for(&schema).expect("ci_verdict_body.schema.json must compile");
+
+    let fixtures: [(&str, Value); 5] = [
+        (
+            "passing_body",
+            serde_json::to_value(fixture::passing_body()).unwrap(),
+        ),
+        (
+            "failing_body",
+            serde_json::to_value(fixture::failing_body()).unwrap(),
+        ),
+        (
+            "maximal_body",
+            serde_json::to_value(fixture::maximal_body()).unwrap(),
+        ),
+        (
+            "merge_basis_body",
+            serde_json::to_value(fixture::merge_basis_body()).unwrap(),
+        ),
+        (
+            "branch_basis_body",
+            serde_json::to_value(fixture::branch_basis_body()).unwrap(),
+        ),
+    ];
+
+    for (name, instance) in &fixtures {
+        let errors: Vec<String> = validator
+            .iter_errors(instance)
+            .map(|e| e.to_string())
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "fixture {name:?} failed schema validation:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+}
+
+/// Pin the BasisKind shape explicitly from both directions: the canonical
+/// `"branch"` string MUST validate, and the historically-wrong `{"branch": null}`
+/// form MUST NOT. This is the regression guard for the schema/serde mismatch.
+#[test]
+fn basis_kind_branch_schema_accepts_string_rejects_object_form() {
+    let schema = parse("body", BODY_SCHEMA);
+    let basis_kind = &schema["$defs"]["BasisKind"];
+    let validator = jsonschema::validator_for(basis_kind).expect("BasisKind subschema compiles");
+
+    // serde's actual output for BasisKind::Branch — the bare string.
+    assert!(
+        validator.is_valid(&Value::String("branch".into())),
+        "schema must accept the bare \"branch\" string (serde's real Branch form)"
+    );
+    // The old, wrong internally-tagged form must now be rejected.
+    assert!(
+        !validator.is_valid(&serde_json::json!({ "branch": null })),
+        "schema must REJECT the {{\"branch\": null}} object form — it is not serde's output"
+    );
+    // The struct variant still validates.
+    assert!(
+        validator.is_valid(&serde_json::json!({
+            "merged_with": { "target_state": "hd-x", "behind_count": 0 }
+        })),
+        "schema must accept the merged_with struct variant"
+    );
+}

--- a/crates/treadle-schema/tests/vectors.rs
+++ b/crates/treadle-schema/tests/vectors.rs
@@ -1,0 +1,147 @@
+//! Golden signing-vector conformance test.
+//!
+//! Loads `tests/fixtures/vectors.json` and, for each vector, rebuilds the named
+//! fixture and asserts that this crate reproduces the pinned `canonical_bytes`,
+//! `body_digest`, signing preimage, and `signature` exactly — and that the
+//! resulting [`SignedVerdict`] verifies. This is the artifact a cross-language
+//! re-implementation checks itself against (see the header comment in the JSON).
+//!
+//! If any assertion here fails after an intentional pre-freeze change, regenerate
+//! the vectors deliberately (the bytes are produced by the same fixtures + the
+//! fixed seed below) — do NOT loosen the test.
+
+use ed25519_dalek::SigningKey;
+use serde_json::Value;
+use treadle_schema::{
+    CiVerdictBody, SIGNING_PAYLOAD_VERSION_TAG, SignerKind, fixture, sign, signed_payload,
+};
+
+/// The fixed deterministic test seed pinned in `vectors.json` (`test_key.seed_hex`).
+/// NEVER use this key for anything real.
+const TEST_SEED: [u8; 32] = [1u8; 32];
+
+fn hexstr(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Map a `fixture` name in the JSON to its constructor. A vector naming an unknown
+/// fixture fails loudly rather than silently skipping.
+fn fixture_by_name(name: &str) -> CiVerdictBody {
+    match name {
+        "passing_body" => fixture::passing_body(),
+        "maximal_body" => fixture::maximal_body(),
+        "merge_basis_body" => fixture::merge_basis_body(),
+        "branch_basis_body" => fixture::branch_basis_body(),
+        other => panic!("vectors.json references unknown fixture {other:?}"),
+    }
+}
+
+fn signer_kind_by_name(name: &str) -> SignerKind {
+    match name {
+        "service_account" => SignerKind::ServiceAccount,
+        "delegated" => SignerKind::Delegated,
+        "device" => SignerKind::Device,
+        other => panic!("vectors.json has unknown signer_kind {other:?}"),
+    }
+}
+
+#[test]
+fn golden_vectors_reproduce() {
+    let raw = include_str!("fixtures/vectors.json");
+    let doc: Value = serde_json::from_str(raw).expect("vectors.json is valid JSON");
+
+    // The fixed key the vectors were signed with must match what the JSON declares.
+    let key = SigningKey::from_bytes(&TEST_SEED);
+    let declared_pub = doc["test_key"]["public_key_hex"]
+        .as_str()
+        .expect("test_key.public_key_hex");
+    assert_eq!(
+        hexstr(key.verifying_key().as_bytes()),
+        declared_pub,
+        "fixed test key drifted from vectors.json"
+    );
+    assert_eq!(
+        doc["test_key"]["seed_hex"].as_str().unwrap(),
+        hexstr(&TEST_SEED),
+        "seed_hex in vectors.json must match the test seed"
+    );
+
+    let vectors = doc["vectors"].as_array().expect("vectors array");
+    assert!(!vectors.is_empty(), "expected at least one vector");
+
+    for v in vectors {
+        let name = v["name"].as_str().expect("vector.name");
+        let fixture_name = v["fixture"].as_str().expect("vector.fixture");
+        let signed_at = v["signed_at"]
+            .as_str()
+            .expect("vector.signed_at")
+            .to_string();
+        let signer_kind = signer_kind_by_name(v["signer_kind"].as_str().expect("signer_kind"));
+
+        let body = fixture_by_name(fixture_name);
+
+        // 1. canonical bytes (the UTF-8 form is the human-readable pin).
+        let cb = body.canonical_bytes();
+        let cb_utf8 = String::from_utf8(cb.clone()).expect("canonical bytes are utf8");
+        assert_eq!(
+            cb_utf8,
+            v["canonical_bytes_utf8"].as_str().unwrap(),
+            "[{name}] canonical bytes drifted"
+        );
+
+        // 2. body digest.
+        let digest = body.body_digest();
+        assert_eq!(
+            digest,
+            v["body_digest"].as_str().unwrap(),
+            "[{name}] body_digest drifted"
+        );
+
+        // 3. signing preimage — independently rebuild it and compare to the pin,
+        //    and assert it actually begins with the domain tag.
+        let preimage = signed_payload(&digest, signer_kind, &signed_at);
+        assert!(
+            preimage.starts_with(SIGNING_PAYLOAD_VERSION_TAG),
+            "[{name}] preimage missing domain tag"
+        );
+        assert_eq!(
+            hexstr(&preimage),
+            v["signing_preimage_hex"].as_str().unwrap(),
+            "[{name}] signing preimage drifted"
+        );
+
+        // 4. signature, and the signed verdict verifies.
+        let signed = sign(body, &key, signed_at.clone(), signer_kind);
+        assert_eq!(
+            signed.signature,
+            v["signature"].as_str().unwrap(),
+            "[{name}] signature drifted"
+        );
+        assert_eq!(
+            signed.body_digest, digest,
+            "[{name}] embedded digest mismatch"
+        );
+        signed
+            .verify()
+            .unwrap_or_else(|e| panic!("[{name}] golden vector must verify: {e:?}"));
+    }
+}
+
+#[test]
+fn domain_tag_is_exactly_what_the_json_declares() {
+    let raw = include_str!("fixtures/vectors.json");
+    let doc: Value = serde_json::from_str(raw).unwrap();
+    // Tolerate any incidental whitespace in the declared hex (there is none today,
+    // but keep the comparison robust to a future reformat).
+    let declared: String = doc["signing_payload_version_tag_hex"]
+        .as_str()
+        .unwrap()
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    assert_eq!(hexstr(SIGNING_PAYLOAD_VERSION_TAG), declared);
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,10 @@ publish_allow_dirty = false
 
 # Publishable OSS crates — all release = true.
 [[package]]
+name = "treadle-schema"
+release = true
+
+[[package]]
 name = "heddle-format"
 release = true
 


### PR DESCRIPTION
## Summary

- host the treadle#20 `treadle-schema` source, schemas, golden vectors, and tests as a Heddle workspace leaf crate
- preserve the `heddle-ci-verdict-v1` and `heddle-ci-verdict-v2` payloads, delegated signer behavior, and verification semantics
- publish `treadle-schema` first in the release-plz and publish-crates graphs at the workspace `0.15.9` line

## Verification

- `cargo test -p treadle-schema` (30 unit + 7 schema + 2 vector + 1 doctest)
- `cargo build --workspace`
- `cargo clippy --workspace -- -D warnings`
- nightly rustfmt check on touched Rust files
- `scripts/check-publish-pipeline.sh`
- dependency-version and published-heddle-api graph gates
- `cargo package -p treadle-schema --no-verify`

After this lands and publishes, weft#1348 can replace its private treadle Git dependency with the published crate.

Closes #1627

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790859585&installation_model_id=21489&pr_number=1635&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1635&signature=2d7c9cb671298b97dafaf04cbd595bf9e955151457da4840cc908f5640aee844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->