### PR TITLE
fix(hosted): persist stable identity on native first push

### DIFF
--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -690,6 +690,7 @@ impl HostedClient {
                     metadata,
                     (!thread_id.is_empty()).then_some(thread_id.as_str()),
                     remote_refs.as_deref().unwrap_or_default(),
+                    new_value,
                 )
             })
             .transpose()?;
@@ -938,16 +939,21 @@ impl HostedClient {
             operation_id.as_str(),
         );
         let transport_mode = preferred_transport_mode(&self.transport, object_count);
-        let thread_metadata = load_thread_metadata(repo, target_thread, local_state)?
-            .as_ref()
-            .map(|metadata| {
-                to_proto_thread_metadata(
-                    metadata,
-                    (!target_thread_id.is_empty()).then_some(target_thread_id.as_str()),
-                    &remote_refs,
-                )
-            })
-            .transpose()?;
+        let local_thread_metadata = load_thread_metadata(repo, target_thread, local_state)?;
+        let thread_metadata = match local_thread_metadata.as_ref() {
+            Some(metadata) => Some(to_proto_thread_metadata(
+                metadata,
+                (!target_thread_id.is_empty()).then_some(target_thread_id.as_str()),
+                &remote_refs,
+                local_state,
+            )?),
+            None if git_lane.is_none() => {
+                return Err(ProtocolError::InvalidState(format!(
+                    "native push target '{target_thread}' has no local thread record with a stable identity"
+                )));
+            }
+            None => None,
+        };
         let mut push_request = PushRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             local_state: super::helpers::proto_state_id(local_state),
@@ -3530,12 +3536,9 @@ mod pull_bootstrap_tests {
     }
 }
 
-fn state_id_string_to_bytes(s: &str) -> Vec<u8> {
-    if s.is_empty() {
-        return Vec::new();
-    }
-    objects::object::StateId::parse(s)
-        .map(|id| id.as_bytes().to_vec())
+fn content_hash_string_to_bytes(value: &str) -> Vec<u8> {
+    ContentHash::from_hex(value)
+        .map(|hash| hash.as_bytes().to_vec())
         .unwrap_or_default()
 }
 
@@ -3563,9 +3566,10 @@ fn to_proto_thread_metadata(
     metadata: &SyncedThreadMetadata,
     thread_id: Option<&str>,
     remote_refs: &[HostedRefEntry],
+    pushed_state: StateId,
 ) -> Result<ThreadMetadata, ProtocolError> {
     Ok(ThreadMetadata {
-        name: metadata.thread.clone(),
+        name: metadata.id.clone(),
         target_thread: metadata.target_thread.clone(),
         parent_thread: metadata.parent_thread.clone(),
         task: metadata.task.clone(),
@@ -3591,12 +3595,8 @@ fn to_proto_thread_metadata(
         base_state: StateId::parse(&metadata.base_state)
             .ok()
             .and_then(super::helpers::proto_state_id),
-        base_root: state_id_string_to_bytes(&metadata.base_root),
-        current_state: metadata.current_state.as_deref().and_then(|state| {
-            StateId::parse(state)
-                .ok()
-                .and_then(super::helpers::proto_state_id)
-        }),
+        base_root: content_hash_string_to_bytes(&metadata.base_root),
+        current_state: super::helpers::proto_state_id(pushed_state),
         merged_state: metadata.merged_state.as_deref().and_then(|state| {
             StateId::parse(state)
                 .ok()
@@ -3727,6 +3727,10 @@ fn partial_fetch_status_for_repo(repo: &Repository) -> i32 {
 #[cfg(test)]
 mod native_exchange_tests {
     use objects::object::{Attribution, Principal};
+    use repo::{
+        ThreadFreshness, ThreadManager, ThreadMode, ThreadRecord, ThreadState,
+        ThreadVerificationSummary,
+    };
     use tempfile::TempDir;
 
     use super::*;
@@ -3745,11 +3749,150 @@ mod native_exchange_tests {
         (repo, state)
     }
 
+    fn save_thread_record(
+        repo: &Repository,
+        state: StateId,
+        stable_id: &str,
+        thread: &str,
+    ) -> ThreadRecord {
+        let stored_state = repo.store().get_state(&state).unwrap().unwrap();
+        let now = chrono::Utc::now();
+        let record = ThreadRecord {
+            id: stable_id.to_string(),
+            thread: thread.to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode: ThreadMode::Solid,
+            state: ThreadState::Active,
+            base_state: state.to_string_full(),
+            base_root: stored_state.tree.to_hex(),
+            current_state: Some(state.to_string_full()),
+            merged_state: None,
+            task: Some("prove first-push identity".to_string()),
+            changed_paths: vec!["tracked.txt".to_string()],
+            impact_categories: Vec::new(),
+            heavy_impact_paths: Vec::new(),
+            promotion_suggested: false,
+            freshness: ThreadFreshness::Current,
+            verification_summary: ThreadVerificationSummary::default(),
+            confidence_summary: Default::default(),
+            integration_policy_result: Default::default(),
+            created_at: now,
+            updated_at: now,
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        };
+        ThreadManager::new(repo.heddle_dir())
+            .save_record(&record)
+            .unwrap();
+        record
+    }
+
+    #[tokio::test]
+    async fn native_first_push_sends_complete_stable_local_thread_metadata() {
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_push().await;
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let record = save_thread_record(&repo, state, "thread-stable-01", "main");
+
+        let pushed = client
+            .push_with_expected_head_profiled(
+                &repo,
+                "acme/widgets",
+                state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "first-push-metadata-test-op".to_string(),
+            )
+            .await
+            .unwrap()
+            .0;
+        assert!(!pushed.success);
+
+        let request = captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .first()
+            .cloned()
+            .expect("test server must capture the first push request");
+        assert!(request.create_thread, "empty ListRefs means a first push");
+        assert!(request.target_thread_id.is_empty());
+        assert_eq!(request.target_thread, record.thread);
+
+        let metadata = request
+            .thread_metadata
+            .expect("a native first push must carry local thread metadata");
+        assert_eq!(
+            metadata.name, record.id,
+            "weft persists metadata.name as the stable thread identity"
+        );
+        assert!(
+            metadata.thread_id.is_empty(),
+            "the remote has no identity yet"
+        );
+        assert!(metadata.base_state.is_some());
+        assert!(!metadata.base_root.is_empty());
+        assert_eq!(metadata.current_state, request.local_state);
+        assert_eq!(
+            metadata.thread_mode,
+            ProtoThreadMode::Solid as i32,
+            "weft must be able to parse the local thread mode"
+        );
+        assert_eq!(
+            metadata.thread_state,
+            ProtoThreadState::ThreadStateActive as i32,
+            "weft must be able to parse the local lifecycle state"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn native_push_without_local_stable_identity_fails_before_sending_request() {
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_push().await;
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+
+        let error = client
+            .push_with_expected_head_profiled(
+                &repo,
+                "acme/widgets",
+                state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "missing-local-metadata-test-op".to_string(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("no local thread record with a stable identity")
+        );
+        assert!(
+            captured
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .is_empty(),
+            "native push must not send an identity-less request"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
     #[tokio::test]
     async fn native_push_and_clone_pull_complete_the_real_framed_exchange() {
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
         let source = TempDir::new().unwrap();
         let (repo, state) = repository(&source);
+        save_thread_record(&repo, state, "thread-stable-main", "main");
 
         assert!(client.list_refs("acme/widgets").await.unwrap().is_empty());
         let pushed = client

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -18,8 +18,8 @@ use api::{
         ListContextResponse, ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd,
         ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind,
         PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete, PushReady,
-        PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint, TransportMode,
-        UpdateSpoolRequest, get_context_history_response, list_context_response,
+        PushRequest, PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint,
+        TransportMode, UpdateSpoolRequest, get_context_history_response, list_context_response,
         list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
         push_client_frame, push_server_frame,
     },
@@ -52,7 +52,21 @@ fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
 }
 
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None, BlobFixture::default(), None, None).await
+    start_inner(None, BlobFixture::default(), None, None, None).await
+}
+
+pub(crate) async fn start_recording_push()
+-> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<PushRequest>>>) {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let (client, server) = start_inner(
+        None,
+        BlobFixture::default(),
+        None,
+        None,
+        Some(Arc::clone(&captured)),
+    )
+    .await;
+    (client, server, captured)
 }
 
 pub(crate) async fn start_recording_create_spool() -> (
@@ -65,6 +79,7 @@ pub(crate) async fn start_recording_create_spool() -> (
         None,
         BlobFixture::default(),
         Some(Arc::clone(&captured)),
+        None,
         None,
     )
     .await;
@@ -82,6 +97,7 @@ pub(crate) async fn start_recording_spool_mutations() -> (
         BlobFixture::default(),
         None,
         Some(Arc::clone(&captured)),
+        None,
     )
     .await;
     (client, server, captured)
@@ -96,6 +112,7 @@ pub(crate) async fn start_with_remote_state(
             pack: None,
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
     )
@@ -113,6 +130,7 @@ pub(crate) async fn start_with_pull_pack(
             pack: Some((pack_data, index_data)),
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
     )
@@ -150,7 +168,7 @@ async fn start_with_get_blob_contents_and_pull(
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(pull, fixture, None, None).await;
+    let (client, server) = start_inner(pull, fixture, None, None, None).await;
     (client, server, requested)
 }
 
@@ -171,6 +189,7 @@ async fn start_inner(
     blobs: BlobFixture,
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
+    push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
 ) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
@@ -196,6 +215,7 @@ async fn start_inner(
                 blobs.clone(),
                 create_spool.clone(),
                 spool_mutations.clone(),
+                push_requests.clone(),
             ));
         }
         server.close().await;
@@ -224,6 +244,7 @@ async fn serve_call(
     blobs: BlobFixture,
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
+    push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -262,7 +283,7 @@ async fn serve_call(
         }
         StreamingShape::Bidirectional => {
             if method == "/heddle.api.v1alpha1.RepoSyncService/Push" {
-                serve_push(send, recv, request.split_off(prelude_len)).await;
+                serve_push(send, recv, request.split_off(prelude_len), push_requests).await;
                 return;
             }
             tokio::spawn(async move {
@@ -286,8 +307,9 @@ async fn serve_push(
     mut send: iroh::endpoint::SendStream,
     mut recv: iroh::endpoint::RecvStream,
     mut buffered: Vec<u8>,
+    captured: Option<Arc<Mutex<Vec<PushRequest>>>>,
 ) {
-    let advertised = loop {
+    let request = loop {
         if let Some((frame, consumed)) = decode_stream_frame(&buffered).unwrap() {
             let request = match frame {
                 StreamFrame::Message(body) => PushClientFrame::decode(body).unwrap(),
@@ -295,7 +317,7 @@ async fn serve_push(
             };
             buffered.drain(..consumed);
             if let Some(push_client_frame::Frame::Request(request)) = request.frame {
-                break request.objects;
+                break *request;
             }
             continue;
         }
@@ -306,6 +328,13 @@ async fn serve_push(
             .expect("push request frame");
         buffered.extend_from_slice(&chunk);
     };
+    let advertised = request.objects.clone();
+    if let Some(captured) = captured {
+        captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .push(request);
+    }
 
     let ready = PushServerFrame {
         frame: Some(push_server_frame::Frame::Ready(PushReady {

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
@@ -21,6 +21,12 @@ pub(super) fn from_summary(
             format!("was named '{}'", summary.name),
         ));
     }
+    if summary.thread_id.is_empty() {
+        return Err(invalid_metadata(
+            remote_thread,
+            "is missing its stable identity",
+        ));
+    }
     let base_state = super::helpers::parse_proto_state_id(summary.base_state)?
         .ok_or_else(|| invalid_metadata(remote_thread, "is missing its managed base state"))?;
     let advertised_current = super::helpers::parse_proto_state_id(summary.current_state)?;
@@ -45,7 +51,7 @@ pub(super) fn from_summary(
     let now = chrono::Utc::now();
 
     Ok(SyncedThreadMetadata {
-        id: remote_thread.to_string(),
+        id: summary.thread_id,
         thread: remote_thread.to_string(),
         target_thread: summary.target_thread,
         parent_thread: summary.parent_thread,
@@ -206,6 +212,7 @@ mod tests {
         let tip = repo.snapshot(Some("runner".to_string()), None).unwrap();
         let summary = ThreadSummary {
             name: "shuttle/runner".to_string(),
+            thread_id: "thread-stable-runner".to_string(),
             base_state: super::super::helpers::proto_state_id(base.state_id),
             current_state: super::super::helpers::proto_state_id(tip.state_id),
             target_thread: Some("main".to_string()),
@@ -218,6 +225,7 @@ mod tests {
         };
 
         let metadata = from_summary(&repo, "shuttle/runner", tip.state_id, summary).unwrap();
+        assert_eq!(metadata.id, "thread-stable-runner");
         assert_eq!(metadata.thread, "shuttle/runner");
         assert_eq!(metadata.target_thread.as_deref(), Some("main"));
         assert_eq!(metadata.state, repo::ThreadState::Ready);


### PR DESCRIPTION
Closes #1636

## What changed

- Native push now requires the local `heddle-repo::ThreadRecord` for the target thread and fails closed before sending when no stable local identity exists.
- `ThreadMetadata.name` is sourced from `ThreadRecord.id`; `PushRequest.target_thread` remains the local record thread/ref name.
- `ThreadMetadata.current_state` is bound directly to the pushed `StateId`, and local mode/state continue through the existing proto enum mapping.
- The existing remote-summary rehydration path now preserves `ThreadSummary.thread_id` as the local record id for later pushes.
- Corrected `base_root` encoding to parse the local `ContentHash` rather than a `StateId`.

## Weft validation contract

For a fresh `main` push with no remote summary/ref identity:

- `metadata.name == local ThreadRecord.id` (stable across pushes)
- `request.target_thread == local ThreadRecord.thread`
- `metadata.current_state == request.local_state == pushed StateId`
- `thread_mode` and `thread_state` are populated with valid proto enum values

## Proof

The new framed-exchange regression captures the actual first `PushRequest` against an empty `ListRefs` test server. Before the production fix it failed because `metadata.name` was `main` instead of stable id `thread-stable-01`; after the fix it passes and also checks target/current state/mode/state/base metadata. A companion test proves a native push with no local stable identity sends no request.

- `cargo test -p heddle-hosted-client --features client`: 336 passed, 1 ignored
- `cargo build --workspace`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `rustfmt +nightly --check` on touched files: passed

## Not run here

The live push → weft persistence → ListRefs thread_id → second push e2e needs live weft + Postgres (heddle#1634/manual staging), so it was not run or simulated here. This client fix still requires a rebuilt Heddle CLI and the already-merged/redeployed weft side to clear the owner push blocker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790864436&installation_model_id=21489&pr_number=1637&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1637&signature=1e85d13ea96a8dc5e9e7e5b2c6ce0bc24662e9f267fbe11f2aa5bcc5d3978591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->