### PR TITLE
Persist stable identity for default main thread

### DIFF
--- a/crates/cli/src/cli/commands/undo_apply/atomic_tests.rs
+++ b/crates/cli/src/cli/commands/undo_apply/atomic_tests.rs
@@ -867,6 +867,14 @@ fn sample_main_thread(current_state: &str, materialized: &str) -> Thread {
     }
 }
 
+const ATOMIC_RECORD_THREAD: &str = "atomic-record-test";
+
+fn sample_atomic_record_thread(current_state: &str, materialized: &str) -> Thread {
+    let mut record = sample_main_thread(current_state, materialized);
+    record.thread = ATOMIC_RECORD_THREAD.to_string();
+    record
+}
+
 fn encode_thread_record_set(manager: &ThreadManager, records: &[Thread]) -> Vec<Vec<u8>> {
     records
         .iter()
@@ -1106,7 +1114,7 @@ fn step_nonatomic_restores_record_and_workspace_on_save_failure() {
 
     // R0: the prior persisted record (record half: current_state; workspace
     // half: materialized_path).
-    let r0 = sample_main_thread("current-A", "/work/A");
+    let r0 = sample_atomic_record_thread("current-A", "/work/A");
     manager.save(&r0).unwrap();
 
     // R1: what the (faulted) save writes — different in BOTH halves.
@@ -1118,7 +1126,10 @@ fn step_nonatomic_restores_record_and_workspace_on_save_failure() {
         with_nonatomic_forward_fault(0, || repo::atomic::execute(&repo, SaveOnly { record: r1 }));
     assert!(result.is_err(), "the injected save fault must fail the op");
 
-    let restored = manager.find_by_thread("main").unwrap().unwrap();
+    let restored = manager
+        .find_by_thread(ATOMIC_RECORD_THREAD)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         restored.current_state.as_deref(),
         Some("current-A"),
@@ -1144,8 +1155,8 @@ fn step_nonatomic_restores_replacement_save_deleting_leaked_new_record() {
     let repo = Repository::init_default(temp.path()).unwrap();
     let manager = ThreadManager::new(repo.heddle_dir());
 
-    // R0: the prior persisted record for thread "main".
-    let mut r0 = sample_main_thread("current-A", "/work/A");
+    // R0: the prior persisted record for the isolated test thread.
+    let mut r0 = sample_atomic_record_thread("current-A", "/work/A");
     r0.id = "thread-main-v1".to_string();
     r0.updated_at = chrono::Utc::now();
     manager.save(&r0).unwrap();
@@ -1165,13 +1176,21 @@ fn step_nonatomic_restores_replacement_save_deleting_leaked_new_record() {
         manager.load("thread-main-v2").unwrap().is_none(),
         "the leaked new_id record must be deleted on rollback"
     );
-    let remaining = manager.list().unwrap();
+    let remaining: Vec<_> = manager
+        .list()
+        .unwrap()
+        .into_iter()
+        .filter(|record| record.thread == ATOMIC_RECORD_THREAD)
+        .collect();
     assert_eq!(
         remaining.len(),
         1,
         "only the prior record survives for the thread, no leaked newer record"
     );
-    let restored = manager.find_by_thread("main").unwrap().unwrap();
+    let restored = manager
+        .find_by_thread(ATOMIC_RECORD_THREAD)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         restored.id, "thread-main-v1",
         "find_by_thread returns ONLY prev"
@@ -1188,7 +1207,7 @@ fn step_nonatomic_create_save_rollback_removes_created_record() {
     let repo = Repository::init_default(temp.path()).unwrap();
     let manager = ThreadManager::new(repo.heddle_dir());
 
-    let mut created = sample_main_thread("current-A", "/work/A");
+    let mut created = sample_atomic_record_thread("current-A", "/work/A");
     created.id = "thread-main-new".to_string();
 
     let result = with_nonatomic_forward_fault(0, || {
@@ -1201,7 +1220,10 @@ fn step_nonatomic_create_save_rollback_removes_created_record() {
         "the created record must be removed on rollback"
     );
     assert!(
-        manager.find_by_thread("main").unwrap().is_none(),
+        manager
+            .find_by_thread(ATOMIC_RECORD_THREAD)
+            .unwrap()
+            .is_none(),
         "no record survives for a rolled-back create save"
     );
 }
@@ -1251,8 +1273,8 @@ fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
     let repo = Repository::init_default(temp.path()).unwrap();
     let manager = ThreadManager::new(repo.heddle_dir());
 
-    // R0: the prior persisted record for thread "main".
-    let mut r0 = sample_main_thread("current-A", "/work/A");
+    // R0: the prior persisted record for the isolated test thread.
+    let mut r0 = sample_atomic_record_thread("current-A", "/work/A");
     r0.id = "thread-main-v1".to_string();
     r0.updated_at = chrono::Utc::now();
     manager.save(&r0).unwrap();
@@ -1265,10 +1287,18 @@ fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
     snap_rec.current_state = Some("current-B".to_string());
     snap_rec.updated_at = r0.updated_at + chrono::Duration::seconds(60);
     manager.save(&snap_rec).unwrap();
-    let snapshot = manager.snapshot_thread_record("main").unwrap().unwrap();
+    let snapshot = manager
+        .snapshot_thread_record(ATOMIC_RECORD_THREAD)
+        .unwrap()
+        .unwrap();
     manager.delete("thread-main-v2").unwrap();
     assert_eq!(
-        manager.list().unwrap().len(),
+        manager
+            .list()
+            .unwrap()
+            .iter()
+            .filter(|record| record.thread == ATOMIC_RECORD_THREAD)
+            .count(),
         1,
         "precondition: only the prior record exists at capture time"
     );
@@ -1277,7 +1307,7 @@ fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
         repo::atomic::execute(
             &repo,
             RestoreSnapshotOnly {
-                name: "main".to_string(),
+                name: ATOMIC_RECORD_THREAD.to_string(),
                 bytes: snapshot,
             },
         )
@@ -1292,11 +1322,19 @@ fn step_nonatomic_restores_redo_snapshot_deleting_leaked_record() {
         "the leaked snapshot-id record must be deleted on rollback"
     );
     assert_eq!(
-        manager.list().unwrap().len(),
+        manager
+            .list()
+            .unwrap()
+            .iter()
+            .filter(|record| record.thread == ATOMIC_RECORD_THREAD)
+            .count(),
         1,
         "only the prior record survives, no leaked newer record"
     );
-    let restored = manager.find_by_thread("main").unwrap().unwrap();
+    let restored = manager
+        .find_by_thread(ATOMIC_RECORD_THREAD)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         restored.id, "thread-main-v1",
         "find_by_thread returns ONLY prev"
@@ -1319,16 +1357,19 @@ fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
     let manager = ThreadManager::new(repo.heddle_dir());
 
     // The record the redo snapshot will restore (older timestamp).
-    let mut to_restore = sample_main_thread("current-restored", "/work/R");
+    let mut to_restore = sample_atomic_record_thread("current-restored", "/work/R");
     to_restore.id = "rec-restored".to_string();
     to_restore.updated_at = chrono::Utc::now();
     manager.save(&to_restore).unwrap();
-    let snapshot = manager.snapshot_thread_record("main").unwrap().unwrap();
+    let snapshot = manager
+        .snapshot_thread_record(ATOMIC_RECORD_THREAD)
+        .unwrap()
+        .unwrap();
     manager.delete("rec-restored").unwrap();
 
     // A pre-existing DUPLICATE under the same name with a NEWER timestamp, so
     // a raw-save redo would leave it winning `find_by_thread`.
-    let mut dup = sample_main_thread("current-dup", "/work/D");
+    let mut dup = sample_atomic_record_thread("current-dup", "/work/D");
     dup.id = "rec-dup".to_string();
     dup.updated_at = to_restore.updated_at + chrono::Duration::seconds(60);
     manager.save(&dup).unwrap();
@@ -1337,7 +1378,7 @@ fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
             .list()
             .unwrap()
             .iter()
-            .filter(|t| t.thread == "main")
+            .filter(|t| t.thread == ATOMIC_RECORD_THREAD)
             .count(),
         1,
         "precondition: only the duplicate is filed at redo time"
@@ -1347,7 +1388,7 @@ fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
     repo::atomic::execute(
         &repo,
         RestoreSnapshotOnly {
-            name: "main".to_string(),
+            name: ATOMIC_RECORD_THREAD.to_string(),
             bytes: snapshot,
         },
     )
@@ -1357,7 +1398,7 @@ fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
         .list()
         .unwrap()
         .into_iter()
-        .filter(|t| t.thread == "main")
+        .filter(|t| t.thread == ATOMIC_RECORD_THREAD)
         .collect();
     assert_eq!(
         under_name.len(),
@@ -1366,7 +1407,11 @@ fn redo_restore_thread_record_converges_away_preexisting_duplicate() {
     );
     assert_eq!(under_name[0].id, "rec-restored");
     assert_eq!(
-        manager.find_by_thread("main").unwrap().unwrap().id,
+        manager
+            .find_by_thread(ATOMIC_RECORD_THREAD)
+            .unwrap()
+            .unwrap()
+            .id,
         "rec-restored",
         "find_by_thread returns the restored record, not the leaked duplicate"
     );
@@ -1419,17 +1464,22 @@ fn remove_thread_manager_record_converges_name_to_empty() {
     let repo = Repository::init_default(temp.path()).unwrap();
     let manager = ThreadManager::new(repo.heddle_dir());
 
-    // Two records under "main": a winner (newer) + an older duplicate.
-    let mut winner = sample_main_thread("current-A", "/work/A");
+    // Two records under the isolated test thread: a winner + an older duplicate.
+    let mut winner = sample_atomic_record_thread("current-A", "/work/A");
     winner.id = "rec-winner".to_string();
     winner.updated_at = chrono::Utc::now();
     manager.save(&winner).unwrap();
-    let mut older = sample_main_thread("current-B", "/work/B");
+    let mut older = sample_atomic_record_thread("current-B", "/work/B");
     older.id = "rec-older".to_string();
     older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
     manager.save(&older).unwrap();
     assert_eq!(
-        manager.list().unwrap().len(),
+        manager
+            .list()
+            .unwrap()
+            .iter()
+            .filter(|record| record.thread == ATOMIC_RECORD_THREAD)
+            .count(),
         2,
         "precondition: two records"
     );
@@ -1437,17 +1487,24 @@ fn remove_thread_manager_record_converges_name_to_empty() {
     repo::atomic::execute(
         &repo,
         RemoveRecordOnly {
-            name: "main".to_string(),
+            name: ATOMIC_RECORD_THREAD.to_string(),
         },
     )
     .unwrap();
 
     assert!(
-        manager.find_by_thread("main").unwrap().is_none(),
+        manager
+            .find_by_thread(ATOMIC_RECORD_THREAD)
+            .unwrap()
+            .is_none(),
         "converge-to-empty: no record survives under the name"
     );
     assert!(
-        manager.list().unwrap().iter().all(|t| t.thread != "main"),
+        manager
+            .list()
+            .unwrap()
+            .iter()
+            .all(|t| t.thread != ATOMIC_RECORD_THREAD),
         "EVERY same-name record removed, not just the find_by_thread winner"
     );
 }
@@ -1465,11 +1522,11 @@ fn remove_thread_manager_record_rollback_resaves_all_records() {
     let repo = Repository::init_default(temp.path()).unwrap();
     let manager = ThreadManager::new(repo.heddle_dir());
 
-    let mut winner = sample_main_thread("current-A", "/work/A");
+    let mut winner = sample_atomic_record_thread("current-A", "/work/A");
     winner.id = "rec-winner".to_string();
     winner.updated_at = chrono::Utc::now();
     manager.save(&winner).unwrap();
-    let mut older = sample_main_thread("current-B", "/work/B");
+    let mut older = sample_atomic_record_thread("current-B", "/work/B");
     older.id = "rec-older".to_string();
     older.updated_at = winner.updated_at - chrono::Duration::seconds(60);
     manager.save(&older).unwrap();
@@ -1481,7 +1538,7 @@ fn remove_thread_manager_record_rollback_resaves_all_records() {
         repo::atomic::execute(
             &repo,
             RemoveRecordOnly {
-                name: "main".to_string(),
+                name: ATOMIC_RECORD_THREAD.to_string(),
             },
         )
     });
@@ -1490,7 +1547,12 @@ fn remove_thread_manager_record_rollback_resaves_all_records() {
         "the injected forward fault must fail the op"
     );
 
-    let remaining = manager.list().unwrap();
+    let remaining: Vec<_> = manager
+        .list()
+        .unwrap()
+        .into_iter()
+        .filter(|record| record.thread == ATOMIC_RECORD_THREAD)
+        .collect();
     assert_eq!(
         remaining.len(),
         2,
@@ -1502,7 +1564,11 @@ fn remove_thread_manager_record_rollback_resaves_all_records() {
         "both the winner and the older duplicate were restored"
     );
     assert_eq!(
-        manager.find_by_thread("main").unwrap().unwrap().id,
+        manager
+            .find_by_thread(ATOMIC_RECORD_THREAD)
+            .unwrap()
+            .unwrap()
+            .id,
         "rec-winner",
         "find_by_thread still selects the newer winner after rollback"
     );

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -2844,7 +2844,11 @@ fn load_thread_metadata(
     local_state: StateId,
 ) -> Result<Option<SyncedThreadMetadata>, ProtocolError> {
     let thread_manager = ThreadManager::new(repo.heddle_dir());
-    Ok(thread_manager.find_synced_record_by_thread(repo, target_thread, Some(local_state))?)
+    Ok(thread_manager.find_or_materialize_synced_record_by_thread(
+        repo,
+        target_thread,
+        Some(local_state),
+    )?)
 }
 
 fn first_blob_path_in_state(
@@ -3795,7 +3799,10 @@ mod native_exchange_tests {
             crate::hosted_runtime::hosted::test_server::start_recording_push().await;
         let source = TempDir::new().unwrap();
         let (repo, state) = repository(&source);
-        let record = save_thread_record(&repo, state, "thread-stable-01", "main");
+        let record = ThreadManager::new(repo.heddle_dir())
+            .find_synced_record_by_thread(&repo, "main", Some(state))
+            .unwrap()
+            .expect("init_default must persist main thread metadata");
 
         let pushed = client
             .push_with_expected_head_profiled(
@@ -3838,7 +3845,7 @@ mod native_exchange_tests {
         assert_eq!(metadata.current_state, request.local_state);
         assert_eq!(
             metadata.thread_mode,
-            ProtoThreadMode::Solid as i32,
+            ProtoThreadMode::Materialized as i32,
             "weft must be able to parse the local thread mode"
         );
         assert_eq!(
@@ -3846,6 +3853,71 @@ mod native_exchange_tests {
             ProtoThreadState::ThreadStateActive as i32,
             "weft must be able to parse the local lifecycle state"
         );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn legacy_ref_only_main_push_materializes_once_and_reuses_stable_identity() {
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_push().await;
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let manager = ThreadManager::new(repo.heddle_dir());
+        if let Some(existing) = manager.find_by_thread("main").unwrap() {
+            manager.delete(&existing.id).unwrap();
+        }
+        assert!(
+            manager
+                .find_synced_record_by_thread(&repo, "main", Some(state))
+                .unwrap()
+                .is_none(),
+            "fixture must match a legacy ref-only main thread"
+        );
+
+        for operation_id in ["legacy-main-push-1", "legacy-main-push-2"] {
+            let pushed = client
+                .push_with_expected_head_profiled(
+                    &repo,
+                    "acme/widgets",
+                    state,
+                    "main",
+                    false,
+                    ExpectedRemoteHead::Missing,
+                    operation_id.to_string(),
+                )
+                .await
+                .unwrap()
+                .0;
+            assert!(!pushed.success);
+        }
+
+        let requests = captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone();
+        assert_eq!(requests.len(), 2);
+        let first_metadata = requests[0]
+            .thread_metadata
+            .as_ref()
+            .expect("first legacy main push must carry materialized metadata");
+        let second_metadata = requests[1]
+            .thread_metadata
+            .as_ref()
+            .expect("second legacy main push must reuse materialized metadata");
+        assert_eq!(first_metadata.name, second_metadata.name);
+        assert_eq!(requests[0].target_thread, "main");
+        assert_eq!(requests[1].target_thread, "main");
+        assert_eq!(first_metadata.current_state, requests[0].local_state);
+        assert_eq!(second_metadata.current_state, requests[1].local_state);
+
+        let persisted = manager
+            .find_synced_record_by_thread(&repo, "main", Some(state))
+            .unwrap()
+            .expect("legacy main metadata must be persisted after the first push");
+        assert_eq!(persisted.id, first_metadata.name);
+        assert_eq!(persisted.thread, "main");
 
         client.close().await;
         server.await.unwrap();
@@ -3863,17 +3935,16 @@ mod native_exchange_tests {
                 &repo,
                 "acme/widgets",
                 state,
-                "main",
+                "missing",
                 false,
                 ExpectedRemoteHead::Missing,
                 "missing-local-metadata-test-op".to_string(),
             )
             .await
             .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("no local thread record with a stable identity")
+        assert_eq!(
+            error.to_string(),
+            "invalid state: native push target 'missing' has no local thread record with a stable identity"
         );
         assert!(
             captured

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -127,8 +127,6 @@ mod repository_operation_status;
 pub use repository_operation_status::{OperationKind, OperationScope, RepositoryOperationStatus};
 #[path = "repository_identity.rs"]
 mod repository_identity;
-pub use repository_identity::is_synthetic_root;
-use repository_identity::seed_principal;
 #[cfg(test)]
 use discovery::bounded_ancestor_paths_with_device;
 #[cfg(test)]
@@ -143,6 +141,8 @@ use overlay::{GitHeadState, detect_git_head_state, detect_git_in_progress_branch
 pub use overlay::{
     GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitOverlayShortStatus, GitOverlayTagTip,
 };
+pub use repository_identity::is_synthetic_root;
+use repository_identity::seed_principal;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepositoryCapability {
@@ -807,10 +807,11 @@ impl Repository {
 
     /// Seed a `main` thread pointing at an empty-tree root state.
     ///
-    /// The seeded state is written to the object store and pointed at by the
-    /// `main` thread ref, but is deliberately NOT recorded in the oplog: `init`
-    /// is a point-of-creation event, not user work, and should not be
-    /// undoable. No-op if `main` already exists.
+    /// The seeded state is written to the object store, pointed at by the
+    /// `main` thread ref, and given a stable persisted thread record. It is
+    /// deliberately NOT recorded in the oplog: `init` is a point-of-creation
+    /// event, not user work, and should not be undoable. If `main` already
+    /// exists, its missing legacy record is materialized without moving the ref.
     ///
     /// The seed state uses a stable `Heddle <init@heddle>` attribution
     /// instead of the user's principal because the user's principal may
@@ -821,15 +822,24 @@ impl Repository {
     /// user-facing log output (see `repository_history::is_synthetic_root`).
     pub fn seed_default_thread(&self) -> Result<()> {
         let main_thread = ThreadName::from("main");
-        if self.refs.get_thread(&main_thread)?.is_some() {
-            return Ok(());
+        if self.refs.get_thread(&main_thread)?.is_none() {
+            let empty_tree = Tree::new();
+            let tree_hash = self.store.put_tree(&empty_tree)?;
+            let state =
+                State::new_snapshot(tree_hash, vec![], Attribution::human(seed_principal()));
+            self.store.put_state(&state)?;
+            self.refs.set_thread(&main_thread, &state.id())?;
         }
 
-        let empty_tree = Tree::new();
-        let tree_hash = self.store.put_tree(&empty_tree)?;
-        let state = State::new_snapshot(tree_hash, vec![], Attribution::human(seed_principal()));
-        self.store.put_state(&state)?;
-        self.refs.set_thread(&main_thread, &state.id())?;
+        let manager = crate::ThreadManager::new(self.heddle_dir());
+        if manager
+            .find_or_materialize_synced_record_by_thread(self, "main", None)?
+            .is_none()
+        {
+            return Err(HeddleError::Config(
+                "default main thread ref disappeared while persisting its record".to_string(),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -32,6 +32,40 @@ fn create_test_repo() -> (TempDir, Repository) {
 }
 
 #[test]
+fn init_default_persists_and_reuses_stable_main_thread_record() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let main_state = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .unwrap()
+        .expect("init_default must seed the main ref");
+    let manager = ThreadManager::new(repo.heddle_dir());
+
+    let first = manager
+        .find_synced_record_by_thread(&repo, "main", Some(main_state))
+        .unwrap()
+        .expect("init_default must persist main thread metadata");
+    assert!(uuid::Uuid::parse_str(&first.id).is_ok());
+    assert_eq!(first.thread, "main");
+    assert_eq!(
+        first.current_state.as_deref(),
+        Some(main_state.to_string_full().as_str())
+    );
+
+    drop(repo);
+    let reopened = Repository::open(temp_dir.path()).unwrap();
+    let second = ThreadManager::new(reopened.heddle_dir())
+        .find_or_materialize_synced_record_by_thread(&reopened, "main", Some(main_state))
+        .unwrap()
+        .expect("reopening must reuse the persisted main thread metadata");
+    assert_eq!(
+        second.id, first.id,
+        "main's stable id must not be regenerated"
+    );
+}
+
+#[test]
 fn snapshot_modify_then_revert_keeps_epoch_anchor_readable_after_reopen() {
     let (temp_dir, repo) = create_test_repo();
     for index in 0..128 {

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Thread storage and lifecycle management.
 
-use schemars::JsonSchema;
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -10,11 +9,13 @@ use std::{
 use chrono::{DateTime, Utc};
 use objects::{
     lock::RepoLock,
-    object::StateId,
+    object::{StateId, ThreadName},
     store::{HeddleError, ObjectStore, Result},
 };
+use schemars::JsonSchema;
 
 use crate::{
+    summarize_confidence, summarize_verification,
     thread_model::{
         EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadImpactCategory,
         ThreadIntegrationPolicy, ThreadMode, ThreadRecord, ThreadRuntimeOverlay, ThreadState,
@@ -401,17 +402,15 @@ impl ThreadManager {
     }
 
     pub fn find_record_by_thread(&self, thread: &str) -> Result<Option<ThreadRecord>> {
-        let mut records = self
-            .list_records()?
+        Ok(self
+            .list_record_files()?
             .into_iter()
             .filter(|record| record.thread == thread)
-            .collect::<Vec<_>>();
-        records.sort_by(|a, b| {
-            a.updated_at
-                .cmp(&b.updated_at)
-                .then_with(|| a.id.cmp(&b.id))
-        });
-        Ok(records.pop())
+            .max_by(|a, b| {
+                a.updated_at
+                    .cmp(&b.updated_at)
+                    .then_with(|| a.id.cmp(&b.id))
+            }))
     }
 
     pub fn find_synced_record_by_thread(
@@ -423,6 +422,75 @@ impl ThreadManager {
         self.find_record_by_thread(thread)?
             .map(|record| SyncedThreadMetadata::from_record(repo, &record, current_state_override))
             .transpose()
+    }
+
+    /// Return persisted sync metadata for `thread`, materializing it once when
+    /// a real local ref predates the thread-record store.
+    ///
+    /// The second lookup under the record lock closes the race between two
+    /// pushes that both observe a legacy ref-only thread. Exactly one UUID is
+    /// persisted; every later metadata build reuses that stable identity.
+    pub fn find_or_materialize_synced_record_by_thread(
+        &self,
+        repo: &crate::Repository,
+        thread: &str,
+        current_state_override: Option<StateId>,
+    ) -> Result<Option<SyncedThreadMetadata>> {
+        if let Some(record) = self.find_record_by_thread(thread)? {
+            return SyncedThreadMetadata::from_record(repo, &record, current_state_override)
+                .map(Some);
+        }
+
+        let _lock = self.write_lock()?;
+        if let Some(record) = self.find_record_by_thread(thread)? {
+            return SyncedThreadMetadata::from_record(repo, &record, current_state_override)
+                .map(Some);
+        }
+
+        let Some(ref_state) = repo.refs().get_thread(&ThreadName::from(thread))? else {
+            return Ok(None);
+        };
+        let state = repo.store().get_state(&ref_state)?.ok_or_else(|| {
+            HeddleError::NotFound(format!(
+                "thread '{thread}' points to missing state {}",
+                ref_state.to_string_full()
+            ))
+        })?;
+        let now = Utc::now();
+        let materialized = Thread {
+            id: uuid::Uuid::now_v7().to_string(),
+            thread: thread.to_string(),
+            target_thread: None,
+            parent_thread: None,
+            mode: ThreadMode::Materialized,
+            state: ThreadState::Active,
+            base_state: ref_state.to_string_full(),
+            base_root: state.tree.to_hex(),
+            current_state: Some(ref_state.to_string_full()),
+            merged_state: None,
+            task: None,
+            execution_path: repo.root().to_path_buf(),
+            materialized_path: None,
+            changed_paths: Vec::new(),
+            impact_categories: Vec::new(),
+            heavy_impact_paths: Vec::new(),
+            promotion_suggested: false,
+            freshness: ThreadFreshness::Current,
+            verification_summary: summarize_verification(state.verification.as_ref()),
+            confidence_summary: summarize_confidence(state.confidence),
+            integration_policy_result: ThreadIntegrationPolicy::default(),
+            created_at: now,
+            updated_at: now,
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        };
+        let record = materialized.to_record();
+        self.save_record_file(&record)?;
+        objects::fault_inject::maybe_fail_at("thread_manager_save_before_workspace")?;
+        self.save_workspace_file(&materialized.id, &materialized.workspace_state())?;
+
+        SyncedThreadMetadata::from_record(repo, &record, current_state_override).map(Some)
     }
 
     pub fn delete_record(&self, record_id: &str) -> Result<()> {


### PR DESCRIPTION
Closes #1638

## Summary
- atomically materialize a persisted UUIDv7 ThreadRecord when a real local thread ref has no record
- seed fresh main refs through the same materialization path
- lazily backfill legacy ref-only threads during native-push metadata loading
- retain the fail-closed guard for targets with no real local ref

## Verification
- cargo build -p heddle-repo -p heddle-hosted-client --features heddle-hosted-client/client
- cargo test -p heddle-repo
- cargo test -p heddle-hosted-client --features client
- cargo clippy --workspace --all-targets -- -D warnings
- rustfmt +nightly --edition 2024 on touched files
- revert-and-watch-fail: removing the push fallback reproduces InvalidState("native push target main has no local thread record with a stable identity"); restoring it builds two consecutive metadata requests with the same persisted id

## Follow-up
The live weft + Postgres e2e (including hosted_thread_records persistence across two pushes) remains tracked by #1634; it is not reachable from this sandbox.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790883696&installation_model_id=21489&pr_number=1639&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1639&signature=b65fe292254a2cc79456006d758e33a3dcd5ff893efc92198add05f9511e4509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->