### PR TITLE
fix(discuss): persist Discussions attachment so hosted pull can resolve

### DIFF
--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -101,6 +101,17 @@ fn open_store(repo: &repo::Repository) -> Result<CollaborationStore> {
     Ok(store)
 }
 
+/// Hosted pull bootstrap reads `StateAttachmentKind::Discussions` on the tip.
+/// Persist the live op-log onto HEAD so `heddle push` can emit the attachment.
+fn persist_tip_discussions_snapshot(repo: &repo::Repository) -> Result<()> {
+    let Some(state_id) = repo.head().context("resolve HEAD for discussion snapshot")? else {
+        return Ok(());
+    };
+    repo.persist_discussions_snapshot(state_id)
+        .context("persist discussions snapshot for push")?;
+    Ok(())
+}
+
 fn run_open(
     cli: &Cli,
     repo: &repo::Repository,
@@ -140,6 +151,7 @@ fn run_open(
         },
     )?;
     let outcome = store.write_operation(&operation)?;
+    persist_tip_discussions_snapshot(repo)?;
     emit_locality_notice_once(repo, AnnotationSurface::Discuss);
     emit_write(cli, "discuss_open", store, discussion_id, outcome)
 }
@@ -269,6 +281,7 @@ fn write_descendant(
         body,
     )?;
     let outcome = store.write_operation(&operation)?;
+    persist_tip_discussions_snapshot(repo)?;
     emit_write(cli, output_kind, store, discussion_id, outcome)
 }
 

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -9,7 +9,8 @@
 //! * **Push (write path):** after a successful `heddle push`, replay local
 //!   symbol-anchored discussion turns *we authored* to the server via the
 //!   caller-authenticated `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode
-//!   signed). #549 rejects attachments in the pack, so they cannot ride it.
+//!   signed). The per-state `Discussions` snapshot attachment rides the
+//!   out-of-pack sidecar (weft#549 rejects attachments in the push pack).
 //! * **Pull/clone (read path):** after a successful clone/pull, consume the
 //!   pull bootstrap's discussions when present, falling back to `ListByState`
 //!   for older servers, and materialize unseen turns into the local op-log.

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -906,6 +906,12 @@ impl HostedClient {
             |expected| native_push_boundaries_from_expected_head(repo, expected, local_state),
         )?;
         profile.remote_ref_discovery = remote_ref_discovery_started.elapsed();
+        // Discussions live in the op-log. Fold them onto the pushed tip before
+        // closure planning so the sidecar lane advertises
+        // `StateAttachmentKind::Discussions` + blob (exact-tip push included).
+        // Pull bootstrap fail-closes if weft sets `discussions_from_pack`
+        // without this attachment.
+        repo.persist_discussions_snapshot(local_state)?;
         let closure_planning_started = std::time::Instant::now();
         let closure = if native_boundaries.is_empty() {
             wire::enumerate_state_closure_transfer_with_options(
@@ -3537,6 +3543,87 @@ mod pull_bootstrap_tests {
 
         assert_eq!(resolved.discussions, vec![discussion]);
         assert_eq!(resolved.context, vec![(target, context_blob)]);
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_when_discussions_attachment_is_missing() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        let snapshot = repo
+            .snapshot(Some("seed".to_string()), None)
+            .expect("snapshot");
+
+        let error = PullBootstrapMetadata {
+            discussions_from_pack: true,
+            discussions: Vec::new(),
+            context_from_pack: false,
+            context: Vec::new(),
+        }
+        .resolve(&repo, Some(snapshot.state_id))
+        .expect_err("missing packed discussions must fail closed");
+
+        assert!(
+            error.to_string().contains(
+                "pull bootstrap advertised packed discussions but the attachment is missing"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn persist_then_resolve_reads_op_log_discussions_from_the_pack_attachment() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        let snapshot = repo
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                Attribution::human(Principal::new("Ada", "ada@example.com")),
+            )
+            .expect("snapshot");
+        let store = repo::CollaborationStore::open(repo.heddle_dir()).expect("open collab");
+        let discussion_id = objects::object::DiscussionRecordId::generate();
+        store
+            .write_operation(
+                &objects::object::CollaborationOperationEnvelope::new(
+                    discussion_id,
+                    Vec::new(),
+                    objects::object::CollaborationIdempotencyKey::new("open-1").unwrap(),
+                    Attribution::human(Principal::new("Ada", "ada@example.com")),
+                    1_700_000_000_000,
+                    objects::object::CollaborationOperationBodyV1::Open {
+                        title: "run".to_string(),
+                        anchor: objects::object::CollaborationAnchor::Symbol {
+                            state_id: snapshot.state_id,
+                            path: "lib.rs".to_string(),
+                            symbol: "run".to_string(),
+                        },
+                        visibility: VisibilityTier::Internal,
+                        turn: objects::object::DiscussionTurnV1::new("keep this invariant")
+                            .unwrap(),
+                        thread_ref: Some("alice".to_string()),
+                    },
+                )
+                .unwrap(),
+            )
+            .expect("write open");
+        repo.persist_discussions_snapshot(snapshot.state_id)
+            .expect("persist snapshot")
+            .expect("snapshot hash");
+
+        let resolved = PullBootstrapMetadata {
+            discussions_from_pack: true,
+            discussions: Vec::new(),
+            context_from_pack: false,
+            context: Vec::new(),
+        }
+        .resolve(&repo, Some(snapshot.state_id))
+        .expect("resolve packed bootstrap after persist");
+        assert_eq!(resolved.discussions.len(), 1);
+        assert_eq!(resolved.discussions[0].id, discussion_id.to_string());
+        assert_eq!(resolved.discussions[0].turns[0].body, "keep this invariant");
     }
 }
 
@@ -6231,6 +6318,112 @@ mod attachment_sidecar_tests {
         assert_eq!(transfer.attachment_object, canonical.data);
         assert!(!ObjectType::StateAttachment.packable_for_push());
         assert!(ObjectType::StateAttachment.packable_for_pull());
+    }
+
+    #[test]
+    fn discussions_snapshot_is_advertised_and_emits_sidecar_carrier() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        let snapshot = repo
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                Attribution::human(Principal::new("Ada", "ada@example.com")),
+            )
+            .expect("snapshot");
+        let store = repo::CollaborationStore::open(repo.heddle_dir()).expect("open collab");
+        store
+            .write_operation(
+                &objects::object::CollaborationOperationEnvelope::new(
+                    objects::object::DiscussionRecordId::generate(),
+                    Vec::new(),
+                    objects::object::CollaborationIdempotencyKey::new("open-1").unwrap(),
+                    Attribution::human(Principal::new("Ada", "ada@example.com")),
+                    1_700_000_000_000,
+                    objects::object::CollaborationOperationBodyV1::Open {
+                        title: "run".to_string(),
+                        anchor: objects::object::CollaborationAnchor::Symbol {
+                            state_id: snapshot.state_id,
+                            path: "lib.rs".to_string(),
+                            symbol: "run".to_string(),
+                        },
+                        visibility: objects::object::VisibilityTier::Internal,
+                        turn: objects::object::DiscussionTurnV1::new("review this").unwrap(),
+                        thread_ref: Some("alice".to_string()),
+                    },
+                )
+                .unwrap(),
+            )
+            .expect("write open");
+        let hash = repo
+            .persist_discussions_snapshot(snapshot.state_id)
+            .expect("persist")
+            .expect("hash");
+        let attachment = repo
+            .latest_state_attachment(&snapshot.state_id, objects::object::StateAttachmentKind::Discussions)
+            .expect("list")
+            .expect("attachment");
+
+        let transfer = wire::enumerate_state_closure_transfer_with_options(
+            repo.store(),
+            snapshot.state_id,
+            wire::StateClosureOptions::default(),
+            512,
+        )
+        .expect("plan push closure");
+        let planned = transfer.planned_objects;
+        assert!(
+            planned.iter().any(|object| {
+                matches!(
+                    (&object.id, object.obj_type),
+                    (
+                        wire::ObjectId::StateAttachment {
+                            kind: objects::object::StateAttachmentKind::Discussions,
+                            ..
+                        },
+                        ObjectType::StateAttachment
+                    )
+                )
+            }),
+            "push plan must advertise the Discussions attachment: {planned:?}"
+        );
+        assert!(
+            planned.iter().any(|object| {
+                matches!(
+                    (&object.id, object.obj_type),
+                    (wire::ObjectId::Hash(blob), ObjectType::Blob) if *blob == hash
+                )
+            }),
+            "push plan must advertise the Discussions blob: {planned:?}"
+        );
+
+        let id = ObjectId::StateAttachment {
+            state: snapshot.state_id,
+            id: attachment.id(),
+            kind: attachment.body.kind(),
+        };
+        let canonical = wire::load_object_data(repo.store(), &id, ObjectType::StateAttachment)
+            .expect("load canonical attachment");
+        let message = sidecar_push_message(
+            &repo,
+            ObjectInfo {
+                id,
+                obj_type: ObjectType::StateAttachment,
+                size: canonical.data.len() as u64,
+                delta_base: None,
+            },
+            "op-discuss",
+        )
+        .expect("build attachment sidecar");
+        let Some(push_client_frame::Frame::StateAttachment(transfer)) = message.frame else {
+            panic!("expected StateAttachmentTransfer")
+        };
+        assert_eq!(
+            transfer.attachment_kind,
+            ProtoStateAttachmentKind::Discussions as i32
+        );
+        assert_eq!(transfer.attachment_object, canonical.data);
     }
 }
 

--- a/crates/repo/src/discussion_snapshot.rs
+++ b/crates/repo/src/discussion_snapshot.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Persist the live collaboration op-log as a per-state `Discussions` attachment.
+//!
+//! Local discussions live in `.heddle/collaboration`. Hosted pull bootstrap
+//! (`discussions_from_pack`) reads `StateAttachmentKind::Discussions` on the
+//! pulled tip. This snapshot is how they travel over `heddle push` / `heddle
+//! pull` — they are not Git-projected.
+
+use chrono::Utc;
+use objects::{
+    object::{
+        Blob, CollaborationAnchor, CollaborationAnchorStatus, CollaborationResolution,
+        ContentHash, Discussion, DiscussionResolution, DiscussionTurn, DiscussionsBlob,
+        MaterializedDiscussion, StateAttachment, StateAttachmentBody, StateId, SymbolAnchor,
+    },
+    store::ObjectStore,
+};
+use oplog::OpLogBackend;
+use refs::RefBackend;
+
+use crate::{CollaborationStore, HeddleError, Repository, Result, StateAttachmentKind};
+
+impl<R, O, S> Repository<R, O, S>
+where
+    R: RefBackend,
+    O: OpLogBackend,
+    S: ObjectStore,
+{
+    /// Encode current symbol-anchored discussions as a blob and attach it to
+    /// `state_id`. Returns the blob hash when a snapshot was written, or `None`
+    /// when the op-log has nothing to send.
+    pub fn persist_discussions_snapshot(&self, state_id: StateId) -> Result<Option<ContentHash>> {
+        let Some(hash) = self.encode_collaboration_discussions_blob()? else {
+            return Ok(None);
+        };
+        let prior = self.latest_state_attachment(&state_id, StateAttachmentKind::Discussions)?;
+        if let Some(prior_attachment) = &prior {
+            if let StateAttachmentBody::Discussions(existing) = &prior_attachment.body {
+                if *existing == hash {
+                    return Ok(Some(hash));
+                }
+            }
+        }
+        if !self.store().has_state(&state_id)? {
+            return Err(HeddleError::StateNotFound(state_id));
+        }
+        let state = self
+            .store()
+            .get_state(&state_id)?
+            .ok_or(HeddleError::StateNotFound(state_id))?;
+        let created_at = prior
+            .as_ref()
+            .map(|attachment| attachment.created_at + chrono::Duration::nanoseconds(1))
+            .map_or_else(Utc::now, |minimum| minimum.max(Utc::now()));
+        self.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: state.attribution.clone(),
+            created_at,
+            supersedes: prior.map(|attachment| attachment.id()),
+        })?;
+        Ok(Some(hash))
+    }
+
+    /// Encode the live op-log as a `DiscussionsBlob` without attaching it.
+    /// Snapshot travel uses the hash; push attaches it to the tip.
+    pub(crate) fn encode_collaboration_discussions_blob(
+        &self,
+    ) -> Result<Option<ContentHash>> {
+        if !self.heddle_dir().join("collaboration").exists() {
+            return Ok(None);
+        }
+        let store = CollaborationStore::open(self.heddle_dir())?;
+        let discussions = collaboration_discussions_blob(&store)?;
+        if discussions.is_empty() {
+            return Ok(None);
+        }
+        let bytes = DiscussionsBlob::new(discussions).encode().map_err(|err| {
+            HeddleError::Serialization(format!("encode discussions blob: {err}"))
+        })?;
+        Ok(Some(self.store().put_blob(&Blob::new(bytes))?))
+    }
+}
+
+fn collaboration_discussions_blob(store: &CollaborationStore) -> Result<Vec<Discussion>> {
+    let materialized = store.materialize()?;
+    let mut discussions = Vec::new();
+    for discussion in materialized.discussions.values() {
+        if let Some(converted) = discussion_from_materialized(store, discussion)? {
+            discussions.push(converted);
+        }
+    }
+    discussions.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(discussions)
+}
+
+fn discussion_from_materialized(
+    store: &CollaborationStore,
+    discussion: &MaterializedDiscussion,
+) -> Result<Option<Discussion>> {
+    let CollaborationAnchor::Symbol {
+        state_id,
+        path,
+        symbol,
+    } = &discussion.anchor
+    else {
+        return Ok(None);
+    };
+    let mut turns = Vec::with_capacity(discussion.turns.len());
+    let mut opened_at = 0i64;
+    for (index, (operation_id, turn)) in discussion.turns.iter().enumerate() {
+        let decoded = store.read_operation(operation_id)?.ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "discussion {} references missing operation {operation_id}",
+                discussion.discussion_id
+            ))
+        })?;
+        let posted_at = millis_to_secs(decoded.operation.occurred_at_ms);
+        if index == 0 {
+            opened_at = posted_at;
+        }
+        turns.push(DiscussionTurn {
+            author: decoded.operation.author.principal,
+            body: turn.body.clone(),
+            posted_at,
+            references: Vec::new(),
+        });
+    }
+    if turns.is_empty() {
+        return Ok(None);
+    }
+    let (resolution, resolved_annotation_id) = blob_resolution(&discussion.resolution);
+    Ok(Some(Discussion {
+        id: discussion.discussion_id.to_string(),
+        anchor: SymbolAnchor::new(path, symbol),
+        opened_against_state: *state_id,
+        opened_at,
+        thread_ref: discussion.thread_ref.clone(),
+        turns,
+        resolution,
+        body_changed_since_open: discussion.body_changed_since_open,
+        anchor_ambiguous: matches!(discussion.anchor_status, CollaborationAnchorStatus::Ambiguous),
+        orphaned: matches!(discussion.anchor_status, CollaborationAnchorStatus::Orphaned),
+        visibility: discussion.visibility.clone(),
+        resolved_annotation_id,
+    }))
+}
+
+fn blob_resolution(
+    resolution: &Option<CollaborationResolution>,
+) -> (DiscussionResolution, Option<String>) {
+    match resolution {
+        None => (DiscussionResolution::Open, None),
+        Some(CollaborationResolution::AddressedByState { state_id }) => {
+            (DiscussionResolution::ResolvedByEdit { state_id: *state_id }, None)
+        }
+        Some(CollaborationResolution::Dismissed { reason }) => (
+            DiscussionResolution::Dismissed {
+                reason: reason.clone(),
+            },
+            None,
+        ),
+        Some(CollaborationResolution::Annotation { annotation_id }) => (
+            DiscussionResolution::ResolvedIntoAnnotation {
+                annotation_id: annotation_id.clone(),
+            },
+            Some(annotation_id.clone()),
+        ),
+        // Hosted blob form has no ChangeId pin and cannot name an annotation
+        // that has not been minted yet. Keep the discussion visible as open.
+        Some(CollaborationResolution::AddressedByChange { .. })
+        | Some(CollaborationResolution::IntoAnnotation { .. }) => (DiscussionResolution::Open, None),
+    }
+}
+
+fn millis_to_secs(ms: i64) -> i64 {
+    if ms > 0 {
+        ms / 1000
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{
+        Attribution, CollaborationAnchor, CollaborationIdempotencyKey,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
+        DiscussionTurnV1, Principal, VisibilityTier,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_open(
+        repo: &Repository,
+        store: &CollaborationStore,
+        path: &str,
+        symbol: &str,
+        body: &str,
+        thread_ref: Option<&str>,
+    ) -> (DiscussionRecordId, StateId) {
+        let state_id = repo.head().unwrap().unwrap();
+        let discussion_id = DiscussionRecordId::generate();
+        let author = Attribution::human(Principal::new("Alice", "alice@example.com"));
+        let operation = CollaborationOperationEnvelope::new(
+            discussion_id,
+            Vec::new(),
+            CollaborationIdempotencyKey::new("open-1").unwrap(),
+            author,
+            1_700_000_000_000,
+            CollaborationOperationBodyV1::Open {
+                title: symbol.to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id,
+                    path: path.to_string(),
+                    symbol: symbol.to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new(body).unwrap(),
+                thread_ref: thread_ref.map(str::to_string),
+            },
+        )
+        .unwrap();
+        store.write_operation(&operation).unwrap();
+        (discussion_id, state_id)
+    }
+
+    #[test]
+    fn persist_writes_discussions_attachment_and_blob() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("greet.py"), "def greet():\n    return 'hi'\n").unwrap();
+        let state = repo
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let (discussion_id, _) = write_open(&repo, &store, "greet.py", "greet", "please check", Some("alice"));
+
+        let hash = repo
+            .persist_discussions_snapshot(state.id())
+            .unwrap()
+            .expect("snapshot hash");
+        let attachment = repo
+            .latest_state_attachment(&state.id(), StateAttachmentKind::Discussions)
+            .unwrap()
+            .expect("discussions attachment");
+        let StateAttachmentBody::Discussions(attached) = attachment.body else {
+            panic!("wrong attachment kind");
+        };
+        assert_eq!(attached, hash);
+        let blob = repo.store().get_blob(&hash).unwrap().expect("blob");
+        let decoded = DiscussionsBlob::decode(blob.content()).unwrap();
+        assert_eq!(decoded.discussions.len(), 1);
+        assert_eq!(decoded.discussions[0].id, discussion_id.to_string());
+        assert_eq!(decoded.discussions[0].anchor.file, "greet.py");
+        assert_eq!(decoded.discussions[0].anchor.symbol, "greet");
+        assert_eq!(decoded.discussions[0].thread_ref.as_deref(), Some("alice"));
+        assert_eq!(decoded.discussions[0].turns[0].body, "please check");
+
+        assert_eq!(
+            repo.persist_discussions_snapshot(state.id()).unwrap(),
+            Some(hash),
+            "identical snapshot must not mint a new blob"
+        );
+        assert_eq!(
+            repo.list_state_attachments(&state.id())
+                .unwrap()
+                .into_iter()
+                .filter(|attachment| attachment.body.kind() == StateAttachmentKind::Discussions)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn persist_skips_when_op_log_has_no_symbol_discussions() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let state_id = repo.head().unwrap().unwrap();
+        assert_eq!(repo.persist_discussions_snapshot(state_id).unwrap(), None);
+        assert!(
+            repo.latest_state_attachment(&state_id, StateAttachmentKind::Discussions)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn persist_ignores_repository_anchored_discussions() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let state_id = repo.head().unwrap().unwrap();
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let discussion_id = DiscussionRecordId::generate();
+        let operation = CollaborationOperationEnvelope::new(
+            discussion_id,
+            Vec::new(),
+            CollaborationIdempotencyKey::new("repo-open").unwrap(),
+            Attribution::human(Principal::new("Alice", "alice@example.com")),
+            1,
+            CollaborationOperationBodyV1::Open {
+                title: "repo".to_string(),
+                anchor: CollaborationAnchor::Repository,
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("whole repo").unwrap(),
+                thread_ref: None,
+            },
+        )
+        .unwrap();
+        store.write_operation(&operation).unwrap();
+        assert_eq!(repo.persist_discussions_snapshot(state_id).unwrap(), None);
+    }
+}

--- a/crates/repo/src/discussion_snapshot.rs
+++ b/crates/repo/src/discussion_snapshot.rs
@@ -34,12 +34,11 @@ where
             return Ok(None);
         };
         let prior = self.latest_state_attachment(&state_id, StateAttachmentKind::Discussions)?;
-        if let Some(prior_attachment) = &prior {
-            if let StateAttachmentBody::Discussions(existing) = &prior_attachment.body {
-                if *existing == hash {
-                    return Ok(Some(hash));
-                }
-            }
+        if let Some(prior_attachment) = &prior
+            && let StateAttachmentBody::Discussions(existing) = &prior_attachment.body
+            && *existing == hash
+        {
+            return Ok(Some(hash));
         }
         if !self.store().has_state(&state_id)? {
             return Err(HeddleError::StateNotFound(state_id));

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -18,8 +18,8 @@ use oplog::OpLogBackend;
 use refs::RefBackend;
 
 use crate::{
-    CollaborationStore, HeddleError, Repository, Result,
     discussion_anchor_travel::{travel_anchors, travel_symbol_anchor},
+    CollaborationStore, HeddleError, Repository, Result,
 };
 
 impl<R, O, S> Repository<R, O, S>
@@ -75,7 +75,10 @@ where
         }
 
         let Some(parent_discussions_hash) = parent_discussions_hash else {
-            return Ok(None);
+            // First snapshot after `discuss open`: the op-log has discussions
+            // but no parent attachment yet. Seed the hosted blob so push can
+            // emit `StateAttachmentKind::Discussions`.
+            return self.encode_collaboration_discussions_blob();
         };
         let parent_blob = self
             .store()
@@ -324,8 +327,10 @@ mod tests {
     use std::fs;
 
     use objects::object::{
-        Attribution, Discussion, DiscussionTurn, Principal, StateAttachment, StateId, SymbolAnchor,
-        TreeEntry, VisibilityTier,
+        Attribution, CollaborationAnchor, CollaborationIdempotencyKey,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, Discussion,
+        DiscussionRecordId, DiscussionTurn, DiscussionTurnV1, Principal, StateAttachment, StateId,
+        SymbolAnchor, TreeEntry, VisibilityTier,
     };
     use tempfile::TempDir;
 
@@ -388,6 +393,67 @@ mod tests {
             .expect("snapshot should carry discussions");
         let blob = repo.store().get_blob(&hash).unwrap().unwrap();
         DiscussionsBlob::decode(blob.content()).unwrap()
+    }
+
+    #[test]
+    fn snapshot_seeds_discussions_attachment_from_collaboration_op_log() {
+        let (temp, repo) = create_test_repo();
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 1;\n}\n",
+        )
+        .unwrap();
+        let first = repo
+            .snapshot_with_attribution(
+                Some("first".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let discussion_id = DiscussionRecordId::generate();
+        let open = CollaborationOperationEnvelope::new(
+            discussion_id,
+            Vec::new(),
+            CollaborationIdempotencyKey::new("seed-open").unwrap(),
+            Attribution::human(Principal::new("Alice", "alice@example.com")),
+            1_700_000_000_000,
+            CollaborationOperationBodyV1::Open {
+                title: "foo".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: first.id(),
+                    path: "src.rs".to_string(),
+                    symbol: "foo".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("please check this").unwrap(),
+                thread_ref: Some("alice".to_string()),
+            },
+        )
+        .unwrap();
+        store.write_operation(&open).unwrap();
+
+        fs::write(
+            temp.path().join("src.rs"),
+            "fn foo() {\n    let x = 2;\n}\n",
+        )
+        .unwrap();
+        let second = repo
+            .snapshot_with_attribution(
+                Some("second".to_string()),
+                None,
+                Attribution::human(Principal::new("Alice", "alice@example.com")),
+            )
+            .unwrap();
+
+        let persisted = read_discussions(&repo, &second);
+        assert_eq!(persisted.discussions.len(), 1);
+        assert_eq!(persisted.discussions[0].id, discussion_id.to_string());
+        assert_eq!(persisted.discussions[0].anchor.symbol, "foo");
+        assert_eq!(
+            persisted.discussions[0].thread_ref.as_deref(),
+            Some("alice")
+        );
     }
 
     #[test]

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -29,6 +29,7 @@ mod context_anchor_travel;
 #[cfg(feature = "tree-sitter-symbols")]
 mod context_snapshot_travel;
 pub mod daemon;
+mod discussion_snapshot;
 #[cfg(feature = "tree-sitter-symbols")]
 mod discussion_anchor_travel;
 #[cfg(feature = "tree-sitter-symbols")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle discuss open` wrote only the collaboration op-log. Hosted push therefore never sent `StateAttachmentKind::Discussions`, while weft still sets `discussions_from_pack` on pull. Clone/pull fail-closed with `pull bootstrap advertised packed discussions but the attachment is missing`.
- Persist the live op-log as a Discussions snapshot on the tip before push plans its closure (exact-tip sidecar path included). Seed the same blob on the first snapshot after `discuss open`.
- Fail-closed resolve is unchanged: `discussions_from_pack` still requires `latest_state_attachment` + blob.

## Closes

Closes HeddleCo/heddle#1642

Companion weft#1961 is a separate agent. This PR does not ignore the flag; flag true still means the attachment must be in the pack.

## Surfaces

- **The verb.** `discuss open` / append / resolve / reopen now persist a tip snapshot. Help/clap unchanged.
- **Human and agent.** Default discuss output unchanged; `--json` unchanged.
- **Git interop.** Discussions stay in `.heddle` and travel over `heddle push` / `heddle pull`. Not Git-projected.
- **The wire.** Existing `StateAttachment` sidecar + pull-pack attachment. No new proto field.
- **Reverse states.** Way in: persist on discuss write and before push. Way out / way to see: pull bootstrap resolve → `discuss list` / `discuss show`.

## Red commit

`35a55b0c` (main / live AX: discuss open + push left no Discussions attachment; clone/pull of that tip fail-closed)

## Test evidence

Re-run on tip `8f4f638a3ef9082516eefcc414bb300b54c344e3`. All PASS. No `--no-run`, compile-only, or `#[ignore]`.

```
=== 1. cargo test -p heddle-repo --lib discussion_snapshot ===
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out

=== 2. cargo test -p heddle-repo --features tree-sitter-symbols --lib discussion_snapshot ===
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 788 filtered out
  including snapshot_seeds_discussions_attachment_from_collaboration_op_log

=== 3. cargo test -p heddle-hosted-client --features client --lib -- pull_bootstrap_tests ===
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 331 filtered out
  including packed_bootstrap_fail_closes_when_discussions_attachment_is_missing
  including persist_then_resolve_reads_op_log_discussions_from_the_pack_attachment

=== 4. cargo test -p heddle-hosted-client --features client --lib -- attachment_sidecar_tests ===
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 340 filtered out
  including discussions_snapshot_is_advertised_and_emits_sidecar_carrier

=== 5. cargo test -p heddle-hosted-client --features client --lib -- discussion_sync ===
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 335 filtered out

=== 6. cargo test -p heddle-cli --test cli_workflow discuss ===
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 368 filtered out
```

Proof of contract:

1. Push emits attachment+blob: `discussions_snapshot_is_advertised_and_emits_sidecar_carrier` — transfer plan contains `StateAttachmentKind::Discussions` and the blob hash; sidecar frame is `StateAttachmentTransfer` with Discussions kind.
2. Pull applies before resolve: `persist_then_resolve_reads_op_log_discussions_from_the_pack_attachment` — after the attachment is installed, `PullBootstrapMetadata { discussions_from_pack: true }.resolve` reads the blob.
3. True missing blob still fail-closes: `packed_bootstrap_fail_closes_when_discussions_attachment_is_missing` — exact existing error string.

## Manual verification

N/A — covered by tests. Live AX against api-staging.heddle.sh is the original report.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1461265e-d745-4802-80a1-b66b45e8907f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1461265e-d745-4802-80a1-b66b45e8907f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790897386&installation_model_id=21489&pr_number=1643&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1643&signature=110af8ad90e601e89314614f6e6fac5df85cffcb77ed8e8fffdeaf67849757a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->