### PR TITLE
pull: don't clone-kill on discussions_from_pack — handle/ignore the StateAttachment frame, fall back to ListByState

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1767,6 +1767,7 @@ async fn clone_network_connected(
             client,
             repo_path,
             bootstrap.discussions.as_deref(),
+            Some(final_state),
         )
         .await
         {
@@ -2008,6 +2009,7 @@ async fn recover_interrupted_clone_connected(
         client,
         &intent.repository,
         bootstrap.discussions.as_deref(),
+        Some(final_state),
     )
     .await
     {

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1766,7 +1766,7 @@ async fn clone_network_connected(
             &local_repo,
             client,
             repo_path,
-            Some(bootstrap.discussions.as_slice()),
+            bootstrap.discussions.as_deref(),
         )
         .await
         {
@@ -2007,7 +2007,7 @@ async fn recover_interrupted_clone_connected(
         &repo,
         client,
         &intent.repository,
-        Some(bootstrap.discussions.as_slice()),
+        bootstrap.discussions.as_deref(),
     )
     .await
     {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1222,7 +1222,7 @@ async fn pull_network_connected(
                 repo_path,
                 bootstrap
                     .as_ref()
-                    .map(|metadata| metadata.discussions.as_slice()),
+                    .and_then(|metadata| metadata.discussions.as_deref()),
             )
             .await
             {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1223,6 +1223,7 @@ async fn pull_network_connected(
                 bootstrap
                     .as_ref()
                     .and_then(|metadata| metadata.discussions.as_deref()),
+                final_state_id,
             )
             .await
             {

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -12,7 +12,10 @@
 //!   signed). #549 rejects attachments in the pack, so they cannot ride it.
 //! * **Pull/clone (read path):** after a successful clone/pull, consume the
 //!   pull bootstrap's discussions when present, falling back to `ListByState`
-//!   for older servers, and materialize unseen turns into the local op-log.
+//!   for older servers and when the server advertised `discussions_from_pack`
+//!   but this client cannot consume the attachment (missing / wrong kind /
+//!   version skew). Live discussions are not a pack snapshot. Materialize
+//!   unseen turns into the local op-log.
 //!
 //! ## Turn identity
 //!
@@ -528,6 +531,10 @@ pub async fn pull_discussions(
     };
     let change_id = state.change_id;
 
+    // `None` is ListByState: older servers, or `discussions_from_pack`
+    // advertised a snapshot this client cannot consume (missing attachment /
+    // version skew). `Some` is the packed or inline bootstrap set, including
+    // an explicit empty page.
     let hosted = match bootstrap {
         Some(discussions) => discussions
             .iter()

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -500,14 +500,19 @@ async fn push_into_annotation_resolution(
     Ok(true)
 }
 
-/// Fetch hosted discussions for the repository head and materialize any turns we
-/// do not already hold. Saves the mirror after each discussion and continues
-/// past a per-discussion failure.
+/// Fetch hosted discussions for `against` (or repository HEAD) and materialize
+/// any turns we do not already hold. Saves the mirror after each discussion
+/// and continues past a per-discussion failure.
+///
+/// `against` is the pulled/cloned tip. Clone publishes HEAD only after this
+/// call, and `heddle pull feature --local-thread feature` leaves HEAD on the
+/// current checkout — ListByState must not re-read HEAD.
 pub async fn pull_discussions(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
     bootstrap: Option<&[Discussion]>,
+    against: Option<StateId>,
 ) -> Result<usize> {
     // Hosted discussions arrive as server-minted `Discussions` state-attachments
     // on the pulled objects. Those are the transport form of what we
@@ -518,8 +523,9 @@ pub async fn pull_discussions(
     // legacy discussions, and existing repos already hold the marker.
     mark_legacy_discussions_migrated(repo).context("claim legacy discussion migration marker")?;
 
-    let Some(head_state) = repo.head().context("resolve repository head")? else {
-        // weft#638: a repo with no HEAD cannot resolve a state to list against.
+    let Some(head_state) = discussion_sync_state(repo, against)? else {
+        // weft#638: a repo with no HEAD cannot resolve a state to list against
+        // unless the caller passed the pulled/cloned tip.
         return Ok(0);
     };
     let Some(state) = repo
@@ -583,6 +589,15 @@ pub async fn pull_discussions(
     }
 
     Ok(changed)
+}
+
+/// Prefer the pulled/cloned tip. HEAD is wrong on clone (not published yet)
+/// and on `pull --local-thread` into a thread that is not checked out.
+fn discussion_sync_state(repo: &Repository, against: Option<StateId>) -> Result<Option<StateId>> {
+    match against {
+        Some(state) => Ok(Some(state)),
+        None => repo.head().context("resolve repository head"),
+    }
 }
 
 fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion {
@@ -1007,6 +1022,25 @@ mod tests {
         assert!(turns.iter().all(|t| t.is_self));
     }
 
+    #[test]
+    fn discussion_sync_state_prefers_the_pulled_tip_over_head() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap().id();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() { 1 }\n").unwrap();
+        let second = repo
+            .snapshot(Some("second".to_string()), None)
+            .unwrap()
+            .id();
+        assert_eq!(repo.head().unwrap(), Some(second));
+        assert_eq!(
+            discussion_sync_state(&repo, Some(first)).unwrap(),
+            Some(first)
+        );
+        assert_eq!(discussion_sync_state(&repo, None).unwrap(), Some(second));
+    }
+
     // F3: no local principal ⇒ turns are NOT treated as ours (fail closed).
     #[test]
     fn collect_local_turns_fails_closed_without_self_principal() {
@@ -1079,15 +1113,27 @@ mod tests {
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
 
         assert_eq!(
-            pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
-                .await
-                .unwrap(),
+            pull_discussions(
+                &repo,
+                &mut client,
+                "acme/widgets",
+                Some(&bootstrap),
+                Some(state)
+            )
+            .await
+            .unwrap(),
             1
         );
         assert_eq!(
-            pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
-                .await
-                .unwrap(),
+            pull_discussions(
+                &repo,
+                &mut client,
+                "acme/widgets",
+                Some(&bootstrap),
+                Some(state)
+            )
+            .await
+            .unwrap(),
             0
         );
         assert!(mirror_path(repo.heddle_dir()).is_file());

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -248,7 +248,7 @@ enum PackedDiscussions {
     Unconsumable(String),
 }
 
-pub(crate) fn discussions_from_pull_pack(
+fn discussions_from_pull_pack(
     repo: &Repository,
     state_id: StateId,
 ) -> Result<PackedDiscussions, ProtocolError> {

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -26,8 +26,9 @@ use objects::{
     Progress,
     error::HeddleError,
     object::{
-        AnnotationStatus, ContentHash, ContextBlob, ContextTarget, Discussion, DiscussionsBlob,
-        MarkerName, StateAttachmentBody, StateAttachmentKind, StateId, ThreadName, TreeEntryTarget,
+        AnnotationStatus, ContentHash, ContextBlob, ContextTarget, Discussion, DiscussionError,
+        DiscussionsBlob, MarkerName, StateAttachmentBody, StateAttachmentKind, StateId, ThreadName,
+        TreeEntryTarget,
     },
     store::{FsStore, ObjectStore, PackObjectId, SnapshotCommitDescriptor},
 };
@@ -97,7 +98,16 @@ pub struct PullBootstrapMetadata {
 
 #[derive(Debug, Clone)]
 pub struct ResolvedPullBootstrapMetadata {
-    pub discussions: Vec<Discussion>,
+    /// Packed or inline bootstrap discussions. `None` means the server
+    /// advertised `discussions_from_pack` and this client cannot consume the
+    /// attachment (missing, wrong kind, or version skew) — callers pass that
+    /// to `pull_discussions` so it ListByState-falls-back instead of treating
+    /// an empty vec as "no discussions".
+    pub discussions: Option<Vec<Discussion>>,
+    /// Human-facing reason when [`Self::discussions`] is `None` because the
+    /// packed attachment was unconsumable. Absent on the inline-bootstrap path
+    /// and when the pack decoded.
+    pub discussions_pack_fallback: Option<String>,
     pub context: Vec<(ContextTarget, ContextBlob)>,
 }
 
@@ -116,10 +126,22 @@ impl PullBootstrapMetadata {
         let state_id = state_id.ok_or_else(|| {
             ProtocolError::InvalidState("pull bootstrap is missing its final state".to_string())
         })?;
-        let discussions = if self.discussions_from_pack {
-            discussions_from_pull_pack(repo, state_id)?
+        let (discussions, discussions_pack_fallback) = if self.discussions_from_pack {
+            match discussions_from_pull_pack(repo, state_id)? {
+                PackedDiscussions::Ready(discussions) => (Some(discussions), None),
+                PackedDiscussions::Unconsumable(reason) => {
+                    let warning = format!(
+                        "pull bootstrap advertised packed discussions but this client cannot consume them ({reason}); falling back to ListByState"
+                    );
+                    eprintln!(
+                        "{} {warning}",
+                        heddle_cli_render::cli::style::warn_marker()
+                    );
+                    (None, Some(warning))
+                }
+            }
         } else {
-            self.discussions.clone()
+            (Some(self.discussions.clone()), None)
         };
         let context = if self.context_from_pack {
             context_from_pull_pack(repo, state_id)?
@@ -128,6 +150,7 @@ impl PullBootstrapMetadata {
         };
         Ok(ResolvedPullBootstrapMetadata {
             discussions,
+            discussions_pack_fallback,
             context,
         })
     }
@@ -221,21 +244,27 @@ fn decode_bootstrap_state_id(value: Vec<u8>, field: &str) -> Result<StateId, Pro
     Ok(StateId::from_bytes(value))
 }
 
+enum PackedDiscussions {
+    Ready(Vec<Discussion>),
+    /// Server advertised a pack optimization this client cannot consume.
+    /// Clone/pull must ListByState instead of exiting 76.
+    Unconsumable(String),
+}
+
 pub(crate) fn discussions_from_pull_pack(
     repo: &Repository,
     state_id: StateId,
-) -> Result<Vec<Discussion>, ProtocolError> {
+) -> Result<PackedDiscussions, ProtocolError> {
     let Some(attachment) =
         repo.latest_state_attachment(&state_id, StateAttachmentKind::Discussions)?
     else {
-        return Err(ProtocolError::InvalidState(
-            "pull bootstrap advertised packed discussions but the attachment is missing"
-                .to_string(),
+        return Ok(PackedDiscussions::Unconsumable(
+            "the attachment is missing".to_string(),
         ));
     };
     let StateAttachmentBody::Discussions(hash) = attachment.body else {
-        return Err(ProtocolError::InvalidState(
-            "packed discussions attachment has the wrong kind".to_string(),
+        return Ok(PackedDiscussions::Unconsumable(
+            "the attachment has the wrong kind".to_string(),
         ));
     };
     let blob = repo.store().get_blob(&hash)?.ok_or_else(|| {
@@ -243,9 +272,16 @@ pub(crate) fn discussions_from_pull_pack(
             "packed discussions attachment references missing blob {hash}"
         ))
     })?;
-    DiscussionsBlob::decode(blob.content())
-        .map(|blob| blob.discussions)
-        .map_err(|error| ProtocolError::InvalidState(error.to_string()))
+    match DiscussionsBlob::decode(blob.content()) {
+        Ok(blob) => Ok(PackedDiscussions::Ready(blob.discussions)),
+        Err(DiscussionError::UnsupportedVersion(version)) => Ok(PackedDiscussions::Unconsumable(
+            format!("unsupported blob version {version}"),
+        )),
+        Err(DiscussionError::Encoding(error)) => Ok(PackedDiscussions::Unconsumable(format!(
+            "blob encoding is not this client's DiscussionsBlob v1: {error}"
+        ))),
+        Err(error) => Err(ProtocolError::InvalidState(error.to_string())),
+    }
 }
 
 pub(crate) fn context_from_pull_pack(
@@ -2173,6 +2209,10 @@ impl HostedClient {
                         owned_repo,
                     ));
                 }
+                // weft may send Frame::StateAttachment here. That is not the
+                // live discussions transport (v2 named-map chain vs this
+                // client's v1 blob). resolve() ListByState-falls-back when the
+                // advertised pack attachment is missing or undecodable.
                 _ => {}
             }
         }
@@ -3159,9 +3199,9 @@ mod pull_bootstrap_tests {
     use chrono::Utc;
     use objects::{
         object::{
-            Annotation, AnnotationKind, AnnotationScope, Attribution, Blob, DiscussionResolution,
-            DiscussionTurn, Principal, State, StateAttachment, SymbolAnchor, Tree, TreeEntry,
-            VisibilityTier,
+            Annotation, AnnotationKind, AnnotationScope, Attribution, Blob, ContentHash,
+            Discussion, DiscussionResolution, DiscussionTurn, DiscussionsBlob, Principal, State,
+            StateAttachment, StateAttachmentBody, SymbolAnchor, Tree, TreeEntry, VisibilityTier,
         },
         store::ObjectStore,
     };
@@ -3535,8 +3575,194 @@ mod pull_bootstrap_tests {
         .resolve(&repo, Some(snapshot.state_id))
         .expect("resolve packed bootstrap");
 
-        assert_eq!(resolved.discussions, vec![discussion]);
+        assert_eq!(resolved.discussions, Some(vec![discussion]));
+        assert!(resolved.discussions_pack_fallback.is_none());
         assert_eq!(resolved.context, vec![(target, context_blob)]);
+    }
+
+    fn seed_snapshot() -> (TempDir, Repository, StateId) {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        let snapshot = repo
+            .snapshot(Some("seed".to_string()), None)
+            .expect("snapshot");
+        (temp, repo, snapshot.state_id)
+    }
+
+    fn sample_discussion(state_id: StateId) -> Discussion {
+        Discussion {
+            id: "discussion-1".to_string(),
+            anchor: SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: state_id,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: Principal::new("Ada", "ada@example.com"),
+                body: "keep this invariant".to_string(),
+                posted_at: 1_700_000_001,
+                references: Vec::new(),
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: VisibilityTier::Public,
+            resolved_annotation_id: None,
+        }
+    }
+
+    fn packed_metadata() -> PullBootstrapMetadata {
+        PullBootstrapMetadata {
+            discussions_from_pack: true,
+            discussions: Vec::new(),
+            context_from_pack: false,
+            context: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn packed_bootstrap_falls_back_when_discussions_attachment_is_missing() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let resolved = packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect("missing packed discussions must not clone-kill");
+        assert!(
+            resolved.discussions.is_none(),
+            "None means ListByState, not an empty inline set"
+        );
+        let warning = resolved
+            .discussions_pack_fallback
+            .expect("warned fallback");
+        assert!(
+            warning.contains("the attachment is missing"),
+            "{warning}"
+        );
+        assert!(
+            warning.contains("falling back to ListByState"),
+            "{warning}"
+        );
+        assert!(
+            !warning.contains("pull bootstrap advertised packed discussions but the attachment is missing"),
+            "the clone-killer error string must not return as success warning verbatim: {warning}"
+        );
+    }
+
+    #[test]
+    fn packed_bootstrap_falls_back_on_version_skew() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let principal = Principal::new("Ada", "ada@example.com");
+        #[derive(serde::Serialize)]
+        struct NamedV2 {
+            format_version: u8,
+            discussions: Vec<Discussion>,
+        }
+        let bytes = rmp_serde::to_vec_named(&NamedV2 {
+            format_version: 2,
+            discussions: vec![sample_discussion(state_id)],
+        })
+        .expect("encode weft-like named-map v2");
+        let hash = repo
+            .store()
+            .put_blob(&Blob::from(bytes))
+            .expect("store v2 blob");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: Attribution::human(principal),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach v2 discussions");
+
+        let resolved = packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect("version skew must not clone-kill");
+        assert!(resolved.discussions.is_none());
+        let warning = resolved
+            .discussions_pack_fallback
+            .expect("warned fallback");
+        assert!(
+            warning.contains("falling back to ListByState"),
+            "{warning}"
+        );
+        assert!(
+            warning.contains("unsupported blob version")
+                || warning.contains("blob encoding is not this client's DiscussionsBlob v1"),
+            "{warning}"
+        );
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_when_discussions_blob_is_corrupt() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let mut discussion = sample_discussion(state_id);
+        discussion.id.clear();
+        let blob = DiscussionsBlob {
+            format_version: DiscussionsBlob::FORMAT_VERSION,
+            discussions: vec![discussion],
+        };
+        let bytes = rmp_serde::to_vec(&blob).expect("encode corrupt v1 without validate");
+        let hash = repo
+            .store()
+            .put_blob(&Blob::from(bytes))
+            .expect("store corrupt blob");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach corrupt discussions");
+
+        let error = packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect_err("decoded v1 with invalid items is true corruption");
+        assert!(
+            error.to_string().contains("discussion id must not be empty"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_when_discussions_blob_is_missing() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let missing = ContentHash::compute(b"not-stored-discussions");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(missing),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach dangling discussions hash");
+
+        let error = packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect_err("attachment present with missing blob is corruption");
+        assert!(
+            error
+                .to_string()
+                .contains("packed discussions attachment references missing blob"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn unpacked_bootstrap_keeps_inline_discussions() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let discussion = sample_discussion(state_id);
+        let resolved = PullBootstrapMetadata {
+            discussions_from_pack: false,
+            discussions: vec![discussion.clone()],
+            context_from_pack: false,
+            context: Vec::new(),
+        }
+        .resolve(&repo, Some(state_id))
+        .expect("inline bootstrap");
+        assert_eq!(resolved.discussions, Some(vec![discussion]));
+        assert!(resolved.discussions_pack_fallback.is_none());
     }
 }
 

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -133,10 +133,7 @@ impl PullBootstrapMetadata {
                     let warning = format!(
                         "pull bootstrap advertised packed discussions but this client cannot consume them ({reason}); falling back to ListByState"
                     );
-                    eprintln!(
-                        "{} {warning}",
-                        heddle_cli_render::cli::style::warn_marker()
-                    );
+                    eprintln!("{} {warning}", heddle_cli_render::cli::style::warn_marker());
                     (None, Some(warning))
                 }
             }
@@ -3631,19 +3628,13 @@ mod pull_bootstrap_tests {
             resolved.discussions.is_none(),
             "None means ListByState, not an empty inline set"
         );
-        let warning = resolved
-            .discussions_pack_fallback
-            .expect("warned fallback");
+        let warning = resolved.discussions_pack_fallback.expect("warned fallback");
+        assert!(warning.contains("the attachment is missing"), "{warning}");
+        assert!(warning.contains("falling back to ListByState"), "{warning}");
         assert!(
-            warning.contains("the attachment is missing"),
-            "{warning}"
-        );
-        assert!(
-            warning.contains("falling back to ListByState"),
-            "{warning}"
-        );
-        assert!(
-            !warning.contains("pull bootstrap advertised packed discussions but the attachment is missing"),
+            !warning.contains(
+                "pull bootstrap advertised packed discussions but the attachment is missing"
+            ),
             "the clone-killer error string must not return as success warning verbatim: {warning}"
         );
     }
@@ -3679,13 +3670,8 @@ mod pull_bootstrap_tests {
             .resolve(&repo, Some(state_id))
             .expect("version skew must not clone-kill");
         assert!(resolved.discussions.is_none());
-        let warning = resolved
-            .discussions_pack_fallback
-            .expect("warned fallback");
-        assert!(
-            warning.contains("falling back to ListByState"),
-            "{warning}"
-        );
+        let warning = resolved.discussions_pack_fallback.expect("warned fallback");
+        assert!(warning.contains("falling back to ListByState"), "{warning}");
         assert!(
             warning.contains("unsupported blob version")
                 || warning.contains("blob encoding is not this client's DiscussionsBlob v1"),
@@ -3720,7 +3706,9 @@ mod pull_bootstrap_tests {
             .resolve(&repo, Some(state_id))
             .expect_err("decoded v1 with invalid items is true corruption");
         assert!(
-            error.to_string().contains("discussion id must not be empty"),
+            error
+                .to_string()
+                .contains("discussion id must not be empty"),
             "{error}"
         );
     }

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -274,11 +274,20 @@ fn discussions_from_pull_pack(
         Err(DiscussionError::UnsupportedVersion(version)) => Ok(PackedDiscussions::Unconsumable(
             format!("unsupported blob version {version}"),
         )),
-        Err(DiscussionError::Encoding(error)) => Ok(PackedDiscussions::Unconsumable(format!(
-            "blob encoding is not this client's DiscussionsBlob v1: {error}"
-        ))),
+        Err(DiscussionError::Encoding(error)) if msgpack_named_map(blob.content()) => {
+            Ok(PackedDiscussions::Unconsumable(format!(
+                "blob encoding is not this client's DiscussionsBlob v1: {error}"
+            )))
+        }
         Err(error) => Err(ProtocolError::InvalidState(error.to_string())),
     }
+}
+
+/// weft's v2 discussion root is a named-map MessagePack object. This client's
+/// v1 blob is a positional array. A leading map is version skew; a leading
+/// array (or anything else) that fails decode is corruption.
+fn msgpack_named_map(bytes: &[u8]) -> bool {
+    matches!(bytes.first(), Some(0x80..=0x8f | 0xde | 0xdf))
 }
 
 pub(crate) fn context_from_pull_pack(
@@ -3739,6 +3748,35 @@ mod pull_bootstrap_tests {
                 .contains("packed discussions attachment references missing blob"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_when_discussions_blob_is_truncated_v1() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let valid = DiscussionsBlob::new(vec![sample_discussion(state_id)])
+            .encode()
+            .expect("encode v1");
+        let truncated = &valid[..valid.len().saturating_sub(2)];
+        assert!(
+            !msgpack_named_map(truncated),
+            "truncated v1 must stay an array, not a named map"
+        );
+        let hash = repo
+            .store()
+            .put_blob(&Blob::from(truncated.to_vec()))
+            .expect("store truncated v1");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach truncated discussions");
+
+        packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect_err("truncated v1 positional blob is corruption, not version skew");
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -2032,6 +2032,14 @@ impl HostedClient {
                     let decode_elapsed = decode_start.elapsed();
                     profile.store_receive_object += decode_elapsed;
                 }
+                Some(pull_server_frame::Frame::StateAttachment(_)) => {
+                    // Recognized and ignored. Weft streams attachments on this
+                    // frame, not in the native pack. Discussions are a v2
+                    // named-map chain; this client decodes v1 positional
+                    // DiscussionsBlob and must not treat the chain as
+                    // transport. resolve() ListByState-falls-back when
+                    // discussions_from_pack is advertised but unconsumable.
+                }
                 Some(pull_server_frame::Frame::Complete(complete)) => {
                     tx.take();
                     request_pump
@@ -2206,10 +2214,6 @@ impl HostedClient {
                         owned_repo,
                     ));
                 }
-                // weft may send Frame::StateAttachment here. That is not the
-                // live discussions transport (v2 named-map chain vs this
-                // client's v1 blob). resolve() ListByState-falls-back when the
-                // advertised pack attachment is missing or undecodable.
                 _ => {}
             }
         }

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -274,7 +274,7 @@ fn discussions_from_pull_pack(
         Err(DiscussionError::UnsupportedVersion(version)) => Ok(PackedDiscussions::Unconsumable(
             format!("unsupported blob version {version}"),
         )),
-        Err(DiscussionError::Encoding(error)) if msgpack_named_map(blob.content()) => {
+        Err(DiscussionError::Encoding(error)) if named_map_version_skew(blob.content()) => {
             Ok(PackedDiscussions::Unconsumable(format!(
                 "blob encoding is not this client's DiscussionsBlob v1: {error}"
             )))
@@ -283,11 +283,23 @@ fn discussions_from_pull_pack(
     }
 }
 
-/// weft's v2 discussion root is a named-map MessagePack object. This client's
-/// v1 blob is a positional array. A leading map is version skew; a leading
-/// array (or anything else) that fails decode is corruption.
-fn msgpack_named_map(bytes: &[u8]) -> bool {
-    matches!(bytes.first(), Some(0x80..=0x8f | 0xde | 0xdf))
+/// weft's v2 root is a named map with a version that is not this client's
+/// positional `DiscussionsBlob` v1. Peek enough of that map to identify skew
+/// (`format_version` / `version` ≠ 1). An empty or keyless map is corruption.
+fn named_map_version_skew(bytes: &[u8]) -> bool {
+    #[derive(serde::Deserialize)]
+    struct Peek {
+        #[serde(default)]
+        format_version: Option<u8>,
+        #[serde(default)]
+        version: Option<u8>,
+    }
+    let Ok(peek) = rmp_serde::from_slice::<Peek>(bytes) else {
+        return false;
+    };
+    peek.format_version
+        .or(peek.version)
+        .is_some_and(|version| version != DiscussionsBlob::FORMAT_VERSION)
 }
 
 pub(crate) fn context_from_pull_pack(
@@ -3693,6 +3705,43 @@ mod pull_bootstrap_tests {
     }
 
     #[test]
+    fn packed_bootstrap_falls_back_on_foreign_named_map_version() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        #[derive(serde::Serialize)]
+        struct ForeignRoot {
+            version: u8,
+            kind: String,
+        }
+        let bytes = rmp_serde::to_vec_named(&ForeignRoot {
+            version: 2,
+            kind: "DiscussionRootFrame".to_string(),
+        })
+        .expect("encode foreign named map");
+        let hash = repo
+            .store()
+            .put_blob(&Blob::from(bytes))
+            .expect("store foreign root");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach foreign root");
+
+        let resolved = packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect("positively identified v2 named map must not clone-kill");
+        assert!(resolved.discussions.is_none());
+        let warning = resolved.discussions_pack_fallback.expect("warned fallback");
+        assert!(
+            warning.contains("blob encoding is not this client's DiscussionsBlob v1"),
+            "{warning}"
+        );
+    }
+
+    #[test]
     fn packed_bootstrap_fail_closes_when_discussions_blob_is_corrupt() {
         let (_temp, repo, state_id) = seed_snapshot();
         let mut discussion = sample_discussion(state_id);
@@ -3757,10 +3806,6 @@ mod pull_bootstrap_tests {
             .encode()
             .expect("encode v1");
         let truncated = &valid[..valid.len().saturating_sub(2)];
-        assert!(
-            !msgpack_named_map(truncated),
-            "truncated v1 must stay an array, not a named map"
-        );
         let hash = repo
             .store()
             .put_blob(&Blob::from(truncated.to_vec()))
@@ -3777,6 +3822,28 @@ mod pull_bootstrap_tests {
         packed_metadata()
             .resolve(&repo, Some(state_id))
             .expect_err("truncated v1 positional blob is corruption, not version skew");
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_on_empty_named_map() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        // MessagePack empty fixmap (`0x80`): map-shaped but not a v2 schema.
+        let hash = repo
+            .store()
+            .put_blob(&Blob::from(vec![0x80]))
+            .expect("store empty map");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(hash),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach empty map");
+
+        packed_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect_err("empty map is corruption, not version skew");
     }
 
     #[test]

--- a/crates/objects/src/transfer/graph.rs
+++ b/crates/objects/src/transfer/graph.rs
@@ -165,10 +165,11 @@ impl ObjectType {
 
     /// Whether this object type may ride the server→client **pull/clone** pack.
     ///
-    /// Identical to [`ObjectType::packable`]: attachments are carried in the
-    /// pull pack exactly as today. The push/pull split exists solely so the
-    /// push direction can exclude `StateAttachment` without disturbing the
-    /// working pull carriage.
+    /// Same boolean as [`ObjectType::packable`] so planners still list
+    /// `StateAttachment`. Weft does not put those records in the native pack:
+    /// it streams `PullServerFrame::StateAttachment`. Discussions attachments
+    /// are not the live transport (v2 chain vs this client's v1 blob); clone
+    /// treats an advertised-but-unconsumable pack as a ListByState fallback.
     pub fn packable_for_pull(self) -> bool {
         self.packable()
     }
@@ -1015,10 +1016,7 @@ fn missing_blob(hash: ContentHash) -> HeddleError {
     }
 }
 
-fn blob_has_purge_evidence(
-    store: &impl ObjectStore,
-    hash: &ContentHash,
-) -> Result<bool> {
+fn blob_has_purge_evidence(store: &impl ObjectStore, hash: &ContentHash) -> Result<bool> {
     let Some(bytes) = store.get_redactions_bytes_for_blob(hash)? else {
         return Ok(false);
     };

--- a/crates/objects/src/transfer/mod.rs
+++ b/crates/objects/src/transfer/mod.rs
@@ -49,7 +49,9 @@ mod tests {
             assert!(packable.packable_for_push(), "{packable:?} push");
             assert!(packable.packable_for_pull(), "{packable:?} pull");
         }
-        // The attachment record: excluded from the push pack, kept on pull.
+        // The attachment record: excluded from the push pack. The pull
+        // predicate stays true so planners still list it; weft delivers the
+        // record on Frame::StateAttachment, not in the native pack.
         assert!(!ObjectType::StateAttachment.packable_for_push());
         assert!(ObjectType::StateAttachment.packable_for_pull());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `discussions_from_pack` is a weft optimization, not the live discussions transport. This client cannot consume that snapshot (missing `StateAttachment`, wrong kind, or weft v2 named-map vs heddle v1 positional `DiscussionsBlob` / `UnsupportedRootVersion`).
- Pull loop **handles/ignores** `Frame::StateAttachment` (no longer a silent `_ => {}`). It does **not** persist or decode the v2 chain as transport.
- Flag-advertised-but-not-installed / undecodable is a **warned, non-fatal ListByState fallback**. `heddle clone` / `pull` succeed instead of exiting 76.
- ListByState keys off the **pulled/cloned tip**, not `repo.head()`. Clone publishes HEAD after this call; `pull --local-thread` leaves HEAD on the current checkout.
- Hard fail-close **only** for true blob corruption: attachment present + dangling hash, invalid decoded v1 items, truncated positional v1, or a map that is not a foreign version (empty `0x80` map included). Encoding fallback requires a peekable `format_version`/`version` ≠ 1.
- `graph.rs:172` no longer claims attachments ride the pull pack. Weft streams `PullServerFrame::StateAttachment`; the packability predicate stays true so planners still list the type.
- The client still does **not** mint, persist, or push `StateAttachmentKind::Discussions`. Live delivery is heddle#1644 (event-cursor). This PR only unblocks clone.

## Closes

Closes HeddleCo/heddle#1642

Companion weft#1961 (separate agent) stops setting the flag. Live discussions: heddle#1644.

## Surfaces

- **The verb.** `clone` / `pull` resolve no longer exit 76 on an unconsumable packed-discussions ad. Help/clap unchanged.
- **Human and agent.** Default output stays human: a warn line, then ListByState. `--json` / agent mode unchanged.
- **Git interop.** None. Discussions stay in `.heddle`.
- **The wire.** No new proto field. No client-pushed Discussions attachment. Existing `PullServerFrame::StateAttachment` is recognized and ignored.
- **Reverse states.** Way in: warned ListByState when the pack ad is unconsumable, keyed on the pulled tip. Way out / way to see: `discuss list` / `discuss show` after clone/pull. True corrupt blob still fail-closes.

## Red commit

`35a55b0c` (main / live AX: weft set `discussions_from_pack`, client fail-closed on missing attachment; every clone of a discussed tip died)

## Test evidence

Re-run on tip `dfd5302688d64cc2d571f37497ff0e1d919b986f`. rustc 1.98.0. All PASS. No `--no-run`, compile-only, or `#[ignore]`.

```
=== cargo test -p heddle-hosted-client --features client --lib -- pull_bootstrap_tests ===
running 17 tests
test ...packed_bootstrap_fail_closes_on_empty_named_map ... ok
test ...packed_bootstrap_fail_closes_when_discussions_blob_is_corrupt ... ok
test ...packed_bootstrap_fail_closes_when_discussions_blob_is_missing ... ok
test ...packed_bootstrap_fail_closes_when_discussions_blob_is_truncated_v1 ... ok
test ...packed_bootstrap_falls_back_on_version_skew ... ok
test ...packed_bootstrap_falls_back_on_foreign_named_map_version ... ok
test ...packed_bootstrap_falls_back_when_discussions_attachment_is_missing ... ok
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 331 filtered out
```

Proof of contract:

1. Missing attachment is not the clone-killer: `packed_bootstrap_falls_back_when_discussions_attachment_is_missing`.
2. Version skew: named v2 (`format_version: 2`) and a foreign map with `version: 2` both ListByState-fall-back.
3. True corrupt still fail-closes: invalid v1 items, dangling hash, truncated positional v1, empty named map `0x80`.
4. ListByState uses the pulled tip (prior commit). `Frame::StateAttachment` is an explicit ignore arm.

## Manual verification

N/A — covered by tests. Live AX against api-staging.heddle.sh is the original report.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28ec5c25-a64b-4d44-84e7-9edbec95fb86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28ec5c25-a64b-4d44-84e7-9edbec95fb86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790898597&installation_model_id=21489&pr_number=1645&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1645&signature=053f40682baa3bd29f6b1918ed20a7fe1b101b41ec3d1138d6c3936db0e2fa86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->