### PR TITLE
Live-deliver discussions over the event-cursor channel

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_discuss.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_discuss.rs
@@ -17,6 +17,8 @@ pub enum DiscussCommands {
     List(DiscussListArgs),
     /// Show one discussion and its causal heads.
     Show(DiscussShowArgs),
+    /// Replay hosted discussion events after the local watermark, then go live.
+    Wait(DiscussWaitArgs),
 }
 
 #[derive(Clone, Debug, Args)]
@@ -161,4 +163,20 @@ pub struct DiscussListArgs {
 #[derive(Clone, Debug, Args)]
 pub struct DiscussShowArgs {
     pub discussion_id: String,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct DiscussWaitArgs {
+    /// Resume after this hosted event id. Defaults to the persisted watermark.
+    #[arg(long)]
+    pub after: Option<i64>,
+    /// Hosted remote that owns the event cursor. Defaults to the repository default.
+    #[arg(long)]
+    pub remote: Option<String>,
+    /// Restrict the subscription to this thread name.
+    #[arg(long)]
+    pub thread: Option<String>,
+    /// Internal helper for tests: stop after this many events (including ignored ones).
+    #[arg(long, hide = true)]
+    pub max_events: Option<usize>,
 }

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -63,7 +63,7 @@ pub use commands_context::ContextCommands;
 pub use commands_context::ContextReasonCommands;
 pub use commands_discuss::{
     DiscussAppendArgs, DiscussCommands, DiscussListArgs, DiscussOpenArgs, DiscussReopenArgs,
-    DiscussResolveArgs, DiscussShowArgs, ResolveModeArg,
+    DiscussResolveArgs, DiscussShowArgs, DiscussWaitArgs, ResolveModeArg,
 };
 #[cfg(feature = "git-overlay")]
 pub use commands_git_projection::{BridgeCommands, BridgeGitCommands, GitSource, SyncCommands};

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -2003,6 +2003,23 @@ const CONTRACTS: &[CommandContractEntry] = &[
         ),
     ),
     entry(
+        &["discuss", "wait"],
+        json_discriminators(
+            documented_schemas(
+                CommandContract {
+                    json_kind: "jsonl",
+                    ..NETWORK_METADATA_MUTATION_NO_OP_ID
+                },
+                &["discuss wait"],
+            ),
+            &[json_discriminator(
+                Some("discuss wait"),
+                "output_kind",
+                "discuss_wait",
+            )],
+        ),
+    ),
+    entry(
         &["doctor"],
         front_door(
             json_discriminators(
@@ -4497,6 +4514,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             DiscussCommands::Reopen(_) => vec!["discuss", "reopen"],
             DiscussCommands::List(_) => vec!["discuss", "list"],
             DiscussCommands::Show(_) => vec!["discuss", "show"],
+            DiscussCommands::Wait(_) => vec!["discuss", "wait"],
         },
         Commands::Query(_) => vec!["query"],
         Commands::Review { command } => match command {

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -258,6 +258,7 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     ),
     sample(&["discuss", "list"], &["discuss", "list"]),
     sample(&["discuss", "show"], &["discuss", "show", "discussion-1"]),
+    sample(&["discuss", "wait"], &["discuss", "wait"]),
     sample(&["doctor"], &["doctor"]),
     sample(&["doctor", "docs"], &["doctor", "docs"]),
     sample(&["doctor", "schemas"], &["doctor", "schemas"]),
@@ -1642,6 +1643,7 @@ fn json_kind_marks_streaming_command_surfaces() {
     let catalog = build_command_catalog();
     for (display, kind) in [
         ("watch", "jsonl"),
+        ("discuss wait", "jsonl"),
         ("status", "json_or_jsonl"),
         ("thread show", "json_or_jsonl"),
     ] {
@@ -1824,6 +1826,7 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "discuss reopen",
             "discuss list",
             "discuss show",
+            "discuss wait",
             "doctor",
             "doctor docs",
             "doctor schemas",

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -30,7 +30,8 @@ use super::{
     init_output::InitOutput,
     wire::{
         AdoptOutput, BlameOutput, CloneOutput, CommitOutput, DiscussionListOutput,
-        DiscussionShowOutput, DiscussionWriteOutput, ExpandOutput, ExportGitOutput,
+        DiscussWaitLineOutput, DiscussionShowOutput, DiscussionWriteOutput, ExpandOutput,
+        ExportGitOutput,
         ImportGitOutput, IntegrationStatusOutput, LandOutput, LogOutput, MarkerBulkDeleteOutput,
         MarkerListOutput, MarkerOpOutput, MultiLandOutput, OperatorCommandOutput, PullOutput,
         PushOutput, ReadyOutput, ReflogOutput, RemoteMutationOutput, RepackOutput, RevertOutput,
@@ -152,6 +153,7 @@ schema_registry! {
     (&["discuss open", "discuss append", "discuss resolve", "discuss reopen"], DiscussionWriteOutput),
     (&["discuss show"], DiscussionShowOutput),
     (&["discuss list"], DiscussionListOutput),
+    (&["discuss wait"], DiscussWaitLineOutput),
     (&["query --attribution"], BlameOutput),
     (&["bridge git export"], ExportGitOutput),
     (&["bridge git import"], ImportGitOutput),
@@ -1434,6 +1436,7 @@ mod tests {
             "discuss reopen",
             "discuss list",
             "discuss show",
+            "discuss wait",
             "query",
             "query --attribution",
         ] {

--- a/crates/cli-contract/src/cli/commands/wire/collab.rs
+++ b/crates/cli-contract/src/cli/commands/wire/collab.rs
@@ -99,6 +99,19 @@ pub struct DiscussionListOutput {
     pub discussions: Vec<DiscussionOutput>,
 }
 
+/// One `heddle discuss wait` JSONL line.
+#[derive(Serialize, JsonSchema)]
+#[schemars(rename = "DiscussWaitLineSchema")]
+pub struct DiscussWaitLineOutput {
+    pub output_kind: &'static str,
+    pub status: &'static str,
+    pub event_id: i64,
+    pub event_type: String,
+    pub discussion_id: Option<String>,
+    pub applied: bool,
+    pub after_event_id: i64,
+}
+
 // ---- review ----------------------------------------------------------------
 
 #[derive(Serialize, JsonSchema)]

--- a/crates/cli-contract/src/cli/commands/wire/collab.rs
+++ b/crates/cli-contract/src/cli/commands/wire/collab.rs
@@ -110,6 +110,9 @@ pub struct DiscussWaitLineOutput {
     pub discussion_id: Option<String>,
     pub applied: bool,
     pub after_event_id: i64,
+    /// Present on `status = "skipped"` so a person (and JSONL) can see why.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<String>,
 }
 
 // ---- review ----------------------------------------------------------------

--- a/crates/cli-contract/src/cli/commands/wire/mod.rs
+++ b/crates/cli-contract/src/cli/commands/wire/mod.rs
@@ -44,10 +44,11 @@ pub use bridge::{
     LossyImportEntryOutput, RepackOutput, SyncGitOutput,
 };
 pub use collab::{
-    AnchorOutput, DiscussionListOutput, DiscussionOutput, DiscussionShowOutput, DiscussionView,
-    DiscussionWriteOutput, HealthEntry, NextStateView, RequiredNullableNextState, ResolutionOutput,
-    ReviewHealthOutput, ReviewNextOutput, ReviewShowOutput, ReviewSignOutput, SignalView,
-    SignatureView, TurnOutput, WatchActorInfo, WatchLineOutput,
+    AnchorOutput, DiscussWaitLineOutput, DiscussionListOutput, DiscussionOutput,
+    DiscussionShowOutput, DiscussionView, DiscussionWriteOutput, HealthEntry, NextStateView,
+    RequiredNullableNextState, ResolutionOutput, ReviewHealthOutput, ReviewNextOutput,
+    ReviewShowOutput, ReviewSignOutput, SignalView, SignatureView, TurnOutput, WatchActorInfo,
+    WatchLineOutput,
 };
 pub use core_loop::{
     CommitOutput, SnapshotAgentOutput, SnapshotOutput, SnapshotPrincipalOutput, UndoRedoOutput,

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -889,7 +889,7 @@ Tick budget: at most 3 signals per state by default. Priority:\n\
 invariant_adjacency > self_flagged_uncertainty > pattern_deviation >\n\
 novelty > test_reachability.\n";
 
-const DISCUSS_TOPIC: &str = "`heddle discuss open | append | resolve | reopen | list | show`\n\
+const DISCUSS_TOPIC: &str = "`heddle discuss open | append | resolve | reopen | list | show | wait`\n\
 \n\
 Scope: native Heddle only. Discussions are stored in `.heddle` and travel over\n\
 `heddle push` / `heddle pull` to a Heddle remote. They are deliberately not\n\
@@ -916,7 +916,12 @@ file, and symbol where the discussion began:\n\
 the symbol-anchored discussion to a thread; it does not replace the anchor.\n\
 \n\
 Visibility: `--visibility public|internal|team:NAME|restricted:LABEL|private:LABEL`.\n\
-Empty visibility uses the configured discussion visibility policy.\n";
+Empty visibility uses the configured discussion visibility policy.\n\
+\n\
+`wait` tails hosted discussion events (`discussion.opened` / `turn.appended` /\n\
+`discussion.resolved`) after a ListByState snapshot bootstrap. A turn opened\n\
+on another machine appears here without a full pull. `--after` overrides the\n\
+persisted watermark. Pack attachments are not the live channel.\n";
 
 const GIT_OVERLAY_TOPIC: &str = r#"Git Overlay workflow
 

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -392,6 +392,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
         repo_path: repo_path.clone(),
         thread: thread_name.clone(),
         thread_id: thread_id.clone(),
+        principal: client.authenticated_username().unwrap_or_default(),
     };
     if let Some(after) = args.after {
         let mut cursor = load_scoped_cursor(repo.heddle_dir(), &cursor_scope)?;

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -918,9 +918,12 @@ mod tests {
     #[test]
     fn list_and_show_materialize_legacy_attachments() {
         use chrono::Utc;
-        use objects::object::{
-            Attribution, Blob, Discussion, DiscussionResolution, DiscussionTurn, DiscussionsBlob,
-            Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+        use objects::{
+            object::{
+                Attribution, Blob, Discussion, DiscussionResolution, DiscussionTurn,
+                DiscussionsBlob, Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+            },
+            store::ObjectStore,
         };
 
         let temp = tempfile::TempDir::new().unwrap();

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -70,9 +70,28 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
                 );
             }
         },
+        #[cfg(feature = "client")]
+        DiscussCommands::Wait(args) => {
+            // Like clone/pull: do not run legacy blob→op-log migration first.
+            // Hosted bootstrap claims the marker, then GetDiscussion / ListByState
+            // are authoritative. Migrating pulled Discussions attachments here
+            // would duplicate every hosted discussion.
+            let repo = cli.open_repo().context("open Heddle repository")?;
+            return run_wait(cli, &repo, args).await;
+        }
+        #[cfg(not(feature = "client"))]
+        DiscussCommands::Wait(_) => {
+            return Err(anyhow!(
+                "discuss wait requires the hosted client feature"
+            ));
+        }
         _ => cli.open_repo().context("open Heddle repository")?,
     };
-    let store = open_store(&repo)?;
+    let store = if migrates_legacy_on_entry(command) {
+        open_store(&repo)?
+    } else {
+        CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?
+    };
     match command {
         DiscussCommands::Open(args) => run_open(cli, &repo, &store, args),
         DiscussCommands::Append(args) => run_append(cli, &repo, &store, args),
@@ -80,13 +99,18 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
         DiscussCommands::Reopen(args) => run_reopen(cli, &repo, &store, args),
         DiscussCommands::List(args) => run_list(cli, &repo, &store, args),
         DiscussCommands::Show(args) => run_show(cli, &store, args),
-        #[cfg(feature = "client")]
-        DiscussCommands::Wait(args) => run_wait(cli, &repo, args).await,
-        #[cfg(not(feature = "client"))]
-        DiscussCommands::Wait(_) => Err(anyhow!(
-            "discuss wait requires the hosted client feature"
-        )),
+        DiscussCommands::Wait(_) => unreachable!("wait returns before opening the store"),
     }
+}
+
+fn migrates_legacy_on_entry(command: &DiscussCommands) -> bool {
+    matches!(
+        command,
+        DiscussCommands::Open(_)
+            | DiscussCommands::Append(_)
+            | DiscussCommands::Resolve(_)
+            | DiscussCommands::Reopen(_)
+    )
 }
 
 impl CompactProjection for DiscussionWriteOutput {
@@ -828,6 +852,43 @@ fn anchor_path(value: &CollaborationAnchor) -> Option<&str> {
             Some(path)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::cli_args::{DiscussListArgs, DiscussShowArgs, DiscussWaitArgs};
+
+    #[test]
+    fn wait_does_not_run_legacy_migration_on_entry() {
+        let wait = DiscussCommands::Wait(DiscussWaitArgs {
+            after: None,
+            remote: None,
+            thread: None,
+            max_events: None,
+        });
+        assert!(
+            !migrates_legacy_on_entry(&wait),
+            "discuss wait must not migrate legacy discussions before hosted bootstrap"
+        );
+        let list = DiscussCommands::List(DiscussListArgs {
+            state: None,
+            file: None,
+            symbol: None,
+            status: "open".to_string(),
+        });
+        assert!(
+            !migrates_legacy_on_entry(&list),
+            "discuss list stays read-only"
+        );
+        let show = DiscussCommands::Show(DiscussShowArgs {
+            discussion_id: "disc-1".to_string(),
+        });
+        assert!(
+            !migrates_legacy_on_entry(&show),
+            "discuss show stays read-only"
+        );
     }
 }
 

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -339,7 +339,7 @@ fn run_list(
 async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) -> Result<()> {
     use hosted_client::client::discussion_live::{
         DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventOutcome,
-        load_scoped_cursor, save_scoped_cursor,
+        load_scoped_cursor, paired_thread_scope, save_scoped_cursor,
     };
     use hosted_client::client::{HostedAuthMode, HostedClient};
 
@@ -381,11 +381,17 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
     )
     .await?;
 
+    let (thread_name, thread_id) = if let Some(thread) = args.thread.as_deref() {
+        let record = super::thread_cmd::load_thread(repo, thread)?;
+        paired_thread_scope(&record.thread, &record.id)?
+    } else {
+        (String::new(), String::new())
+    };
     let cursor_scope = DiscussionCursorScope {
         authority: authority.clone(),
         repo_path: repo_path.clone(),
-        thread: args.thread.clone().unwrap_or_default(),
-        thread_id: String::new(),
+        thread: thread_name.clone(),
+        thread_id: thread_id.clone(),
     };
     if let Some(after) = args.after {
         let mut cursor = load_scoped_cursor(repo.heddle_dir(), &cursor_scope)?;
@@ -397,8 +403,8 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
     'session: loop {
         let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone())
             .with_authority(authority.clone());
-        if let Some(thread) = args.thread.as_deref() {
-            consumer = consumer.with_thread(thread, "");
+        if !thread_name.is_empty() {
+            consumer = consumer.with_thread(&thread_name, &thread_id);
         }
         let mut subscription = consumer.start(None).await?;
         emit_wait_line(

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -363,7 +363,7 @@ fn run_list(
 async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) -> Result<()> {
     use hosted_client::client::discussion_live::{
         DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventOutcome,
-        load_scoped_cursor, paired_thread_scope, save_scoped_cursor,
+        load_scoped_cursor, paired_thread_scope, save_scoped_cursor, wait_reconnect_backoff,
     };
     use hosted_client::client::{HostedAuthMode, HostedClient};
 
@@ -425,6 +425,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
     }
 
     let mut seen = 0usize;
+    let mut reconnects = 0u32;
     'session: loop {
         let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone())
             .with_authority(authority.clone());
@@ -442,6 +443,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
                 discussion_id: None,
                 applied: false,
                 after_event_id: subscription.last_event_id(),
+                skip_reason: None,
             },
         )?;
 
@@ -451,6 +453,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
             }
             match consumer.consume_next(&mut subscription).await {
                 Ok((event, outcome)) => {
+                    reconnects = 0;
                     seen += 1;
                     let status = match &outcome {
                         DiscussionEventOutcome::Applied { .. } => "applied",
@@ -468,6 +471,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
                             discussion_id: outcome.discussion_id().map(ToString::to_string),
                             applied: outcome.applied(),
                             after_event_id: subscription.last_event_id(),
+                            skip_reason: outcome.skip_reason().map(ToString::to_string),
                         },
                     )?;
                     if args.max_events.is_some_and(|max| seen >= max) {
@@ -475,10 +479,17 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
                     }
                 }
                 Err(error) if error.resume_after_event_id().is_some() => {
+                    let Some(delay) = wait_reconnect_backoff(reconnects) else {
+                        return Err(anyhow!(
+                            "discuss wait reconnect ceiling reached after {reconnects} attempts"
+                        ));
+                    };
+                    reconnects += 1;
                     // Stream died (staging drops iroh endpoints). Persist
                     // already happened per event; reopen and subscribe after
                     // the watermark.
                     drop(consumer);
+                    tokio::time::sleep(delay).await;
                     client.close().await;
                     client = HostedClient::open_session_with_insecure(
                         &authority,
@@ -521,7 +532,7 @@ fn emit_wait_line(cli: &Cli, line: DiscussWaitLineOutput) -> Result<()> {
             line.discussion_id.as_deref().unwrap_or("-"),
             line.event_id
         ),
-        "skipped" => println!("skipped {} ({})", line.event_type, line.event_id),
+        "skipped" => println!("{}", format_wait_skip(&line)),
         "ignored" => {}
         other => println!("{other} {} ({})", line.event_type, line.event_id),
     }
@@ -855,6 +866,13 @@ fn anchor_path(value: &CollaborationAnchor) -> Option<&str> {
     }
 }
 
+fn format_wait_skip(line: &DiscussWaitLineOutput) -> String {
+    match line.skip_reason.as_deref().filter(|reason| !reason.is_empty()) {
+        Some(reason) => format!("skipped {} ({}) — {reason}", line.event_type, line.event_id),
+        None => format!("skipped {} ({})", line.event_type, line.event_id),
+    }
+}
+
 fn anchor_label(value: &AnchorOutput) -> String {
     match value {
         AnchorOutput::Repository => "repository".to_string(),
@@ -900,4 +918,28 @@ mod tests {
             "discuss show stays read-only"
         );
     }
+
+    #[test]
+    fn skipped_wait_line_carries_the_reason() {
+        let line = DiscussWaitLineOutput {
+            output_kind: "discuss_wait",
+            status: "skipped",
+            event_id: 44,
+            event_type: "discussion.opened".to_string(),
+            discussion_id: None,
+            applied: false,
+            after_event_id: 44,
+            skip_reason: Some("discussion disc-hidden is not visible to this caller".to_string()),
+        };
+        let json = serde_json::to_value(&line).unwrap();
+        assert_eq!(
+            json["skip_reason"],
+            "discussion disc-hidden is not visible to this caller"
+        );
+        assert!(
+            format_wait_skip(&line).contains("not visible"),
+            "human skip lines must include the reason"
+        );
+    }
 }
+

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -373,7 +373,7 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
     let mut client = HostedClient::open_session(
         &authority,
         &user_config,
-        server_key,
+        server_key.clone(),
         HostedAuthMode::CredentialFallback,
     )
     .await?;
@@ -384,51 +384,72 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
         save_cursor(repo.heddle_dir(), &repo_path, &cursor)?;
     }
 
-    let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone());
-    if let Some(thread) = args.thread.as_deref() {
-        consumer = consumer.with_thread(thread, "");
-    }
-    let mut subscription = consumer.start(None).await?;
-    emit_wait_line(
-        cli,
-        DiscussWaitLineOutput {
-            output_kind: "discuss_wait",
-            status: "listening",
-            event_id: subscription.last_event_id(),
-            event_type: String::new(),
-            discussion_id: None,
-            applied: false,
-            after_event_id: subscription.last_event_id(),
-        },
-    )?;
-
     let mut seen = 0usize;
-    loop {
-        if args.max_events.is_some_and(|max| seen >= max) {
-            break;
+    'session: loop {
+        let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone());
+        if let Some(thread) = args.thread.as_deref() {
+            consumer = consumer.with_thread(thread, "");
         }
-        let (event, outcome) = consumer.consume_next(&mut subscription).await?;
-        seen += 1;
-        let status = match &outcome {
-            DiscussionEventOutcome::Applied { .. } => "applied",
-            DiscussionEventOutcome::Unchanged { .. } => "unchanged",
-            DiscussionEventOutcome::Skipped { .. } => "skipped",
-            DiscussionEventOutcome::Ignored => "ignored",
-        };
+        let mut subscription = consumer.start(None).await?;
         emit_wait_line(
             cli,
             DiscussWaitLineOutput {
                 output_kind: "discuss_wait",
-                status,
-                event_id: event.event_id,
-                event_type: event.event_type,
-                discussion_id: outcome.discussion_id().map(ToString::to_string),
-                applied: outcome.applied(),
+                status: "listening",
+                event_id: subscription.last_event_id(),
+                event_type: String::new(),
+                discussion_id: None,
+                applied: false,
                 after_event_id: subscription.last_event_id(),
             },
         )?;
-        if args.max_events.is_some_and(|max| seen >= max) {
-            break;
+
+        loop {
+            if args.max_events.is_some_and(|max| seen >= max) {
+                break 'session;
+            }
+            match consumer.consume_next(&mut subscription).await {
+                Ok((event, outcome)) => {
+                    seen += 1;
+                    let status = match &outcome {
+                        DiscussionEventOutcome::Applied { .. } => "applied",
+                        DiscussionEventOutcome::Unchanged { .. } => "unchanged",
+                        DiscussionEventOutcome::Skipped { .. } => "skipped",
+                        DiscussionEventOutcome::Ignored => "ignored",
+                    };
+                    emit_wait_line(
+                        cli,
+                        DiscussWaitLineOutput {
+                            output_kind: "discuss_wait",
+                            status,
+                            event_id: event.event_id,
+                            event_type: event.event_type,
+                            discussion_id: outcome.discussion_id().map(ToString::to_string),
+                            applied: outcome.applied(),
+                            after_event_id: subscription.last_event_id(),
+                        },
+                    )?;
+                    if args.max_events.is_some_and(|max| seen >= max) {
+                        break 'session;
+                    }
+                }
+                Err(error) if error.resume_after_event_id().is_some() => {
+                    // Stream died (staging drops iroh endpoints). Persist
+                    // already happened per event; reopen and subscribe after
+                    // the watermark.
+                    drop(consumer);
+                    client.close().await;
+                    client = HostedClient::open_session(
+                        &authority,
+                        &user_config,
+                        server_key.clone(),
+                        HostedAuthMode::CredentialFallback,
+                    )
+                    .await?;
+                    continue 'session;
+                }
+                Err(error) => return Err(error.into()),
+            }
         }
     }
     client.close().await;

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result, anyhow};
 // The discussion wire payloads live in cli-contract so the schema registry
 // registers the real serialization types.
 pub(crate) use heddle_cli_contract::cli::commands::wire::collab::{
-    AnchorOutput, DiscussionListOutput, DiscussionOutput, DiscussionShowOutput,
-    DiscussionWriteOutput, ResolutionOutput, TurnOutput,
+    AnchorOutput, DiscussWaitLineOutput, DiscussionListOutput, DiscussionOutput,
+    DiscussionShowOutput, DiscussionWriteOutput, ResolutionOutput, TurnOutput,
 };
 use objects::object::{
     AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationAnchorStatus,
@@ -38,7 +38,8 @@ use crate::{
     cli::{
         cli_args::{
             Cli, DiscussAppendArgs, DiscussCommands, DiscussListArgs, DiscussOpenArgs,
-            DiscussReopenArgs, DiscussResolveArgs, DiscussShowArgs, ResolveModeArg,
+            DiscussReopenArgs, DiscussResolveArgs, DiscussShowArgs, DiscussWaitArgs,
+            ResolveModeArg,
         },
         should_output_json,
     },
@@ -79,6 +80,12 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
         DiscussCommands::Reopen(args) => run_reopen(cli, &repo, &store, args),
         DiscussCommands::List(args) => run_list(cli, &repo, &store, args),
         DiscussCommands::Show(args) => run_show(cli, &store, args),
+        #[cfg(feature = "client")]
+        DiscussCommands::Wait(args) => run_wait(cli, &repo, args).await,
+        #[cfg(not(feature = "client"))]
+        DiscussCommands::Wait(_) => Err(anyhow!(
+            "discuss wait requires the hosted client feature"
+        )),
     }
 }
 
@@ -324,6 +331,136 @@ fn run_list(
                 discussion.title
             );
         }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "client")]
+async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) -> Result<()> {
+    use hosted_client::client::discussion_live::{
+        DiscussionEventConsumer, DiscussionEventOutcome, load_cursor, save_cursor,
+    };
+    use hosted_client::client::{HostedAuthMode, HostedClient};
+
+    use super::remote::resolve_default_remote_name;
+    use crate::remote::{RemoteTarget, resolve_remote_with_key};
+
+    let remote_name = resolve_default_remote_name(repo, args.remote.as_deref())?;
+    let (target, server_key) = resolve_remote_with_key(repo, Some(&remote_name))?;
+    let (authority, repo_path) = match target {
+        RemoteTarget::Network {
+            authority,
+            repo_path,
+        } => (
+            authority,
+            repo_path.context("hosted remote must include a repository path")?,
+        ),
+        RemoteTarget::Local(_) => {
+            return Err(anyhow!(RecoveryAdvice::safety_refusal(
+                "hosted_remote_required",
+                format!("discuss wait requires a hosted remote; remote '{remote_name}' is local"),
+                "Configure a hosted remote, then retry `heddle discuss wait`.",
+                format!("remote '{remote_name}' is local, but live discussion delivery is hosted"),
+                "a local remote has no event cursor",
+                "no hosted request was sent and local repository state was left unchanged",
+                "heddle remote list",
+                vec!["heddle remote list".to_string()],
+            )));
+        }
+    };
+
+    let user_config = UserConfig::load_default()?;
+    let mut client = HostedClient::open_session(
+        &authority,
+        &user_config,
+        server_key,
+        HostedAuthMode::CredentialFallback,
+    )
+    .await?;
+
+    if let Some(after) = args.after {
+        let mut cursor = load_cursor(repo.heddle_dir(), &repo_path)?;
+        cursor.after_event_id = after;
+        save_cursor(repo.heddle_dir(), &repo_path, &cursor)?;
+    }
+
+    let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone());
+    if let Some(thread) = args.thread.as_deref() {
+        consumer = consumer.with_thread(thread, "");
+    }
+    let mut subscription = consumer.start(None).await?;
+    emit_wait_line(
+        cli,
+        DiscussWaitLineOutput {
+            output_kind: "discuss_wait",
+            status: "listening",
+            event_id: subscription.last_event_id(),
+            event_type: String::new(),
+            discussion_id: None,
+            applied: false,
+            after_event_id: subscription.last_event_id(),
+        },
+    )?;
+
+    let mut seen = 0usize;
+    loop {
+        if args.max_events.is_some_and(|max| seen >= max) {
+            break;
+        }
+        let (event, outcome) = consumer.consume_next(&mut subscription).await?;
+        seen += 1;
+        let status = match &outcome {
+            DiscussionEventOutcome::Applied { .. } => "applied",
+            DiscussionEventOutcome::Unchanged { .. } => "unchanged",
+            DiscussionEventOutcome::Skipped { .. } => "skipped",
+            DiscussionEventOutcome::Ignored => "ignored",
+        };
+        emit_wait_line(
+            cli,
+            DiscussWaitLineOutput {
+                output_kind: "discuss_wait",
+                status,
+                event_id: event.event_id,
+                event_type: event.event_type,
+                discussion_id: outcome.discussion_id().map(ToString::to_string),
+                applied: outcome.applied(),
+                after_event_id: subscription.last_event_id(),
+            },
+        )?;
+        if args.max_events.is_some_and(|max| seen >= max) {
+            break;
+        }
+    }
+    client.close().await;
+    Ok(())
+}
+
+#[cfg(feature = "client")]
+fn emit_wait_line(cli: &Cli, line: DiscussWaitLineOutput) -> Result<()> {
+    if should_output_json(cli, None) {
+        println!("{}", serde_json::to_string(&line)?);
+        return Ok(());
+    }
+    match line.status {
+        "listening" => println!(
+            "waiting for discussion events after {}",
+            line.after_event_id
+        ),
+        "applied" => println!(
+            "applied {} {} ({})",
+            line.event_type,
+            line.discussion_id.as_deref().unwrap_or("-"),
+            line.event_id
+        ),
+        "unchanged" => println!(
+            "already had {} {} ({})",
+            line.event_type,
+            line.discussion_id.as_deref().unwrap_or("-"),
+            line.event_id
+        ),
+        "skipped" => println!("skipped {} ({})", line.event_type, line.event_id),
+        "ignored" => {}
+        other => println!("{other} {} ({})", line.event_type, line.event_id),
     }
     Ok(())
 }

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -982,7 +982,7 @@ mod tests {
         );
         assert!(
             store
-                .materialize_discussion(&discussion.id)
+                .materialize_discussion(&discussion.discussion_id)
                 .unwrap()
                 .is_some(),
             "discuss show must be able to load the migrated discussion by id"

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -75,15 +75,13 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
             // Like clone/pull: do not run legacy blob→op-log migration first.
             // Hosted bootstrap claims the marker, then GetDiscussion / ListByState
             // are authoritative. Migrating pulled Discussions attachments here
-            // would duplicate every hosted discussion.
+            // would duplicate every hosted discussion. list/show still migrate.
             let repo = cli.open_repo().context("open Heddle repository")?;
             return run_wait(cli, &repo, args).await;
         }
         #[cfg(not(feature = "client"))]
         DiscussCommands::Wait(_) => {
-            return Err(anyhow!(
-                "discuss wait requires the hosted client feature"
-            ));
+            return Err(anyhow!("discuss wait requires the hosted client feature"));
         }
         _ => cli.open_repo().context("open Heddle repository")?,
     };
@@ -104,13 +102,7 @@ pub async fn run(cli: &Cli, command: &DiscussCommands) -> Result<()> {
 }
 
 fn migrates_legacy_on_entry(command: &DiscussCommands) -> bool {
-    matches!(
-        command,
-        DiscussCommands::Open(_)
-            | DiscussCommands::Append(_)
-            | DiscussCommands::Resolve(_)
-            | DiscussCommands::Reopen(_)
-    )
+    !matches!(command, DiscussCommands::Wait(_))
 }
 
 impl CompactProjection for DiscussionWriteOutput {
@@ -362,8 +354,8 @@ fn run_list(
 #[cfg(feature = "client")]
 async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) -> Result<()> {
     use hosted_client::client::discussion_live::{
-        DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventOutcome,
-        load_scoped_cursor, paired_thread_scope, save_scoped_cursor, wait_reconnect_backoff,
+        DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventOutcome, load_scoped_cursor,
+        paired_thread_scope, save_scoped_cursor, wait_reconnect_backoff,
     };
     use hosted_client::client::{HostedAuthMode, HostedClient};
 
@@ -867,7 +859,11 @@ fn anchor_path(value: &CollaborationAnchor) -> Option<&str> {
 }
 
 fn format_wait_skip(line: &DiscussWaitLineOutput) -> String {
-    match line.skip_reason.as_deref().filter(|reason| !reason.is_empty()) {
+    match line
+        .skip_reason
+        .as_deref()
+        .filter(|reason| !reason.is_empty())
+    {
         Some(reason) => format!("skipped {} ({}) — {reason}", line.event_type, line.event_id),
         None => format!("skipped {} ({})", line.event_type, line.event_id),
     }
@@ -889,7 +885,7 @@ mod tests {
     use crate::cli::cli_args::{DiscussListArgs, DiscussShowArgs, DiscussWaitArgs};
 
     #[test]
-    fn wait_does_not_run_legacy_migration_on_entry() {
+    fn wait_is_the_only_discuss_verb_that_skips_legacy_migration() {
         let wait = DiscussCommands::Wait(DiscussWaitArgs {
             after: None,
             remote: None,
@@ -907,15 +903,86 @@ mod tests {
             status: "open".to_string(),
         });
         assert!(
-            !migrates_legacy_on_entry(&list),
-            "discuss list stays read-only"
+            migrates_legacy_on_entry(&list),
+            "discuss list must still convert legacy attachments"
         );
         let show = DiscussCommands::Show(DiscussShowArgs {
             discussion_id: "disc-1".to_string(),
         });
         assert!(
-            !migrates_legacy_on_entry(&show),
-            "discuss show stays read-only"
+            migrates_legacy_on_entry(&show),
+            "discuss show must still convert legacy attachments"
+        );
+    }
+
+    #[test]
+    fn list_and_show_materialize_legacy_attachments() {
+        use chrono::Utc;
+        use objects::object::{
+            Attribution, Blob, Discussion, DiscussionResolution, DiscussionTurn, DiscussionsBlob,
+            Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+        };
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let repo = repo::Repository::init_default(temp.path()).unwrap();
+        let state_id = repo.head().unwrap().unwrap();
+        let bytes = DiscussionsBlob::new(vec![Discussion {
+            id: "legacy-1".to_string(),
+            anchor: SymbolAnchor::new("src/lib.rs", "run"),
+            opened_against_state: state_id,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: Principal::new("Ada", "ada@example.com"),
+                body: "why?".to_string(),
+                posted_at: 1_700_000_000,
+                references: Vec::new(),
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: VisibilityTier::default(),
+            resolved_annotation_id: None,
+        }])
+        .encode()
+        .unwrap();
+        let blob_hash = repo.store().put_blob(&Blob::new(bytes)).unwrap();
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Discussions(blob_hash),
+            attribution: Attribution::human(Principal::new("Importer", "importer@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .unwrap();
+        let marker = repo
+            .heddle_dir()
+            .join("collaboration/migrations/legacy-discussions-v1");
+        assert!(
+            !marker.exists(),
+            "the fixture is an unmigrated clone with legacy attachments"
+        );
+
+        let store = open_store(&repo).expect("list/show open the store through migrate");
+        let materialized = store.materialize().unwrap();
+        assert_eq!(
+            materialized.discussions.len(),
+            1,
+            "list/show must still convert legacy attachments when the marker is unset"
+        );
+        let discussion = materialized.discussions.into_values().next().unwrap();
+        assert_eq!(discussion.turns[0].1.body, "why?");
+        assert!(
+            marker.exists(),
+            "list/show claim the marker after converting the attachment"
+        );
+        assert!(
+            store
+                .materialize_discussion(&discussion.id)
+                .unwrap()
+                .is_some(),
+            "discuss show must be able to load the migrated discussion by id"
         );
     }
 
@@ -942,4 +1009,3 @@ mod tests {
         );
     }
 }
-

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -855,6 +855,16 @@ fn anchor_path(value: &CollaborationAnchor) -> Option<&str> {
     }
 }
 
+fn anchor_label(value: &AnchorOutput) -> String {
+    match value {
+        AnchorOutput::Repository => "repository".to_string(),
+        AnchorOutput::State { state_id } => state_id.clone(),
+        AnchorOutput::Change { change_id } => change_id.clone(),
+        AnchorOutput::Path { path, .. } => path.clone(),
+        AnchorOutput::Symbol { path, symbol, .. } => format!("{path}:{symbol}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -889,15 +899,5 @@ mod tests {
             !migrates_legacy_on_entry(&show),
             "discuss show stays read-only"
         );
-    }
-}
-
-fn anchor_label(value: &AnchorOutput) -> String {
-    match value {
-        AnchorOutput::Repository => "repository".to_string(),
-        AnchorOutput::State { state_id } => state_id.clone(),
-        AnchorOutput::Change { change_id } => change_id.clone(),
-        AnchorOutput::Path { path, .. } => path.clone(),
-        AnchorOutput::Symbol { path, symbol, .. } => format!("{path}:{symbol}"),
     }
 }

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -338,15 +338,17 @@ fn run_list(
 #[cfg(feature = "client")]
 async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) -> Result<()> {
     use hosted_client::client::discussion_live::{
-        DiscussionEventConsumer, DiscussionEventOutcome, load_cursor, save_cursor,
+        DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventOutcome,
+        load_scoped_cursor, save_scoped_cursor,
     };
     use hosted_client::client::{HostedAuthMode, HostedClient};
 
     use super::remote::resolve_default_remote_name;
-    use crate::remote::{RemoteTarget, resolve_remote_with_key};
+    use crate::remote::{RemoteTarget, resolve_remote_with_key_and_insecure};
 
     let remote_name = resolve_default_remote_name(repo, args.remote.as_deref())?;
-    let (target, server_key) = resolve_remote_with_key(repo, Some(&remote_name))?;
+    let (target, server_key, insecure) =
+        resolve_remote_with_key_and_insecure(repo, Some(&remote_name))?;
     let (authority, repo_path) = match target {
         RemoteTarget::Network {
             authority,
@@ -370,23 +372,31 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
     };
 
     let user_config = UserConfig::load_default()?;
-    let mut client = HostedClient::open_session(
+    let mut client = HostedClient::open_session_with_insecure(
         &authority,
         &user_config,
         server_key.clone(),
         HostedAuthMode::CredentialFallback,
+        insecure,
     )
     .await?;
 
+    let cursor_scope = DiscussionCursorScope {
+        authority: authority.clone(),
+        repo_path: repo_path.clone(),
+        thread: args.thread.clone().unwrap_or_default(),
+        thread_id: String::new(),
+    };
     if let Some(after) = args.after {
-        let mut cursor = load_cursor(repo.heddle_dir(), &repo_path)?;
+        let mut cursor = load_scoped_cursor(repo.heddle_dir(), &cursor_scope)?;
         cursor.after_event_id = after;
-        save_cursor(repo.heddle_dir(), &repo_path, &cursor)?;
+        save_scoped_cursor(repo.heddle_dir(), &cursor_scope, &cursor)?;
     }
 
     let mut seen = 0usize;
     'session: loop {
-        let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone());
+        let mut consumer = DiscussionEventConsumer::new(repo, &mut client, repo_path.clone())
+            .with_authority(authority.clone());
         if let Some(thread) = args.thread.as_deref() {
             consumer = consumer.with_thread(thread, "");
         }
@@ -439,11 +449,12 @@ async fn run_wait(cli: &Cli, repo: &repo::Repository, args: &DiscussWaitArgs) ->
                     // the watermark.
                     drop(consumer);
                     client.close().await;
-                    client = HostedClient::open_session(
+                    client = HostedClient::open_session_with_insecure(
                         &authority,
                         &user_config,
                         server_key.clone(),
                         HostedAuthMode::CredentialFallback,
+                        insecure,
                     )
                     .await?;
                     continue 'session;

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -93,6 +93,7 @@ const SWEPT: &[&str] = &[
     "discuss reopen",
     "discuss list",
     "discuss show",
+    "discuss wait",
     "context set",
     "context get",
     "context list",

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -8,8 +8,8 @@
 //! 1. Bootstrap a fresh clone via [`super::discussion_sync::pull_discussions`]
 //!    (pull-bootstrap discussions when present, otherwise `ListByState` — the
 //!    same non-fatal path #1642 falls back to). A `--thread` wait filters
-//!    that ListByState snapshot by `thread_ref` before apply; clone/pull
-//!    pull-fold stays repo-wide.
+//!    that ListByState snapshot by `thread_ref` / wire `thread_id` before
+//!    apply; clone/pull pull-fold stays repo-wide.
 //! 2. Subscribe from the persisted client watermark (`after_event_id`).
 //! 3. Treat live events as doorbells. `GetDiscussion` is the snapshot for
 //!    `discussion.opened` / `discussion.resolved` and for any append whose
@@ -110,6 +110,13 @@ impl DiscussionEventOutcome {
 
     pub fn applied(&self) -> bool {
         matches!(self, Self::Applied { .. })
+    }
+
+    pub fn skip_reason(&self) -> Option<&str> {
+        match self {
+            Self::Skipped { reason } => Some(reason.as_str()),
+            _ => None,
+        }
     }
 }
 
@@ -254,11 +261,15 @@ pub fn load_scoped_cursor(
 }
 
 /// Persist the watermark for `scope`. Always writes the scoped slot.
+///
+/// Takes the cursor lock for the load/insert/save so two `discuss wait`
+/// processes cannot clobber each other's slots.
 pub fn save_scoped_cursor(
     heddle_dir: &Path,
     scope: &DiscussionCursorScope,
     cursor: &DiscussionEventCursor,
 ) -> Result<()> {
+    let _guard = lock_cursor_write(heddle_dir)?;
     let mut cursors = load_cursors(heddle_dir)?;
     cursors.repos.insert(scope.slot(), cursor.clone());
     save_cursors(heddle_dir, &cursors)
@@ -476,12 +487,10 @@ async fn apply_discussion_event(
     ) {
         Ok(true) => Ok(DiscussionEventOutcome::Applied { discussion_id }),
         Ok(false) => Ok(DiscussionEventOutcome::Unchanged { discussion_id }),
-        Err(error) => Ok(DiscussionEventOutcome::Skipped {
-            reason: format!(
-                "could not materialize hosted discussion {discussion_id} after {}: {error}",
-                event.event_type
-            ),
-        }),
+        Err(error) => Err(error).context(format!(
+            "could not materialize hosted discussion {discussion_id} after {}",
+            event.event_type
+        )),
     }
 }
 
@@ -580,6 +589,7 @@ fn append_from_payload(payload: &EventPayload, already_mirrored: bool) -> Option
         opened_against_state: None,
         visibility: String::new(),
         thread_ref: None,
+        thread_id: None,
         turns: vec![HostedDiscussionTurn {
             author_name,
             author_email: payload.author_email.clone().unwrap_or_default(),
@@ -801,6 +811,17 @@ impl DiscussionEventSubscription {
     pub fn resume_request(&self) -> SubscribeRepoEventsRequest {
         self.inner.resume_request()
     }
+}
+
+/// Bounded reconnect delay for `discuss wait`. `None` means the retry
+/// ceiling was hit and the session should stop rather than spin.
+pub fn wait_reconnect_backoff(attempt: u32) -> Option<std::time::Duration> {
+    const CEILING: u32 = 8;
+    if attempt >= CEILING {
+        return None;
+    }
+    let exp = attempt.min(5);
+    Some(std::time::Duration::from_millis(200 * (1u64 << exp)))
 }
 
 /// Failure to bootstrap, subscribe, or apply a live discussion event.

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -234,6 +234,22 @@ pub fn is_discussion_event(event: &RepoEvent) -> bool {
 }
 
 /// Subscribe request for the discussion live tail.
+/// Pair a thread name with its stable record id for a scoped subscribe.
+///
+/// heddle-api 0.23.0 `SubscribeRepoEventsRequest` requires both when the
+/// subscription is thread-scoped. An empty pair is the unfiltered wait.
+pub fn paired_thread_scope(thread: &str, thread_id: &str) -> Result<(String, String)> {
+    if thread.is_empty() && thread_id.is_empty() {
+        return Ok((String::new(), String::new()));
+    }
+    if thread.is_empty() || thread_id.is_empty() {
+        return Err(anyhow!(
+            "thread-scoped discuss wait requires both the thread name and its stable id"
+        ));
+    }
+    Ok((thread.to_string(), thread_id.to_string()))
+}
+
 pub fn subscribe_request(
     repo_id: &str,
     after_event_id: i64,
@@ -395,15 +411,16 @@ async fn apply_discussion_event(
 }
 
 fn is_hidden_discussion(error: &wire::ProtocolError) -> bool {
+    // Skip only a real visibility denial or a missing object. Unauthenticated
+    // / expired credentials are fatal: skipping would advance the watermark
+    // and permanently miss the discussion after re-auth.
     match error {
         wire::ProtocolError::AuthorizationFailed(_) | wire::ProtocolError::ObjectNotFound(_) => {
             true
         }
         wire::ProtocolError::RemoteFailure { code, .. } => matches!(
             code,
-            wire::RemoteFailureCode::PermissionDenied
-                | wire::RemoteFailureCode::NotFound
-                | wire::RemoteFailureCode::Unauthenticated
+            wire::RemoteFailureCode::PermissionDenied | wire::RemoteFailureCode::NotFound
         ),
         _ => false,
     }

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -34,8 +34,10 @@ use repo::Repository;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    discussion_sync::{apply_hosted_discussion, pull_discussions},
-    repo_events::{RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription, SubscribeRepoEventsRequest},
+    discussion_sync::{apply_hosted_discussion, discussion_is_mirrored, pull_discussions},
+    repo_events::{
+        RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription, SubscribeRepoEventsRequest,
+    },
 };
 use crate::{
     client::HostedClient,
@@ -186,9 +188,9 @@ pub async fn bootstrap_discussions(
         .context("bootstrap hosted discussions")?;
     let mut cursor = load_cursor(repo.heddle_dir(), repo_path)?;
     cursor.bootstrapped = true;
-    if cursor.repo_id.is_empty() {
-        cursor.repo_id = repo_path.to_string();
-    }
+    // SubscribeRepoEvents keys on the hosted repo id (`RepoEvent.repo_id`, a
+    // weft UUID). owner/name is a RepositoryRef path used by GetDiscussion /
+    // ListByState. Do not persist the path into this slot.
     save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
     Ok(cursor)
 }
@@ -206,8 +208,6 @@ pub async fn consume_discussion_event(
     cursor.after_event_id = cursor.after_event_id.max(event.event_id);
     if !event.repo_id.is_empty() {
         cursor.repo_id = event.repo_id.clone();
-    } else if cursor.repo_id.is_empty() {
-        cursor.repo_id = repo_path.to_string();
     }
     save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
     Ok(outcome)
@@ -229,7 +229,13 @@ async fn apply_discussion_event(
         });
     };
 
-    let hosted = match discussion_from_payload(event.event_type.as_str(), &payload) {
+    let already_mirrored =
+        discussion_is_mirrored(repo.heddle_dir(), repo_path, &discussion_id)?;
+    let hosted = match discussion_from_payload(
+        event.event_type.as_str(),
+        &payload,
+        already_mirrored,
+    ) {
         Some(discussion) => discussion,
         None => match client.get_discussion(repo_path, &discussion_id).await {
             Ok(discussion) => discussion,
@@ -261,11 +267,18 @@ async fn apply_discussion_event(
 }
 
 fn is_hidden_discussion(error: &wire::ProtocolError) -> bool {
-    let text = error.to_string();
-    text.contains("PermissionDenied")
-        || text.contains("NotFound")
-        || text.contains("permission denied")
-        || text.contains("not found")
+    match error {
+        wire::ProtocolError::AuthorizationFailed(_) | wire::ProtocolError::ObjectNotFound(_) => {
+            true
+        }
+        wire::ProtocolError::RemoteFailure { code, .. } => matches!(
+            code,
+            wire::RemoteFailureCode::PermissionDenied
+                | wire::RemoteFailureCode::NotFound
+                | wire::RemoteFailureCode::Unauthenticated
+        ),
+        _ => false,
+    }
 }
 
 #[derive(Debug, Default)]
@@ -286,36 +299,28 @@ struct EventPayload {
 }
 
 fn parse_event_payload(event: &RepoEvent) -> EventPayload {
+    // weft emit (scope.rs transactional sidecar): a flat object keyed with the
+    // CollaborationService field names. Not a nested `{discussion, turn}`
+    // envelope and not an alias map. Doorbells carry discussion_id + turn
+    // identity; opened/resolved may also carry the DiscussionTurn / resolution
+    // fields from state_review.proto.
     let value = if event.payload_json.trim().is_empty() {
         serde_json::Value::Object(serde_json::Map::new())
     } else {
         serde_json::from_str(&event.payload_json).unwrap_or(serde_json::Value::Null)
     };
-    let nested = value.get("discussion");
-    let discussion_id = string_field(&value, &["discussion_id", "id"])
-        .or_else(|| nested.and_then(|nested| string_field(nested, &["id", "discussion_id"])));
-    let turn = value.get("turn").cloned().unwrap_or(serde_json::Value::Null);
     EventPayload {
-        discussion_id,
-        turn_id: string_field(&value, &["turn_id"])
-            .or_else(|| string_field(&turn, &["turn_id", "id"])),
-        turn_seq: u64_field(&value, "turn_seq")
-            .or_else(|| u64_field(&turn, "turn_seq"))
-            .unwrap_or(0),
-        body: string_field(&value, &["body"]).or_else(|| string_field(&turn, &["body"])),
-        author_name: string_field(&value, &["author_name"])
-            .or_else(|| string_field(&turn, &["author_name"])),
-        author_email: string_field(&value, &["author_email"])
-            .or_else(|| string_field(&turn, &["author_email"])),
-        posted_at_secs: i64_field(&value, &["posted_at", "posted_at_secs"])
-            .or_else(|| i64_field(&turn, &["posted_at", "posted_at_secs"]))
-            .unwrap_or(0),
-        file: string_field(&value, &["file", "path"])
-            .or_else(|| nested.and_then(|nested| string_field(nested, &["file", "path"]))),
-        symbol: string_field(&value, &["symbol"])
-            .or_else(|| nested.and_then(|nested| string_field(nested, &["symbol"]))),
-        visibility: string_field(&value, &["visibility"]),
-        thread_ref: string_field(&value, &["thread_ref"])
+        discussion_id: string_field(&value, "discussion_id"),
+        turn_id: string_field(&value, "turn_id"),
+        turn_seq: u64_field(&value, "turn_seq").unwrap_or(0),
+        body: string_field(&value, "body"),
+        author_name: string_field(&value, "author_name"),
+        author_email: string_field(&value, "author_email"),
+        posted_at_secs: i64_field(&value, "posted_at").unwrap_or(0),
+        file: string_field(&value, "file"),
+        symbol: string_field(&value, "symbol"),
+        visibility: string_field(&value, "visibility"),
+        thread_ref: string_field(&value, "thread_ref")
             .or_else(|| (!event.thread.is_empty()).then(|| event.thread.clone())),
         opened_against_state: value
             .get("opened_against_state")
@@ -325,78 +330,87 @@ fn parse_event_payload(event: &RepoEvent) -> EventPayload {
     }
 }
 
-fn discussion_from_payload(event_type: &str, payload: &EventPayload) -> Option<HostedDiscussion> {
+fn discussion_from_payload(
+    event_type: &str,
+    payload: &EventPayload,
+    already_mirrored: bool,
+) -> Option<HostedDiscussion> {
     let discussion_id = payload.discussion_id.clone()?;
-    // Doorbell events (id only) and incomplete appends must fetch. A fat
-    // `turn.appended` without turn identity would look like ordinal 0 and
-    // either drop the new turn or collide with the bootstrap snapshot.
-    let body = payload.body.clone()?;
+    // Fat append/resolve on an unknown server id must not mint Open: pull_one's
+    // None arm treats turns[0] as the first turn. Fetch (or skip) until the
+    // mirror already has this discussion. Only discussion.opened may Open.
+    if event_type != "discussion.opened" && !already_mirrored {
+        return None;
+    }
+    if event_type == "discussion.opened" && payload.visibility.is_none() {
+        return None;
+    }
+    if event_type == "discussion.resolved" && already_mirrored {
+        return Some(hosted_from_payload(discussion_id, payload));
+    }
+    let body = payload.body.as_deref()?;
     if body.trim().is_empty() {
         return None;
     }
-    if event_type == "turn.appended"
-        && payload.turn_id.is_none()
-        && payload.turn_seq == 0
-    {
+    if event_type == "turn.appended" && payload.turn_id.is_none() && payload.turn_seq == 0 {
         return None;
     }
-    Some(HostedDiscussion {
+    Some(hosted_from_payload(discussion_id, payload))
+}
+
+fn hosted_from_payload(discussion_id: String, payload: &EventPayload) -> HostedDiscussion {
+    let turns = payload
+        .body
+        .as_deref()
+        .filter(|body| !body.trim().is_empty())
+        .map(|body| {
+            vec![HostedDiscussionTurn {
+                author_name: payload.author_name.clone().unwrap_or_default(),
+                author_email: payload.author_email.clone().unwrap_or_default(),
+                body: body.to_string(),
+                posted_at_secs: payload.posted_at_secs,
+                turn_id: payload.turn_id.clone().unwrap_or_default(),
+                turn_seq: payload.turn_seq,
+            }]
+        })
+        .unwrap_or_default();
+    HostedDiscussion {
         id: discussion_id,
         file: payload.file.clone().unwrap_or_default(),
         symbol: payload.symbol.clone().unwrap_or_default(),
         opened_against_state: payload.opened_against_state,
-        visibility: payload
-            .visibility
-            .clone()
-            .unwrap_or_else(|| "internal".to_string()),
+        visibility: payload.visibility.clone().unwrap_or_default(),
         thread_ref: payload.thread_ref.clone(),
-        turns: vec![HostedDiscussionTurn {
-            author_name: payload.author_name.clone().unwrap_or_default(),
-            author_email: payload.author_email.clone().unwrap_or_default(),
-            body,
-            posted_at_secs: payload.posted_at_secs,
-            turn_id: payload.turn_id.clone().unwrap_or_default(),
-            turn_seq: payload.turn_seq,
-        }],
+        turns,
         resolution: payload.resolution.clone(),
-    })
+    }
 }
 
 fn parse_resolution(value: &serde_json::Value) -> HostedResolution {
     let Some(resolution) = value.get("resolution") else {
-        if value.get("dismissed_reason").is_some() {
-            return HostedResolution::Dismissed {
-                reason: string_field(value, &["dismissed_reason"]).unwrap_or_default(),
-            };
-        }
         return HostedResolution::Open;
     };
-    match string_field(resolution, &["kind", "type"])
-        .unwrap_or_default()
-        .as_str()
-    {
-        "dismissed" | "dismiss" => HostedResolution::Dismissed {
-            reason: string_field(resolution, &["reason"]).unwrap_or_default(),
+    match string_field(resolution, "kind").unwrap_or_default().as_str() {
+        "dismissed" => HostedResolution::Dismissed {
+            reason: string_field(resolution, "reason").unwrap_or_default(),
         },
-        "by_edit" | "by-edit" | "addressed_by_state" => HostedResolution::ByEdit {
+        "by_edit" => HostedResolution::ByEdit {
             state_id: resolution.get("state_id").and_then(parse_state_id),
         },
-        "into_annotation" | "annotation" => HostedResolution::IntoAnnotation {
-            annotation_id: string_field(resolution, &["annotation_id", "id"]).unwrap_or_default(),
+        "into_annotation" => HostedResolution::IntoAnnotation {
+            annotation_id: string_field(resolution, "annotation_id").unwrap_or_default(),
         },
         _ => HostedResolution::Open,
     }
 }
 
-fn string_field(value: &serde_json::Value, names: &[&str]) -> Option<String> {
-    names.iter().find_map(|name| {
-        value
-            .get(*name)
-            .and_then(|field| field.as_str())
-            .map(str::trim)
-            .filter(|field| !field.is_empty())
-            .map(ToString::to_string)
-    })
+fn string_field(value: &serde_json::Value, name: &str) -> Option<String> {
+    value
+        .get(name)
+        .and_then(|field| field.as_str())
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+        .map(ToString::to_string)
 }
 
 fn u64_field(value: &serde_json::Value, name: &str) -> Option<u64> {
@@ -408,14 +422,12 @@ fn u64_field(value: &serde_json::Value, name: &str) -> Option<u64> {
     })
 }
 
-fn i64_field(value: &serde_json::Value, names: &[&str]) -> Option<i64> {
-    names.iter().find_map(|name| {
-        value.get(*name).and_then(|field| {
-            field
-                .as_i64()
-                .or_else(|| field.as_u64().and_then(|n| i64::try_from(n).ok()))
-                .or_else(|| field.as_str()?.parse().ok())
-        })
+fn i64_field(value: &serde_json::Value, name: &str) -> Option<i64> {
+    value.get(name).and_then(|field| {
+        field
+            .as_i64()
+            .or_else(|| field.as_u64().and_then(|n| i64::try_from(n).ok()))
+            .or_else(|| field.as_str()?.parse().ok())
     })
 }
 
@@ -484,15 +496,34 @@ impl<'a> DiscussionEventConsumer<'a> {
                 .await
                 .map_err(DiscussionLiveError::bootstrap)?;
         }
+        self.subscribe_from_cursor(&cursor).await
+    }
+
+    /// Subscribe from the persisted watermark without repeating bootstrap.
+    pub async fn resume(
+        &mut self,
+    ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+        let cursor = load_cursor(self.repo.heddle_dir(), &self.repo_path)
+            .map_err(DiscussionLiveError::cursor)?;
+        self.subscribe_from_cursor(&cursor).await
+    }
+
+    async fn subscribe_from_cursor(
+        &mut self,
+        cursor: &DiscussionEventCursor,
+    ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+        // weft keys SubscribeRepoEvents on the hosted repo UUID. After the
+        // first event we have that id; before it, owner/name is the path
+        // weft resolves the same way RepositoryRef.canonical_path does.
         let repo_id = if cursor.repo_id.is_empty() {
-            self.repo_path.clone()
+            self.repo_path.as_str()
         } else {
-            cursor.repo_id.clone()
+            cursor.repo_id.as_str()
         };
         let subscription = self
             .events
             .subscribe(subscribe_request(
-                &repo_id,
+                repo_id,
                 cursor.after_event_id,
                 &self.thread,
                 &self.thread_id,
@@ -508,11 +539,17 @@ impl<'a> DiscussionEventConsumer<'a> {
         &mut self,
         subscription: &mut DiscussionEventSubscription,
     ) -> Result<(RepoEvent, DiscussionEventOutcome), DiscussionLiveError> {
-        let event = subscription
-            .inner
-            .next()
-            .await
-            .map_err(DiscussionLiveError::Subscribe)?;
+        let event = match subscription.inner.next().await {
+            Ok(event) => event,
+            Err(error) if error.resume_after_event_id().is_some() => {
+                *subscription = self.resume().await?;
+                match subscription.inner.next().await {
+                    Ok(event) => event,
+                    Err(error) => return Err(DiscussionLiveError::Subscribe(error)),
+                }
+            }
+            Err(error) => return Err(DiscussionLiveError::Subscribe(error)),
+        };
         let outcome = consume_discussion_event(self.repo, self.client, &self.repo_path, &event)
             .await
             .map_err(DiscussionLiveError::apply)?;

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -11,11 +11,8 @@
 //!    that ListByState snapshot by `thread_ref` / wire `thread_id` before
 //!    apply; clone/pull pull-fold stays repo-wide.
 //! 2. Subscribe from the persisted client watermark (`after_event_id`).
-//! 3. Treat live events as doorbells. `GetDiscussion` is the snapshot for
-//!    `discussion.opened` / `discussion.resolved` and for any append whose
-//!    id is not already mirrored. An already-mirrored `turn.appended` with
-//!    minted identity and a non-empty body may apply without a refetch.
-//!    Never reconstruct a `HostedDiscussion` from opened/resolved JSON.
+//! 3. Treat every live event as a doorbell. `GetDiscussion` is the authorized
+//!    snapshot; event JSON never supplies discussion or turn contents.
 //! 4. Persist the watermark after apply, skip, or ignore — not after apply Err.
 //!
 //! Fail-closed on visibility: the server already filters emission by audience.
@@ -35,25 +32,19 @@ use api::heddle::api::v1alpha1::CallFailureCode;
 use objects::{
     fs_atomic::write_file_atomic,
     lock::RepoLock,
-    object::{Discussion, StateId},
+    object::{CollaborationCodecError, Discussion, StateId},
 };
 use repo::Repository;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    discussion_sync::{
-        apply_hosted_discussion, discussion_is_mirrored, pull_discussions,
-        pull_discussions_for_thread,
-    },
+    discussion_sync::{apply_hosted_discussion, pull_discussions, pull_discussions_for_thread},
     repo_events::{
         RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription,
         SubscribeRepoEventsRequest,
     },
 };
-use crate::{
-    client::HostedClient,
-    hosted_runtime::hosted::{HostedDiscussion, HostedDiscussionTurn, HostedResolution},
-};
+use crate::{client::HostedClient, hosted_runtime::hosted::HostedDiscussion};
 
 /// Event types this consumer subscribes to. Unknown types are ignored.
 pub const DISCUSSION_EVENT_TYPES: &[&str] =
@@ -87,9 +78,9 @@ struct CursorFile {
 pub enum DiscussionEventOutcome {
     /// Not a discussion event; watermark still advances.
     Ignored,
-    /// Authorized event that could not be materialized (missing id,
-    /// GetDiscussion hid it, or apply could not write a valid op). Watermark
-    /// advances so we do not retry forever.
+    /// Authorized event that could not be materialized because it was hidden,
+    /// missing, malformed, or failed local validation. Watermark advances so
+    /// deterministic poison events are not retried forever.
     Skipped { reason: String },
     /// Local op-log changed.
     Applied { discussion_id: String },
@@ -363,7 +354,7 @@ pub async fn bootstrap_discussions_scoped(
         .await
         .context("bootstrap hosted discussions for thread")?;
     } else {
-        pull_discussions(repo, client, repo_path, bootstrap)
+        pull_discussions(repo, client, repo_path, bootstrap, None)
             .await
             .context("bootstrap hosted discussions")?;
     }
@@ -378,8 +369,8 @@ pub async fn bootstrap_discussions_scoped(
 }
 
 /// Apply one already-received repo event into the local op-log and advance
-/// the audience-scoped watermark. Opened/resolved always fetch; an
-/// already-mirrored append may apply from the event.
+/// the audience-scoped watermark. Every discussion event fetches the
+/// authorized snapshot before applying it.
 pub async fn consume_discussion_event(
     repo: &Repository,
     client: &mut HostedClient,
@@ -444,23 +435,7 @@ async fn apply_discussion_event(
         });
     };
 
-    let already_mirrored = discussion_is_mirrored(repo.heddle_dir(), repo_path, &discussion_id)?;
-    let hosted = if event.event_type == "turn.appended" {
-        if let Some(discussion) = append_from_payload(&payload, already_mirrored) {
-            discussion
-        } else {
-            match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload)
-                .await?
-            {
-                Some(discussion) => discussion,
-                None => {
-                    return Ok(DiscussionEventOutcome::Skipped {
-                        reason: format!("discussion {discussion_id} is not visible to this caller"),
-                    });
-                }
-            }
-        }
-    } else {
+    let hosted =
         match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload).await? {
             Some(discussion) => discussion,
             None => {
@@ -468,8 +443,7 @@ async fn apply_discussion_event(
                     reason: format!("discussion {discussion_id} is not visible to this caller"),
                 });
             }
-        }
-    };
+        };
 
     match apply_hosted_discussion(
         repo,
@@ -479,11 +453,22 @@ async fn apply_discussion_event(
     ) {
         Ok(true) => Ok(DiscussionEventOutcome::Applied { discussion_id }),
         Ok(false) => Ok(DiscussionEventOutcome::Unchanged { discussion_id }),
+        Err(error) if is_invalid_hosted_discussion(&error) => Ok(DiscussionEventOutcome::Skipped {
+            reason: format!(
+                "could not materialize malformed hosted discussion {discussion_id}: {error:#}"
+            ),
+        }),
         Err(error) => Err(error).context(format!(
             "could not materialize hosted discussion {discussion_id} after {}",
             event.event_type
         )),
     }
+}
+
+fn is_invalid_hosted_discussion(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<CollaborationCodecError>().is_some())
 }
 
 /// `Ok(None)` is a visibility/NotFound skip. Other errors stay fatal.
@@ -526,13 +511,6 @@ fn is_hidden_discussion(error: &wire::ProtocolError) -> bool {
 #[derive(Debug, Default)]
 struct EventPayload {
     discussion_id: Option<String>,
-    turn_id: Option<String>,
-    turn_seq: u64,
-    /// Untrimmed. `None` when missing or whitespace-only (emptiness test).
-    body: Option<String>,
-    author_name: Option<String>,
-    author_email: Option<String>,
-    posted_at_secs: i64,
     opened_against_state: Option<StateId>,
 }
 
@@ -546,53 +524,11 @@ fn parse_event_payload(event: &RepoEvent) -> EventPayload {
     };
     EventPayload {
         discussion_id: string_field(&value, "discussion_id"),
-        turn_id: string_field(&value, "turn_id"),
-        turn_seq: u64_field(&value, "turn_seq").unwrap_or(0),
-        body: body_field(&value),
-        author_name: string_field(&value, "author_name"),
-        author_email: string_field(&value, "author_email"),
-        posted_at_secs: i64_field(&value, "posted_at").unwrap_or(0),
         opened_against_state: value
             .get("opened_against_state")
             .and_then(parse_state_id)
             .or_else(|| event.new_state.as_ref().and_then(proto_state_id)),
     }
-}
-
-/// Already-mirrored append with minted identity and a real body.
-/// Never mints Open. Author and posted_at must both be present; otherwise fetch.
-fn append_from_payload(payload: &EventPayload, already_mirrored: bool) -> Option<HostedDiscussion> {
-    if !already_mirrored {
-        return None;
-    }
-    let discussion_id = payload.discussion_id.clone()?;
-    let body = payload.body.clone()?;
-    if payload.turn_id.is_none() || payload.turn_seq == 0 {
-        return None;
-    }
-    let author_name = payload.author_name.clone()?;
-    if payload.posted_at_secs <= 0 {
-        return None;
-    }
-    Some(HostedDiscussion {
-        id: discussion_id,
-        file: String::new(),
-        symbol: String::new(),
-        opened_against_state: None,
-        visibility: String::new(),
-        thread_ref: None,
-        thread_id: None,
-        turns: vec![HostedDiscussionTurn {
-            author_name,
-            author_email: payload.author_email.clone().unwrap_or_default(),
-            body,
-            posted_at_secs: payload.posted_at_secs,
-            turn_id: payload.turn_id.clone().unwrap_or_default(),
-            turn_seq: payload.turn_seq,
-        }],
-        resolution: HostedResolution::Open,
-        kind: 0,
-    })
 }
 
 fn string_field(value: &serde_json::Value, name: &str) -> Option<String> {
@@ -602,33 +538,6 @@ fn string_field(value: &serde_json::Value, name: &str) -> Option<String> {
         .map(str::trim)
         .filter(|field| !field.is_empty())
         .map(ToString::to_string)
-}
-
-fn body_field(value: &serde_json::Value) -> Option<String> {
-    let body = value.get("body")?.as_str()?;
-    if body.trim().is_empty() {
-        None
-    } else {
-        Some(body.to_string())
-    }
-}
-
-fn u64_field(value: &serde_json::Value, name: &str) -> Option<u64> {
-    value.get(name).and_then(|field| {
-        field
-            .as_u64()
-            .or_else(|| field.as_i64().and_then(|n| u64::try_from(n).ok()))
-            .or_else(|| field.as_str()?.parse().ok())
-    })
-}
-
-fn i64_field(value: &serde_json::Value, name: &str) -> Option<i64> {
-    value.get(name).and_then(|field| {
-        field
-            .as_i64()
-            .or_else(|| field.as_u64().and_then(|n| i64::try_from(n).ok()))
-            .or_else(|| field.as_str()?.parse().ok())
-    })
 }
 
 fn parse_state_id(value: &serde_json::Value) -> Option<StateId> {

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -31,6 +31,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
+use api::heddle::api::v1alpha1::CallFailureCode;
 use objects::{
     fs_atomic::write_file_atomic,
     lock::RepoLock,
@@ -45,7 +46,8 @@ use super::{
         pull_discussions_for_thread,
     },
     repo_events::{
-        RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription, SubscribeRepoEventsRequest,
+        RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription,
+        SubscribeRepoEventsRequest,
     },
 };
 use crate::{
@@ -54,11 +56,8 @@ use crate::{
 };
 
 /// Event types this consumer subscribes to. Unknown types are ignored.
-pub const DISCUSSION_EVENT_TYPES: &[&str] = &[
-    "discussion.opened",
-    "turn.appended",
-    "discussion.resolved",
-];
+pub const DISCUSSION_EVENT_TYPES: &[&str] =
+    &["discussion.opened", "turn.appended", "discussion.resolved"];
 
 const CURSOR_FILE: &str = "event-cursor.json";
 
@@ -278,8 +277,7 @@ pub fn save_scoped_cursor(
 /// True when this event is a discussion doorbell or payload.
 pub fn is_discussion_event(event: &RepoEvent) -> bool {
     DISCUSSION_EVENT_TYPES.contains(&event.event_type.as_str())
-        || event.kind
-            == api::heddle::api::v1alpha1::RepoEventKind::DiscussionTurn as i32
+        || event.kind == api::heddle::api::v1alpha1::RepoEventKind::DiscussionTurn as i32
 }
 
 /// Subscribe request for the discussion live tail.
@@ -348,11 +346,7 @@ pub async fn bootstrap_discussions_scoped(
     scope: &DiscussionCursorScope,
     bootstrap: Option<&[Discussion]>,
 ) -> Result<DiscussionEventCursor> {
-    if repo
-        .head()
-        .context("resolve repository head")?
-        .is_none()
-    {
+    if repo.head().context("resolve repository head")?.is_none() {
         return Err(anyhow!(
             "cannot bootstrap hosted discussions without a repository HEAD"
         ));
@@ -450,20 +444,18 @@ async fn apply_discussion_event(
         });
     };
 
-    let already_mirrored =
-        discussion_is_mirrored(repo.heddle_dir(), repo_path, &discussion_id)?;
+    let already_mirrored = discussion_is_mirrored(repo.heddle_dir(), repo_path, &discussion_id)?;
     let hosted = if event.event_type == "turn.appended" {
         if let Some(discussion) = append_from_payload(&payload, already_mirrored) {
             discussion
         } else {
-            match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload).await?
+            match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload)
+                .await?
             {
                 Some(discussion) => discussion,
                 None => {
                     return Ok(DiscussionEventOutcome::Skipped {
-                        reason: format!(
-                            "discussion {discussion_id} is not visible to this caller"
-                        ),
+                        reason: format!("discussion {discussion_id} is not visible to this caller"),
                     });
                 }
             }
@@ -704,10 +696,7 @@ impl<'a> DiscussionEventConsumer<'a> {
             repo_path: self.repo_path.clone(),
             thread: self.thread.clone(),
             thread_id: self.thread_id.clone(),
-            principal: self
-                .client
-                .authenticated_username()
-                .unwrap_or_default(),
+            principal: self.client.authenticated_username().unwrap_or_default(),
         }
     }
 
@@ -735,9 +724,7 @@ impl<'a> DiscussionEventConsumer<'a> {
     }
 
     /// Subscribe from the persisted watermark without repeating bootstrap.
-    pub async fn resume(
-        &mut self,
-    ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+    pub async fn resume(&mut self) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
         let cursor = load_scoped_cursor(self.repo.heddle_dir(), &self.cursor_scope())
             .map_err(DiscussionLiveError::cursor)?;
         self.subscribe_from_cursor(&cursor).await
@@ -747,6 +734,19 @@ impl<'a> DiscussionEventConsumer<'a> {
         &mut self,
         cursor: &DiscussionEventCursor,
     ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+        match self.open_subscription(cursor).await {
+            Ok(subscription) => Ok(subscription),
+            Err(error) if !cursor.repo_id.is_empty() && is_repository_not_found(&error) => {
+                self.recover_stale_repo_identity().await
+            }
+            Err(error) => Err(DiscussionLiveError::Subscribe(error)),
+        }
+    }
+
+    async fn open_subscription(
+        &mut self,
+        cursor: &DiscussionEventCursor,
+    ) -> Result<DiscussionEventSubscription, RepoEventError> {
         // weft keys SubscribeRepoEvents on the hosted repo UUID. After the
         // first event we have that id; before it, owner/name is the path
         // weft resolves the same way RepositoryRef.canonical_path does.
@@ -763,11 +763,42 @@ impl<'a> DiscussionEventConsumer<'a> {
                 &self.thread,
                 &self.thread_id,
             ))
-            .await
-            .map_err(DiscussionLiveError::Subscribe)?;
+            .await?;
         Ok(DiscussionEventSubscription {
             inner: subscription,
         })
+    }
+
+    fn can_recover_stale_repo_id(&self, error: &RepoEventError) -> bool {
+        if !is_repository_not_found(error) {
+            return false;
+        }
+        load_scoped_cursor(self.repo.heddle_dir(), &self.cursor_scope())
+            .ok()
+            .is_some_and(|cursor| !cursor.repo_id.is_empty())
+    }
+
+    /// The spool was deleted and recreated at the same owner/path. The
+    /// persisted UUID is dead; `--after 0` does not clear it. Drop the id,
+    /// re-bootstrap this slot, and subscribe once via `repo_path`.
+    async fn recover_stale_repo_identity(
+        &mut self,
+    ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+        let scope = self.cursor_scope();
+        let mut cursor = load_scoped_cursor(self.repo.heddle_dir(), &scope)
+            .map_err(DiscussionLiveError::cursor)?;
+        cursor.repo_id.clear();
+        cursor.after_event_id = 0;
+        cursor.bootstrapped = false;
+        save_scoped_cursor(self.repo.heddle_dir(), &scope, &cursor)
+            .map_err(DiscussionLiveError::cursor)?;
+        let cursor =
+            bootstrap_discussions_scoped(self.repo, self.client, &self.repo_path, &scope, None)
+                .await
+                .map_err(DiscussionLiveError::bootstrap)?;
+        self.open_subscription(&cursor)
+            .await
+            .map_err(DiscussionLiveError::Subscribe)
     }
 
     pub async fn consume_next(
@@ -778,6 +809,13 @@ impl<'a> DiscussionEventConsumer<'a> {
             Ok(event) => event,
             Err(error) if error.resume_after_event_id().is_some() => {
                 *subscription = self.resume().await?;
+                match subscription.inner.next().await {
+                    Ok(event) => event,
+                    Err(error) => return Err(DiscussionLiveError::Subscribe(error)),
+                }
+            }
+            Err(error) if self.can_recover_stale_repo_id(&error) => {
+                *subscription = self.recover_stale_repo_identity().await?;
                 match subscription.inner.next().await {
                     Ok(event) => event,
                     Err(error) => return Err(DiscussionLiveError::Subscribe(error)),
@@ -855,6 +893,21 @@ impl DiscussionLiveError {
             Self::Subscribe(error) => error.resume_after_event_id(),
             _ => None,
         }
+    }
+}
+
+fn is_repository_not_found(error: &RepoEventError) -> bool {
+    match error {
+        RepoEventError::Refused { source } | RepoEventError::Disconnected { source, .. } => {
+            matches!(
+                source,
+                crate::hosted_runtime::hosted::HostedError::Call {
+                    code: CallFailureCode::NotFound,
+                    ..
+                }
+            )
+        }
+        _ => false,
     }
 }
 

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -200,23 +200,19 @@ pub fn save_cursor(
 
 /// Load the watermark for `scope`.
 ///
-/// Unfiltered + authority falls back to the bare `repo_path` slot so files
-/// written before authority scoping still resume. Filtered scopes never fall
-/// back to the unfiltered watermark.
+/// Filtered scopes never fall back to the unfiltered watermark. An
+/// authority-scoped unfiltered wait also does not inherit the bare
+/// `repo_path` slot — that file has no hosted authority, so applying it
+/// would skip events on a different remote that shares owner/name.
 pub fn load_scoped_cursor(
     heddle_dir: &Path,
     scope: &DiscussionCursorScope,
 ) -> Result<DiscussionEventCursor> {
-    let cursors = load_cursors(heddle_dir)?;
-    if let Some(cursor) = cursors.repos.get(&scope.slot()) {
-        return Ok(cursor.clone());
-    }
-    if !scope.is_filtered() && !scope.authority.is_empty() {
-        if let Some(cursor) = cursors.repos.get(&scope.repo_path) {
-            return Ok(cursor.clone());
-        }
-    }
-    Ok(DiscussionEventCursor::default())
+    Ok(load_cursors(heddle_dir)?
+        .repos
+        .get(&scope.slot())
+        .cloned()
+        .unwrap_or_default())
 }
 
 /// Persist the watermark for `scope`. Always writes the scoped slot.
@@ -496,7 +492,10 @@ fn discussion_from_payload(
             if body.trim().is_empty() {
                 return None;
             }
-            if payload.turn_id.is_none() && payload.turn_seq == 0 {
+            // turn_seq 0 is "not minted". A one-turn HostedDiscussion then
+            // lands at list-index/ordinal 0 and pull_one drops it as the
+            // already-linked Open turn. Fetch unless identity is complete.
+            if payload.turn_id.is_none() || payload.turn_seq == 0 {
                 return None;
             }
             Some(hosted_from_payload(discussion_id, payload))

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -7,7 +7,9 @@
 //!
 //! 1. Bootstrap a fresh clone via [`super::discussion_sync::pull_discussions`]
 //!    (pull-bootstrap discussions when present, otherwise `ListByState` — the
-//!    same non-fatal path #1642 falls back to).
+//!    same non-fatal path #1642 falls back to). A `--thread` wait filters
+//!    that ListByState snapshot by `thread_ref` before apply; clone/pull
+//!    pull-fold stays repo-wide.
 //! 2. Subscribe from the persisted client watermark (`after_event_id`).
 //! 3. Treat live events as doorbells. `GetDiscussion` is the snapshot for
 //!    `discussion.opened` / `discussion.resolved` and for any append whose
@@ -38,7 +40,10 @@ use repo::Repository;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    discussion_sync::{apply_hosted_discussion, discussion_is_mirrored, pull_discussions},
+    discussion_sync::{
+        apply_hosted_discussion, discussion_is_mirrored, pull_discussions,
+        pull_discussions_for_thread,
+    },
     repo_events::{
         RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription, SubscribeRepoEventsRequest,
     },
@@ -322,6 +327,9 @@ pub async fn bootstrap_discussions(
 }
 
 /// Snapshot bootstrap, writing the bootstrapped flag on `scope`'s cursor.
+///
+/// A filtered scope (wait `--thread`) ListByState-filters by `thread_ref`
+/// before apply. Pull-fold `Some(discussions)` stays repo-wide.
 pub async fn bootstrap_discussions_scoped(
     repo: &Repository,
     client: &mut HostedClient,
@@ -338,9 +346,22 @@ pub async fn bootstrap_discussions_scoped(
             "cannot bootstrap hosted discussions without a repository HEAD"
         ));
     }
-    pull_discussions(repo, client, repo_path, bootstrap)
+    if scope.is_filtered() {
+        pull_discussions_for_thread(
+            repo,
+            client,
+            repo_path,
+            bootstrap,
+            &scope.thread,
+            &scope.thread_id,
+        )
         .await
-        .context("bootstrap hosted discussions")?;
+        .context("bootstrap hosted discussions for thread")?;
+    } else {
+        pull_discussions(repo, client, repo_path, bootstrap)
+            .await
+            .context("bootstrap hosted discussions")?;
+    }
     let _guard = lock_cursor_write(repo.heddle_dir())?;
     let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     cursor.bootstrapped = true;

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -9,9 +9,12 @@
 //!    (pull-bootstrap discussions when present, otherwise `ListByState` — the
 //!    same non-fatal path #1642 falls back to).
 //! 2. Subscribe from the persisted client watermark (`after_event_id`).
-//! 3. Apply each event into the local collab op-log, preserving server turn
-//!    identity (`turn_id` / `turn_seq`) so the linear blob cannot erase it.
-//! 4. Persist the watermark after each event so a reconnect resumes.
+//! 3. Treat live events as doorbells. `GetDiscussion` is the snapshot for
+//!    `discussion.opened` / `discussion.resolved` and for any append whose
+//!    id is not already mirrored. An already-mirrored `turn.appended` with
+//!    minted identity and a non-empty body may apply without a refetch.
+//!    Never reconstruct a `HostedDiscussion` from opened/resolved JSON.
+//! 4. Persist the watermark after apply, skip, or ignore — not after apply Err.
 //!
 //! Fail-closed on visibility: the server already filters emission by audience.
 //! This consumer uses the caller's credentials, treats a refused subscription
@@ -28,6 +31,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use objects::{
     fs_atomic::write_file_atomic,
+    lock::RepoLock,
     object::{Discussion, StateId},
 };
 use repo::Repository;
@@ -79,8 +83,9 @@ struct CursorFile {
 pub enum DiscussionEventOutcome {
     /// Not a discussion event; watermark still advances.
     Ignored,
-    /// Authorized event that could not be materialized (missing id, or
-    /// GetDiscussion hid it). Watermark advances so we do not retry forever.
+    /// Authorized event that could not be materialized (missing id,
+    /// GetDiscussion hid it, or apply could not write a valid op). Watermark
+    /// advances so we do not retry forever.
     Skipped { reason: String },
     /// Local op-log changed.
     Applied { discussion_id: String },
@@ -123,6 +128,18 @@ fn save_cursors(heddle_dir: &Path, cursors: &CursorFile) -> Result<()> {
     let bytes = serde_json::to_vec_pretty(cursors).context("encode discussion event cursor")?;
     write_file_atomic(&path, &bytes).context("write discussion event cursor")?;
     Ok(())
+}
+
+fn cursor_lock(heddle_dir: &Path) -> Result<RepoLock> {
+    let dir = heddle_dir.join("collaboration");
+    fs::create_dir_all(&dir).context("create collaboration dir")?;
+    Ok(RepoLock::at(dir.join("event-cursor.lock")))
+}
+
+fn lock_cursor_write(heddle_dir: &Path) -> Result<objects::lock::WriteLockGuard> {
+    cursor_lock(heddle_dir)?
+        .write()
+        .map_err(|error| anyhow!("lock discussion event cursor: {error}"))
 }
 
 /// Subscription identity for the durable event cursor.
@@ -324,6 +341,7 @@ pub async fn bootstrap_discussions_scoped(
     pull_discussions(repo, client, repo_path, bootstrap)
         .await
         .context("bootstrap hosted discussions")?;
+    let _guard = lock_cursor_write(repo.heddle_dir())?;
     let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     cursor.bootstrapped = true;
     // SubscribeRepoEvents keys on the hosted repo id (`RepoEvent.repo_id`, a
@@ -334,8 +352,8 @@ pub async fn bootstrap_discussions_scoped(
 }
 
 /// Apply one already-received repo event into the local op-log and advance
-/// the unfiltered watermark. Fetches via `GetDiscussion` when the payload
-/// is a doorbell.
+/// the audience-scoped watermark. Opened/resolved always fetch; an
+/// already-mirrored append may apply from the event.
 pub async fn consume_discussion_event(
     repo: &Repository,
     client: &mut HostedClient,
@@ -346,13 +364,26 @@ pub async fn consume_discussion_event(
         repo,
         client,
         repo_path,
-        &DiscussionCursorScope::unfiltered(repo_path),
+        &audience_cursor_scope(client, repo_path),
         event,
     )
     .await
 }
 
+/// Cursor identity for `discuss wait` / the unfiltered helper: repo path plus
+/// the authenticated hosted subject. Empty principal keeps the legacy slot.
+pub fn audience_cursor_scope(client: &HostedClient, repo_path: &str) -> DiscussionCursorScope {
+    DiscussionCursorScope {
+        repo_path: repo_path.to_string(),
+        principal: client.authenticated_username().unwrap_or_default(),
+        ..DiscussionCursorScope::default()
+    }
+}
+
 /// Apply one event and advance only `scope`'s watermark.
+///
+/// The watermark moves only after apply, skip, or ignore. Fetch/apply `Err`
+/// leaves the cursor untouched so a retry can see the same event_id.
 pub async fn consume_discussion_event_scoped(
     repo: &Repository,
     client: &mut HostedClient,
@@ -360,8 +391,9 @@ pub async fn consume_discussion_event_scoped(
     scope: &DiscussionCursorScope,
     event: &RepoEvent,
 ) -> Result<DiscussionEventOutcome> {
-    let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     let outcome = apply_discussion_event(repo, client, repo_path, event).await?;
+    let _guard = lock_cursor_write(repo.heddle_dir())?;
+    let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     cursor.after_event_id = cursor.after_event_id.max(event.event_id);
     if !event.repo_id.is_empty() {
         cursor.repo_id = event.repo_id.clone();
@@ -388,42 +420,69 @@ async fn apply_discussion_event(
 
     let already_mirrored =
         discussion_is_mirrored(repo.heddle_dir(), repo_path, &discussion_id)?;
-    let hosted = match discussion_from_payload(
-        event.event_type.as_str(),
-        &payload,
-        already_mirrored,
-    ) {
-        Some(discussion) => discussion,
-        None => match client
-            .get_discussion(repo_path, &discussion_id, payload.opened_against_state)
-            .await
-        {
-            Ok(discussion) => discussion,
-            Err(error) if is_hidden_discussion(&error) => {
+    let hosted = if event.event_type == "turn.appended" {
+        if let Some(discussion) = append_from_payload(&payload, already_mirrored) {
+            discussion
+        } else {
+            match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload).await?
+            {
+                Some(discussion) => discussion,
+                None => {
+                    return Ok(DiscussionEventOutcome::Skipped {
+                        reason: format!(
+                            "discussion {discussion_id} is not visible to this caller"
+                        ),
+                    });
+                }
+            }
+        }
+    } else {
+        match fetch_hosted_discussion(client, repo_path, event, &discussion_id, &payload).await? {
+            Some(discussion) => discussion,
+            None => {
                 return Ok(DiscussionEventOutcome::Skipped {
                     reason: format!("discussion {discussion_id} is not visible to this caller"),
                 });
             }
-            Err(error) => {
-                return Err(anyhow!(error).context(format!(
-                    "fetch hosted discussion {discussion_id} after {}",
-                    event.event_type
-                )));
-            }
-        },
+        }
     };
 
-    let changed = apply_hosted_discussion(
+    match apply_hosted_discussion(
         repo,
         repo_path,
         client.authenticated_username().as_deref(),
         &hosted,
-    )?;
-    Ok(if changed {
-        DiscussionEventOutcome::Applied { discussion_id }
-    } else {
-        DiscussionEventOutcome::Unchanged { discussion_id }
-    })
+    ) {
+        Ok(true) => Ok(DiscussionEventOutcome::Applied { discussion_id }),
+        Ok(false) => Ok(DiscussionEventOutcome::Unchanged { discussion_id }),
+        Err(error) => Ok(DiscussionEventOutcome::Skipped {
+            reason: format!(
+                "could not materialize hosted discussion {discussion_id} after {}: {error}",
+                event.event_type
+            ),
+        }),
+    }
+}
+
+/// `Ok(None)` is a visibility/NotFound skip. Other errors stay fatal.
+async fn fetch_hosted_discussion(
+    client: &mut HostedClient,
+    repo_path: &str,
+    event: &RepoEvent,
+    discussion_id: &str,
+    payload: &EventPayload,
+) -> Result<Option<HostedDiscussion>> {
+    match client
+        .get_discussion(repo_path, discussion_id, payload.opened_against_state)
+        .await
+    {
+        Ok(discussion) => Ok(Some(discussion)),
+        Err(error) if is_hidden_discussion(&error) => Ok(None),
+        Err(error) => Err(anyhow!(error).context(format!(
+            "fetch hosted discussion {discussion_id} after {}",
+            event.event_type
+        ))),
+    }
 }
 
 fn is_hidden_discussion(error: &wire::ProtocolError) -> bool {
@@ -447,24 +506,17 @@ struct EventPayload {
     discussion_id: Option<String>,
     turn_id: Option<String>,
     turn_seq: u64,
+    /// Untrimmed. `None` when missing or whitespace-only (emptiness test).
     body: Option<String>,
     author_name: Option<String>,
     author_email: Option<String>,
     posted_at_secs: i64,
-    file: Option<String>,
-    symbol: Option<String>,
-    visibility: Option<String>,
-    thread_ref: Option<String>,
     opened_against_state: Option<StateId>,
-    resolution: HostedResolution,
 }
 
 fn parse_event_payload(event: &RepoEvent) -> EventPayload {
-    // weft emit (scope.rs transactional sidecar): a flat object keyed with the
-    // CollaborationService field names. Not a nested `{discussion, turn}`
-    // envelope and not an alias map. Doorbells carry discussion_id + turn
-    // identity; opened/resolved may also carry the DiscussionTurn / resolution
-    // fields from state_review.proto.
+    // Doorbell identity only. Opened/resolved never reconstruct a
+    // HostedDiscussion from this JSON — GetDiscussion is the snapshot.
     let value = if event.payload_json.trim().is_empty() {
         serde_json::Value::Object(serde_json::Map::new())
     } else {
@@ -474,139 +526,50 @@ fn parse_event_payload(event: &RepoEvent) -> EventPayload {
         discussion_id: string_field(&value, "discussion_id"),
         turn_id: string_field(&value, "turn_id"),
         turn_seq: u64_field(&value, "turn_seq").unwrap_or(0),
-        body: string_field(&value, "body"),
+        body: body_field(&value),
         author_name: string_field(&value, "author_name"),
         author_email: string_field(&value, "author_email"),
         posted_at_secs: i64_field(&value, "posted_at").unwrap_or(0),
-        file: string_field(&value, "file"),
-        symbol: string_field(&value, "symbol"),
-        visibility: string_field(&value, "visibility"),
-        thread_ref: string_field(&value, "thread_ref")
-            .or_else(|| (!event.thread.is_empty()).then(|| event.thread.clone())),
         opened_against_state: value
             .get("opened_against_state")
             .and_then(parse_state_id)
             .or_else(|| event.new_state.as_ref().and_then(proto_state_id)),
-        resolution: parse_resolution(&value),
     }
 }
 
-fn discussion_from_payload(
-    event_type: &str,
-    payload: &EventPayload,
-    already_mirrored: bool,
-) -> Option<HostedDiscussion> {
-    let discussion_id = payload.discussion_id.clone()?;
-    // Fat append/resolve on an unknown server id must not mint Open: pull_one's
-    // None arm treats turns[0] as the first turn. Fetch (or skip) until the
-    // mirror already has this discussion. Only discussion.opened may Open.
-    if event_type != "discussion.opened" && !already_mirrored {
+/// Already-mirrored append with minted identity and a real body.
+/// Never mints Open. Author and posted_at must both be present; otherwise fetch.
+fn append_from_payload(payload: &EventPayload, already_mirrored: bool) -> Option<HostedDiscussion> {
+    if !already_mirrored {
         return None;
     }
-    match event_type {
-        "discussion.opened" => {
-            if payload.visibility.is_none() || !payload_has_anchor(payload) {
-                return None;
-            }
-            let body = payload.body.as_deref()?;
-            if body.trim().is_empty() {
-                return None;
-            }
-            Some(hosted_from_payload(discussion_id, payload))
-        }
-        "discussion.resolved" => {
-            if !payload_has_resolution(&payload.resolution) {
-                return None;
-            }
-            Some(hosted_from_payload(discussion_id, payload))
-        }
-        "turn.appended" => {
-            let body = payload.body.as_deref()?;
-            if body.trim().is_empty() {
-                return None;
-            }
-            // turn_seq 0 is "not minted". A one-turn HostedDiscussion then
-            // lands at list-index/ordinal 0 and pull_one drops it as the
-            // already-linked Open turn. Fetch unless identity is complete.
-            if payload.turn_id.is_none() || payload.turn_seq == 0 {
-                return None;
-            }
-            Some(hosted_from_payload(discussion_id, payload))
-        }
-        _ => None,
+    let discussion_id = payload.discussion_id.clone()?;
+    let body = payload.body.clone()?;
+    if payload.turn_id.is_none() || payload.turn_seq == 0 {
+        return None;
     }
-}
-
-fn payload_has_anchor(payload: &EventPayload) -> bool {
-    // file+symbol names a code-anchored discussion; the event state is the
-    // other half. Missing opened_against_state / event.new_state must fetch
-    // — pull_one must not substitute the receiving clone's HEAD.
-    payload.opened_against_state.is_some()
-        && payload
-            .file
-            .as_deref()
-            .is_some_and(|file| !file.is_empty())
-        && payload
-            .symbol
-            .as_deref()
-            .is_some_and(|symbol| !symbol.is_empty())
-}
-
-fn payload_has_resolution(resolution: &HostedResolution) -> bool {
-    match resolution {
-        HostedResolution::Open => false,
-        HostedResolution::ByEdit { state_id: None } => false,
-        HostedResolution::ByEdit { state_id: Some(_) } => true,
-        HostedResolution::Dismissed { .. } => true,
-        HostedResolution::IntoAnnotation { annotation_id } => !annotation_id.is_empty(),
+    let author_name = payload.author_name.clone()?;
+    if payload.posted_at_secs <= 0 {
+        return None;
     }
-}
-
-fn hosted_from_payload(discussion_id: String, payload: &EventPayload) -> HostedDiscussion {
-    let turns = payload
-        .body
-        .as_deref()
-        .filter(|body| !body.trim().is_empty())
-        .map(|body| {
-            vec![HostedDiscussionTurn {
-                author_name: payload.author_name.clone().unwrap_or_default(),
-                author_email: payload.author_email.clone().unwrap_or_default(),
-                body: body.to_string(),
-                posted_at_secs: payload.posted_at_secs,
-                turn_id: payload.turn_id.clone().unwrap_or_default(),
-                turn_seq: payload.turn_seq,
-            }]
-        })
-        .unwrap_or_default();
-    HostedDiscussion {
+    Some(HostedDiscussion {
         id: discussion_id,
-        file: payload.file.clone().unwrap_or_default(),
-        symbol: payload.symbol.clone().unwrap_or_default(),
-        opened_against_state: payload.opened_against_state,
-        visibility: payload.visibility.clone().unwrap_or_default(),
-        thread_ref: payload.thread_ref.clone(),
-        turns,
-        resolution: payload.resolution.clone(),
+        file: String::new(),
+        symbol: String::new(),
+        opened_against_state: None,
+        visibility: String::new(),
+        thread_ref: None,
+        turns: vec![HostedDiscussionTurn {
+            author_name,
+            author_email: payload.author_email.clone().unwrap_or_default(),
+            body,
+            posted_at_secs: payload.posted_at_secs,
+            turn_id: payload.turn_id.clone().unwrap_or_default(),
+            turn_seq: payload.turn_seq,
+        }],
+        resolution: HostedResolution::Open,
         kind: 0,
-    }
-}
-
-fn parse_resolution(value: &serde_json::Value) -> HostedResolution {
-    let Some(resolution) = value.get("resolution") else {
-        return HostedResolution::Open;
-    };
-    match string_field(resolution, "kind").unwrap_or_default().as_str() {
-        "dismissed" => HostedResolution::Dismissed {
-            reason: string_field(resolution, "reason").unwrap_or_default(),
-        },
-        "by_edit" => HostedResolution::ByEdit {
-            state_id: resolution.get("state_id").and_then(parse_state_id),
-        },
-        "into_annotation" => HostedResolution::IntoAnnotation {
-            annotation_id: string_field(resolution, "annotation_id").unwrap_or_default(),
-        },
-        _ => HostedResolution::Open,
-    }
+    })
 }
 
 fn string_field(value: &serde_json::Value, name: &str) -> Option<String> {
@@ -616,6 +579,15 @@ fn string_field(value: &serde_json::Value, name: &str) -> Option<String> {
         .map(str::trim)
         .filter(|field| !field.is_empty())
         .map(ToString::to_string)
+}
+
+fn body_field(value: &serde_json::Value) -> Option<String> {
+    let body = value.get("body")?.as_str()?;
+    if body.trim().is_empty() {
+        None
+    } else {
+        Some(body.to_string())
+    }
 }
 
 fn u64_field(value: &serde_json::Value, name: &str) -> Option<u64> {

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Live discussion delivery over [`RepoEventClient`].
+//!
+//! Pack attachments are a snapshot, not a stream. Live turns belong on the
+//! #1585 event-cursor channel. weft already emits `discussion.opened` /
+//! `turn.appended` / `discussion.resolved`; this module is the consumer:
+//!
+//! 1. Bootstrap a fresh clone via [`super::discussion_sync::pull_discussions`]
+//!    (pull-bootstrap discussions when present, otherwise `ListByState` — the
+//!    same non-fatal path #1642 falls back to).
+//! 2. Subscribe from the persisted client watermark (`after_event_id`).
+//! 3. Apply each event into the local collab op-log, preserving server turn
+//!    identity (`turn_id` / `turn_seq`) so the linear blob cannot erase it.
+//! 4. Persist the watermark after each event so a reconnect resumes.
+//!
+//! Fail-closed on visibility: the server already filters emission by audience.
+//! This consumer uses the caller's credentials, treats a refused subscription
+//! as fatal, and does not invent a discussion from an event that lacks a
+//! server id. `discussions_from_pack` is not read or written here.
+
+#![cfg(feature = "client")]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow};
+use objects::{
+    fs_atomic::write_file_atomic,
+    object::{Discussion, StateId},
+};
+use repo::Repository;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    discussion_sync::{apply_hosted_discussion, pull_discussions},
+    repo_events::{RepoEvent, RepoEventClient, RepoEventError, RepoEventSubscription, SubscribeRepoEventsRequest},
+};
+use crate::{
+    client::HostedClient,
+    hosted_runtime::hosted::{HostedDiscussion, HostedDiscussionTurn, HostedResolution},
+};
+
+/// Event types this consumer subscribes to. Unknown types are ignored.
+pub const DISCUSSION_EVENT_TYPES: &[&str] = &[
+    "discussion.opened",
+    "turn.appended",
+    "discussion.resolved",
+];
+
+const CURSOR_FILE: &str = "event-cursor.json";
+
+/// Per-repo durable resume cursor for discussion events.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiscussionEventCursor {
+    /// Last successfully consumed `RepoEvent.event_id`. Placed in
+    /// `after_event_id` on the next subscribe.
+    #[serde(default)]
+    pub after_event_id: i64,
+    /// Hosted repo id last seen on the wire. Empty until the first event.
+    #[serde(default)]
+    pub repo_id: String,
+    /// True after a ListByState / bootstrap snapshot has been applied.
+    #[serde(default)]
+    pub bootstrapped: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CursorFile {
+    #[serde(default)]
+    repos: std::collections::BTreeMap<String, DiscussionEventCursor>,
+}
+
+/// What happened when one event was consumed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscussionEventOutcome {
+    /// Not a discussion event; watermark still advances.
+    Ignored,
+    /// Authorized event that could not be materialized (missing id, or
+    /// GetDiscussion hid it). Watermark advances so we do not retry forever.
+    Skipped { reason: String },
+    /// Local op-log changed.
+    Applied { discussion_id: String },
+    /// Event was already represented locally.
+    Unchanged { discussion_id: String },
+}
+
+impl DiscussionEventOutcome {
+    pub fn discussion_id(&self) -> Option<&str> {
+        match self {
+            Self::Applied { discussion_id } | Self::Unchanged { discussion_id } => {
+                Some(discussion_id.as_str())
+            }
+            Self::Ignored | Self::Skipped { .. } => None,
+        }
+    }
+
+    pub fn applied(&self) -> bool {
+        matches!(self, Self::Applied { .. })
+    }
+}
+
+fn cursor_path(heddle_dir: &Path) -> PathBuf {
+    heddle_dir.join("collaboration").join(CURSOR_FILE)
+}
+
+fn load_cursors(heddle_dir: &Path) -> Result<CursorFile> {
+    match fs::read(cursor_path(heddle_dir)) {
+        Ok(bytes) => serde_json::from_slice(&bytes).context("decode discussion event cursor"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(CursorFile::default()),
+        Err(error) => Err(error).context("read discussion event cursor"),
+    }
+}
+
+fn save_cursors(heddle_dir: &Path, cursors: &CursorFile) -> Result<()> {
+    let path = cursor_path(heddle_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create collaboration dir")?;
+    }
+    let bytes = serde_json::to_vec_pretty(cursors).context("encode discussion event cursor")?;
+    write_file_atomic(&path, &bytes).context("write discussion event cursor")?;
+    Ok(())
+}
+
+/// Load the persisted watermark for `repo_path`.
+pub fn load_cursor(heddle_dir: &Path, repo_path: &str) -> Result<DiscussionEventCursor> {
+    Ok(load_cursors(heddle_dir)?
+        .repos
+        .get(repo_path)
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// Persist the watermark for `repo_path`.
+pub fn save_cursor(
+    heddle_dir: &Path,
+    repo_path: &str,
+    cursor: &DiscussionEventCursor,
+) -> Result<()> {
+    let mut cursors = load_cursors(heddle_dir)?;
+    cursors
+        .repos
+        .insert(repo_path.to_string(), cursor.clone());
+    save_cursors(heddle_dir, &cursors)
+}
+
+/// True when this event is a discussion doorbell or payload.
+pub fn is_discussion_event(event: &RepoEvent) -> bool {
+    DISCUSSION_EVENT_TYPES.contains(&event.event_type.as_str())
+        || event.kind
+            == api::heddle::api::v1alpha1::RepoEventKind::DiscussionTurn as i32
+}
+
+/// Subscribe request for the discussion live tail.
+pub fn subscribe_request(
+    repo_id: &str,
+    after_event_id: i64,
+    thread: &str,
+    thread_id: &str,
+) -> SubscribeRepoEventsRequest {
+    SubscribeRepoEventsRequest {
+        repo_id: repo_id.to_string(),
+        thread: thread.to_string(),
+        after_event_id,
+        event_types: DISCUSSION_EVENT_TYPES
+            .iter()
+            .map(|event_type| (*event_type).to_string())
+            .collect(),
+        thread_id: thread_id.to_string(),
+    }
+}
+
+/// Snapshot bootstrap for a fresh clone, then mark the cursor bootstrapped.
+///
+/// Does not start the live tail. `bootstrap` is the pull-fold discussions
+/// when the clone/pull already decoded them; `None` falls back to ListByState.
+pub async fn bootstrap_discussions(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    bootstrap: Option<&[Discussion]>,
+) -> Result<DiscussionEventCursor> {
+    pull_discussions(repo, client, repo_path, bootstrap)
+        .await
+        .context("bootstrap hosted discussions")?;
+    let mut cursor = load_cursor(repo.heddle_dir(), repo_path)?;
+    cursor.bootstrapped = true;
+    if cursor.repo_id.is_empty() {
+        cursor.repo_id = repo_path.to_string();
+    }
+    save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
+    Ok(cursor)
+}
+
+/// Apply one already-received repo event into the local op-log and advance
+/// the watermark. Fetches via `GetDiscussion` when the payload is a doorbell.
+pub async fn consume_discussion_event(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    event: &RepoEvent,
+) -> Result<DiscussionEventOutcome> {
+    let mut cursor = load_cursor(repo.heddle_dir(), repo_path)?;
+    let outcome = apply_discussion_event(repo, client, repo_path, event).await?;
+    cursor.after_event_id = cursor.after_event_id.max(event.event_id);
+    if !event.repo_id.is_empty() {
+        cursor.repo_id = event.repo_id.clone();
+    } else if cursor.repo_id.is_empty() {
+        cursor.repo_id = repo_path.to_string();
+    }
+    save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
+    Ok(outcome)
+}
+
+async fn apply_discussion_event(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    event: &RepoEvent,
+) -> Result<DiscussionEventOutcome> {
+    if !is_discussion_event(event) {
+        return Ok(DiscussionEventOutcome::Ignored);
+    }
+    let payload = parse_event_payload(event);
+    let Some(discussion_id) = payload.discussion_id.clone() else {
+        return Ok(DiscussionEventOutcome::Skipped {
+            reason: "discussion event is missing a server discussion id".to_string(),
+        });
+    };
+
+    let hosted = match discussion_from_payload(event.event_type.as_str(), &payload) {
+        Some(discussion) => discussion,
+        None => match client.get_discussion(repo_path, &discussion_id).await {
+            Ok(discussion) => discussion,
+            Err(error) if is_hidden_discussion(&error) => {
+                return Ok(DiscussionEventOutcome::Skipped {
+                    reason: format!("discussion {discussion_id} is not visible to this caller"),
+                });
+            }
+            Err(error) => {
+                return Err(anyhow!(error).context(format!(
+                    "fetch hosted discussion {discussion_id} after {}",
+                    event.event_type
+                )));
+            }
+        },
+    };
+
+    let changed = apply_hosted_discussion(
+        repo,
+        repo_path,
+        client.authenticated_username().as_deref(),
+        &hosted,
+    )?;
+    Ok(if changed {
+        DiscussionEventOutcome::Applied { discussion_id }
+    } else {
+        DiscussionEventOutcome::Unchanged { discussion_id }
+    })
+}
+
+fn is_hidden_discussion(error: &wire::ProtocolError) -> bool {
+    let text = error.to_string();
+    text.contains("PermissionDenied")
+        || text.contains("NotFound")
+        || text.contains("permission denied")
+        || text.contains("not found")
+}
+
+#[derive(Debug, Default)]
+struct EventPayload {
+    discussion_id: Option<String>,
+    turn_id: Option<String>,
+    turn_seq: u64,
+    body: Option<String>,
+    author_name: Option<String>,
+    author_email: Option<String>,
+    posted_at_secs: i64,
+    file: Option<String>,
+    symbol: Option<String>,
+    visibility: Option<String>,
+    thread_ref: Option<String>,
+    opened_against_state: Option<StateId>,
+    resolution: HostedResolution,
+}
+
+fn parse_event_payload(event: &RepoEvent) -> EventPayload {
+    let value = if event.payload_json.trim().is_empty() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_str(&event.payload_json).unwrap_or(serde_json::Value::Null)
+    };
+    let nested = value.get("discussion");
+    let discussion_id = string_field(&value, &["discussion_id", "id"])
+        .or_else(|| nested.and_then(|nested| string_field(nested, &["id", "discussion_id"])));
+    let turn = value.get("turn").cloned().unwrap_or(serde_json::Value::Null);
+    EventPayload {
+        discussion_id,
+        turn_id: string_field(&value, &["turn_id"])
+            .or_else(|| string_field(&turn, &["turn_id", "id"])),
+        turn_seq: u64_field(&value, "turn_seq")
+            .or_else(|| u64_field(&turn, "turn_seq"))
+            .unwrap_or(0),
+        body: string_field(&value, &["body"]).or_else(|| string_field(&turn, &["body"])),
+        author_name: string_field(&value, &["author_name"])
+            .or_else(|| string_field(&turn, &["author_name"])),
+        author_email: string_field(&value, &["author_email"])
+            .or_else(|| string_field(&turn, &["author_email"])),
+        posted_at_secs: i64_field(&value, &["posted_at", "posted_at_secs"])
+            .or_else(|| i64_field(&turn, &["posted_at", "posted_at_secs"]))
+            .unwrap_or(0),
+        file: string_field(&value, &["file", "path"])
+            .or_else(|| nested.and_then(|nested| string_field(nested, &["file", "path"]))),
+        symbol: string_field(&value, &["symbol"])
+            .or_else(|| nested.and_then(|nested| string_field(nested, &["symbol"]))),
+        visibility: string_field(&value, &["visibility"]),
+        thread_ref: string_field(&value, &["thread_ref"])
+            .or_else(|| (!event.thread.is_empty()).then(|| event.thread.clone())),
+        opened_against_state: value
+            .get("opened_against_state")
+            .and_then(parse_state_id)
+            .or_else(|| event.new_state.as_ref().and_then(proto_state_id)),
+        resolution: parse_resolution(&value),
+    }
+}
+
+fn discussion_from_payload(event_type: &str, payload: &EventPayload) -> Option<HostedDiscussion> {
+    let discussion_id = payload.discussion_id.clone()?;
+    // Doorbell events (id only) and incomplete appends must fetch. A fat
+    // `turn.appended` without turn identity would look like ordinal 0 and
+    // either drop the new turn or collide with the bootstrap snapshot.
+    let body = payload.body.clone()?;
+    if body.trim().is_empty() {
+        return None;
+    }
+    if event_type == "turn.appended"
+        && payload.turn_id.is_none()
+        && payload.turn_seq == 0
+    {
+        return None;
+    }
+    Some(HostedDiscussion {
+        id: discussion_id,
+        file: payload.file.clone().unwrap_or_default(),
+        symbol: payload.symbol.clone().unwrap_or_default(),
+        opened_against_state: payload.opened_against_state,
+        visibility: payload
+            .visibility
+            .clone()
+            .unwrap_or_else(|| "internal".to_string()),
+        thread_ref: payload.thread_ref.clone(),
+        turns: vec![HostedDiscussionTurn {
+            author_name: payload.author_name.clone().unwrap_or_default(),
+            author_email: payload.author_email.clone().unwrap_or_default(),
+            body,
+            posted_at_secs: payload.posted_at_secs,
+            turn_id: payload.turn_id.clone().unwrap_or_default(),
+            turn_seq: payload.turn_seq,
+        }],
+        resolution: payload.resolution.clone(),
+    })
+}
+
+fn parse_resolution(value: &serde_json::Value) -> HostedResolution {
+    let Some(resolution) = value.get("resolution") else {
+        if value.get("dismissed_reason").is_some() {
+            return HostedResolution::Dismissed {
+                reason: string_field(value, &["dismissed_reason"]).unwrap_or_default(),
+            };
+        }
+        return HostedResolution::Open;
+    };
+    match string_field(resolution, &["kind", "type"])
+        .unwrap_or_default()
+        .as_str()
+    {
+        "dismissed" | "dismiss" => HostedResolution::Dismissed {
+            reason: string_field(resolution, &["reason"]).unwrap_or_default(),
+        },
+        "by_edit" | "by-edit" | "addressed_by_state" => HostedResolution::ByEdit {
+            state_id: resolution.get("state_id").and_then(parse_state_id),
+        },
+        "into_annotation" | "annotation" => HostedResolution::IntoAnnotation {
+            annotation_id: string_field(resolution, &["annotation_id", "id"]).unwrap_or_default(),
+        },
+        _ => HostedResolution::Open,
+    }
+}
+
+fn string_field(value: &serde_json::Value, names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        value
+            .get(*name)
+            .and_then(|field| field.as_str())
+            .map(str::trim)
+            .filter(|field| !field.is_empty())
+            .map(ToString::to_string)
+    })
+}
+
+fn u64_field(value: &serde_json::Value, name: &str) -> Option<u64> {
+    value.get(name).and_then(|field| {
+        field
+            .as_u64()
+            .or_else(|| field.as_i64().and_then(|n| u64::try_from(n).ok()))
+            .or_else(|| field.as_str()?.parse().ok())
+    })
+}
+
+fn i64_field(value: &serde_json::Value, names: &[&str]) -> Option<i64> {
+    names.iter().find_map(|name| {
+        value.get(*name).and_then(|field| {
+            field
+                .as_i64()
+                .or_else(|| field.as_u64().and_then(|n| i64::try_from(n).ok()))
+                .or_else(|| field.as_str()?.parse().ok())
+        })
+    })
+}
+
+fn parse_state_id(value: &serde_json::Value) -> Option<StateId> {
+    if let Some(hex) = value.as_str() {
+        let bytes = hex::decode(hex).ok()?;
+        return StateId::try_from_slice(&bytes).ok();
+    }
+    if let Some(bytes) = value.get("value").and_then(|field| field.as_array()) {
+        let bytes: Option<Vec<u8>> = bytes
+            .iter()
+            .map(|n| n.as_u64().and_then(|n| u8::try_from(n).ok()))
+            .collect();
+        return StateId::try_from_slice(&bytes?).ok();
+    }
+    None
+}
+
+fn proto_state_id(state: &api::heddle::api::v1alpha1::StateId) -> Option<StateId> {
+    StateId::try_from_slice(&state.value).ok()
+}
+
+/// One live-tail session: bootstrap if needed, subscribe, apply, persist.
+pub struct DiscussionEventConsumer<'a> {
+    repo: &'a Repository,
+    client: &'a mut HostedClient,
+    events: RepoEventClient,
+    repo_path: String,
+    thread: String,
+    thread_id: String,
+}
+
+impl<'a> DiscussionEventConsumer<'a> {
+    pub fn new(
+        repo: &'a Repository,
+        client: &'a mut HostedClient,
+        repo_path: impl Into<String>,
+    ) -> Self {
+        let events = RepoEventClient::from_hosted_client(client.clone());
+        Self {
+            repo,
+            client,
+            events,
+            repo_path: repo_path.into(),
+            thread: String::new(),
+            thread_id: String::new(),
+        }
+    }
+
+    pub fn with_thread(mut self, thread: impl Into<String>, thread_id: impl Into<String>) -> Self {
+        self.thread = thread.into();
+        self.thread_id = thread_id.into();
+        self
+    }
+
+    /// Snapshot bootstrap (if this clone has no cursor yet) then open the
+    /// replay-then-live subscription.
+    pub async fn start(
+        &mut self,
+        bootstrap: Option<&[Discussion]>,
+    ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
+        let mut cursor = load_cursor(self.repo.heddle_dir(), &self.repo_path)
+            .map_err(DiscussionLiveError::cursor)?;
+        if !cursor.bootstrapped {
+            cursor = bootstrap_discussions(self.repo, self.client, &self.repo_path, bootstrap)
+                .await
+                .map_err(DiscussionLiveError::bootstrap)?;
+        }
+        let repo_id = if cursor.repo_id.is_empty() {
+            self.repo_path.clone()
+        } else {
+            cursor.repo_id.clone()
+        };
+        let subscription = self
+            .events
+            .subscribe(subscribe_request(
+                &repo_id,
+                cursor.after_event_id,
+                &self.thread,
+                &self.thread_id,
+            ))
+            .await
+            .map_err(DiscussionLiveError::Subscribe)?;
+        Ok(DiscussionEventSubscription {
+            inner: subscription,
+        })
+    }
+
+    pub async fn consume_next(
+        &mut self,
+        subscription: &mut DiscussionEventSubscription,
+    ) -> Result<(RepoEvent, DiscussionEventOutcome), DiscussionLiveError> {
+        let event = subscription
+            .inner
+            .next()
+            .await
+            .map_err(DiscussionLiveError::Subscribe)?;
+        let outcome = consume_discussion_event(self.repo, self.client, &self.repo_path, &event)
+            .await
+            .map_err(DiscussionLiveError::apply)?;
+        Ok((event, outcome))
+    }
+}
+
+/// Wrapper so callers do not have to name [`RepoEventSubscription`].
+pub struct DiscussionEventSubscription {
+    inner: RepoEventSubscription,
+}
+
+impl DiscussionEventSubscription {
+    pub fn last_event_id(&self) -> i64 {
+        self.inner.last_event_id()
+    }
+
+    pub fn resume_request(&self) -> SubscribeRepoEventsRequest {
+        self.inner.resume_request()
+    }
+}
+
+/// Failure to bootstrap, subscribe, or apply a live discussion event.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscussionLiveError {
+    #[error("failed to persist the discussion event cursor: {0}")]
+    Cursor(String),
+    #[error("failed to bootstrap hosted discussions: {0}")]
+    Bootstrap(String),
+    #[error(transparent)]
+    Subscribe(#[from] RepoEventError),
+    #[error("failed to apply a discussion event: {0}")]
+    Apply(String),
+}
+
+impl DiscussionLiveError {
+    fn cursor(error: anyhow::Error) -> Self {
+        Self::Cursor(error.to_string())
+    }
+
+    fn bootstrap(error: anyhow::Error) -> Self {
+        Self::Bootstrap(error.to_string())
+    }
+
+    fn apply(error: anyhow::Error) -> Self {
+        Self::Apply(error.to_string())
+    }
+
+    pub fn resume_after_event_id(&self) -> Option<i64> {
+        match self {
+            Self::Subscribe(error) => error.resume_after_event_id(),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "discussion_live_tests.rs"]
+mod tests;

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -127,11 +127,13 @@ fn save_cursors(heddle_dir: &Path, cursors: &CursorFile) -> Result<()> {
 
 /// Subscription identity for the durable event cursor.
 ///
-/// Unfiltered waits (no thread filter, no authority) keep the legacy
-/// `repo_path` slot so existing files keep working. A filtered wait must
-/// never share that slot: skipping bar-thread events and then advancing a
-/// repo-wide watermark would leave an unfiltered `discuss wait` permanently
-/// past them.
+/// Unfiltered waits (no thread filter, no authority, no principal) keep the
+/// legacy `repo_path` slot so existing files keep working. A filtered wait
+/// must never share that slot: skipping bar-thread events and then advancing
+/// a repo-wide watermark would leave an unfiltered `discuss wait` permanently
+/// past them. Authenticated principals also get their own slot — the server
+/// filters events by audience, so Alice skipping a restricted event must not
+/// advance Bob's cursor past it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DiscussionCursorScope {
     /// Hosted authority (`host:port`). Empty for tests that only have a path.
@@ -139,6 +141,9 @@ pub struct DiscussionCursorScope {
     pub repo_path: String,
     pub thread: String,
     pub thread_id: String,
+    /// Authenticated hosted subject (`principal:<name>` without the prefix).
+    /// Empty for unsigned/anonymous clients and the legacy unfiltered helper.
+    pub principal: String,
 }
 
 impl DiscussionCursorScope {
@@ -160,11 +165,18 @@ impl DiscussionCursorScope {
             &self.repo_path,
             &self.thread,
             &self.thread_id,
+            &self.principal,
         )
     }
 }
 
-fn cursor_slot(authority: &str, repo_path: &str, thread: &str, thread_id: &str) -> String {
+fn cursor_slot(
+    authority: &str,
+    repo_path: &str,
+    thread: &str,
+    thread_id: &str,
+    principal: &str,
+) -> String {
     let mut key = String::new();
     if !authority.is_empty() {
         key.push_str(authority);
@@ -176,6 +188,10 @@ fn cursor_slot(authority: &str, repo_path: &str, thread: &str, thread_id: &str) 
         key.push_str(thread);
         key.push_str("\nthread_id=");
         key.push_str(thread_id);
+    }
+    if !principal.is_empty() {
+        key.push_str("\nprincipal=");
+        key.push_str(principal);
     }
     key
 }
@@ -522,10 +538,14 @@ fn discussion_from_payload(
 }
 
 fn payload_has_anchor(payload: &EventPayload) -> bool {
-    payload
-        .file
-        .as_deref()
-        .is_some_and(|file| !file.is_empty())
+    // file+symbol names a code-anchored discussion; the event state is the
+    // other half. Missing opened_against_state / event.new_state must fetch
+    // — pull_one must not substitute the receiving clone's HEAD.
+    payload.opened_against_state.is_some()
+        && payload
+            .file
+            .as_deref()
+            .is_some_and(|file| !file.is_empty())
         && payload
             .symbol
             .as_deref()
@@ -567,6 +587,7 @@ fn hosted_from_payload(discussion_id: String, payload: &EventPayload) -> HostedD
         thread_ref: payload.thread_ref.clone(),
         turns,
         resolution: payload.resolution.clone(),
+        kind: 0,
     }
 }
 
@@ -680,6 +701,10 @@ impl<'a> DiscussionEventConsumer<'a> {
             repo_path: self.repo_path.clone(),
             thread: self.thread.clone(),
             thread_id: self.thread_id.clone(),
+            principal: self
+                .client
+                .authenticated_username()
+                .unwrap_or_default(),
         }
     }
 

--- a/crates/hosted-client/src/client/discussion_live.rs
+++ b/crates/hosted-client/src/client/discussion_live.rs
@@ -125,25 +125,108 @@ fn save_cursors(heddle_dir: &Path, cursors: &CursorFile) -> Result<()> {
     Ok(())
 }
 
-/// Load the persisted watermark for `repo_path`.
-pub fn load_cursor(heddle_dir: &Path, repo_path: &str) -> Result<DiscussionEventCursor> {
-    Ok(load_cursors(heddle_dir)?
-        .repos
-        .get(repo_path)
-        .cloned()
-        .unwrap_or_default())
+/// Subscription identity for the durable event cursor.
+///
+/// Unfiltered waits (no thread filter, no authority) keep the legacy
+/// `repo_path` slot so existing files keep working. A filtered wait must
+/// never share that slot: skipping bar-thread events and then advancing a
+/// repo-wide watermark would leave an unfiltered `discuss wait` permanently
+/// past them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiscussionCursorScope {
+    /// Hosted authority (`host:port`). Empty for tests that only have a path.
+    pub authority: String,
+    pub repo_path: String,
+    pub thread: String,
+    pub thread_id: String,
 }
 
-/// Persist the watermark for `repo_path`.
+impl DiscussionCursorScope {
+    pub fn unfiltered(repo_path: impl Into<String>) -> Self {
+        Self {
+            repo_path: repo_path.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn is_filtered(&self) -> bool {
+        !self.thread.is_empty() || !self.thread_id.is_empty()
+    }
+
+    /// Stable map key. Filtered keys never equal the unfiltered `repo_path`.
+    pub fn slot(&self) -> String {
+        cursor_slot(
+            &self.authority,
+            &self.repo_path,
+            &self.thread,
+            &self.thread_id,
+        )
+    }
+}
+
+fn cursor_slot(authority: &str, repo_path: &str, thread: &str, thread_id: &str) -> String {
+    let mut key = String::new();
+    if !authority.is_empty() {
+        key.push_str(authority);
+        key.push('\n');
+    }
+    key.push_str(repo_path);
+    if !thread.is_empty() || !thread_id.is_empty() {
+        key.push_str("\nthread=");
+        key.push_str(thread);
+        key.push_str("\nthread_id=");
+        key.push_str(thread_id);
+    }
+    key
+}
+
+/// Load the persisted watermark for the unfiltered `repo_path` slot.
+pub fn load_cursor(heddle_dir: &Path, repo_path: &str) -> Result<DiscussionEventCursor> {
+    load_scoped_cursor(heddle_dir, &DiscussionCursorScope::unfiltered(repo_path))
+}
+
+/// Persist the watermark for the unfiltered `repo_path` slot.
 pub fn save_cursor(
     heddle_dir: &Path,
     repo_path: &str,
     cursor: &DiscussionEventCursor,
 ) -> Result<()> {
+    save_scoped_cursor(
+        heddle_dir,
+        &DiscussionCursorScope::unfiltered(repo_path),
+        cursor,
+    )
+}
+
+/// Load the watermark for `scope`.
+///
+/// Unfiltered + authority falls back to the bare `repo_path` slot so files
+/// written before authority scoping still resume. Filtered scopes never fall
+/// back to the unfiltered watermark.
+pub fn load_scoped_cursor(
+    heddle_dir: &Path,
+    scope: &DiscussionCursorScope,
+) -> Result<DiscussionEventCursor> {
+    let cursors = load_cursors(heddle_dir)?;
+    if let Some(cursor) = cursors.repos.get(&scope.slot()) {
+        return Ok(cursor.clone());
+    }
+    if !scope.is_filtered() && !scope.authority.is_empty() {
+        if let Some(cursor) = cursors.repos.get(&scope.repo_path) {
+            return Ok(cursor.clone());
+        }
+    }
+    Ok(DiscussionEventCursor::default())
+}
+
+/// Persist the watermark for `scope`. Always writes the scoped slot.
+pub fn save_scoped_cursor(
+    heddle_dir: &Path,
+    scope: &DiscussionCursorScope,
+    cursor: &DiscussionEventCursor,
+) -> Result<()> {
     let mut cursors = load_cursors(heddle_dir)?;
-    cursors
-        .repos
-        .insert(repo_path.to_string(), cursor.clone());
+    cursors.repos.insert(scope.slot(), cursor.clone());
     save_cursors(heddle_dir, &cursors)
 }
 
@@ -183,33 +266,79 @@ pub async fn bootstrap_discussions(
     repo_path: &str,
     bootstrap: Option<&[Discussion]>,
 ) -> Result<DiscussionEventCursor> {
+    bootstrap_discussions_scoped(
+        repo,
+        client,
+        repo_path,
+        &DiscussionCursorScope::unfiltered(repo_path),
+        bootstrap,
+    )
+    .await
+}
+
+/// Snapshot bootstrap, writing the bootstrapped flag on `scope`'s cursor.
+pub async fn bootstrap_discussions_scoped(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    scope: &DiscussionCursorScope,
+    bootstrap: Option<&[Discussion]>,
+) -> Result<DiscussionEventCursor> {
+    if repo
+        .head()
+        .context("resolve repository head")?
+        .is_none()
+    {
+        return Err(anyhow!(
+            "cannot bootstrap hosted discussions without a repository HEAD"
+        ));
+    }
     pull_discussions(repo, client, repo_path, bootstrap)
         .await
         .context("bootstrap hosted discussions")?;
-    let mut cursor = load_cursor(repo.heddle_dir(), repo_path)?;
+    let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     cursor.bootstrapped = true;
     // SubscribeRepoEvents keys on the hosted repo id (`RepoEvent.repo_id`, a
     // weft UUID). owner/name is a RepositoryRef path used by GetDiscussion /
     // ListByState. Do not persist the path into this slot.
-    save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
+    save_scoped_cursor(repo.heddle_dir(), scope, &cursor)?;
     Ok(cursor)
 }
 
 /// Apply one already-received repo event into the local op-log and advance
-/// the watermark. Fetches via `GetDiscussion` when the payload is a doorbell.
+/// the unfiltered watermark. Fetches via `GetDiscussion` when the payload
+/// is a doorbell.
 pub async fn consume_discussion_event(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
     event: &RepoEvent,
 ) -> Result<DiscussionEventOutcome> {
-    let mut cursor = load_cursor(repo.heddle_dir(), repo_path)?;
+    consume_discussion_event_scoped(
+        repo,
+        client,
+        repo_path,
+        &DiscussionCursorScope::unfiltered(repo_path),
+        event,
+    )
+    .await
+}
+
+/// Apply one event and advance only `scope`'s watermark.
+pub async fn consume_discussion_event_scoped(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    scope: &DiscussionCursorScope,
+    event: &RepoEvent,
+) -> Result<DiscussionEventOutcome> {
+    let mut cursor = load_scoped_cursor(repo.heddle_dir(), scope)?;
     let outcome = apply_discussion_event(repo, client, repo_path, event).await?;
     cursor.after_event_id = cursor.after_event_id.max(event.event_id);
     if !event.repo_id.is_empty() {
         cursor.repo_id = event.repo_id.clone();
     }
-    save_cursor(repo.heddle_dir(), repo_path, &cursor)?;
+    save_scoped_cursor(repo.heddle_dir(), scope, &cursor)?;
     Ok(outcome)
 }
 
@@ -237,7 +366,10 @@ async fn apply_discussion_event(
         already_mirrored,
     ) {
         Some(discussion) => discussion,
-        None => match client.get_discussion(repo_path, &discussion_id).await {
+        None => match client
+            .get_discussion(repo_path, &discussion_id, payload.opened_against_state)
+            .await
+        {
             Ok(discussion) => discussion,
             Err(error) if is_hidden_discussion(&error) => {
                 return Ok(DiscussionEventOutcome::Skipped {
@@ -342,20 +474,56 @@ fn discussion_from_payload(
     if event_type != "discussion.opened" && !already_mirrored {
         return None;
     }
-    if event_type == "discussion.opened" && payload.visibility.is_none() {
-        return None;
+    match event_type {
+        "discussion.opened" => {
+            if payload.visibility.is_none() || !payload_has_anchor(payload) {
+                return None;
+            }
+            let body = payload.body.as_deref()?;
+            if body.trim().is_empty() {
+                return None;
+            }
+            Some(hosted_from_payload(discussion_id, payload))
+        }
+        "discussion.resolved" => {
+            if !payload_has_resolution(&payload.resolution) {
+                return None;
+            }
+            Some(hosted_from_payload(discussion_id, payload))
+        }
+        "turn.appended" => {
+            let body = payload.body.as_deref()?;
+            if body.trim().is_empty() {
+                return None;
+            }
+            if payload.turn_id.is_none() && payload.turn_seq == 0 {
+                return None;
+            }
+            Some(hosted_from_payload(discussion_id, payload))
+        }
+        _ => None,
     }
-    if event_type == "discussion.resolved" && already_mirrored {
-        return Some(hosted_from_payload(discussion_id, payload));
+}
+
+fn payload_has_anchor(payload: &EventPayload) -> bool {
+    payload
+        .file
+        .as_deref()
+        .is_some_and(|file| !file.is_empty())
+        && payload
+            .symbol
+            .as_deref()
+            .is_some_and(|symbol| !symbol.is_empty())
+}
+
+fn payload_has_resolution(resolution: &HostedResolution) -> bool {
+    match resolution {
+        HostedResolution::Open => false,
+        HostedResolution::ByEdit { state_id: None } => false,
+        HostedResolution::ByEdit { state_id: Some(_) } => true,
+        HostedResolution::Dismissed { .. } => true,
+        HostedResolution::IntoAnnotation { annotation_id } => !annotation_id.is_empty(),
     }
-    let body = payload.body.as_deref()?;
-    if body.trim().is_empty() {
-        return None;
-    }
-    if event_type == "turn.appended" && payload.turn_id.is_none() && payload.turn_seq == 0 {
-        return None;
-    }
-    Some(hosted_from_payload(discussion_id, payload))
 }
 
 fn hosted_from_payload(discussion_id: String, payload: &EventPayload) -> HostedDiscussion {
@@ -456,6 +624,7 @@ pub struct DiscussionEventConsumer<'a> {
     client: &'a mut HostedClient,
     events: RepoEventClient,
     repo_path: String,
+    authority: String,
     thread: String,
     thread_id: String,
 }
@@ -472,9 +641,15 @@ impl<'a> DiscussionEventConsumer<'a> {
             client,
             events,
             repo_path: repo_path.into(),
+            authority: String::new(),
             thread: String::new(),
             thread_id: String::new(),
         }
+    }
+
+    pub fn with_authority(mut self, authority: impl Into<String>) -> Self {
+        self.authority = authority.into();
+        self
     }
 
     pub fn with_thread(mut self, thread: impl Into<String>, thread_id: impl Into<String>) -> Self {
@@ -483,18 +658,34 @@ impl<'a> DiscussionEventConsumer<'a> {
         self
     }
 
+    fn cursor_scope(&self) -> DiscussionCursorScope {
+        DiscussionCursorScope {
+            authority: self.authority.clone(),
+            repo_path: self.repo_path.clone(),
+            thread: self.thread.clone(),
+            thread_id: self.thread_id.clone(),
+        }
+    }
+
     /// Snapshot bootstrap (if this clone has no cursor yet) then open the
     /// replay-then-live subscription.
     pub async fn start(
         &mut self,
         bootstrap: Option<&[Discussion]>,
     ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
-        let mut cursor = load_cursor(self.repo.heddle_dir(), &self.repo_path)
+        let scope = self.cursor_scope();
+        let mut cursor = load_scoped_cursor(self.repo.heddle_dir(), &scope)
             .map_err(DiscussionLiveError::cursor)?;
         if !cursor.bootstrapped {
-            cursor = bootstrap_discussions(self.repo, self.client, &self.repo_path, bootstrap)
-                .await
-                .map_err(DiscussionLiveError::bootstrap)?;
+            cursor = bootstrap_discussions_scoped(
+                self.repo,
+                self.client,
+                &self.repo_path,
+                &scope,
+                bootstrap,
+            )
+            .await
+            .map_err(DiscussionLiveError::bootstrap)?;
         }
         self.subscribe_from_cursor(&cursor).await
     }
@@ -503,7 +694,7 @@ impl<'a> DiscussionEventConsumer<'a> {
     pub async fn resume(
         &mut self,
     ) -> Result<DiscussionEventSubscription, DiscussionLiveError> {
-        let cursor = load_cursor(self.repo.heddle_dir(), &self.repo_path)
+        let cursor = load_scoped_cursor(self.repo.heddle_dir(), &self.cursor_scope())
             .map_err(DiscussionLiveError::cursor)?;
         self.subscribe_from_cursor(&cursor).await
     }
@@ -550,9 +741,15 @@ impl<'a> DiscussionEventConsumer<'a> {
             }
             Err(error) => return Err(DiscussionLiveError::Subscribe(error)),
         };
-        let outcome = consume_discussion_event(self.repo, self.client, &self.repo_path, &event)
-            .await
-            .map_err(DiscussionLiveError::apply)?;
+        let outcome = consume_discussion_event_scoped(
+            self.repo,
+            self.client,
+            &self.repo_path,
+            &self.cursor_scope(),
+            &event,
+        )
+        .await
+        .map_err(DiscussionLiveError::apply)?;
         Ok((event, outcome))
     }
 }

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -641,11 +641,13 @@ async fn get_discussion_not_found_is_skipped_and_advances_the_watermark() {
 #[tokio::test]
 async fn bootstrap_none_hits_list_by_state() {
     let (_temp, repo) = seed_repo();
-    let mut fixture = CollaborationFixture::default();
-    fixture.list = vec![proto_discussion(
-        "disc-list",
-        &[("turn-open", "from list", 1)],
-    )];
+    let fixture = CollaborationFixture {
+        list: vec![proto_discussion(
+            "disc-list",
+            &[("turn-open", "from list", 1)],
+        )],
+        ..CollaborationFixture::default()
+    };
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
@@ -1169,10 +1171,10 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
 #[tokio::test]
 async fn thread_scoped_subscribe_request_carries_thread_id() {
     let (_temp, repo) = seed_repo();
-    let mut fixture = CollaborationFixture::default();
-    fixture
-        .events
-        .push(opened_event(1, "disc-1", "hello", "turn-1"));
+    let fixture = CollaborationFixture {
+        events: vec![opened_event(1, "disc-1", "hello", "turn-1")],
+        ..CollaborationFixture::default()
+    };
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -10,7 +10,8 @@ use tempfile::TempDir;
 
 use super::{
     DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
-    audience_cursor_scope, bootstrap_discussions, consume_discussion_event,
+    audience_cursor_scope, bootstrap_discussions, bootstrap_discussions_scoped,
+    consume_discussion_event,
     consume_discussion_event_scoped, is_discussion_event, load_cursor, load_scoped_cursor,
     paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor, subscribe_request,
 };
@@ -1698,6 +1699,161 @@ async fn bootstrap_claims_legacy_migration_marker_before_local_import() {
     assert!(
         report.is_none(),
         "pull_discussions must claim the legacy marker so Wait cannot convert server-minted attachments first"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+fn proto_discussion_on_thread(
+    id: &str,
+    thread_ref: &str,
+    turns: &[(&str, &str, u64)],
+) -> ProtoDiscussion {
+    let mut discussion = proto_discussion(id, turns);
+    discussion.thread_ref = thread_ref.to_string();
+    discussion
+}
+
+#[tokio::test]
+async fn thread_scoped_bootstrap_does_not_import_another_thread_ref() {
+    let foo = proto_discussion_on_thread("disc-foo", "foo", &[("turn-foo", "from foo", 1)]);
+    let bar = proto_discussion_on_thread("disc-bar", "bar", &[("turn-bar", "from bar", 1)]);
+
+    let (_temp_scoped, repo_scoped) = seed_repo();
+    let fixture = CollaborationFixture {
+        list: vec![foo.clone(), bar.clone()],
+        ..CollaborationFixture::default()
+    };
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let scoped = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        thread_id: "thr-foo".into(),
+        ..DiscussionCursorScope::default()
+    };
+    bootstrap_discussions_scoped(&repo_scoped, &mut client, "acme/widgets", &scoped, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        *fixture
+            .list_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()),
+        1,
+        "thread-scoped wait must reuse ListByState, not a second list RPC"
+    );
+
+    let scoped_store = CollaborationStore::open(repo_scoped.heddle_dir()).unwrap();
+    let scoped_discussions = scoped_store.materialize().unwrap().discussions;
+    assert_eq!(
+        scoped_discussions.len(),
+        1,
+        "wait --thread foo must not materialize bar-thread discussions"
+    );
+    let only = scoped_discussions.into_values().next().unwrap();
+    assert_eq!(only.thread_ref.as_deref(), Some("foo"));
+    assert_eq!(only.turns[0].1.body, "from foo");
+
+    let (_temp_all, repo_all) = seed_repo();
+    bootstrap_discussions(&repo_all, &mut client, "acme/widgets", None)
+        .await
+        .unwrap();
+    let all_store = CollaborationStore::open(repo_all.heddle_dir()).unwrap();
+    let mut bodies: Vec<_> = all_store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .map(|discussion| discussion.turns[0].1.body)
+        .collect();
+    bodies.sort();
+    assert_eq!(
+        bodies,
+        ["from bar".to_string(), "from foo".to_string()],
+        "unfiltered wait still imports every thread at HEAD"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn thread_scoped_pull_fold_bootstrap_stays_repo_wide() {
+    let (_temp, repo) = seed_repo();
+    let head = repo.head().unwrap().unwrap();
+    let bootstrap = vec![
+        objects::object::Discussion {
+            id: "disc-foo".to_string(),
+            anchor: objects::object::SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: head,
+            opened_at: 1_700_000_000,
+            thread_ref: Some("foo".to_string()),
+            turns: vec![objects::object::DiscussionTurn {
+                author: Principal::new("Ada", "ada@example.com"),
+                body: "from foo".to_string(),
+                posted_at: 1_700_000_000,
+                references: Vec::new(),
+            }],
+            resolution: objects::object::DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: objects::object::VisibilityTier::Internal,
+            resolved_annotation_id: None,
+        },
+        objects::object::Discussion {
+            id: "disc-bar".to_string(),
+            anchor: objects::object::SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: head,
+            opened_at: 1_700_000_000,
+            thread_ref: Some("bar".to_string()),
+            turns: vec![objects::object::DiscussionTurn {
+                author: Principal::new("Ada", "ada@example.com"),
+                body: "from bar".to_string(),
+                posted_at: 1_700_000_000,
+                references: Vec::new(),
+            }],
+            resolution: objects::object::DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: objects::object::VisibilityTier::Internal,
+            resolved_annotation_id: None,
+        },
+    ];
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let scoped = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        thread_id: "thr-foo".into(),
+        ..DiscussionCursorScope::default()
+    };
+    bootstrap_discussions_scoped(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &scoped,
+        Some(&bootstrap),
+    )
+    .await
+    .unwrap();
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let mut bodies: Vec<_> = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .map(|discussion| discussion.turns[0].1.body)
+        .collect();
+    bodies.sort();
+    assert_eq!(
+        bodies,
+        ["from bar".to_string(), "from foo".to_string()],
+        "clone/pull fold stays repo-wide even when the wait cursor is thread-scoped"
     );
 
     client.close().await;

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -4,9 +4,12 @@ use api::heddle::api::v1alpha1::{
     CallFailureCode, Discussion as ProtoDiscussion, DiscussionKind, DiscussionTurn as ProtoTurn,
     PathSymbolRef, RepoEvent, RepoEventKind, StateId as ProtoStateId, discussion_resolution,
 };
-use objects::object::{
-    Attribution, Blob, CollaborationAnchor, Discussion, DiscussionResolution, DiscussionTurn,
-    DiscussionsBlob, Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+use objects::{
+    object::{
+        Attribution, Blob, CollaborationAnchor, Discussion, DiscussionResolution, DiscussionTurn,
+        DiscussionsBlob, Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+    },
+    store::ObjectStore,
 };
 use repo::{CollaborationStore, Repository, migrate_legacy_discussions_once};
 use tempfile::TempDir;
@@ -2182,9 +2185,8 @@ async fn filtered_bootstrap_does_not_claim_the_legacy_migration_marker() {
         report.is_some(),
         "a later list/migrate must still see the other thread's legacy discussion"
     );
-    let bodies: Vec<_> = store
-        .materialize()
-        .unwrap()
+    let after = store.materialize().unwrap();
+    let bodies: Vec<_> = after
         .discussions
         .values()
         .flat_map(|discussion| discussion.turns.iter().map(|turn| turn.1.body.as_str()))

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -794,6 +794,29 @@ fn fat_append_on_unknown_discussion_is_not_self_contained() {
 }
 
 #[test]
+fn fat_append_with_turn_id_but_zero_seq_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "turn.appended".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": "second turn",
+            "author_name": "Ada",
+            "author_email": "ada@example.com",
+            "posted_at": 1_700_000_010,
+            "turn_id": "turn-append",
+            "turn_seq": 0
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_none());
+    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
+}
+
+#[test]
 fn opened_without_file_or_symbol_is_a_doorbell() {
     let event = RepoEvent {
         event_type: "discussion.opened".into(),
@@ -856,7 +879,7 @@ fn filtered_cursor_slot_does_not_share_the_unfiltered_watermark() {
 }
 
 #[test]
-fn unfiltered_authority_cursor_falls_back_to_legacy_repo_path() {
+fn authority_scoped_cursor_does_not_inherit_the_legacy_repo_path_slot() {
     let temp = TempDir::new().unwrap();
     let legacy = DiscussionEventCursor {
         after_event_id: 7,
@@ -864,30 +887,19 @@ fn unfiltered_authority_cursor_falls_back_to_legacy_repo_path() {
         bootstrapped: true,
     };
     save_cursor(temp.path(), "acme/widgets", &legacy).unwrap();
-    let scoped = DiscussionCursorScope {
-        authority: "weft.example:443".into(),
+    let other_host = DiscussionCursorScope {
+        authority: "other.example:443".into(),
         repo_path: "acme/widgets".into(),
         ..DiscussionCursorScope::default()
     };
     assert_eq!(
-        load_scoped_cursor(temp.path(), &scoped).unwrap(),
+        load_scoped_cursor(temp.path(), &other_host).unwrap(),
+        DiscussionEventCursor::default(),
+        "a different hosted authority must not inherit the bare repo_path cursor"
+    );
+    assert_eq!(
+        load_cursor(temp.path(), "acme/widgets").unwrap(),
         legacy
-    );
-    let advanced = DiscussionEventCursor {
-        after_event_id: 9,
-        repo_id: "repo-1".into(),
-        bootstrapped: true,
-    };
-    save_scoped_cursor(temp.path(), &scoped, &advanced).unwrap();
-    assert_eq!(
-        load_cursor(temp.path(), "acme/widgets").unwrap().after_event_id,
-        7
-    );
-    assert_eq!(
-        load_scoped_cursor(temp.path(), &scoped)
-            .unwrap()
-            .after_event_id,
-        9
     );
 }
 
@@ -1058,6 +1070,83 @@ async fn incomplete_resolve_without_resolution_doorbell_fetches() {
             .as_slice(),
         ["disc-res"]
     );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-zero".to_string(),
+        proto_discussion(
+            "disc-zero",
+            &[
+                ("turn-open", "first turn", 1),
+                ("turn-append", "second turn", 2),
+            ],
+        ),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(1, "disc-zero", "first turn", "turn-open"),
+    )
+    .await
+    .unwrap();
+
+    let fat_zero = RepoEvent {
+        event_id: 2,
+        repo_id: "repo-1".to_string(),
+        event_type: "turn.appended".to_string(),
+        kind: RepoEventKind::DiscussionTurn as i32,
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-zero",
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": "second turn",
+            "author_name": "Ada",
+            "author_email": "ada@example.com",
+            "posted_at": 1_700_000_010,
+            "turn_id": "turn-append",
+            "turn_seq": 0
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &fat_zero)
+        .await
+        .unwrap();
+    assert!(
+        outcome.applied(),
+        "a new turn_id must be kept, not dropped as ordinal 0"
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-zero"]
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns.len(), 2);
+    assert_eq!(discussion.turns[0].1.body, "first turn");
+    assert_eq!(discussion.turns[1].1.body, "second turn");
 
     client.close().await;
     server.await.unwrap();

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -413,15 +413,10 @@ async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
     )
     .await
     .unwrap();
-    assert!(
-        matches!(
-            &replay,
-            DiscussionEventOutcome::Applied { discussion_id }
-            | DiscussionEventOutcome::Unchanged { discussion_id }
-                if discussion_id == "server-boot"
-        ),
-        "replay may attach a minted turn_id to the bootstrap link, got {replay:?}"
-    );
+    assert!(matches!(
+        replay,
+        DiscussionEventOutcome::Unchanged { discussion_id } if discussion_id == "server-boot"
+    ));
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
     let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -9,9 +9,10 @@ use repo::{CollaborationStore, Repository};
 use tempfile::TempDir;
 
 use super::{
-    DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome, bootstrap_discussions,
-    consume_discussion_event, is_discussion_event, load_cursor, parse_event_payload, save_cursor,
-    subscribe_request,
+    DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
+    bootstrap_discussions, consume_discussion_event, consume_discussion_event_scoped,
+    is_discussion_event, load_cursor, load_scoped_cursor, parse_event_payload, save_cursor,
+    save_scoped_cursor, subscribe_request,
 };
 use crate::hosted_runtime::hosted::HostedResolution;
 use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
@@ -790,4 +791,274 @@ fn fat_append_on_unknown_discussion_is_not_self_contained() {
     let payload = parse_event_payload(&event);
     assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
     assert!(super::discussion_from_payload("turn.appended", &payload, true).is_some());
+}
+
+#[test]
+fn opened_without_file_or_symbol_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "discussion.opened".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "visibility": "internal",
+            "body": "hello",
+            "turn_id": "turn-1",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+}
+
+#[test]
+fn resolved_without_a_real_resolution_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "discussion.resolved".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": "first",
+            "turn_id": "turn-1",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("discussion.resolved", &payload, true).is_none());
+    assert!(super::discussion_from_payload("discussion.resolved", &payload, false).is_none());
+}
+
+#[test]
+fn filtered_cursor_slot_does_not_share_the_unfiltered_watermark() {
+    let temp = TempDir::new().unwrap();
+    let filtered = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let cursor = DiscussionEventCursor {
+        after_event_id: 41,
+        repo_id: "repo-1".into(),
+        bootstrapped: true,
+    };
+    save_scoped_cursor(temp.path(), &filtered, &cursor).unwrap();
+    assert_eq!(
+        load_cursor(temp.path(), "acme/widgets").unwrap(),
+        DiscussionEventCursor::default()
+    );
+    assert_eq!(
+        load_scoped_cursor(temp.path(), &filtered).unwrap(),
+        cursor
+    );
+}
+
+#[test]
+fn unfiltered_authority_cursor_falls_back_to_legacy_repo_path() {
+    let temp = TempDir::new().unwrap();
+    let legacy = DiscussionEventCursor {
+        after_event_id: 7,
+        repo_id: "repo-1".into(),
+        bootstrapped: true,
+    };
+    save_cursor(temp.path(), "acme/widgets", &legacy).unwrap();
+    let scoped = DiscussionCursorScope {
+        authority: "weft.example:443".into(),
+        repo_path: "acme/widgets".into(),
+        ..DiscussionCursorScope::default()
+    };
+    assert_eq!(
+        load_scoped_cursor(temp.path(), &scoped).unwrap(),
+        legacy
+    );
+    let advanced = DiscussionEventCursor {
+        after_event_id: 9,
+        repo_id: "repo-1".into(),
+        bootstrapped: true,
+    };
+    save_scoped_cursor(temp.path(), &scoped, &advanced).unwrap();
+    assert_eq!(
+        load_cursor(temp.path(), "acme/widgets").unwrap().after_event_id,
+        7
+    );
+    assert_eq!(
+        load_scoped_cursor(temp.path(), &scoped)
+            .unwrap()
+            .after_event_id,
+        9
+    );
+}
+
+#[tokio::test]
+async fn filtered_wait_does_not_advance_the_unfiltered_watermark() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let filtered = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let outcome = consume_discussion_event_scoped(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &filtered,
+        &opened_event(10, "disc-foo", "from foo", "turn-1"),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Applied { .. }));
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        0
+    );
+    assert_eq!(
+        load_scoped_cursor(repo.heddle_dir(), &filtered)
+            .unwrap()
+            .after_event_id,
+        10
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn get_discussion_is_called_with_the_event_state_id() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-prior".to_string(),
+        proto_discussion("disc-prior", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let mut event = doorbell(21, "discussion.opened", "disc-prior", "turn-open", 1);
+    event.new_state = Some(ProtoStateId {
+        value: vec![0xab; 32],
+    });
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        DiscussionEventOutcome::Applied { discussion_id } if discussion_id == "disc-prior"
+    ));
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-prior"]
+    );
+    assert_eq!(
+        fixture
+            .get_request_state_ids
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        [Some(vec![0xab; 32])]
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn incomplete_open_without_anchor_doorbell_fetches() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-open".to_string(),
+        proto_discussion("disc-open", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let event = RepoEvent {
+        event_id: 31,
+        repo_id: "repo-1".to_string(),
+        event_type: "discussion.opened".to_string(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-open",
+            "visibility": "internal",
+            "body": "hello without an anchor",
+            "turn_id": "turn-open",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Applied { .. }));
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-open"]
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn incomplete_resolve_without_resolution_doorbell_fetches() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-res".to_string(),
+        proto_discussion("disc-res", &[("turn-1", "first", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(1, "disc-res", "first", "turn-1"),
+    )
+    .await
+    .unwrap();
+
+    let event = RepoEvent {
+        event_id: 32,
+        repo_id: "repo-1".to_string(),
+        event_type: "discussion.resolved".to_string(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-res",
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": "first",
+            "turn_id": "turn-1",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-res"]
+    );
+
+    client.close().await;
+    server.await.unwrap();
 }

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1198,6 +1198,26 @@ async fn incomplete_resolve_without_resolution_doorbell_fetches() {
 #[tokio::test]
 async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
     let (_temp, repo) = seed_repo();
+    let head = repo.head().unwrap().unwrap();
+    let bootstrap = vec![objects::object::Discussion {
+        id: "disc-zero".to_string(),
+        anchor: objects::object::SymbolAnchor::new("lib.rs", "run"),
+        opened_against_state: head,
+        opened_at: 1_700_000_000,
+        thread_ref: None,
+        turns: vec![objects::object::DiscussionTurn {
+            author: Principal::new("Ada", "ada@example.com"),
+            body: "first turn".to_string(),
+            posted_at: 1_700_000_000,
+            references: Vec::new(),
+        }],
+        resolution: objects::object::DiscussionResolution::Open,
+        body_changed_since_open: false,
+        anchor_ambiguous: false,
+        orphaned: false,
+        visibility: objects::object::VisibilityTier::Internal,
+        resolved_annotation_id: None,
+    }];
     let mut fixture = CollaborationFixture::default();
     fixture.discussions.insert(
         "disc-zero".to_string(),
@@ -1211,15 +1231,9 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
     );
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
-
-    consume_discussion_event(
-        &repo,
-        &mut client,
-        "acme/widgets",
-        &opened_event(1, "disc-zero", "first turn", "turn-open"),
-    )
-    .await
-    .unwrap();
+    bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
+        .await
+        .unwrap();
 
     let fat_zero = RepoEvent {
         event_id: 2,
@@ -1253,8 +1267,8 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
             .as_slice(),
-        ["disc-zero", "disc-zero"],
-        "opened doorbells; zero-seq append cannot use the fast path"
+        ["disc-zero"],
+        "already-mirrored zero-seq append cannot use the fast path"
     );
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -413,10 +413,15 @@ async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
     )
     .await
     .unwrap();
-    assert!(matches!(
-        replay,
-        DiscussionEventOutcome::Unchanged { discussion_id } if discussion_id == "server-boot"
-    ));
+    assert!(
+        matches!(
+            &replay,
+            DiscussionEventOutcome::Applied { discussion_id }
+            | DiscussionEventOutcome::Unchanged { discussion_id }
+                if discussion_id == "server-boot"
+        ),
+        "replay may attach a minted turn_id to the bootstrap link, got {replay:?}"
+    );
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
     let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use api::heddle::api::v1alpha1::{RepoEvent, RepoEventKind, StateId as ProtoStateId};
+use objects::object::{Attribution, Principal};
+use repo::{CollaborationStore, Repository};
+use tempfile::TempDir;
+
+use super::{
+    DiscussionEventCursor, DiscussionEventOutcome, bootstrap_discussions, consume_discussion_event,
+    is_discussion_event, load_cursor, parse_event_payload, save_cursor, subscribe_request,
+};
+use crate::hosted_runtime::hosted::HostedResolution;
+
+fn seed_repo() -> (TempDir, Repository) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+    repo.snapshot_with_attribution(
+        Some("seed".to_string()),
+        None,
+        Attribution::human(Principal::new("Test", "test@example.com")),
+    )
+    .unwrap();
+    (temp, repo)
+}
+
+fn opened_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str) -> RepoEvent {
+    RepoEvent {
+        event_id,
+        repo_id: "repo-1".to_string(),
+        event_type: "discussion.opened".to_string(),
+        payload_json: serde_json::json!({
+            "discussion_id": discussion_id,
+            "file": "lib.rs",
+            "symbol": "run",
+            "visibility": "internal",
+            "body": body,
+            "author_name": "Ada",
+            "author_email": "ada@example.com",
+            "posted_at": 1_700_000_000,
+            "turn_id": turn_id,
+            "turn_seq": 1,
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    }
+}
+
+fn appended_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str, seq: u64) -> RepoEvent {
+    RepoEvent {
+        event_id,
+        repo_id: "repo-1".to_string(),
+        event_type: "turn.appended".to_string(),
+        kind: RepoEventKind::DiscussionTurn as i32,
+        payload_json: serde_json::json!({
+            "discussion_id": discussion_id,
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": body,
+            "author_name": "Ada",
+            "author_email": "ada@example.com",
+            "posted_at": 1_700_000_010,
+            "turn_id": turn_id,
+            "turn_seq": seq,
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    }
+}
+
+fn resolved_event(event_id: i64, discussion_id: &str) -> RepoEvent {
+    RepoEvent {
+        event_id,
+        repo_id: "repo-1".to_string(),
+        event_type: "discussion.resolved".to_string(),
+        payload_json: serde_json::json!({
+            "discussion_id": discussion_id,
+            "file": "lib.rs",
+            "symbol": "run",
+            "body": "first",
+            "author_name": "Ada",
+            "author_email": "ada@example.com",
+            "posted_at": 1_700_000_000,
+            "turn_id": "turn-1",
+            "turn_seq": 1,
+            "resolution": { "kind": "dismissed", "reason": "done" },
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    }
+}
+
+#[test]
+fn discussion_event_types_are_recognized_and_others_are_not() {
+    assert!(is_discussion_event(&RepoEvent {
+        event_type: "discussion.opened".into(),
+        ..RepoEvent::default()
+    }));
+    assert!(is_discussion_event(&RepoEvent {
+        event_type: "turn.appended".into(),
+        ..RepoEvent::default()
+    }));
+    assert!(is_discussion_event(&RepoEvent {
+        event_type: "discussion.resolved".into(),
+        ..RepoEvent::default()
+    }));
+    assert!(is_discussion_event(&RepoEvent {
+        event_type: "something.else".into(),
+        kind: RepoEventKind::DiscussionTurn as i32,
+        ..RepoEvent::default()
+    }));
+    assert!(!is_discussion_event(&RepoEvent {
+        event_type: "ref.updated".into(),
+        ..RepoEvent::default()
+    }));
+}
+
+#[test]
+fn payload_parser_accepts_nested_discussion_and_turn_objects() {
+    let event = RepoEvent {
+        event_type: "turn.appended".into(),
+        payload_json: serde_json::json!({
+            "discussion": { "id": "disc-9", "file": "a.rs", "symbol": "f" },
+            "turn": {
+                "id": "turn-9",
+                "turn_seq": 2,
+                "body": "second",
+                "author_name": "bob",
+                "posted_at": 9
+            }
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert_eq!(payload.discussion_id.as_deref(), Some("disc-9"));
+    assert_eq!(payload.turn_id.as_deref(), Some("turn-9"));
+    assert_eq!(payload.turn_seq, 2);
+    assert_eq!(payload.body.as_deref(), Some("second"));
+    assert_eq!(payload.file.as_deref(), Some("a.rs"));
+}
+
+#[test]
+fn subscribe_request_filters_to_discussion_event_types() {
+    let request = subscribe_request("repo-1", 7, "main", "thread-main");
+    assert_eq!(request.repo_id, "repo-1");
+    assert_eq!(request.after_event_id, 7);
+    assert_eq!(
+        request.event_types,
+        ["discussion.opened", "turn.appended", "discussion.resolved"]
+    );
+    assert_eq!(request.thread, "main");
+    assert_eq!(request.thread_id, "thread-main");
+}
+
+#[test]
+fn cursor_round_trips_per_repo() {
+    let temp = TempDir::new().unwrap();
+    let cursor = DiscussionEventCursor {
+        after_event_id: 41,
+        repo_id: "repo-1".into(),
+        bootstrapped: true,
+    };
+    save_cursor(temp.path(), "acme/widgets", &cursor).unwrap();
+    assert_eq!(load_cursor(temp.path(), "acme/widgets").unwrap(), cursor);
+    assert_eq!(
+        load_cursor(temp.path(), "other/repo").unwrap(),
+        DiscussionEventCursor::default()
+    );
+}
+
+#[tokio::test]
+async fn opened_and_appended_events_materialize_distinct_turns_and_advance_watermark() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+
+    let opened = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(11, "disc-live-1", "keep this invariant", "turn-open"),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        opened,
+        DiscussionEventOutcome::Applied { discussion_id } if discussion_id == "disc-live-1"
+    ));
+
+    let appended = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &appended_event(12, "disc-live-1", "second turn", "turn-append", 2),
+    )
+    .await
+    .unwrap();
+    assert!(appended.applied());
+
+    let replay = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &appended_event(12, "disc-live-1", "second turn", "turn-append", 2),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        replay,
+        DiscussionEventOutcome::Unchanged { discussion_id } if discussion_id == "disc-live-1"
+    ));
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let materialized = store.materialize().unwrap();
+    assert_eq!(materialized.discussions.len(), 1);
+    let discussion = materialized.discussions.values().next().unwrap();
+    assert_eq!(discussion.turns.len(), 2);
+    assert_eq!(discussion.turns[0].1.body, "keep this invariant");
+    assert_eq!(discussion.turns[1].1.body, "second turn");
+
+    let cursor = load_cursor(repo.heddle_dir(), "acme/widgets").unwrap();
+    assert_eq!(cursor.after_event_id, 12);
+    assert_eq!(cursor.repo_id, "repo-1");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn resolved_event_writes_a_local_resolution() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(1, "disc-res", "first", "turn-1"),
+    )
+    .await
+    .unwrap();
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &resolved_event(2, "disc-res"),
+    )
+    .await
+    .unwrap();
+    assert!(outcome.applied());
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    assert!(discussion.resolution.is_some());
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn missing_discussion_id_is_skipped_and_still_advances_the_watermark() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let event = RepoEvent {
+        event_id: 99,
+        event_type: "turn.appended".into(),
+        payload_json: r#"{"body":"orphan"}"#.into(),
+        ..RepoEvent::default()
+    };
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        99
+    );
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn unknown_event_types_are_ignored_without_touching_the_op_log() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let event = RepoEvent {
+        event_id: 5,
+        event_type: "ref.updated".into(),
+        payload_json: "{}".into(),
+        new_state: Some(ProtoStateId {
+            value: [1u8; 32].to_vec(),
+        }),
+        ..RepoEvent::default()
+    };
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert_eq!(outcome, DiscussionEventOutcome::Ignored);
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    assert!(store.materialize().unwrap().discussions.is_empty());
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        5
+    );
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_marks_the_cursor_then_live_events_append() {
+    let (_temp, repo) = seed_repo();
+    let head = repo.head().unwrap().unwrap();
+    let bootstrap = vec![objects::object::Discussion {
+        id: "server-boot".to_string(),
+        anchor: objects::object::SymbolAnchor::new("lib.rs", "run"),
+        opened_against_state: head,
+        opened_at: 1_700_000_000,
+        thread_ref: None,
+        turns: vec![objects::object::DiscussionTurn {
+            author: Principal::new("Reviewer", "reviewer@example.com"),
+            body: "from snapshot".to_string(),
+            posted_at: 1_700_000_001,
+            references: Vec::new(),
+        }],
+        resolution: objects::object::DiscussionResolution::Open,
+        body_changed_since_open: false,
+        anchor_ambiguous: false,
+        orphaned: false,
+        visibility: objects::object::VisibilityTier::Internal,
+        resolved_annotation_id: None,
+    }];
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let cursor = bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
+        .await
+        .unwrap();
+    assert!(cursor.bootstrapped);
+
+    consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &appended_event(20, "server-boot", "live turn", "turn-live", 2),
+    )
+    .await
+    .unwrap();
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    assert_eq!(discussion.turns.len(), 2);
+    assert_eq!(discussion.turns[1].1.body, "live turn");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
+    let (_temp, repo) = seed_repo();
+    let head = repo.head().unwrap().unwrap();
+    let bootstrap = vec![objects::object::Discussion {
+        id: "server-boot".to_string(),
+        anchor: objects::object::SymbolAnchor::new("lib.rs", "run"),
+        opened_against_state: head,
+        opened_at: 1_700_000_000,
+        thread_ref: None,
+        turns: vec![objects::object::DiscussionTurn {
+            author: Principal::new("Ada", "ada@example.com"),
+            body: "keep this invariant".to_string(),
+            posted_at: 1_700_000_000,
+            references: Vec::new(),
+        }],
+        resolution: objects::object::DiscussionResolution::Open,
+        body_changed_since_open: false,
+        anchor_ambiguous: false,
+        orphaned: false,
+        visibility: objects::object::VisibilityTier::Internal,
+        resolved_annotation_id: None,
+    }];
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
+        .await
+        .unwrap();
+
+    let replay = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(3, "server-boot", "keep this invariant", "turn-open"),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        replay,
+        DiscussionEventOutcome::Unchanged { discussion_id } if discussion_id == "server-boot"
+    ));
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    assert_eq!(discussion.turns.len(), 1);
+    assert_eq!(discussion.turns[0].1.body, "keep this invariant");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[test]
+fn appended_without_turn_identity_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "turn.appended".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "body": "second"
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("turn.appended", &payload).is_none());
+    assert!(super::discussion_from_payload(
+        "discussion.opened",
+        &payload
+    )
+    .is_some());
+}
+
+#[test]
+fn dismissed_resolution_parses_from_payload() {
+    let event = resolved_event(1, "disc-x");
+    let payload = parse_event_payload(&event);
+    assert!(matches!(
+        payload.resolution,
+        HostedResolution::Dismissed { reason } if reason == "done"
+    ));
+}

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -4,19 +4,22 @@ use api::heddle::api::v1alpha1::{
     CallFailureCode, Discussion as ProtoDiscussion, DiscussionKind, DiscussionTurn as ProtoTurn,
     PathSymbolRef, RepoEvent, RepoEventKind, StateId as ProtoStateId, discussion_resolution,
 };
-use objects::object::{Attribution, CollaborationAnchor, Principal};
+use objects::object::{
+    Attribution, Blob, CollaborationAnchor, Discussion, DiscussionResolution, DiscussionTurn,
+    DiscussionsBlob, Principal, StateAttachment, StateAttachmentBody, SymbolAnchor,
+};
 use repo::{CollaborationStore, Repository, migrate_legacy_discussions_once};
 use tempfile::TempDir;
 
 use super::{
     DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
     audience_cursor_scope, bootstrap_discussions, bootstrap_discussions_scoped,
-    consume_discussion_event, wait_reconnect_backoff,
-    consume_discussion_event_scoped, is_discussion_event, load_cursor, load_scoped_cursor,
-    paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor, subscribe_request,
+    consume_discussion_event, consume_discussion_event_scoped, is_discussion_event, load_cursor,
+    load_scoped_cursor, paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor,
+    subscribe_request, wait_reconnect_backoff,
 };
-use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
 use crate::client::HostedClient;
+use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
 
 fn seed_repo() -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
@@ -66,7 +69,13 @@ fn opened_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str) -
     }
 }
 
-fn appended_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str, seq: u64) -> RepoEvent {
+fn appended_event(
+    event_id: i64,
+    discussion_id: &str,
+    body: &str,
+    turn_id: &str,
+    seq: u64,
+) -> RepoEvent {
     RepoEvent {
         event_id,
         repo_id: "repo-1".to_string(),
@@ -295,11 +304,7 @@ async fn resolved_event_writes_a_local_resolution() {
     let mut fixture = CollaborationFixture::default();
     fixture.discussions.insert(
         "disc-res".to_string(),
-        proto_dismissed_discussion(
-            "disc-res",
-            &[("turn-1", "first", 1)],
-            "done",
-        ),
+        proto_dismissed_discussion("disc-res", &[("turn-1", "first", 1)], "done"),
     );
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
@@ -322,7 +327,13 @@ async fn resolved_event_writes_a_local_resolution() {
     );
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
-    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
     assert!(discussion.resolution.is_some());
 
     client.close().await;
@@ -417,7 +428,13 @@ async fn bootstrap_marks_the_cursor_then_live_events_append() {
     .unwrap();
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
-    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
     assert_eq!(discussion.turns.len(), 2);
     assert_eq!(discussion.turns[1].1.body, "live turn");
 
@@ -473,7 +490,13 @@ async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
     ));
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
-    let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
     assert_eq!(discussion.turns.len(), 1);
     assert_eq!(discussion.turns[0].1.body, "keep this invariant");
 
@@ -992,10 +1015,7 @@ fn filtered_cursor_slot_does_not_share_the_unfiltered_watermark() {
         load_cursor(temp.path(), "acme/widgets").unwrap(),
         DiscussionEventCursor::default()
     );
-    assert_eq!(
-        load_scoped_cursor(temp.path(), &filtered).unwrap(),
-        cursor
-    );
+    assert_eq!(load_scoped_cursor(temp.path(), &filtered).unwrap(), cursor);
 }
 
 #[test]
@@ -1017,10 +1037,7 @@ fn authority_scoped_cursor_does_not_inherit_the_legacy_repo_path_slot() {
         DiscussionEventCursor::default(),
         "a different hosted authority must not inherit the bare repo_path cursor"
     );
-    assert_eq!(
-        load_cursor(temp.path(), "acme/widgets").unwrap(),
-        legacy
-    );
+    assert_eq!(load_cursor(temp.path(), "acme/widgets").unwrap(), legacy);
 }
 
 #[tokio::test]
@@ -1554,8 +1571,7 @@ async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
     .await
     .expect_err("empty dismiss reason is a local materialization failure");
     assert!(
-        error.to_string().contains("disc-empty-dismiss")
-            || error.to_string().contains("dismiss"),
+        error.to_string().contains("disc-empty-dismiss") || error.to_string().contains("dismiss"),
         "expected an apply failure, got {error:#}"
     );
     assert_eq!(
@@ -2074,4 +2090,171 @@ fn wait_reconnect_backoff_is_bounded() {
         wait_reconnect_backoff(7),
         Some(std::time::Duration::from_millis(6_400))
     );
+}
+
+fn migration_marker(repo: &Repository) -> std::path::PathBuf {
+    repo.heddle_dir()
+        .join("collaboration/migrations/legacy-discussions-v1")
+}
+
+fn plant_legacy_discussion(repo: &Repository, id: &str, body: &str) {
+    let state_id = repo.head().unwrap().unwrap();
+    let bytes = DiscussionsBlob::new(vec![Discussion {
+        id: id.to_string(),
+        anchor: SymbolAnchor::new("lib.rs", "run"),
+        opened_against_state: state_id,
+        opened_at: 1_700_000_000,
+        thread_ref: Some("bar".to_string()),
+        turns: vec![DiscussionTurn {
+            author: Principal::new("Ada", "ada@example.com"),
+            body: body.to_string(),
+            posted_at: 1_700_000_000,
+            references: Vec::new(),
+        }],
+        resolution: DiscussionResolution::Open,
+        body_changed_since_open: false,
+        anchor_ambiguous: false,
+        orphaned: false,
+        visibility: objects::object::VisibilityTier::default(),
+        resolved_annotation_id: None,
+    }])
+    .encode()
+    .unwrap();
+    let blob_hash = repo.store().put_blob(&Blob::new(bytes)).unwrap();
+    repo.put_state_attachment(&StateAttachment {
+        state_id,
+        body: StateAttachmentBody::Discussions(blob_hash),
+        attribution: Attribution::human(Principal::new("Test", "test@example.com")),
+        created_at: chrono::Utc::now(),
+        supersedes: None,
+    })
+    .unwrap();
+}
+
+#[tokio::test]
+async fn filtered_bootstrap_does_not_claim_the_legacy_migration_marker() {
+    let (_temp, repo) = seed_repo();
+    plant_legacy_discussion(&repo, "legacy-bar", "from bar thread");
+    assert!(
+        !migration_marker(&repo).exists(),
+        "the fixture is an unmigrated clone with a legacy attachment"
+    );
+
+    let foo = proto_discussion_on_thread("disc-foo", "foo", &[("turn-foo", "from foo", 1)]);
+    let fixture = CollaborationFixture {
+        list: vec![foo],
+        ..CollaborationFixture::default()
+    };
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let scoped = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        thread_id: "thr-foo".into(),
+        ..DiscussionCursorScope::default()
+    };
+    bootstrap_discussions_scoped(&repo, &mut client, "acme/widgets", &scoped, None)
+        .await
+        .unwrap();
+    assert!(
+        !migration_marker(&repo).exists(),
+        "wait --thread must not claim the repo-wide marker for discussions it did not import"
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let hosted = store.materialize().unwrap();
+    assert_eq!(hosted.discussions.len(), 1);
+    assert_eq!(
+        hosted
+            .discussions
+            .values()
+            .next()
+            .unwrap()
+            .thread_ref
+            .as_deref(),
+        Some("foo")
+    );
+
+    let report = migrate_legacy_discussions_once(&repo, &store, repo.get_attribution().unwrap())
+        .expect("unfiltered migrate after a filtered wait");
+    assert!(
+        report.is_some(),
+        "a later list/migrate must still see the other thread's legacy discussion"
+    );
+    let bodies: Vec<_> = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .values()
+        .flat_map(|discussion| discussion.turns.iter().map(|turn| turn.1.body.as_str()))
+        .collect();
+    assert!(bodies.contains(&"from foo"));
+    assert!(bodies.contains(&"from bar thread"));
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn stale_repo_uuid_not_found_resubscribes_via_path() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture {
+        unknown_repo_ids: ["dead-uuid".to_string()].into(),
+        events: vec![opened_event(1, "disc-live", "hello", "turn-1")],
+        ..CollaborationFixture::default()
+    };
+    fixture.discussions.insert(
+        "disc-live".to_string(),
+        proto_discussion("disc-live", &[("turn-1", "hello", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let scope = audience_cursor_scope(&client, "acme/widgets");
+    save_scoped_cursor(
+        repo.heddle_dir(),
+        &scope,
+        &DiscussionEventCursor {
+            after_event_id: 99,
+            repo_id: "dead-uuid".into(),
+            bootstrapped: true,
+        },
+    )
+    .unwrap();
+
+    let mut consumer = DiscussionEventConsumer::new(&repo, &mut client, "acme/widgets");
+    let mut subscription = consumer.start(None).await.unwrap();
+    let (event, _) = consumer
+        .consume_next(&mut subscription)
+        .await
+        .expect("stale UUID NotFound must recover via repo_path");
+    assert_eq!(event.event_id, 1);
+    assert_eq!(
+        fixture
+            .subscribe_repo_ids
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["dead-uuid", "acme/widgets"],
+        "second subscribe must use the path, not the dead UUID"
+    );
+    assert_eq!(
+        fixture
+            .subscribe_after
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        [99, 0],
+        "recovery resets the watermark before the path subscribe"
+    );
+
+    let cursor = load_scoped_cursor(repo.heddle_dir(), &scope).unwrap();
+    assert_ne!(
+        cursor.repo_id, "dead-uuid",
+        "the dead UUID must not stay in the slot"
+    );
+
+    client.close().await;
+    server.await.unwrap();
 }

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -11,8 +11,8 @@ use tempfile::TempDir;
 use super::{
     DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
     bootstrap_discussions, consume_discussion_event, consume_discussion_event_scoped,
-    is_discussion_event, load_cursor, load_scoped_cursor, parse_event_payload, save_cursor,
-    save_scoped_cursor, subscribe_request,
+    is_discussion_event, load_cursor, load_scoped_cursor, paired_thread_scope, parse_event_payload,
+    save_cursor, save_scoped_cursor, subscribe_request,
 };
 use crate::hosted_runtime::hosted::HostedResolution;
 use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
@@ -172,6 +172,20 @@ fn subscribe_request_filters_to_discussion_event_types() {
     );
     assert_eq!(request.thread, "main");
     assert_eq!(request.thread_id, "thread-main");
+}
+
+#[test]
+fn paired_thread_scope_requires_both_name_and_stable_id() {
+    assert_eq!(
+        paired_thread_scope("", "").unwrap(),
+        (String::new(), String::new())
+    );
+    assert_eq!(
+        paired_thread_scope("foo", "thr-1").unwrap(),
+        ("foo".to_string(), "thr-1".to_string())
+    );
+    assert!(paired_thread_scope("foo", "").is_err());
+    assert!(paired_thread_scope("", "thr-1").is_err());
 }
 
 #[test]
@@ -1147,6 +1161,63 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
     assert_eq!(discussion.turns.len(), 2);
     assert_eq!(discussion.turns[0].1.body, "first turn");
     assert_eq!(discussion.turns[1].1.body, "second turn");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn thread_scoped_subscribe_request_carries_thread_id() {
+    let (_temp, repo) = seed_repo();
+    let fixture = CollaborationFixture::default();
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let mut consumer = DiscussionEventConsumer::new(&repo, &mut client, "acme/widgets")
+        .with_thread("feature/run", "thr-stable");
+    let _subscription = consumer.start(None).await.unwrap();
+    assert_eq!(
+        fixture
+            .subscribe_thread
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        [("feature/run".to_string(), "thr-stable".to_string())]
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn get_discussion_unauthenticated_does_not_advance_the_watermark() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .hidden
+        .insert("disc-auth".to_string(), CallFailureCode::Unauthenticated);
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let error = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(55, "discussion.opened", "disc-auth", "turn-1", 1),
+    )
+    .await
+    .expect_err("unauthenticated doorbell fetch must be fatal");
+    assert!(
+        error.to_string().contains("disc-auth") || error.to_string().contains("Unauthenticated"),
+        "expected a fetch failure, got {error:#}"
+    );
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        0,
+        "unauthenticated must not advance the watermark"
+    );
 
     client.close().await;
     server.await.unwrap();

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1767,7 +1767,7 @@ async fn thread_scoped_bootstrap_does_not_import_another_thread_ref() {
         .unwrap()
         .discussions
         .into_values()
-        .map(|discussion| discussion.turns[0].1.body)
+        .map(|discussion| discussion.turns[0].1.body.clone())
         .collect();
     bodies.sort();
     assert_eq!(
@@ -1847,7 +1847,7 @@ async fn thread_scoped_pull_fold_bootstrap_stays_repo_wide() {
         .unwrap()
         .discussions
         .into_values()
-        .map(|discussion| discussion.turns[0].1.body)
+        .map(|discussion| discussion.turns[0].1.body.clone())
         .collect();
     bodies.sort();
     assert_eq!(

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -21,8 +21,7 @@ use super::{
     load_scoped_cursor, paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor,
     subscribe_request, wait_reconnect_backoff,
 };
-use crate::client::HostedClient;
-use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
+use crate::{client::HostedClient, hosted_runtime::hosted::test_server::CollaborationFixture};
 
 fn seed_repo() -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
@@ -167,9 +166,7 @@ fn payload_parser_pins_the_weft_flat_doorbell_shape() {
     };
     let payload = parse_event_payload(&event);
     assert_eq!(payload.discussion_id.as_deref(), Some("disc-9"));
-    assert_eq!(payload.turn_id.as_deref(), Some("turn-9"));
-    assert_eq!(payload.turn_seq, 2);
-    assert_eq!(payload.body.as_deref(), Some("second"));
+    assert!(payload.opened_against_state.is_none());
 
     let nested = RepoEvent {
         event_type: "turn.appended".into(),
@@ -182,8 +179,7 @@ fn payload_parser_pins_the_weft_flat_doorbell_shape() {
     };
     let ignored = parse_event_payload(&nested);
     assert_eq!(ignored.discussion_id, None);
-    assert_eq!(ignored.turn_id, None);
-    assert_eq!(ignored.body, None);
+    assert!(ignored.opened_against_state.is_none());
 }
 
 #[test]
@@ -235,7 +231,13 @@ async fn opened_and_appended_events_materialize_distinct_turns_and_advance_water
     let mut fixture = CollaborationFixture::default();
     fixture.discussions.insert(
         "disc-live-1".to_string(),
-        proto_discussion("disc-live-1", &[("turn-open", "keep this invariant", 1)]),
+        proto_discussion(
+            "disc-live-1",
+            &[
+                ("turn-open", "keep this invariant", 1),
+                ("turn-append", "second turn", 2),
+            ],
+        ),
     );
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
@@ -270,7 +272,10 @@ async fn opened_and_appended_events_materialize_distinct_turns_and_advance_water
     )
     .await
     .unwrap();
-    assert!(appended.applied());
+    assert!(matches!(
+        appended,
+        DiscussionEventOutcome::Unchanged { discussion_id } if discussion_id == "disc-live-1"
+    ));
 
     let replay = consume_discussion_event(
         &repo,
@@ -415,7 +420,19 @@ async fn bootstrap_marks_the_cursor_then_live_events_append() {
         visibility: objects::object::VisibilityTier::Internal,
         resolved_annotation_id: None,
     }];
-    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "server-boot".to_string(),
+        proto_discussion(
+            "server-boot",
+            &[
+                ("turn-open", "from snapshot", 1),
+                ("turn-live", "live turn", 2),
+            ],
+        ),
+    );
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
     let cursor = bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
         .await
         .unwrap();
@@ -505,22 +522,6 @@ async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
 
     client.close().await;
     server.await.unwrap();
-}
-
-#[test]
-fn appended_without_turn_identity_is_a_doorbell() {
-    let event = RepoEvent {
-        event_type: "turn.appended".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "body": "second"
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, true).is_none());
-    assert!(super::append_from_payload(&payload, false).is_none());
 }
 
 fn doorbell(
@@ -856,54 +857,11 @@ async fn consume_next_resumes_after_the_stream_ends() {
 }
 
 #[test]
-fn opened_without_visibility_is_a_doorbell() {
-    let event = RepoEvent {
-        event_type: "discussion.opened".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "body": "hello",
-            "file": "lib.rs",
-            "symbol": "run",
-            "turn_id": "turn-1",
-            "turn_seq": 1
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, false).is_none());
-    assert!(super::append_from_payload(&payload, true).is_none());
-}
-
-#[test]
-fn fat_append_on_unknown_discussion_is_not_self_contained() {
+fn event_payload_is_doorbell_identity_not_turn_content() {
     let event = appended_event(2, "disc-unknown", "second turn", "turn-2", 2);
     let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, false).is_none());
-    assert!(super::append_from_payload(&payload, true).is_some());
-}
-
-#[test]
-fn fat_append_with_turn_id_but_zero_seq_is_a_doorbell() {
-    let event = RepoEvent {
-        event_type: "turn.appended".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "file": "lib.rs",
-            "symbol": "run",
-            "body": "second turn",
-            "author_name": "Ada",
-            "author_email": "ada@example.com",
-            "posted_at": 1_700_000_010,
-            "turn_id": "turn-append",
-            "turn_seq": 0
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, true).is_none());
-    assert!(super::append_from_payload(&payload, false).is_none());
+    assert_eq!(payload.discussion_id.as_deref(), Some("disc-unknown"));
+    assert!(payload.opened_against_state.is_none());
 }
 
 #[test]
@@ -925,8 +883,6 @@ fn opened_without_state_id_is_a_doorbell() {
     let payload = parse_event_payload(&event);
     assert!(event.new_state.is_none());
     assert!(payload.opened_against_state.is_none());
-    assert!(super::append_from_payload(&payload, false).is_none());
-    assert!(super::append_from_payload(&payload, true).is_none());
 }
 
 #[test]
@@ -959,45 +915,6 @@ fn principals_do_not_share_a_cursor_slot() {
         "the unscoped repo_path slot must not inherit a principal-scoped watermark"
     );
     assert_eq!(load_scoped_cursor(temp.path(), &alice).unwrap(), cursor);
-}
-
-#[test]
-fn opened_without_file_or_symbol_is_a_doorbell() {
-    let event = RepoEvent {
-        event_type: "discussion.opened".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "visibility": "internal",
-            "body": "hello",
-            "turn_id": "turn-1",
-            "turn_seq": 1
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, false).is_none());
-    assert!(super::append_from_payload(&payload, true).is_none());
-}
-
-#[test]
-fn resolved_without_a_real_resolution_is_a_doorbell() {
-    let event = RepoEvent {
-        event_type: "discussion.resolved".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "file": "lib.rs",
-            "symbol": "run",
-            "body": "first",
-            "turn_id": "turn-1",
-            "turn_seq": 1
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert!(super::append_from_payload(&payload, true).is_none());
-    assert!(super::append_from_payload(&payload, false).is_none());
 }
 
 #[test]
@@ -1555,7 +1472,7 @@ async fn opened_event_never_applies_without_get_discussion() {
 }
 
 #[tokio::test]
-async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
+async fn dismissed_empty_reason_is_skipped_and_advances_watermark() {
     let (_temp, repo) = seed_repo();
     let mut fixture = CollaborationFixture::default();
     fixture.discussions.insert(
@@ -1565,17 +1482,23 @@ async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
-    let error = consume_discussion_event(
+    let outcome = consume_discussion_event(
         &repo,
         &mut client,
         "acme/widgets",
         &resolved_event(82, "disc-empty-dismiss"),
     )
     .await
-    .expect_err("empty dismiss reason is a local materialization failure");
+    .expect("invalid hosted content must not poison the event stream");
     assert!(
-        error.to_string().contains("disc-empty-dismiss") || error.to_string().contains("dismiss"),
-        "expected an apply failure, got {error:#}"
+        matches!(outcome, DiscussionEventOutcome::Skipped { .. }),
+        "expected a skipped poison event, got {outcome:?}"
+    );
+    assert!(
+        outcome
+            .skip_reason()
+            .is_some_and(|reason| reason.contains("dismiss reason must not be empty")),
+        "skip reason must expose the deterministic validation failure: {outcome:?}"
     );
     assert_eq!(
         fixture
@@ -1587,8 +1510,8 @@ async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
     );
     assert_eq!(
         load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
-        0,
-        "apply Err must not acknowledge the event"
+        82,
+        "deterministic validation failures must advance the watermark"
     );
 
     client.close().await;
@@ -1602,7 +1525,13 @@ async fn discussion_bodies_keep_leading_and_trailing_whitespace() {
     let mut fixture = CollaborationFixture::default();
     fixture.discussions.insert(
         "disc-pad".to_string(),
-        proto_discussion("disc-pad", &[("turn-open", padded, 1)]),
+        proto_discussion(
+            "disc-pad",
+            &[
+                ("turn-open", padded, 1),
+                ("turn-append", "  second pad  ", 2),
+            ],
+        ),
     );
     let (mut client, server, _fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
@@ -1634,25 +1563,6 @@ async fn discussion_bodies_keep_leading_and_trailing_whitespace() {
 
     client.close().await;
     server.await.unwrap();
-}
-
-#[test]
-fn payload_body_keeps_leading_and_trailing_whitespace() {
-    let event = RepoEvent {
-        event_type: "turn.appended".into(),
-        payload_json: serde_json::json!({
-            "discussion_id": "disc-9",
-            "turn_id": "turn-9",
-            "turn_seq": 2,
-            "body": "  keep padding  ",
-            "author_name": "Ada",
-            "posted_at": 9
-        })
-        .to_string(),
-        ..RepoEvent::default()
-    };
-    let payload = parse_event_payload(&event);
-    assert_eq!(payload.body.as_deref(), Some("  keep padding  "));
 }
 
 #[tokio::test]

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -11,7 +11,7 @@ use tempfile::TempDir;
 use super::{
     DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
     audience_cursor_scope, bootstrap_discussions, bootstrap_discussions_scoped,
-    consume_discussion_event,
+    consume_discussion_event, wait_reconnect_backoff,
     consume_discussion_event_scoped, is_discussion_event, load_cursor, load_scoped_cursor,
     paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor, subscribe_request,
 };
@@ -632,6 +632,12 @@ async fn get_discussion_permission_denied_is_skipped_and_advances_the_watermark(
     .await
     .unwrap();
     assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
+    assert!(
+        outcome
+            .skip_reason()
+            .is_some_and(|reason| reason.contains("not visible")),
+        "skipped wait lines need a reason: {outcome:?}"
+    );
     assert_eq!(
         load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         44
@@ -1539,20 +1545,18 @@ async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
-    let outcome = consume_discussion_event(
+    let error = consume_discussion_event(
         &repo,
         &mut client,
         "acme/widgets",
         &resolved_event(82, "disc-empty-dismiss"),
     )
     .await
-    .expect("empty dismiss reason must not fail-loop");
+    .expect_err("empty dismiss reason is a local materialization failure");
     assert!(
-        matches!(
-            outcome,
-            DiscussionEventOutcome::Skipped { .. } | DiscussionEventOutcome::Applied { .. }
-        ),
-        "expected fetch+skip or apply, got {outcome:?}"
+        error.to_string().contains("disc-empty-dismiss")
+            || error.to_string().contains("dismiss"),
+        "expected an apply failure, got {error:#}"
     );
     assert_eq!(
         fixture
@@ -1564,8 +1568,8 @@ async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
     );
     assert_eq!(
         load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
-        82,
-        "empty dismiss reason must advance the watermark"
+        0,
+        "apply Err must not acknowledge the event"
     );
 
     client.close().await;
@@ -1858,4 +1862,216 @@ async fn thread_scoped_pull_fold_bootstrap_stays_repo_wide() {
 
     client.close().await;
     server.await.unwrap();
+}
+
+fn seed_repo_without_head() -> (TempDir, Repository) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init(temp.path()).unwrap();
+    assert!(
+        repo.head().unwrap().is_none(),
+        "this fixture must have no HEAD"
+    );
+    (temp, repo)
+}
+
+#[tokio::test]
+async fn local_materialization_error_does_not_advance_the_watermark() {
+    let (_temp, repo) = seed_repo_without_head();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-headless".to_string(),
+        proto_discussion("disc-headless", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let error = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(90, "discussion.opened", "disc-headless", "turn-open", 1),
+    )
+    .await
+    .expect_err("no HEAD is a local apply failure, not a skip");
+    assert!(
+        error.to_string().contains("HEAD") || error.to_string().contains("disc-headless"),
+        "expected a materialization error, got {error:#}"
+    );
+    assert_eq!(
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
+        0,
+        "apply Err must leave the cursor before the event"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_without_head_does_not_mark_the_cursor_bootstrapped() {
+    let (_temp, repo) = seed_repo_without_head();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    bootstrap_discussions(&repo, &mut client, "acme/widgets", None)
+        .await
+        .expect_err("bootstrap must defer until HEAD exists");
+    let cursor = load_cursor(repo.heddle_dir(), "acme/widgets").unwrap();
+    assert!(
+        !cursor.bootstrapped,
+        "a no-HEAD bootstrap must not park the live tail past unseen events"
+    );
+    assert_eq!(cursor.after_event_id, 0);
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn alice_skipping_a_restricted_event_does_not_advance_bob() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .hidden
+        .insert("disc-secret".to_string(), CallFailureCode::PermissionDenied);
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let alice = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        principal: "alice".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let bob = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        principal: "bob".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let outcome = consume_discussion_event_scoped(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &alice,
+        &doorbell(91, "discussion.opened", "disc-secret", "turn-1", 1),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
+    assert_eq!(
+        load_scoped_cursor(repo.heddle_dir(), &alice)
+            .unwrap()
+            .after_event_id,
+        91
+    );
+    assert_eq!(
+        load_scoped_cursor(repo.heddle_dir(), &bob)
+            .unwrap()
+            .after_event_id,
+        0,
+        "Alice skipping a restricted event must not advance Bob's slot"
+    );
+    assert_eq!(
+        audience_cursor_scope(&client, "acme/widgets").principal,
+        "test",
+        "wait/consumer helpers must stamp the authenticated username"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn thread_scoped_bootstrap_matches_stable_thread_id_after_rename() {
+    let mut renamed = proto_discussion_on_thread(
+        "disc-renamed",
+        "old-name",
+        &[("turn-open", "still this thread", 1)],
+    );
+    renamed.thread_id = "thr-stable".to_string();
+    let other = proto_discussion_on_thread("disc-other", "bar", &[("turn-bar", "from bar", 1)]);
+    let (_temp, repo) = seed_repo();
+    let fixture = CollaborationFixture {
+        list: vec![renamed, other],
+        ..CollaborationFixture::default()
+    };
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let scoped = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        thread: "foo".into(),
+        thread_id: "thr-stable".into(),
+        ..DiscussionCursorScope::default()
+    };
+    bootstrap_discussions_scoped(&repo, &mut client, "acme/widgets", &scoped, None)
+        .await
+        .unwrap();
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussions = store.materialize().unwrap().discussions;
+    assert_eq!(
+        discussions.len(),
+        1,
+        "stable thread_id must keep the renamed discussion and drop the other thread"
+    );
+    assert_eq!(
+        discussions.into_values().next().unwrap().turns[0].1.body,
+        "still this thread"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[test]
+fn concurrent_cursor_saves_do_not_clobber_other_slots() {
+    let temp = TempDir::new().unwrap();
+    let heddle_dir = temp.path().to_path_buf();
+    let threads: Vec<_> = (0..8)
+        .map(|i| {
+            let heddle_dir = heddle_dir.clone();
+            std::thread::spawn(move || {
+                let scope = DiscussionCursorScope {
+                    repo_path: "acme/widgets".into(),
+                    principal: format!("agent-{i}"),
+                    ..DiscussionCursorScope::default()
+                };
+                let cursor = DiscussionEventCursor {
+                    after_event_id: i64::from(i) + 1,
+                    repo_id: format!("repo-{i}"),
+                    bootstrapped: true,
+                };
+                save_scoped_cursor(&heddle_dir, &scope, &cursor).unwrap();
+            })
+        })
+        .collect();
+    for handle in threads {
+        handle.join().expect("cursor writer thread");
+    }
+    for i in 0..8 {
+        let scope = DiscussionCursorScope {
+            repo_path: "acme/widgets".into(),
+            principal: format!("agent-{i}"),
+            ..DiscussionCursorScope::default()
+        };
+        let cursor = load_scoped_cursor(&heddle_dir, &scope).unwrap();
+        assert_eq!(
+            cursor.after_event_id,
+            i64::from(i) + 1,
+            "slot agent-{i} must survive concurrent RMW"
+        );
+    }
+}
+
+#[test]
+fn wait_reconnect_backoff_is_bounded() {
+    let first = wait_reconnect_backoff(0).expect("first reconnect waits");
+    let second = wait_reconnect_backoff(1).expect("second reconnect waits longer");
+    assert!(second > first);
+    assert!(
+        wait_reconnect_backoff(8).is_none(),
+        "the ceiling must stop the outer reconnect loop"
+    );
+    assert_eq!(
+        wait_reconnect_backoff(7),
+        Some(std::time::Duration::from_millis(6_400))
+    );
 }

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -2,20 +2,20 @@
 
 use api::heddle::api::v1alpha1::{
     CallFailureCode, Discussion as ProtoDiscussion, DiscussionKind, DiscussionTurn as ProtoTurn,
-    PathSymbolRef, RepoEvent, RepoEventKind, StateId as ProtoStateId,
+    PathSymbolRef, RepoEvent, RepoEventKind, StateId as ProtoStateId, discussion_resolution,
 };
 use objects::object::{Attribution, CollaborationAnchor, Principal};
-use repo::{CollaborationStore, Repository};
+use repo::{CollaborationStore, Repository, migrate_legacy_discussions_once};
 use tempfile::TempDir;
 
 use super::{
     DiscussionCursorScope, DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome,
-    bootstrap_discussions, consume_discussion_event, consume_discussion_event_scoped,
-    is_discussion_event, load_cursor, load_scoped_cursor, paired_thread_scope, parse_event_payload,
-    save_cursor, save_scoped_cursor, subscribe_request,
+    audience_cursor_scope, bootstrap_discussions, consume_discussion_event,
+    consume_discussion_event_scoped, is_discussion_event, load_cursor, load_scoped_cursor,
+    paired_thread_scope, parse_event_payload, save_cursor, save_scoped_cursor, subscribe_request,
 };
-use crate::hosted_runtime::hosted::HostedResolution;
 use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
+use crate::client::HostedClient;
 
 fn seed_repo() -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
@@ -28,6 +28,14 @@ fn seed_repo() -> (TempDir, Repository) {
     )
     .unwrap();
     (temp, repo)
+}
+
+fn load_event_cursor(
+    repo: &Repository,
+    client: &HostedClient,
+    repo_path: &str,
+) -> DiscussionEventCursor {
+    load_scoped_cursor(repo.heddle_dir(), &audience_cursor_scope(client, repo_path)).unwrap()
 }
 
 fn opened_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str) -> RepoEvent {
@@ -149,7 +157,6 @@ fn payload_parser_pins_the_weft_flat_doorbell_shape() {
     assert_eq!(payload.turn_id.as_deref(), Some("turn-9"));
     assert_eq!(payload.turn_seq, 2);
     assert_eq!(payload.body.as_deref(), Some("second"));
-    assert_eq!(payload.file.as_deref(), Some("a.rs"));
 
     let nested = RepoEvent {
         event_type: "turn.appended".into(),
@@ -212,7 +219,13 @@ fn cursor_round_trips_per_repo() {
 #[tokio::test]
 async fn opened_and_appended_events_materialize_distinct_turns_and_advance_watermark() {
     let (_temp, repo) = seed_repo();
-    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-live-1".to_string(),
+        proto_discussion("disc-live-1", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
     let opened = consume_discussion_event(
         &repo,
@@ -222,6 +235,15 @@ async fn opened_and_appended_events_materialize_distinct_turns_and_advance_water
     )
     .await
     .unwrap();
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-live-1"],
+        "opened must GetDiscussion even with a fat payload"
+    );
     assert!(matches!(
         opened,
         DiscussionEventOutcome::Applied { discussion_id } if discussion_id == "disc-live-1"
@@ -258,7 +280,7 @@ async fn opened_and_appended_events_materialize_distinct_turns_and_advance_water
     assert_eq!(discussion.turns[0].1.body, "keep this invariant");
     assert_eq!(discussion.turns[1].1.body, "second turn");
 
-    let cursor = load_cursor(repo.heddle_dir(), "acme/widgets").unwrap();
+    let cursor = load_event_cursor(&repo, &client, "acme/widgets");
     assert_eq!(cursor.after_event_id, 12);
     assert_eq!(cursor.repo_id, "repo-1");
 
@@ -269,15 +291,17 @@ async fn opened_and_appended_events_materialize_distinct_turns_and_advance_water
 #[tokio::test]
 async fn resolved_event_writes_a_local_resolution() {
     let (_temp, repo) = seed_repo();
-    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
-    consume_discussion_event(
-        &repo,
-        &mut client,
-        "acme/widgets",
-        &opened_event(1, "disc-res", "first", "turn-1"),
-    )
-    .await
-    .unwrap();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-res".to_string(),
+        proto_dismissed_discussion(
+            "disc-res",
+            &[("turn-1", "first", 1)],
+            "done",
+        ),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
     let outcome = consume_discussion_event(
         &repo,
         &mut client,
@@ -287,6 +311,14 @@ async fn resolved_event_writes_a_local_resolution() {
     .await
     .unwrap();
     assert!(outcome.applied());
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-res"]
+    );
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
     let discussion = store.materialize().unwrap().discussions.into_values().next().unwrap();
@@ -311,9 +343,7 @@ async fn missing_discussion_id_is_skipped_and_still_advances_the_watermark() {
         .unwrap();
     assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         99
     );
     client.close().await;
@@ -340,9 +370,7 @@ async fn unknown_event_types_are_ignored_without_touching_the_op_log() {
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
     assert!(store.materialize().unwrap().discussions.is_empty());
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         5
     );
     client.close().await;
@@ -419,7 +447,13 @@ async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
         visibility: objects::object::VisibilityTier::Internal,
         resolved_annotation_id: None,
     }];
-    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "server-boot".to_string(),
+        proto_discussion("server-boot", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
     bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap))
         .await
         .unwrap();
@@ -458,19 +492,8 @@ fn appended_without_turn_identity_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_none());
-    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
-    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
-}
-
-#[test]
-fn dismissed_resolution_parses_from_payload() {
-    let event = resolved_event(1, "disc-x");
-    let payload = parse_event_payload(&event);
-    assert!(matches!(
-        payload.resolution,
-        HostedResolution::Dismissed { reason } if reason == "done"
-    ));
+    assert!(super::append_from_payload(&payload, true).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
 }
 
 fn doorbell(
@@ -524,6 +547,22 @@ fn proto_discussion(id: &str, turns: &[(&str, &str, u64)]) -> ProtoDiscussion {
             .collect(),
         ..ProtoDiscussion::default()
     }
+}
+
+fn proto_dismissed_discussion(
+    id: &str,
+    turns: &[(&str, &str, u64)],
+    reason: &str,
+) -> ProtoDiscussion {
+    let mut discussion = proto_discussion(id, turns);
+    discussion.resolution = Some(api::heddle::api::v1alpha1::DiscussionResolution {
+        state: Some(discussion_resolution::State::Dismissed(
+            discussion_resolution::Dismissed {
+                reason: reason.to_string(),
+            },
+        )),
+    });
+    discussion
 }
 
 #[tokio::test]
@@ -593,9 +632,7 @@ async fn get_discussion_permission_denied_is_skipped_and_advances_the_watermark(
     .unwrap();
     assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         44
     );
     assert_eq!(
@@ -633,9 +670,7 @@ async fn get_discussion_not_found_is_skipped_and_advances_the_watermark() {
     .unwrap();
     assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         45
     );
 
@@ -803,15 +838,16 @@ fn opened_without_visibility_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_none());
 }
 
 #[test]
 fn fat_append_on_unknown_discussion_is_not_self_contained() {
     let event = appended_event(2, "disc-unknown", "second turn", "turn-2", 2);
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
-    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_some());
+    assert!(super::append_from_payload(&payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_some());
 }
 
 #[test]
@@ -833,8 +869,8 @@ fn fat_append_with_turn_id_but_zero_seq_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_none());
-    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
 }
 
 #[test]
@@ -856,7 +892,8 @@ fn opened_without_state_id_is_a_doorbell() {
     let payload = parse_event_payload(&event);
     assert!(event.new_state.is_none());
     assert!(payload.opened_against_state.is_none());
-    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_none());
 }
 
 #[test]
@@ -906,7 +943,8 @@ fn opened_without_file_or_symbol_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_none());
 }
 
 #[test]
@@ -925,8 +963,8 @@ fn resolved_without_a_real_resolution_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("discussion.resolved", &payload, true).is_none());
-    assert!(super::discussion_from_payload("discussion.resolved", &payload, false).is_none());
+    assert!(super::append_from_payload(&payload, true).is_none());
+    assert!(super::append_from_payload(&payload, false).is_none());
 }
 
 #[test]
@@ -981,7 +1019,13 @@ fn authority_scoped_cursor_does_not_inherit_the_legacy_repo_path_slot() {
 #[tokio::test]
 async fn filtered_wait_does_not_advance_the_unfiltered_watermark() {
     let (_temp, repo) = seed_repo();
-    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-foo".to_string(),
+        proto_discussion("disc-foo", &[("turn-1", "from foo", 1)]),
+    );
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
     let filtered = DiscussionCursorScope {
         repo_path: "acme/widgets".into(),
         thread: "foo".into(),
@@ -1143,7 +1187,8 @@ async fn incomplete_resolve_without_resolution_doorbell_fetches() {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
             .as_slice(),
-        ["disc-res"]
+        ["disc-res", "disc-res"],
+        "opened and resolved are both doorbells"
     );
 
     client.close().await;
@@ -1208,7 +1253,8 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
             .as_slice(),
-        ["disc-zero"]
+        ["disc-zero", "disc-zero"],
+        "opened doorbells; zero-seq append cannot use the fast path"
     );
 
     let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
@@ -1281,9 +1327,7 @@ async fn get_discussion_unauthenticated_does_not_advance_the_watermark() {
         "expected a fetch failure, got {error:#}"
     );
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         0,
         "unauthenticated must not advance the watermark"
     );
@@ -1360,6 +1404,10 @@ async fn coordination_doorbell_advances_watermark_and_does_not_fail_loop() {
         "disc-coord".to_string(),
         proto_coordination_discussion("disc-coord", &[("turn-open", "handoff the review", 1)]),
     );
+    fixture.discussions.insert(
+        "disc-later".to_string(),
+        proto_discussion("disc-later", &[("turn-1", "a later code discussion", 1)]),
+    );
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
@@ -1376,9 +1424,7 @@ async fn coordination_doorbell_advances_watermark_and_does_not_fail_loop() {
         "expected applied or skipped, got {outcome:?}"
     );
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         71,
         "an empty-anchor coordination doorbell must still advance the watermark"
     );
@@ -1411,10 +1457,233 @@ async fn coordination_doorbell_advances_watermark_and_does_not_fail_loop() {
     .expect("later events must still deliver after a coordination doorbell");
     assert!(matches!(later, DiscussionEventOutcome::Applied { .. }));
     assert_eq!(
-        load_cursor(repo.heddle_dir(), "acme/widgets")
-            .unwrap()
-            .after_event_id,
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
         72
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn opened_event_never_applies_without_get_discussion() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(
+            CollaborationFixture::default(),
+        )
+        .await;
+
+    let fat = opened_event(81, "disc-fat", "keep this invariant", "turn-open");
+    assert!(
+        fat.payload_json.contains("\"file\"")
+            && fat.payload_json.contains("\"symbol\"")
+            && fat.payload_json.contains("\"visibility\"")
+            && fat.payload_json.contains("\"body\""),
+        "this test requires a fat opened payload"
+    );
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &fat)
+        .await
+        .unwrap();
+    assert!(
+        !outcome.applied(),
+        "opened is a doorbell; a fat payload must not reconstruct a HostedDiscussion: {outcome:?}"
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-fat"],
+        "opened must always GetDiscussion"
+    );
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    assert!(
+        store.materialize().unwrap().discussions.is_empty(),
+        "fat opened without a snapshot must not write the op-log"
+    );
+    assert_eq!(
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
+        81,
+        "NotFound skip still advances so the event does not fail-loop"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn dismissed_empty_reason_fetches_or_skips_and_does_not_fail_loop() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-empty-dismiss".to_string(),
+        proto_dismissed_discussion("disc-empty-dismiss", &[("turn-1", "first", 1)], ""),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &resolved_event(82, "disc-empty-dismiss"),
+    )
+    .await
+    .expect("empty dismiss reason must not fail-loop");
+    assert!(
+        matches!(
+            outcome,
+            DiscussionEventOutcome::Skipped { .. } | DiscussionEventOutcome::Applied { .. }
+        ),
+        "expected fetch+skip or apply, got {outcome:?}"
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-empty-dismiss"]
+    );
+    assert_eq!(
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
+        82,
+        "empty dismiss reason must advance the watermark"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn discussion_bodies_keep_leading_and_trailing_whitespace() {
+    let (_temp, repo) = seed_repo();
+    let padded = "  keep padding  ";
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-pad".to_string(),
+        proto_discussion("disc-pad", &[("turn-open", padded, 1)]),
+    );
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(83, "discussion.opened", "disc-pad", "turn-open", 1),
+    )
+    .await
+    .unwrap();
+
+    let appended = appended_event(84, "disc-pad", "  second pad  ", "turn-append", 2);
+    consume_discussion_event(&repo, &mut client, "acme/widgets", &appended)
+        .await
+        .unwrap();
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns[0].1.body, padded);
+    assert_eq!(discussion.turns[1].1.body, "  second pad  ");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[test]
+fn payload_body_keeps_leading_and_trailing_whitespace() {
+    let event = RepoEvent {
+        event_type: "turn.appended".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "turn_id": "turn-9",
+            "turn_seq": 2,
+            "body": "  keep padding  ",
+            "author_name": "Ada",
+            "posted_at": 9
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert_eq!(payload.body.as_deref(), Some("  keep padding  "));
+}
+
+#[tokio::test]
+async fn empty_anchor_get_discussion_uses_repository_and_advances() {
+    let (_temp, repo) = seed_repo();
+    let mut proto = proto_discussion("disc-empty-anchor", &[("turn-open", "repo wide", 1)]);
+    proto.anchor = Some(PathSymbolRef {
+        file: String::new(),
+        symbol: String::new(),
+    });
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .discussions
+        .insert("disc-empty-anchor".to_string(), proto);
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(85, "discussion.opened", "disc-empty-anchor", "turn-open", 1),
+    )
+    .await
+    .expect("empty-anchor GetDiscussion must not fail-loop");
+    assert!(
+        outcome.applied() || matches!(outcome, DiscussionEventOutcome::Skipped { .. }),
+        "expected applied or skipped, got {outcome:?}"
+    );
+    assert_eq!(
+        load_event_cursor(&repo, &client, "acme/widgets").after_event_id,
+        85
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-empty-anchor"]
+    );
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .expect("empty-anchor snapshot should materialize as Repository");
+    assert_eq!(discussion.anchor, CollaborationAnchor::Repository);
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_claims_legacy_migration_marker_before_local_import() {
+    let (_temp, repo) = seed_repo();
+    let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+    bootstrap_discussions(&repo, &mut client, "acme/widgets", Some(&[]))
+        .await
+        .unwrap();
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let report = migrate_legacy_discussions_once(&repo, &store, repo.get_attribution().unwrap())
+        .expect("legacy migration after hosted bootstrap");
+    assert!(
+        report.is_none(),
+        "pull_discussions must claim the legacy marker so Wait cannot convert server-minted attachments first"
     );
 
     client.close().await;

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use api::heddle::api::v1alpha1::{RepoEvent, RepoEventKind, StateId as ProtoStateId};
+use api::heddle::api::v1alpha1::{
+    CallFailureCode, Discussion as ProtoDiscussion, DiscussionTurn as ProtoTurn, PathSymbolRef,
+    RepoEvent, RepoEventKind, StateId as ProtoStateId,
+};
 use objects::object::{Attribution, Principal};
 use repo::{CollaborationStore, Repository};
 use tempfile::TempDir;
 
 use super::{
-    DiscussionEventCursor, DiscussionEventOutcome, bootstrap_discussions, consume_discussion_event,
-    is_discussion_event, load_cursor, parse_event_payload, save_cursor, subscribe_request,
+    DiscussionEventConsumer, DiscussionEventCursor, DiscussionEventOutcome, bootstrap_discussions,
+    consume_discussion_event, is_discussion_event, load_cursor, parse_event_payload, save_cursor,
+    subscribe_request,
 };
 use crate::hosted_runtime::hosted::HostedResolution;
+use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
 
 fn seed_repo() -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
@@ -116,18 +121,19 @@ fn discussion_event_types_are_recognized_and_others_are_not() {
 }
 
 #[test]
-fn payload_parser_accepts_nested_discussion_and_turn_objects() {
+fn payload_parser_pins_the_weft_flat_doorbell_shape() {
     let event = RepoEvent {
         event_type: "turn.appended".into(),
         payload_json: serde_json::json!({
-            "discussion": { "id": "disc-9", "file": "a.rs", "symbol": "f" },
-            "turn": {
-                "id": "turn-9",
-                "turn_seq": 2,
-                "body": "second",
-                "author_name": "bob",
-                "posted_at": 9
-            }
+            "discussion_id": "disc-9",
+            "turn_id": "turn-9",
+            "turn_seq": 2,
+            "body": "second",
+            "author_name": "bob",
+            "author_email": "bob@example.com",
+            "posted_at": 9,
+            "file": "a.rs",
+            "symbol": "f"
         })
         .to_string(),
         ..RepoEvent::default()
@@ -138,6 +144,20 @@ fn payload_parser_accepts_nested_discussion_and_turn_objects() {
     assert_eq!(payload.turn_seq, 2);
     assert_eq!(payload.body.as_deref(), Some("second"));
     assert_eq!(payload.file.as_deref(), Some("a.rs"));
+
+    let nested = RepoEvent {
+        event_type: "turn.appended".into(),
+        payload_json: serde_json::json!({
+            "discussion": { "id": "disc-9", "file": "a.rs" },
+            "turn": { "id": "turn-9", "turn_seq": 2, "body": "second" }
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let ignored = parse_event_payload(&nested);
+    assert_eq!(ignored.discussion_id, None);
+    assert_eq!(ignored.turn_id, None);
+    assert_eq!(ignored.body, None);
 }
 
 #[test]
@@ -418,12 +438,9 @@ fn appended_without_turn_identity_is_a_doorbell() {
         ..RepoEvent::default()
     };
     let payload = parse_event_payload(&event);
-    assert!(super::discussion_from_payload("turn.appended", &payload).is_none());
-    assert!(super::discussion_from_payload(
-        "discussion.opened",
-        &payload
-    )
-    .is_some());
+    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_none());
+    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
+    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
 }
 
 #[test]
@@ -434,4 +451,343 @@ fn dismissed_resolution_parses_from_payload() {
         payload.resolution,
         HostedResolution::Dismissed { reason } if reason == "done"
     ));
+}
+
+fn doorbell(
+    event_id: i64,
+    event_type: &str,
+    discussion_id: &str,
+    turn_id: &str,
+    turn_seq: u64,
+) -> RepoEvent {
+    RepoEvent {
+        event_id,
+        repo_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        event_type: event_type.to_string(),
+        kind: if event_type == "turn.appended" {
+            RepoEventKind::DiscussionTurn as i32
+        } else {
+            0
+        },
+        payload_json: serde_json::json!({
+            "discussion_id": discussion_id,
+            "turn_id": turn_id,
+            "turn_seq": turn_seq,
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    }
+}
+
+fn proto_discussion(id: &str, turns: &[(&str, &str, u64)]) -> ProtoDiscussion {
+    ProtoDiscussion {
+        id: id.to_string(),
+        anchor: Some(PathSymbolRef {
+            file: "lib.rs".to_string(),
+            symbol: "run".to_string(),
+        }),
+        visibility: "internal".to_string(),
+        turns: turns
+            .iter()
+            .map(|(turn_id, body, seq)| ProtoTurn {
+                author_name: "Ada".to_string(),
+                author_email: "ada@example.com".to_string(),
+                body: (*body).to_string(),
+                turn_id: (*turn_id).to_string(),
+                turn_seq: *seq,
+                posted_at: Some(prost_types::Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos: 0,
+                }),
+                ..ProtoTurn::default()
+            })
+            .collect(),
+        ..ProtoDiscussion::default()
+    }
+}
+
+#[tokio::test]
+async fn doorbell_payload_fetches_get_discussion_and_materializes() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-bell".to_string(),
+        proto_discussion("disc-bell", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(11, "discussion.opened", "disc-bell", "turn-open", 1),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        outcome,
+        DiscussionEventOutcome::Applied { discussion_id } if discussion_id == "disc-bell"
+    ));
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-bell"]
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns.len(), 1);
+    assert_eq!(discussion.turns[0].1.body, "keep this invariant");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn get_discussion_permission_denied_is_skipped_and_advances_the_watermark() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .hidden
+        .insert("disc-hidden".to_string(), CallFailureCode::PermissionDenied);
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(44, "turn.appended", "disc-hidden", "turn-2", 2),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        44
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-hidden"]
+    );
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    assert!(store.materialize().unwrap().discussions.is_empty());
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn get_discussion_not_found_is_skipped_and_advances_the_watermark() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .hidden
+        .insert("disc-gone".to_string(), CallFailureCode::NotFound);
+    let (mut client, server, _fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(45, "discussion.opened", "disc-gone", "turn-1", 1),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(outcome, DiscussionEventOutcome::Skipped { .. }));
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        45
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn bootstrap_none_hits_list_by_state() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.list = vec![proto_discussion(
+        "disc-list",
+        &[("turn-open", "from list", 1)],
+    )];
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let cursor = bootstrap_discussions(&repo, &mut client, "acme/widgets", None)
+        .await
+        .unwrap();
+    assert!(cursor.bootstrapped);
+    assert_eq!(
+        *fixture
+            .list_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()),
+        1
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns[0].1.body, "from list");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn fat_append_without_mirror_fetches_instead_of_opening_at_turn_two() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-mid".to_string(),
+        proto_discussion(
+            "disc-mid",
+            &[
+                ("turn-open", "first turn", 1),
+                ("turn-append", "second turn", 2),
+            ],
+        ),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &appended_event(12, "disc-mid", "second turn", "turn-append", 2),
+    )
+    .await
+    .unwrap();
+    assert!(outcome.applied());
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-mid"]
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns.len(), 2);
+    assert_eq!(discussion.turns[0].1.body, "first turn");
+    assert_eq!(discussion.turns[1].1.body, "second turn");
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn consume_next_resumes_after_the_stream_ends() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture {
+        one_event_per_subscribe: true,
+        events: vec![
+            doorbell(1, "discussion.opened", "disc-live", "turn-open", 1),
+            doorbell(2, "turn.appended", "disc-live", "turn-append", 2),
+        ],
+        ..CollaborationFixture::default()
+    };
+    fixture.discussions.insert(
+        "disc-live".to_string(),
+        proto_discussion(
+            "disc-live",
+            &[
+                ("turn-open", "first turn", 1),
+                ("turn-append", "second turn", 2),
+            ],
+        ),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let mut consumer = DiscussionEventConsumer::new(&repo, &mut client, "acme/widgets");
+    let mut subscription = consumer.start(None).await.unwrap();
+
+    let (first, _) = consumer.consume_next(&mut subscription).await.unwrap();
+    assert_eq!(first.event_id, 1);
+    let (second, _) = consumer.consume_next(&mut subscription).await.unwrap();
+    assert_eq!(second.event_id, 2);
+    assert_eq!(
+        fixture
+            .subscribe_after
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        [0, 1]
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .unwrap();
+    assert_eq!(discussion.turns.len(), 2);
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[test]
+fn opened_without_visibility_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "discussion.opened".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "body": "hello",
+            "file": "lib.rs",
+            "symbol": "run",
+            "turn_id": "turn-1",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+}
+
+#[test]
+fn fat_append_on_unknown_discussion_is_not_self_contained() {
+    let event = appended_event(2, "disc-unknown", "second turn", "turn-2", 2);
+    let payload = parse_event_payload(&event);
+    assert!(super::discussion_from_payload("turn.appended", &payload, false).is_none());
+    assert!(super::discussion_from_payload("turn.appended", &payload, true).is_some());
 }

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use api::heddle::api::v1alpha1::{
-    CallFailureCode, Discussion as ProtoDiscussion, DiscussionTurn as ProtoTurn, PathSymbolRef,
-    RepoEvent, RepoEventKind, StateId as ProtoStateId,
+    CallFailureCode, Discussion as ProtoDiscussion, DiscussionKind, DiscussionTurn as ProtoTurn,
+    PathSymbolRef, RepoEvent, RepoEventKind, StateId as ProtoStateId,
 };
-use objects::object::{Attribution, Principal};
+use objects::object::{Attribution, CollaborationAnchor, Principal};
 use repo::{CollaborationStore, Repository};
 use tempfile::TempDir;
 
@@ -48,6 +48,11 @@ fn opened_event(event_id: i64, discussion_id: &str, body: &str, turn_id: &str) -
             "turn_seq": 1,
         })
         .to_string(),
+        // Self-contained opens require the event state. Tests that omit it
+        // (doorbell-fetch) clear `new_state`.
+        new_state: Some(ProtoStateId {
+            value: vec![0x11; 32],
+        }),
         ..RepoEvent::default()
     }
 }
@@ -833,6 +838,60 @@ fn fat_append_with_turn_id_but_zero_seq_is_a_doorbell() {
 }
 
 #[test]
+fn opened_without_state_id_is_a_doorbell() {
+    let event = RepoEvent {
+        event_type: "discussion.opened".into(),
+        payload_json: serde_json::json!({
+            "discussion_id": "disc-9",
+            "file": "lib.rs",
+            "symbol": "run",
+            "visibility": "internal",
+            "body": "hello",
+            "turn_id": "turn-1",
+            "turn_seq": 1
+        })
+        .to_string(),
+        ..RepoEvent::default()
+    };
+    let payload = parse_event_payload(&event);
+    assert!(event.new_state.is_none());
+    assert!(payload.opened_against_state.is_none());
+    assert!(super::discussion_from_payload("discussion.opened", &payload, false).is_none());
+}
+
+#[test]
+fn principals_do_not_share_a_cursor_slot() {
+    let temp = TempDir::new().unwrap();
+    let alice = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        principal: "alice".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let bob = DiscussionCursorScope {
+        repo_path: "acme/widgets".into(),
+        principal: "bob".into(),
+        ..DiscussionCursorScope::default()
+    };
+    let cursor = DiscussionEventCursor {
+        after_event_id: 101,
+        repo_id: "repo-1".into(),
+        bootstrapped: true,
+    };
+    save_scoped_cursor(temp.path(), &alice, &cursor).unwrap();
+    assert_eq!(
+        load_scoped_cursor(temp.path(), &bob).unwrap(),
+        DiscussionEventCursor::default(),
+        "a different hosted principal must not inherit another audience's cursor"
+    );
+    assert_eq!(
+        load_cursor(temp.path(), "acme/widgets").unwrap(),
+        DiscussionEventCursor::default(),
+        "the unscoped repo_path slot must not inherit a principal-scoped watermark"
+    );
+    assert_eq!(load_scoped_cursor(temp.path(), &alice).unwrap(), cursor);
+}
+
+#[test]
 fn opened_without_file_or_symbol_is_a_doorbell() {
     let event = RepoEvent {
         event_type: "discussion.opened".into(),
@@ -1227,6 +1286,135 @@ async fn get_discussion_unauthenticated_does_not_advance_the_watermark() {
             .after_event_id,
         0,
         "unauthenticated must not advance the watermark"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn opened_without_state_id_fetches_get_discussion() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-nostate".to_string(),
+        proto_discussion("disc-nostate", &[("turn-open", "keep this invariant", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let mut event = opened_event(61, "disc-nostate", "hello", "turn-open");
+    event.new_state = None;
+    let outcome = consume_discussion_event(&repo, &mut client, "acme/widgets", &event)
+        .await
+        .unwrap();
+    assert!(matches!(
+        outcome,
+        DiscussionEventOutcome::Applied { discussion_id } if discussion_id == "disc-nostate"
+    ));
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-nostate"],
+        "missing event state must doorbell-fetch instead of opening against local HEAD"
+    );
+
+    client.close().await;
+    server.await.unwrap();
+}
+
+fn proto_coordination_discussion(id: &str, turns: &[(&str, &str, u64)]) -> ProtoDiscussion {
+    ProtoDiscussion {
+        id: id.to_string(),
+        kind: DiscussionKind::Coordination as i32,
+        thread_ref: "feature/run".to_string(),
+        visibility: "internal".to_string(),
+        anchor: None,
+        turns: turns
+            .iter()
+            .map(|(turn_id, body, seq)| ProtoTurn {
+                author_name: "Ada".to_string(),
+                author_email: "ada@example.com".to_string(),
+                body: (*body).to_string(),
+                turn_id: (*turn_id).to_string(),
+                turn_seq: *seq,
+                posted_at: Some(prost_types::Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos: 0,
+                }),
+                ..ProtoTurn::default()
+            })
+            .collect(),
+        ..ProtoDiscussion::default()
+    }
+}
+
+#[tokio::test]
+async fn coordination_doorbell_advances_watermark_and_does_not_fail_loop() {
+    let (_temp, repo) = seed_repo();
+    let mut fixture = CollaborationFixture::default();
+    fixture.discussions.insert(
+        "disc-coord".to_string(),
+        proto_coordination_discussion("disc-coord", &[("turn-open", "handoff the review", 1)]),
+    );
+    let (mut client, server, fixture) =
+        crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+
+    let outcome = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &doorbell(71, "discussion.opened", "disc-coord", "turn-open", 1),
+    )
+    .await
+    .expect("coordination must not fail-loop the event stream");
+    assert!(
+        outcome.applied() || matches!(outcome, DiscussionEventOutcome::Skipped { .. }),
+        "expected applied or skipped, got {outcome:?}"
+    );
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        71,
+        "an empty-anchor coordination doorbell must still advance the watermark"
+    );
+    assert_eq!(
+        fixture
+            .get_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .as_slice(),
+        ["disc-coord"]
+    );
+
+    let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+    let discussion = store
+        .materialize()
+        .unwrap()
+        .discussions
+        .into_values()
+        .next()
+        .expect("coordination should materialize with a repository anchor");
+    assert_eq!(discussion.anchor, CollaborationAnchor::Repository);
+
+    let later = consume_discussion_event(
+        &repo,
+        &mut client,
+        "acme/widgets",
+        &opened_event(72, "disc-later", "a later code discussion", "turn-1"),
+    )
+    .await
+    .expect("later events must still deliver after a coordination doorbell");
+    assert!(matches!(later, DiscussionEventOutcome::Applied { .. }));
+    assert_eq!(
+        load_cursor(repo.heddle_dir(), "acme/widgets")
+            .unwrap()
+            .after_event_id,
+        72
     );
 
     client.close().await;

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -1169,13 +1169,21 @@ async fn fat_append_with_turn_id_and_zero_seq_fetches_and_keeps_the_new_turn() {
 #[tokio::test]
 async fn thread_scoped_subscribe_request_carries_thread_id() {
     let (_temp, repo) = seed_repo();
-    let fixture = CollaborationFixture::default();
+    let mut fixture = CollaborationFixture::default();
+    fixture
+        .events
+        .push(opened_event(1, "disc-1", "hello", "turn-1"));
     let (mut client, server, fixture) =
         crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
 
     let mut consumer = DiscussionEventConsumer::new(&repo, &mut client, "acme/widgets")
         .with_thread("feature/run", "thr-stable");
-    let _subscription = consumer.start(None).await.unwrap();
+    let mut subscription = consumer.start(None).await.unwrap();
+    // start() can return before the server records the request body.
+    // consume_next waits for the first event, which is written only after
+    // serve_subscribe_repo_events has stored the paired thread fields.
+    let (event, _) = consumer.consume_next(&mut subscription).await.unwrap();
+    assert_eq!(event.event_id, 1);
     assert_eq!(
         fixture
             .subscribe_thread

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -1553,23 +1553,6 @@ mod tests {
         server.await.unwrap();
     }
 
-    #[test]
-    fn apply_without_head_does_not_succeed() {
-        let temp = TempDir::new().unwrap();
-        let repo = Repository::init_default(temp.path()).unwrap();
-        let error = apply_hosted_discussion(
-            &repo,
-            "acme/widgets",
-            None,
-            &hosted("disc-1", "first", "turn-1", HostedResolution::Open),
-        )
-        .expect_err("no HEAD must fail rather than acknowledge");
-        assert!(
-            error.to_string().contains("HEAD"),
-            "expected a HEAD refusal, got {error:#}"
-        );
-    }
-
     fn hosted(
         id: &str,
         body: &str,

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -882,9 +882,15 @@ fn pull_one(
             let mut changed = false;
             for (list_index, server_turn) in discussion.turns.iter().enumerate() {
                 let ordinal = server_ordinal(server_turn, list_index);
-                if linked_ordinals.contains(&ordinal)
-                    || server_turn_id(server_turn)
-                        .is_some_and(|turn_id| linked_server_turn_ids.contains(&turn_id))
+                let turn_id = server_turn_id(server_turn);
+                // A minted turn_id is the identity. Ordinal matching is only
+                // for older snapshots that never minted one — otherwise a
+                // fat append with turn_seq=0 would collide with the Open
+                // turn at ordinal 0 and be dropped.
+                if turn_id
+                    .as_ref()
+                    .is_some_and(|id| linked_server_turn_ids.contains(id))
+                    || (turn_id.is_none() && linked_ordinals.contains(&ordinal))
                 {
                     continue;
                 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -544,7 +544,7 @@ async fn push_into_annotation_resolution(
     {
         return Ok(false);
     }
-    client
+    let hosted = client
         .resolve_discussion_into_annotation(
             repo_path,
             server_id,
@@ -561,6 +561,9 @@ async fn push_into_annotation_resolution(
         .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
         .ok_or_else(|| anyhow!("hosted discussion mirror entry disappeared during resolution"))?;
     entry.resolved_into_annotation_operation_id = Some(operation_id);
+    if let Some(key) = hosted_resolution_key(&hosted.resolution) {
+        entry.pulled_resolution_key = Some(key);
+    }
     Ok(true)
 }
 
@@ -971,11 +974,36 @@ fn pull_resolution(
         .materialize_discussion(&local_id)
         .context("materialize mirrored discussion")?
         .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
-    let parents = if existing.resolution.is_some() || !existing.conflict_operations.is_empty() {
+    let pushed_echo = is_pushed_annotation_echo(
+        &mirror.repos[repo_path].discussions[index],
+        &existing,
+        &discussion.resolution,
+    );
+    let parents = if pushed_echo {
+        // Finalize the server's annotation id as a descendant of the local
+        // IntoAnnotation we already pushed — not a sibling that conflicts.
+        existing.heads.iter().copied().collect()
+    } else if existing.resolution.is_some() || !existing.conflict_operations.is_empty() {
         resolution_sibling_parents(store, &existing)?
     } else {
         existing.heads.iter().copied().collect()
     };
+    if pushed_echo
+        && matches!(
+            existing.resolution,
+            Some(CollaborationResolution::Annotation { ref annotation_id })
+                if Some(annotation_id.as_str())
+                    == hosted_annotation_id(&discussion.resolution)
+        )
+    {
+        mirror
+            .repos
+            .get_mut(repo_path)
+            .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+            .ok_or_else(|| anyhow!("hosted discussion mirror entry disappeared during resolution"))?
+            .pulled_resolution_key = Some(hosted_key);
+        return Ok(false);
+    }
     write_local_operation(
         store,
         local_id,
@@ -991,6 +1019,31 @@ fn pull_resolution(
         .ok_or_else(|| anyhow!("hosted discussion mirror entry disappeared during resolution"))?
         .pulled_resolution_key = Some(hosted_key);
     Ok(true)
+}
+
+fn is_pushed_annotation_echo(
+    entry: &MirrorEntry,
+    existing: &MaterializedDiscussion,
+    hosted: &HostedResolution,
+) -> bool {
+    entry.resolved_into_annotation_operation_id.is_some()
+        && hosted_annotation_id(hosted).is_some()
+        && matches!(
+            existing.resolution,
+            Some(
+                CollaborationResolution::IntoAnnotation { .. }
+                    | CollaborationResolution::Annotation { .. }
+            )
+        )
+}
+
+fn hosted_annotation_id(resolution: &HostedResolution) -> Option<&str> {
+    match resolution {
+        HostedResolution::IntoAnnotation { annotation_id } if !annotation_id.is_empty() => {
+            Some(annotation_id.as_str())
+        }
+        _ => None,
+    }
 }
 
 fn hosted_resolution_key(resolution: &HostedResolution) -> Option<String> {
@@ -1669,6 +1722,93 @@ mod tests {
             )
             .unwrap(),
             "the same hosted resolution must not be imported twice"
+        );
+    }
+
+    #[test]
+    fn pushed_into_annotation_echo_does_not_conflict() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        repo.snapshot_with_attribution(
+            Some("seed".to_string()),
+            None,
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        )
+        .unwrap();
+
+        assert!(
+            apply_hosted_discussion(
+                &repo,
+                "acme/widgets",
+                None,
+                &hosted("disc-1", "first", "turn-1", HostedResolution::Open),
+            )
+            .unwrap()
+        );
+
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let existing = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        write_local_operation(
+            &store,
+            existing.discussion_id,
+            existing.heads.iter().copied().collect(),
+            Attribution::human(Principal::new("Local", "local@example.com")),
+            1_700_000_100_000,
+            CollaborationOperationBodyV1::Resolve {
+                resolution: CollaborationResolution::IntoAnnotation {
+                    annotation_kind: AnnotationKind::Invariant,
+                    content: "the cache key includes visibility".to_string(),
+                    tags: vec!["cache".to_string()],
+                },
+            },
+        )
+        .unwrap();
+
+        let path = mirror_path(repo.heddle_dir());
+        let mut mirror: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        mirror["repos"]["acme/widgets"]["discussions"][0]
+            ["resolved_into_annotation_operation_id"] = serde_json::json!("pushed-op");
+        std::fs::write(&path, serde_json::to_vec_pretty(&mirror).unwrap()).unwrap();
+
+        apply_hosted_discussion(
+            &repo,
+            "acme/widgets",
+            None,
+            &hosted(
+                "disc-1",
+                "first",
+                "turn-1",
+                HostedResolution::IntoAnnotation {
+                    annotation_id: "ann-1".to_string(),
+                },
+            ),
+        )
+        .unwrap();
+
+        let echoed = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        assert!(
+            echoed.conflict_operations.is_empty(),
+            "a pushed IntoAnnotation echo must not surface as competing collab state"
+        );
+        assert_eq!(
+            echoed.resolution,
+            Some(CollaborationResolution::Annotation {
+                annotation_id: "ann-1".to_string(),
+            })
         );
     }
 

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -670,7 +670,7 @@ fn discussion_sync_state(repo: &Repository, against: Option<StateId>) -> Result<
 
 /// Import one already-fetched hosted discussion into the local op-log.
 /// Persists the mirror. Used by the live event consumer after GetDiscussion
-/// or a self-contained event payload.
+/// (opened/resolved, or an unmirrored append) and the mirrored-append fast path.
 pub fn apply_hosted_discussion(
     repo: &Repository,
     repo_path: &str,

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -733,6 +733,7 @@ fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion 
                 HostedResolution::Dismissed { reason }
             }
         },
+        kind: 0,
     }
 }
 
@@ -785,11 +786,7 @@ fn pull_one(
                 return Ok(false);
             }
             let local_id = DiscussionRecordId::generate();
-            let anchor = CollaborationAnchor::Symbol {
-                state_id: discussion.opened_against_state.unwrap_or(head_state),
-                path: discussion.file.clone(),
-                symbol: discussion.symbol.clone(),
-            };
+            let anchor = hosted_open_anchor(discussion, head_state);
             let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
             let visibility = parse_visibility_token(&discussion.visibility);
 
@@ -1035,6 +1032,27 @@ fn is_pushed_annotation_echo(
                     | CollaborationResolution::Annotation { .. }
             )
         )
+}
+
+fn hosted_open_anchor(
+    discussion: &HostedDiscussion,
+    head_state: StateId,
+) -> CollaborationAnchor {
+    use api::heddle::api::v1alpha1::DiscussionKind;
+
+    let kind = DiscussionKind::try_from(discussion.kind).unwrap_or(DiscussionKind::Unspecified);
+    let has_symbol = !discussion.file.is_empty() && !discussion.symbol.is_empty();
+    // Coordination has no PathSymbolRef. An empty-anchor fetch of any kind
+    // must still Open — failing validation here would not advance the
+    // watermark and every restart would die on the same event.
+    if kind == DiscussionKind::Coordination || !has_symbol {
+        return CollaborationAnchor::Repository;
+    }
+    CollaborationAnchor::Symbol {
+        state_id: discussion.opened_against_state.unwrap_or(head_state),
+        path: discussion.file.clone(),
+        symbol: discussion.symbol.clone(),
+    }
 }
 
 fn hosted_annotation_id(resolution: &HostedResolution) -> Option<&str> {
@@ -1619,6 +1637,7 @@ mod tests {
             opened_against_state: None,
             visibility: "internal".to_string(),
             thread_ref: None,
+            kind: 0,
             turns: vec![HostedDiscussionTurn {
                 author_name: "Ada".to_string(),
                 author_email: "ada@example.com".to_string(),

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -616,7 +616,14 @@ async fn pull_discussions_filtered(
     against: Option<StateId>,
     thread_filter: Option<(&str, &str)>,
 ) -> Result<usize> {
-    mark_legacy_discussions_migrated(repo).context("claim legacy discussion migration marker")?;
+    // Repo-wide import (clone/pull, unfiltered wait) claims the one-shot
+    // marker so pulled hosted attachments are not also converted. A
+    // `--thread` wait only imports that thread; claiming here would hide
+    // other threads' local legacy discussions from later list/show.
+    if thread_filter.is_none() {
+        mark_legacy_discussions_migrated(repo)
+            .context("claim legacy discussion migration marker")?;
+    }
 
     let Some(head_state) = discussion_sync_state(repo, against)? else {
         // weft#638: a repo with no HEAD cannot resolve a state to list against

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -81,7 +81,7 @@ use objects::{
     fs_atomic::write_file_atomic,
     lock::RepoLock,
     object::{
-        Attribution, ChangeId, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
+        Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
         CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
         Discussion, DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, Principal,
         StateId, VisibilityTier,
@@ -199,29 +199,6 @@ fn lock_mirror_write(heddle_dir: &Path) -> Result<objects::lock::WriteLockGuard>
     mirror_lock(heddle_dir)?
         .write()
         .map_err(|error| anyhow!("lock hosted discussion mirror: {error}"))
-}
-
-fn lock_mirror_read(heddle_dir: &Path) -> Result<objects::lock::ReadLockGuard> {
-    mirror_lock(heddle_dir)?
-        .read()
-        .map_err(|error| anyhow!("lock hosted discussion mirror: {error}"))
-}
-
-/// True when `server_id` is already in the hosted mirror for `repo_path`.
-/// Fat `turn.appended` / `discussion.resolved` payloads may apply only after
-/// this is true; otherwise the consumer must `GetDiscussion`.
-pub fn discussion_is_mirrored(
-    heddle_dir: &Path,
-    repo_path: &str,
-    server_id: &str,
-) -> Result<bool> {
-    let _guard = lock_mirror_read(heddle_dir)?;
-    let mirror = load_mirror(heddle_dir)?;
-    Ok(mirror.repos.get(repo_path).is_some_and(|repo| {
-        repo.discussions
-            .iter()
-            .any(|entry| entry.server_id == server_id)
-    }))
 }
 
 fn open_op_id(repo_path: &str, local_id: &str) -> String {
@@ -426,90 +403,89 @@ async fn push_one(
             heddle_cli_render::cli::style::warn_marker(),
         );
     }
-    let (index, server_id, mut changed) = match entry_index {
-        None => {
-            if candidates.is_empty() {
-                return Ok(false);
-            }
-            let (open_turn_id, open_body) = candidates[0].clone();
-            let hosted = client
-                .open_discussion(
-                    repo_path,
-                    change_id,
-                    path,
-                    symbol,
-                    &open_body,
-                    &visibility,
-                    discussion.thread_ref.as_deref(),
-                    open_op_id(repo_path, local_id),
-                )
-                .await
-                .with_context(|| format!("open hosted discussion for {local_id}"))?;
-            let server_id = hosted.id.clone();
-            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-            repo_mirror.discussions.push(MirrorEntry {
-                local_id: local_id.to_string(),
-                server_id: server_id.clone(),
-                links: vec![TurnLink {
-                    local_turn_id: open_turn_id,
-                    server_ordinal: 0,
-                    server_turn_id: None,
-                }],
-                resolved_into_annotation_operation_id: None,
-                pulled_resolution_key: None,
-            });
-            let index = repo_mirror.discussions.len() - 1;
-            for (turn_id, body) in &candidates[1..] {
+    let (index, server_id, mut changed) =
+        match entry_index {
+            None => {
+                if candidates.is_empty() {
+                    return Ok(false);
+                }
+                let (open_turn_id, open_body) = candidates[0].clone();
                 let hosted = client
-                    .append_turn(
+                    .open_discussion(
                         repo_path,
-                        &server_id,
-                        body,
-                        append_op_id(repo_path, &server_id, turn_id),
+                        change_id,
+                        path,
+                        symbol,
+                        &open_body,
+                        &visibility,
+                        discussion.thread_ref.as_deref(),
+                        open_op_id(repo_path, local_id),
                     )
                     .await
-                    .with_context(|| format!("append hosted turn for {local_id}"))?;
-                push_link(
-                    mirror,
-                    repo_path,
-                    index,
-                    turn_id.clone(),
-                    hosted.turns.len().saturating_sub(1),
-                    hosted
-                        .turns
-                        .last()
-                        .and_then(|turn| (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())),
-                );
-            }
-            (index, server_id, true)
-        }
-        Some(index) => {
-            let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
-            for (turn_id, body) in &candidates {
-                let hosted = client
-                    .append_turn(
+                    .with_context(|| format!("open hosted discussion for {local_id}"))?;
+                let server_id = hosted.id.clone();
+                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                repo_mirror.discussions.push(MirrorEntry {
+                    local_id: local_id.to_string(),
+                    server_id: server_id.clone(),
+                    links: vec![TurnLink {
+                        local_turn_id: open_turn_id,
+                        server_ordinal: 0,
+                        server_turn_id: None,
+                    }],
+                    resolved_into_annotation_operation_id: None,
+                    pulled_resolution_key: None,
+                });
+                let index = repo_mirror.discussions.len() - 1;
+                for (turn_id, body) in &candidates[1..] {
+                    let hosted = client
+                        .append_turn(
+                            repo_path,
+                            &server_id,
+                            body,
+                            append_op_id(repo_path, &server_id, turn_id),
+                        )
+                        .await
+                        .with_context(|| format!("append hosted turn for {local_id}"))?;
+                    push_link(
+                        mirror,
                         repo_path,
-                        &server_id,
-                        body,
-                        append_op_id(repo_path, &server_id, turn_id),
-                    )
-                    .await
-                    .with_context(|| format!("append hosted turn for {local_id}"))?;
-                push_link(
-                    mirror,
-                    repo_path,
-                    index,
-                    turn_id.clone(),
-                    hosted.turns.len().saturating_sub(1),
-                    hosted
-                        .turns
-                        .last()
-                        .and_then(|turn| (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())),
-                );
+                        index,
+                        turn_id.clone(),
+                        hosted.turns.len().saturating_sub(1),
+                        hosted.turns.last().and_then(|turn| {
+                            (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
+                        }),
+                    );
+                }
+                (index, server_id, true)
             }
-            (index, server_id, !candidates.is_empty())
-        }
-    };
+            Some(index) => {
+                let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
+                for (turn_id, body) in &candidates {
+                    let hosted = client
+                        .append_turn(
+                            repo_path,
+                            &server_id,
+                            body,
+                            append_op_id(repo_path, &server_id, turn_id),
+                        )
+                        .await
+                        .with_context(|| format!("append hosted turn for {local_id}"))?;
+                    push_link(
+                        mirror,
+                        repo_path,
+                        index,
+                        turn_id.clone(),
+                        hosted.turns.len().saturating_sub(1),
+                        hosted.turns.last().and_then(|turn| {
+                            (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
+                        }),
+                    );
+                }
+                (index, server_id, !candidates.is_empty())
+            }
+        };
 
     if push_into_annotation_resolution(client, repo_path, mirror, index, &server_id, discussion)
         .await?
@@ -625,22 +601,14 @@ async fn pull_discussions_filtered(
             .context("claim legacy discussion migration marker")?;
     }
 
-    let Some(head_state) = discussion_sync_state(repo, against)? else {
+    let Some((head_state, hosted)) =
+        listed_hosted_discussions(repo, client, repo_path, bootstrap, against, thread_filter)
+            .await?
+    else {
         // weft#638: a repo with no HEAD cannot resolve a state to list against
         // unless the caller passed the pulled/cloned tip.
         return Ok(0);
     };
-    let Some(state) = repo
-        .store()
-        .get_state(&head_state)
-        .context("load head state")?
-    else {
-        return Ok(0);
-    };
-    let change_id = state.change_id;
-
-    let hosted =
-        listed_hosted_discussions(client, repo_path, change_id, bootstrap, thread_filter).await?;
     if hosted.is_empty() {
         return Ok(0);
     }
@@ -691,12 +659,24 @@ fn discussion_sync_state(repo: &Repository, against: Option<StateId>) -> Result<
 }
 
 async fn listed_hosted_discussions(
+    repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
-    change_id: ChangeId,
     bootstrap: Option<&[Discussion]>,
+    against: Option<StateId>,
     thread_filter: Option<(&str, &str)>,
-) -> Result<Vec<HostedDiscussion>> {
+) -> Result<Option<(StateId, Vec<HostedDiscussion>)>> {
+    let Some(state_id) = discussion_sync_state(repo, against)? else {
+        return Ok(None);
+    };
+    let Some(state) = repo
+        .store()
+        .get_state(&state_id)
+        .context("load discussion sync state")?
+    else {
+        return Ok(None);
+    };
+
     // Pull-fold attachments are clone/pull's repo-wide snapshot. Never shrink
     // that set for wait `--thread` — wait's filtered path always passes None.
     let hosted = match bootstrap {
@@ -707,7 +687,7 @@ async fn listed_hosted_discussions(
             .collect(),
         None => {
             let listed = client
-                .list_discussions_by_state(repo_path, change_id, "all")
+                .list_discussions_by_state(repo_path, state.change_id, "all")
                 .await
                 .context("list hosted discussions")?;
             match thread_filter {
@@ -721,7 +701,7 @@ async fn listed_hosted_discussions(
             }
         }
     };
-    Ok(hosted)
+    Ok(Some((state_id, hosted)))
 }
 
 fn discussion_matches_wait_thread(
@@ -1019,16 +999,12 @@ fn pull_resolution(
     let Some(hosted_key) = hosted_resolution_key(&discussion.resolution) else {
         return Ok(false);
     };
-    let Some(index) = mirror
-        .repos
-        .get(repo_path)
-        .and_then(|repo_mirror| {
-            repo_mirror
-                .discussions
-                .iter()
-                .position(|entry| entry.server_id == discussion.id)
-        })
-    else {
+    let Some(index) = mirror.repos.get(repo_path).and_then(|repo_mirror| {
+        repo_mirror
+            .discussions
+            .iter()
+            .position(|entry| entry.server_id == discussion.id)
+    }) else {
         return Ok(false);
     };
     if mirror.repos[repo_path].discussions[index]
@@ -1109,10 +1085,7 @@ fn is_pushed_annotation_echo(
         )
 }
 
-fn hosted_open_anchor(
-    discussion: &HostedDiscussion,
-    head_state: StateId,
-) -> CollaborationAnchor {
+fn hosted_open_anchor(discussion: &HostedDiscussion, head_state: StateId) -> CollaborationAnchor {
     use api::heddle::api::v1alpha1::DiscussionKind;
 
     let kind = DiscussionKind::try_from(discussion.kind).unwrap_or(DiscussionKind::Unspecified);
@@ -1143,9 +1116,9 @@ fn hosted_resolution_key(resolution: &HostedResolution) -> Option<String> {
     match resolution {
         HostedResolution::Open => None,
         HostedResolution::Dismissed { reason } => Some(format!("dismissed:{reason}")),
-        HostedResolution::ByEdit { state_id: Some(state_id) } => {
-            Some(format!("by_edit:{}", hex::encode(state_id.as_bytes())))
-        }
+        HostedResolution::ByEdit {
+            state_id: Some(state_id),
+        } => Some(format!("by_edit:{}", hex::encode(state_id.as_bytes()))),
         HostedResolution::ByEdit { state_id: None } => None,
         HostedResolution::IntoAnnotation { annotation_id } if !annotation_id.is_empty() => {
             Some(format!("annotation:{annotation_id}"))
@@ -1194,8 +1167,9 @@ fn hosted_resolution_to_collab(resolution: &HostedResolution) -> Option<Collabor
                 annotation_id: annotation_id.clone(),
             })
         }
-        HostedResolution::ByEdit { state_id } => state_id
-            .map(|state_id| CollaborationResolution::AddressedByState { state_id }),
+        HostedResolution::ByEdit { state_id } => {
+            state_id.map(|state_id| CollaborationResolution::AddressedByState { state_id })
+        }
         HostedResolution::Dismissed { reason } => Some(CollaborationResolution::Dismissed {
             reason: reason.clone(),
         }),
@@ -1274,7 +1248,7 @@ fn write_local_operation(
     body: CollaborationOperationBodyV1,
 ) -> Result<CollabOpId> {
     let key = CollaborationIdempotencyKey::new(uuid::Uuid::new_v4().to_string())
-        .map_err(|e| anyhow!("invalid idempotency key: {e}"))?;
+        .map_err(|error| anyhow!("invalid idempotency key: {error}"))?;
     let operation = CollaborationOperationEnvelope::new(
         discussion_id,
         parents,
@@ -1283,7 +1257,7 @@ fn write_local_operation(
         occurred_at_ms,
         body,
     )
-    .map_err(|e| anyhow!("build collaboration operation: {e}"))?;
+    .context("build collaboration operation")?;
     Ok(store
         .write_operation(&operation)
         .context("write collaboration operation")?
@@ -1291,7 +1265,7 @@ fn write_local_operation(
 }
 
 fn turn_body(turn: &HostedDiscussionTurn) -> Result<DiscussionTurnV1> {
-    DiscussionTurnV1::new(turn.body.clone()).map_err(|e| anyhow!("invalid discussion turn: {e}"))
+    DiscussionTurnV1::new(turn.body.clone()).context("invalid discussion turn")
 }
 
 fn turn_attribution(turn: &HostedDiscussionTurn) -> Attribution {
@@ -1341,7 +1315,7 @@ mod tests {
         CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
         ContentHash, Discussion, DiscussionRecordId, DiscussionResolution, DiscussionTurn,
         DiscussionTurnV1, LegacyDiscussionId, LegacyDiscussionResolutionV1, LegacySourceLocator,
-        Principal, StateAttachmentId, StateId, SymbolAnchor, VisibilityTier,
+        Principal, State, StateAttachmentId, StateId, SymbolAnchor, Tree, VisibilityTier,
     };
     use tempfile::TempDir;
 
@@ -1502,6 +1476,72 @@ mod tests {
             Some(first)
         );
         assert_eq!(discussion_sync_state(&repo, None).unwrap(), Some(second));
+    }
+
+    #[tokio::test]
+    async fn clone_discussion_sync_uses_against_before_head_is_published() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        let tree = Tree::new();
+        let tree_id = repo.store().put_tree(&tree).unwrap();
+        let state = State::new_snapshot(
+            tree_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        let against = state.id();
+        assert_eq!(
+            repo.head().unwrap(),
+            None,
+            "clone has not published HEAD yet"
+        );
+
+        let bootstrap = vec![Discussion {
+            id: "server-discussion-before-head".to_string(),
+            anchor: SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: against,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: Principal::new("Reviewer", "reviewer@example.com"),
+                body: "keep this invariant".to_string(),
+                posted_at: 1_700_000_001,
+                references: Vec::new(),
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: VisibilityTier::Internal,
+            resolved_annotation_id: None,
+        }];
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+
+        assert_eq!(
+            pull_discussions(
+                &repo,
+                &mut client,
+                "acme/widgets",
+                Some(&bootstrap),
+                Some(against),
+            )
+            .await
+            .unwrap(),
+            1,
+            "discussion sync must not return Ok(0) just because HEAD is unpublished"
+        );
+        assert_eq!(
+            repo.head().unwrap(),
+            None,
+            "sync must not publish clone HEAD"
+        );
+
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        assert_eq!(store.materialize().unwrap().discussions.len(), 1);
+
+        client.close().await;
+        server.await.unwrap();
     }
 
     // F3: no local principal ⇒ turns are NOT treated as ours (fail closed).
@@ -1731,10 +1771,14 @@ mod tests {
         let mut discussion = hosted("disc-1", "first", "turn-1", HostedResolution::Open);
         discussion.thread_ref = Some("foo".to_string());
         assert!(discussion_matches_wait_thread(
-            &discussion, "foo", "thr-foo"
+            &discussion,
+            "foo",
+            "thr-foo"
         ));
         assert!(!discussion_matches_wait_thread(
-            &discussion, "bar", "thr-bar"
+            &discussion,
+            "bar",
+            "thr-bar"
         ));
         discussion.thread_ref = Some("old-name".to_string());
         discussion.thread_id = Some("thr-foo".to_string());
@@ -1750,7 +1794,9 @@ mod tests {
         discussion.thread_ref = None;
         discussion.thread_id = Some("thr-foo".to_string());
         assert!(discussion_matches_wait_thread(
-            &discussion, "foo", "thr-foo"
+            &discussion,
+            "foo",
+            "thr-foo"
         ));
     }
 
@@ -1897,8 +1943,8 @@ mod tests {
         let path = mirror_path(repo.heddle_dir());
         let mut mirror: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        mirror["repos"]["acme/widgets"]["discussions"][0]
-            ["resolved_into_annotation_operation_id"] = serde_json::json!("pushed-op");
+        mirror["repos"]["acme/widgets"]["discussions"][0]["resolved_into_annotation_operation_id"] =
+            serde_json::json!("pushed-op");
         std::fs::write(&path, serde_json::to_vec_pretty(&mirror).unwrap()).unwrap();
 
         apply_hosted_discussion(
@@ -1971,7 +2017,11 @@ mod tests {
         let repo = Repository::open(&path).unwrap();
         let mirror = load_mirror(repo.heddle_dir()).unwrap();
         let discussions = &mirror.repos["acme/widgets"].discussions;
-        assert_eq!(discussions.len(), 2, "both discussions must remain in the mirror");
+        assert_eq!(
+            discussions.len(),
+            2,
+            "both discussions must remain in the mirror"
+        );
         assert!(
             discussions.iter().all(|entry| !entry.links.is_empty()),
             "concurrent apply must not drop TurnLinks"

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -71,6 +71,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
+    fs::OpenOptions,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -78,6 +79,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use objects::{
     fs_atomic::write_file_atomic,
+    lock::RepoLock,
     object::{
         Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
         CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
@@ -124,6 +126,12 @@ struct MirrorEntry {
     /// exist on both sides.
     #[serde(default)]
     resolved_into_annotation_operation_id: Option<String>,
+    /// Hosted resolution already imported (`dismissed:{reason}`,
+    /// `by_edit:{hex}`, `annotation:{id}`). Only this exact hosted operation
+    /// is treated as already applied; a distinct local resolution is a
+    /// competing sibling.
+    #[serde(default)]
+    pulled_resolution_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,6 +183,30 @@ fn save_mirror(heddle_dir: &Path, mirror: &HostedMirror) -> Result<()> {
     Ok(())
 }
 
+fn mirror_lock(heddle_dir: &Path) -> Result<RepoLock> {
+    let dir = heddle_dir.join("collaboration");
+    fs::create_dir_all(&dir).context("create collaboration dir")?;
+    let lock_path = dir.join("hosted-mirror.lock");
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&lock_path)
+        .context("create hosted-mirror lock")?;
+    Ok(RepoLock::at(lock_path))
+}
+
+fn lock_mirror_write(heddle_dir: &Path) -> Result<objects::lock::WriteLockGuard> {
+    mirror_lock(heddle_dir)?
+        .write()
+        .map_err(|error| anyhow!("lock hosted discussion mirror: {error}"))
+}
+
+fn lock_mirror_read(heddle_dir: &Path) -> Result<objects::lock::ReadLockGuard> {
+    mirror_lock(heddle_dir)?
+        .read()
+        .map_err(|error| anyhow!("lock hosted discussion mirror: {error}"))
+}
+
 /// True when `server_id` is already in the hosted mirror for `repo_path`.
 /// Fat `turn.appended` / `discussion.resolved` payloads may apply only after
 /// this is true; otherwise the consumer must `GetDiscussion`.
@@ -183,6 +215,7 @@ pub fn discussion_is_mirrored(
     repo_path: &str,
     server_id: &str,
 ) -> Result<bool> {
+    let _guard = lock_mirror_read(heddle_dir)?;
     let mirror = load_mirror(heddle_dir)?;
     Ok(mirror.repos.get(repo_path).is_some_and(|repo| {
         repo.discussions
@@ -291,6 +324,7 @@ pub async fn push_discussions(
     }
     let self_attr = repo.get_attribution().ok();
 
+    let _guard = lock_mirror_write(repo.heddle_dir())?;
     let mut mirror = load_mirror(repo.heddle_dir())?;
     let mut synced = 0usize;
 
@@ -422,6 +456,7 @@ async fn push_one(
                     server_turn_id: None,
                 }],
                 resolved_into_annotation_operation_id: None,
+                pulled_resolution_key: None,
             });
             let index = repo_mirror.discussions.len() - 1;
             for (turn_id, body) in &candidates[1..] {
@@ -590,6 +625,7 @@ pub async fn pull_discussions(
 
     let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
     let self_attr = repo.get_attribution().ok();
+    let _guard = lock_mirror_write(repo.heddle_dir())?;
     let mut mirror = load_mirror(repo.heddle_dir())?;
     let mut changed = 0usize;
 
@@ -639,12 +675,15 @@ pub fn apply_hosted_discussion(
     discussion: &HostedDiscussion,
 ) -> Result<bool> {
     let Some(head_state) = repo.head().context("resolve repository head")? else {
-        return Ok(false);
+        return Err(anyhow!(
+            "cannot apply a hosted discussion without a repository HEAD"
+        ));
     };
     let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
     let self_attr = repo.get_attribution().ok();
+    let _guard = lock_mirror_write(repo.heddle_dir())?;
     let mut mirror = load_mirror(repo.heddle_dir())?;
-    let changed = import_hosted_discussion(
+    let result = import_hosted_discussion(
         &store,
         repo_path,
         &mut mirror,
@@ -652,9 +691,9 @@ pub fn apply_hosted_discussion(
         hosted_username,
         self_attr.as_ref(),
         discussion,
-    )?;
+    );
     save_mirror(repo.heddle_dir(), &mirror)?;
-    Ok(changed)
+    result
 }
 
 fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion {
@@ -778,6 +817,7 @@ fn pull_one(
                     server_turn_id: server_turn_id(first),
                 }],
                 resolved_into_annotation_operation_id: None,
+                pulled_resolution_key: None,
             });
             let index = repo_mirror.discussions.len() - 1;
 
@@ -901,6 +941,9 @@ fn pull_resolution(
     let Some(resolution) = hosted_resolution_to_collab(&discussion.resolution) else {
         return Ok(false);
     };
+    let Some(hosted_key) = hosted_resolution_key(&discussion.resolution) else {
+        return Ok(false);
+    };
     let Some(index) = mirror
         .repos
         .get(repo_path)
@@ -913,6 +956,13 @@ fn pull_resolution(
     else {
         return Ok(false);
     };
+    if mirror.repos[repo_path].discussions[index]
+        .pulled_resolution_key
+        .as_deref()
+        == Some(hosted_key.as_str())
+    {
+        return Ok(false);
+    }
     let local_id: DiscussionRecordId = mirror.repos[repo_path].discussions[index]
         .local_id
         .parse()
@@ -921,37 +971,73 @@ fn pull_resolution(
         .materialize_discussion(&local_id)
         .context("materialize mirrored discussion")?
         .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
-    if existing.resolution.is_some() {
-        return Ok(false);
-    }
-    let heads: Vec<CollabOpId> = existing.heads.iter().copied().collect();
-    let author = resolution_author(store, &existing, discussion)?;
+    let parents = if existing.resolution.is_some() || !existing.conflict_operations.is_empty() {
+        resolution_sibling_parents(store, &existing)?
+    } else {
+        existing.heads.iter().copied().collect()
+    };
     write_local_operation(
         store,
         local_id,
-        heads,
-        author,
+        parents,
+        hosted_resolution_author(),
         now_ms(),
         CollaborationOperationBodyV1::Resolve { resolution },
     )?;
+    mirror
+        .repos
+        .get_mut(repo_path)
+        .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+        .ok_or_else(|| anyhow!("hosted discussion mirror entry disappeared during resolution"))?
+        .pulled_resolution_key = Some(hosted_key);
     Ok(true)
 }
 
-fn resolution_author(
+fn hosted_resolution_key(resolution: &HostedResolution) -> Option<String> {
+    match resolution {
+        HostedResolution::Open => None,
+        HostedResolution::Dismissed { reason } => Some(format!("dismissed:{reason}")),
+        HostedResolution::ByEdit { state_id: Some(state_id) } => {
+            Some(format!("by_edit:{}", hex::encode(state_id.as_bytes())))
+        }
+        HostedResolution::ByEdit { state_id: None } => None,
+        HostedResolution::IntoAnnotation { annotation_id } if !annotation_id.is_empty() => {
+            Some(format!("annotation:{annotation_id}"))
+        }
+        HostedResolution::IntoAnnotation { .. } => None,
+    }
+}
+
+fn resolution_sibling_parents(
     store: &CollaborationStore,
     existing: &MaterializedDiscussion,
-    discussion: &HostedDiscussion,
-) -> Result<Attribution> {
-    if let Some((op_id, _)) = existing.turns.last() {
-        if let Some(decoded) = store.read_operation(op_id).context("read resolution author")? {
-            return Ok(decoded.operation.author);
+) -> Result<Vec<CollabOpId>> {
+    let candidates: Vec<CollabOpId> = if !existing.conflict_operations.is_empty() {
+        existing.conflict_operations.iter().copied().collect()
+    } else {
+        existing.heads.iter().copied().collect()
+    };
+    for id in &candidates {
+        let Some(decoded) = store
+            .read_operation(id)
+            .context("read head for hosted resolution parents")?
+        else {
+            continue;
+        };
+        match decoded.operation.body {
+            CollaborationOperationBodyV1::Resolve { .. }
+            | CollaborationOperationBodyV1::Reopen { .. }
+            | CollaborationOperationBodyV1::ResolveConflict { .. } => {
+                return Ok(decoded.operation.parents);
+            }
+            _ => {}
         }
     }
-    let turn = discussion.turns.last();
-    Ok(Attribution::human(Principal::new(
-        turn.map(|turn| turn.author_name.as_str()).unwrap_or("hosted"),
-        turn.map(|turn| turn.author_email.as_str()).unwrap_or(""),
-    )))
+    Ok(existing.heads.iter().copied().collect())
+}
+
+fn hosted_resolution_author() -> Attribution {
+    Attribution::human(Principal::new("hosted", ""))
 }
 
 fn hosted_resolution_to_collab(resolution: &HostedResolution) -> Option<CollaborationResolution> {
@@ -1465,5 +1551,186 @@ mod tests {
 
         client.close().await;
         server.await.unwrap();
+    }
+
+    #[test]
+    fn apply_without_head_does_not_succeed() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let error = apply_hosted_discussion(
+            &repo,
+            "acme/widgets",
+            None,
+            &hosted("disc-1", "first", "turn-1", HostedResolution::Open),
+        )
+        .expect_err("no HEAD must fail rather than acknowledge");
+        assert!(
+            error.to_string().contains("HEAD"),
+            "expected a HEAD refusal, got {error:#}"
+        );
+    }
+
+    fn hosted(
+        id: &str,
+        body: &str,
+        turn_id: &str,
+        resolution: HostedResolution,
+    ) -> HostedDiscussion {
+        HostedDiscussion {
+            id: id.to_string(),
+            file: "lib.rs".to_string(),
+            symbol: "run".to_string(),
+            opened_against_state: None,
+            visibility: "internal".to_string(),
+            thread_ref: None,
+            turns: vec![HostedDiscussionTurn {
+                author_name: "Ada".to_string(),
+                author_email: "ada@example.com".to_string(),
+                body: body.to_string(),
+                posted_at_secs: 1_700_000_000,
+                turn_id: turn_id.to_string(),
+                turn_seq: 1,
+            }],
+            resolution,
+        }
+    }
+
+    #[test]
+    fn competing_hosted_resolution_is_recorded_not_unchanged() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        repo.snapshot_with_attribution(
+            Some("seed".to_string()),
+            None,
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        )
+        .unwrap();
+
+        assert!(
+            apply_hosted_discussion(
+                &repo,
+                "acme/widgets",
+                None,
+                &hosted("disc-1", "first", "turn-1", HostedResolution::Open),
+            )
+            .unwrap()
+        );
+
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let existing = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        write_local_operation(
+            &store,
+            existing.discussion_id,
+            existing.heads.iter().copied().collect(),
+            Attribution::human(Principal::new("Local", "local@example.com")),
+            1_700_000_100_000,
+            CollaborationOperationBodyV1::Resolve {
+                resolution: CollaborationResolution::Dismissed {
+                    reason: "local-only".to_string(),
+                },
+            },
+        )
+        .unwrap();
+
+        assert!(
+            apply_hosted_discussion(
+                &repo,
+                "acme/widgets",
+                None,
+                &hosted(
+                    "disc-1",
+                    "first",
+                    "turn-1",
+                    HostedResolution::Dismissed {
+                        reason: "hosted-only".to_string(),
+                    },
+                ),
+            )
+            .unwrap(),
+            "a distinct hosted resolution must be recorded"
+        );
+
+        let conflicted = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        assert!(
+            !conflicted.conflict_operations.is_empty(),
+            "distinct hosted vs local resolutions must surface as competing collab state"
+        );
+        assert_eq!(conflicted.resolution, None);
+
+        assert!(
+            !apply_hosted_discussion(
+                &repo,
+                "acme/widgets",
+                None,
+                &hosted(
+                    "disc-1",
+                    "first",
+                    "turn-1",
+                    HostedResolution::Dismissed {
+                        reason: "hosted-only".to_string(),
+                    },
+                ),
+            )
+            .unwrap(),
+            "the same hosted resolution must not be imported twice"
+        );
+    }
+
+    #[test]
+    fn concurrent_apply_does_not_drop_turn_links() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        repo.snapshot_with_attribution(
+            Some("seed".to_string()),
+            None,
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        )
+        .unwrap();
+        let path = temp.path().to_path_buf();
+        drop(repo);
+
+        let first = hosted("disc-a", "alpha", "turn-a", HostedResolution::Open);
+        let second = hosted("disc-b", "beta", "turn-b", HostedResolution::Open);
+        std::thread::scope(|scope| {
+            let path_a = path.clone();
+            let disc_a = first.clone();
+            scope.spawn(move || {
+                let repo = Repository::open(&path_a).unwrap();
+                apply_hosted_discussion(&repo, "acme/widgets", None, &disc_a)
+                    .expect("apply first discussion");
+            });
+            let path_b = path.clone();
+            let disc_b = second.clone();
+            scope.spawn(move || {
+                let repo = Repository::open(&path_b).unwrap();
+                apply_hosted_discussion(&repo, "acme/widgets", None, &disc_b)
+                    .expect("apply second discussion");
+            });
+        });
+
+        let repo = Repository::open(&path).unwrap();
+        let mirror = load_mirror(repo.heddle_dir()).unwrap();
+        let discussions = &mirror.repos["acme/widgets"].discussions;
+        assert_eq!(discussions.len(), 2, "both discussions must remain in the mirror");
+        assert!(
+            discussions.iter().all(|entry| !entry.links.is_empty()),
+            "concurrent apply must not drop TurnLinks"
+        );
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        assert_eq!(store.materialize().unwrap().discussions.len(), 2);
     }
 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -882,15 +882,9 @@ fn pull_one(
             let mut changed = false;
             for (list_index, server_turn) in discussion.turns.iter().enumerate() {
                 let ordinal = server_ordinal(server_turn, list_index);
-                let turn_id = server_turn_id(server_turn);
-                // A minted turn_id is the identity. Ordinal matching is only
-                // for older snapshots that never minted one — otherwise a
-                // fat append with turn_seq=0 would collide with the Open
-                // turn at ordinal 0 and be dropped.
-                if turn_id
-                    .as_ref()
-                    .is_some_and(|id| linked_server_turn_ids.contains(id))
-                    || (turn_id.is_none() && linked_ordinals.contains(&ordinal))
+                if linked_ordinals.contains(&ordinal)
+                    || server_turn_id(server_turn)
+                        .is_some_and(|turn_id| linked_server_turn_ids.contains(&turn_id))
                 {
                     continue;
                 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -81,7 +81,7 @@ use objects::{
     fs_atomic::write_file_atomic,
     lock::RepoLock,
     object::{
-        Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
+        Attribution, ChangeId, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
         CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
         Discussion, DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, Principal,
         StateId, VisibilityTier,
@@ -574,6 +574,11 @@ async fn push_into_annotation_resolution(
 /// `against` is the pulled/cloned tip. Clone publishes HEAD only after this
 /// call, and `heddle pull feature --local-thread feature` leaves HEAD on the
 /// current checkout — ListByState must not re-read HEAD.
+///
+/// Repo-wide: clone/pull and unfiltered `discuss wait`. Hosted discussions
+/// arrive as server-minted `Discussions` state-attachments; we claim the
+/// one-shot legacy blob→op-log marker so those attachments are not also
+/// converted (duplicates / multi-turn diverge).
 pub async fn pull_discussions(
     repo: &Repository,
     client: &mut HostedClient,
@@ -581,13 +586,35 @@ pub async fn pull_discussions(
     bootstrap: Option<&[Discussion]>,
     against: Option<StateId>,
 ) -> Result<usize> {
-    // Hosted discussions arrive as server-minted `Discussions` state-attachments
-    // on the pulled objects. Those are the transport form of what we
-    // authoritatively re-materialize below via the CollaborationService RPCs —
-    // so claim the one-shot legacy blob->op-log migration marker to keep it from
-    // also converting them (which would duplicate every discussion and diverge
-    // on multi-turn supersede history). Fresh clones have no genuine local
-    // legacy discussions, and existing repos already hold the marker.
+    pull_discussions_filtered(repo, client, repo_path, bootstrap, against, None).await
+}
+
+/// Wait `--thread` bootstrap: same ListByState RPC, then keep only discussions
+/// whose `thread_ref` matches the paired thread name or stable id.
+///
+/// `ListDiscussionsByStateRequest` has no thread fields (heddle-api 0.23.0).
+/// Do not call `ListByThreadRef` — that would be a second list RPC.
+/// Pull-fold `Some(discussions)` stays repo-wide: clone/pull must not shrink.
+pub async fn pull_discussions_for_thread(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    bootstrap: Option<&[Discussion]>,
+    thread: &str,
+    thread_id: &str,
+) -> Result<usize> {
+    let filter = (!thread.is_empty() || !thread_id.is_empty()).then_some((thread, thread_id));
+    pull_discussions_filtered(repo, client, repo_path, bootstrap, None, filter).await
+}
+
+async fn pull_discussions_filtered(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    bootstrap: Option<&[Discussion]>,
+    against: Option<StateId>,
+    thread_filter: Option<(&str, &str)>,
+) -> Result<usize> {
     mark_legacy_discussions_migrated(repo).context("claim legacy discussion migration marker")?;
 
     let Some(head_state) = discussion_sync_state(repo, against)? else {
@@ -604,21 +631,8 @@ pub async fn pull_discussions(
     };
     let change_id = state.change_id;
 
-    // `None` is ListByState: older servers, or `discussions_from_pack`
-    // advertised a snapshot this client cannot consume (missing attachment /
-    // version skew). `Some` is the packed or inline bootstrap set, including
-    // an explicit empty page.
-    let hosted = match bootstrap {
-        Some(discussions) => discussions
-            .iter()
-            .cloned()
-            .map(hosted_discussion_from_bootstrap)
-            .collect(),
-        None => client
-            .list_discussions_by_state(repo_path, change_id, "all")
-            .await
-            .context("list hosted discussions")?,
-    };
+    let hosted =
+        listed_hosted_discussions(client, repo_path, change_id, bootstrap, thread_filter).await?;
     if hosted.is_empty() {
         return Ok(0);
     }
@@ -666,6 +680,52 @@ fn discussion_sync_state(repo: &Repository, against: Option<StateId>) -> Result<
         Some(state) => Ok(Some(state)),
         None => repo.head().context("resolve repository head"),
     }
+}
+
+async fn listed_hosted_discussions(
+    client: &mut HostedClient,
+    repo_path: &str,
+    change_id: ChangeId,
+    bootstrap: Option<&[Discussion]>,
+    thread_filter: Option<(&str, &str)>,
+) -> Result<Vec<HostedDiscussion>> {
+    // Pull-fold attachments are clone/pull's repo-wide snapshot. Never shrink
+    // that set for wait `--thread` — wait's filtered path always passes None.
+    let hosted = match bootstrap {
+        Some(discussions) => discussions
+            .iter()
+            .cloned()
+            .map(hosted_discussion_from_bootstrap)
+            .collect(),
+        None => {
+            let listed = client
+                .list_discussions_by_state(repo_path, change_id, "all")
+                .await
+                .context("list hosted discussions")?;
+            match thread_filter {
+                Some((thread, thread_id)) => listed
+                    .into_iter()
+                    .filter(|discussion| {
+                        discussion_matches_wait_thread(discussion, thread, thread_id)
+                    })
+                    .collect(),
+                None => listed,
+            }
+        }
+    };
+    Ok(hosted)
+}
+
+fn discussion_matches_wait_thread(
+    discussion: &HostedDiscussion,
+    thread: &str,
+    thread_id: &str,
+) -> bool {
+    let Some(thread_ref) = discussion.thread_ref.as_deref() else {
+        return false;
+    };
+    (!thread.is_empty() && thread_ref == thread)
+        || (!thread_id.is_empty() && thread_ref == thread_id)
 }
 
 /// Import one already-fetched hosted discussion into the local op-log.
@@ -1648,6 +1708,28 @@ mod tests {
             }],
             resolution,
         }
+    }
+
+    #[test]
+    fn wait_thread_filter_matches_name_or_stamped_id() {
+        let mut discussion = hosted("disc-1", "first", "turn-1", HostedResolution::Open);
+        discussion.thread_ref = Some("foo".to_string());
+        assert!(discussion_matches_wait_thread(
+            &discussion, "foo", "thr-foo"
+        ));
+        assert!(!discussion_matches_wait_thread(
+            &discussion, "bar", "thr-bar"
+        ));
+        discussion.thread_ref = Some("thr-foo".to_string());
+        assert!(
+            discussion_matches_wait_thread(&discussion, "foo", "thr-foo"),
+            "weft may stamp the stable id in thread_ref"
+        );
+        discussion.thread_ref = None;
+        assert!(
+            !discussion_matches_wait_thread(&discussion, "foo", "thr-foo"),
+            "untagged discussions are not this thread"
+        );
     }
 
     #[test]

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -590,7 +590,8 @@ pub async fn pull_discussions(
 }
 
 /// Wait `--thread` bootstrap: same ListByState RPC, then keep only discussions
-/// whose `thread_ref` matches the paired thread name or stable id.
+/// whose `thread_ref` matches the paired name or whose wire `thread_id`
+/// matches the stable id.
 ///
 /// `ListDiscussionsByStateRequest` has no thread fields (heddle-api 0.23.0).
 /// Do not call `ListByThreadRef` — that would be a second list RPC.
@@ -721,11 +722,17 @@ fn discussion_matches_wait_thread(
     thread: &str,
     thread_id: &str,
 ) -> bool {
-    let Some(thread_ref) = discussion.thread_ref.as_deref() else {
-        return false;
-    };
-    (!thread.is_empty() && thread_ref == thread)
-        || (!thread_id.is_empty() && thread_ref == thread_id)
+    let name_hit = !thread.is_empty()
+        && discussion
+            .thread_ref
+            .as_deref()
+            .is_some_and(|thread_ref| thread_ref == thread);
+    let id_hit = !thread_id.is_empty()
+        && discussion
+            .thread_id
+            .as_deref()
+            .is_some_and(|id| id == thread_id);
+    name_hit || id_hit
 }
 
 /// Import one already-fetched hosted discussion into the local op-log.
@@ -767,6 +774,7 @@ fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion 
         opened_against_state: Some(discussion.opened_against_state),
         visibility: discussion.visibility.as_str().to_string(),
         thread_ref: discussion.thread_ref,
+        thread_id: None,
         turns: discussion
             .turns
             .into_iter()
@@ -1697,6 +1705,7 @@ mod tests {
             opened_against_state: None,
             visibility: "internal".to_string(),
             thread_ref: None,
+            thread_id: None,
             kind: 0,
             turns: vec![HostedDiscussionTurn {
                 author_name: "Ada".to_string(),
@@ -1720,16 +1729,22 @@ mod tests {
         assert!(!discussion_matches_wait_thread(
             &discussion, "bar", "thr-bar"
         ));
-        discussion.thread_ref = Some("thr-foo".to_string());
+        discussion.thread_ref = Some("old-name".to_string());
+        discussion.thread_id = Some("thr-foo".to_string());
         assert!(
             discussion_matches_wait_thread(&discussion, "foo", "thr-foo"),
-            "weft may stamp the stable id in thread_ref"
+            "a renamed thread still matches on the stable wire thread_id"
         );
-        discussion.thread_ref = None;
+        discussion.thread_id = None;
         assert!(
             !discussion_matches_wait_thread(&discussion, "foo", "thr-foo"),
-            "untagged discussions are not this thread"
+            "weft stamps the UUID in thread_id, not thread_ref"
         );
+        discussion.thread_ref = None;
+        discussion.thread_id = Some("thr-foo".to_string());
+        assert!(discussion_matches_wait_thread(
+            &discussion, "foo", "thr-foo"
+        ));
     }
 
     #[test]

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -80,9 +80,9 @@ use objects::{
     fs_atomic::write_file_atomic,
     object::{
         Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
-        CollaborationOperationBodyV1, CollaborationOperationEnvelope, Discussion,
-        DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, Principal, StateId,
-        VisibilityTier,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
+        Discussion, DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, Principal,
+        StateId, VisibilityTier,
     },
     store::ObjectStore,
 };
@@ -91,7 +91,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     client::HostedClient,
-    hosted_runtime::hosted::{HostedDiscussion, HostedDiscussionTurn},
+    hosted_runtime::hosted::{HostedDiscussion, HostedDiscussionTurn, HostedResolution},
 };
 
 /// Deterministic namespace for the derived client-operation-ids so a retried
@@ -133,6 +133,10 @@ struct TurnLink {
     local_turn_id: String,
     /// Position of the turn in the server's linear turn list.
     server_ordinal: usize,
+    /// Server-minted turn identity from the event stream / DiscussionTurn
+    /// wire. Empty on older ListByState snapshots that only had ordinals.
+    #[serde(default)]
+    server_turn_id: Option<String>,
 }
 
 /// One local turn with the identity + attribution the sync bridge reasons over.
@@ -399,6 +403,7 @@ async fn push_one(
                 links: vec![TurnLink {
                     local_turn_id: open_turn_id,
                     server_ordinal: 0,
+                    server_turn_id: None,
                 }],
                 resolved_into_annotation_operation_id: None,
             });
@@ -419,6 +424,10 @@ async fn push_one(
                     index,
                     turn_id.clone(),
                     hosted.turns.len().saturating_sub(1),
+                    hosted
+                        .turns
+                        .last()
+                        .and_then(|turn| (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())),
                 );
             }
             (index, server_id, true)
@@ -441,6 +450,10 @@ async fn push_one(
                     index,
                     turn_id.clone(),
                     hosted.turns.len().saturating_sub(1),
+                    hosted
+                        .turns
+                        .last()
+                        .and_then(|turn| (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())),
                 );
             }
             (index, server_id, !candidates.is_empty())
@@ -600,6 +613,34 @@ fn discussion_sync_state(repo: &Repository, against: Option<StateId>) -> Result<
     }
 }
 
+/// Import one already-fetched hosted discussion into the local op-log.
+/// Persists the mirror. Used by the live event consumer after GetDiscussion
+/// or a self-contained event payload.
+pub fn apply_hosted_discussion(
+    repo: &Repository,
+    repo_path: &str,
+    hosted_username: Option<&str>,
+    discussion: &HostedDiscussion,
+) -> Result<bool> {
+    let Some(head_state) = repo.head().context("resolve repository head")? else {
+        return Ok(false);
+    };
+    let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
+    let self_attr = repo.get_attribution().ok();
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let changed = import_hosted_discussion(
+        &store,
+        repo_path,
+        &mut mirror,
+        head_state,
+        hosted_username,
+        self_attr.as_ref(),
+        discussion,
+    )?;
+    save_mirror(repo.heddle_dir(), &mirror)?;
+    Ok(changed)
+}
+
 fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion {
     HostedDiscussion {
         id: discussion.id,
@@ -616,9 +657,49 @@ fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion 
                 author_email: turn.author.email_lossy().into_owned(),
                 body: turn.body,
                 posted_at_secs: turn.posted_at,
+                turn_id: String::new(),
+                turn_seq: 0,
             })
             .collect(),
+        resolution: match discussion.resolution {
+            objects::object::DiscussionResolution::Open => HostedResolution::Open,
+            objects::object::DiscussionResolution::ResolvedIntoAnnotation { annotation_id } => {
+                HostedResolution::IntoAnnotation { annotation_id }
+            }
+            objects::object::DiscussionResolution::ResolvedByEdit { state_id } => {
+                HostedResolution::ByEdit {
+                    state_id: Some(state_id),
+                }
+            }
+            objects::object::DiscussionResolution::Dismissed { reason } => {
+                HostedResolution::Dismissed { reason }
+            }
+        },
     }
+}
+
+/// Materialize one hosted discussion (snapshot or live fetch) into the local
+/// collab op-log. Idempotent via the hosted mirror: already-linked turns and
+/// resolutions are left alone. Used by pull bootstrap and the event consumer.
+#[allow(clippy::too_many_arguments)]
+fn import_hosted_discussion(
+    store: &CollaborationStore,
+    repo_path: &str,
+    mirror: &mut HostedMirror,
+    head_state: StateId,
+    hosted_username: Option<&str>,
+    self_attr: Option<&Attribution>,
+    discussion: &HostedDiscussion,
+) -> Result<bool> {
+    pull_one(
+        store,
+        repo_path,
+        mirror,
+        head_state,
+        hosted_username,
+        self_attr,
+        discussion,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -631,7 +712,7 @@ fn pull_one(
     self_attr: Option<&Attribution>,
     discussion: &HostedDiscussion,
 ) -> Result<bool> {
-    if discussion.turns.is_empty() {
+    if discussion.turns.is_empty() && matches!(discussion.resolution, HostedResolution::Open) {
         return Ok(false);
     }
     let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
@@ -640,8 +721,11 @@ fn pull_one(
         .iter()
         .position(|entry| entry.server_id == discussion.id);
 
-    match entry_index {
+    let mut changed = match entry_index {
         None => {
+            if discussion.turns.is_empty() {
+                return Ok(false);
+            }
             let local_id = DiscussionRecordId::generate();
             let anchor = CollaborationAnchor::Symbol {
                 state_id: discussion.opened_against_state.unwrap_or(head_state),
@@ -674,14 +758,16 @@ fn pull_one(
                 server_id: discussion.id.clone(),
                 links: vec![TurnLink {
                     local_turn_id: turn_identity(&open_op, 0),
-                    server_ordinal: 0,
+                    server_ordinal: server_ordinal(first, 0),
+                    server_turn_id: server_turn_id(first),
                 }],
                 resolved_into_annotation_operation_id: None,
             });
             let index = repo_mirror.discussions.len() - 1;
 
             let mut heads = vec![open_op];
-            for (ordinal, turn) in discussion.turns.iter().enumerate().skip(1) {
+            for (list_index, turn) in discussion.turns.iter().enumerate().skip(1) {
+                let ordinal = server_ordinal(turn, list_index);
                 let op_id = write_local_operation(
                     store,
                     local_id,
@@ -693,9 +779,16 @@ fn pull_one(
                     },
                 )?;
                 heads = vec![op_id];
-                push_link(mirror, repo_path, index, turn_identity(&op_id, 0), ordinal);
+                push_link(
+                    mirror,
+                    repo_path,
+                    index,
+                    turn_identity(&op_id, 0),
+                    ordinal,
+                    server_turn_id(turn),
+                );
             }
-            Ok(true)
+            true
         }
         Some(index) => {
             let local_id: DiscussionRecordId = repo_mirror.discussions[index]
@@ -706,6 +799,11 @@ fn pull_one(
                 .links
                 .iter()
                 .map(|link| link.server_ordinal)
+                .collect();
+            let linked_server_turn_ids: HashSet<String> = repo_mirror.discussions[index]
+                .links
+                .iter()
+                .filter_map(|link| link.server_turn_id.clone())
                 .collect();
             let linked_turn_ids: HashSet<String> = repo_mirror.discussions[index]
                 .links
@@ -726,13 +824,24 @@ fn pull_one(
                 .collect();
 
             let mut changed = false;
-            for (ordinal, server_turn) in discussion.turns.iter().enumerate() {
-                if linked_ordinals.contains(&ordinal) {
+            for (list_index, server_turn) in discussion.turns.iter().enumerate() {
+                let ordinal = server_ordinal(server_turn, list_index);
+                if linked_ordinals.contains(&ordinal)
+                    || server_turn_id(server_turn)
+                        .is_some_and(|turn_id| linked_server_turn_ids.contains(&turn_id))
+                {
                     continue;
                 }
                 if let Some(pos) = reconcile(&available, server_turn, hosted_username) {
                     let local = available.swap_remove(pos);
-                    push_link(mirror, repo_path, index, local.turn_id, ordinal);
+                    push_link(
+                        mirror,
+                        repo_path,
+                        index,
+                        local.turn_id,
+                        ordinal,
+                        server_turn_id(server_turn),
+                    );
                     changed = true;
                     continue;
                 }
@@ -747,12 +856,114 @@ fn pull_one(
                     },
                 )?;
                 heads = vec![op_id];
-                push_link(mirror, repo_path, index, turn_identity(&op_id, 0), ordinal);
+                push_link(
+                    mirror,
+                    repo_path,
+                    index,
+                    turn_identity(&op_id, 0),
+                    ordinal,
+                    server_turn_id(server_turn),
+                );
                 changed = true;
             }
-            Ok(changed)
+            changed
+        }
+    };
+
+    if pull_resolution(store, repo_path, mirror, discussion)? {
+        changed = true;
+    }
+    Ok(changed)
+}
+
+fn pull_resolution(
+    store: &CollaborationStore,
+    repo_path: &str,
+    mirror: &mut HostedMirror,
+    discussion: &HostedDiscussion,
+) -> Result<bool> {
+    let Some(resolution) = hosted_resolution_to_collab(&discussion.resolution) else {
+        return Ok(false);
+    };
+    let Some(index) = mirror
+        .repos
+        .get(repo_path)
+        .and_then(|repo_mirror| {
+            repo_mirror
+                .discussions
+                .iter()
+                .position(|entry| entry.server_id == discussion.id)
+        })
+    else {
+        return Ok(false);
+    };
+    let local_id: DiscussionRecordId = mirror.repos[repo_path].discussions[index]
+        .local_id
+        .parse()
+        .map_err(|e| anyhow!("mirror map has an invalid local discussion id: {e}"))?;
+    let existing = store
+        .materialize_discussion(&local_id)
+        .context("materialize mirrored discussion")?
+        .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
+    if existing.resolution.is_some() {
+        return Ok(false);
+    }
+    let heads: Vec<CollabOpId> = existing.heads.iter().copied().collect();
+    let author = resolution_author(store, &existing, discussion)?;
+    write_local_operation(
+        store,
+        local_id,
+        heads,
+        author,
+        now_ms(),
+        CollaborationOperationBodyV1::Resolve { resolution },
+    )?;
+    Ok(true)
+}
+
+fn resolution_author(
+    store: &CollaborationStore,
+    existing: &MaterializedDiscussion,
+    discussion: &HostedDiscussion,
+) -> Result<Attribution> {
+    if let Some((op_id, _)) = existing.turns.last() {
+        if let Some(decoded) = store.read_operation(op_id).context("read resolution author")? {
+            return Ok(decoded.operation.author);
         }
     }
+    let turn = discussion.turns.last();
+    Ok(Attribution::human(Principal::new(
+        turn.map(|turn| turn.author_name.as_str()).unwrap_or("hosted"),
+        turn.map(|turn| turn.author_email.as_str()).unwrap_or(""),
+    )))
+}
+
+fn hosted_resolution_to_collab(resolution: &HostedResolution) -> Option<CollaborationResolution> {
+    match resolution {
+        HostedResolution::Open => None,
+        HostedResolution::IntoAnnotation { annotation_id } => {
+            Some(CollaborationResolution::Annotation {
+                annotation_id: annotation_id.clone(),
+            })
+        }
+        HostedResolution::ByEdit { state_id } => state_id
+            .map(|state_id| CollaborationResolution::AddressedByState { state_id }),
+        HostedResolution::Dismissed { reason } => Some(CollaborationResolution::Dismissed {
+            reason: reason.clone(),
+        }),
+    }
+}
+
+fn server_ordinal(turn: &HostedDiscussionTurn, list_index: usize) -> usize {
+    if turn.turn_seq > 0 {
+        (turn.turn_seq as usize).saturating_sub(1)
+    } else {
+        list_index
+    }
+}
+
+fn server_turn_id(turn: &HostedDiscussionTurn) -> Option<String> {
+    (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
 }
 
 /// Match an unlinked server turn against an unlinked local turn by AUTHOR, never
@@ -787,6 +998,7 @@ fn push_link(
     index: usize,
     local_turn_id: String,
     server_ordinal: usize,
+    server_turn_id: Option<String>,
 ) {
     if let Some(entry) = mirror
         .repos
@@ -796,6 +1008,7 @@ fn push_link(
         entry.links.push(TurnLink {
             local_turn_id,
             server_ordinal,
+            server_turn_id,
         });
     }
 }
@@ -914,6 +1127,8 @@ mod tests {
             author_email: author_email.to_string(),
             body: body.to_string(),
             posted_at_secs,
+            turn_id: String::new(),
+            turn_seq: 0,
         }
     }
 

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -175,6 +175,22 @@ fn save_mirror(heddle_dir: &Path, mirror: &HostedMirror) -> Result<()> {
     Ok(())
 }
 
+/// True when `server_id` is already in the hosted mirror for `repo_path`.
+/// Fat `turn.appended` / `discussion.resolved` payloads may apply only after
+/// this is true; otherwise the consumer must `GetDiscussion`.
+pub fn discussion_is_mirrored(
+    heddle_dir: &Path,
+    repo_path: &str,
+    server_id: &str,
+) -> Result<bool> {
+    let mirror = load_mirror(heddle_dir)?;
+    Ok(mirror.repos.get(repo_path).is_some_and(|repo| {
+        repo.discussions
+            .iter()
+            .any(|entry| entry.server_id == server_id)
+    }))
+}
+
 fn open_op_id(repo_path: &str, local_id: &str) -> String {
     uuid::Uuid::new_v5(
         &OP_NAMESPACE,

--- a/crates/hosted-client/src/client/mod.rs
+++ b/crates/hosted-client/src/client/mod.rs
@@ -7,6 +7,8 @@
 #[cfg(feature = "client")]
 pub mod context_sync;
 #[cfg(feature = "client")]
+pub mod discussion_live;
+#[cfg(feature = "client")]
 pub mod discussion_sync;
 #[cfg(feature = "client")]
 pub mod human_signature;

--- a/crates/hosted-client/src/client/repo_events.rs
+++ b/crates/hosted-client/src/client/repo_events.rs
@@ -118,9 +118,15 @@ impl RepoEventClient {
             .routes()
             .subscribe_repo_events(&request)
             .await
-            .map_err(|source| RepoEventError::Disconnected {
-                last_event_id,
-                source,
+            .map_err(|source| {
+                if is_refusal(&source) {
+                    RepoEventError::Refused { source }
+                } else {
+                    RepoEventError::Disconnected {
+                        last_event_id,
+                        source,
+                    }
+                }
             })?;
         Ok(RepoEventSubscription {
             request,

--- a/crates/hosted-client/src/client/repo_events.rs
+++ b/crates/hosted-client/src/client/repo_events.rs
@@ -134,8 +134,11 @@ impl RepoEventClient {
         self.client.close().await;
     }
 
-    #[cfg(test)]
-    fn from_hosted_client(client: HostedClient) -> Self {
+    /// Wrap an already-connected hosted client.
+    ///
+    /// Live discussion delivery shares this connection with `ListByState` /
+    /// `GetDiscussion` so bootstrap and the event tail use one session.
+    pub fn from_hosted_client(client: HostedClient) -> Self {
         Self { client }
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -11,10 +11,14 @@
 //! Wire identity note: the canonical `CollaborationService` proto types the
 //! discussion anchor state as a 32-byte `StateId`, but the hosted server still
 //! resolves the inbound `state_id` field through a 16-byte `ChangeId` decode
-//! (`OpenDiscussion`/`ListByState`). We therefore send the **ChangeId** bytes in
-//! that field (matching weft's own canonical integration tests), while the
+//! for `OpenDiscussion`/`ListByState`. We therefore send the **ChangeId** bytes
+//! in those fields (matching weft's own canonical integration tests), while the
 //! server echoes the genuine 32-byte `StateId` back in
 //! `Discussion.opened_against_state`.
+//!
+//! `GetDiscussion.state_id` is the 32-byte `StateId` (empty = HEAD). Pass
+//! `opened_against_state` / the event's `new_state` so a discussion that
+//! exists on a prior state is not NotFound.
 
 use api::heddle::api::v1alpha1::{
     AppendTurnRequest, ContextAnnotationKind, Discussion as ProtoDiscussion, DiscussionKind,
@@ -133,6 +137,18 @@ fn change_id_state_field(change_id: ChangeId) -> Option<ProtoStateId> {
     })
 }
 
+fn get_discussion_request(
+    repo_path: &str,
+    discussion_id: &str,
+    state_id: Option<StateId>,
+) -> GetDiscussionRequest {
+    GetDiscussionRequest {
+        repo_path: super::helpers::repository_ref(repo_path),
+        discussion_id: discussion_id.to_string(),
+        state_id: state_id.and_then(super::helpers::proto_state_id),
+    }
+}
+
 impl HostedClient {
     /// The authenticated hosted username (the bearer token's `principal:<subject>`
     /// subject). weft stamps discussion turns with `Principal::new(username, "")`,
@@ -230,18 +246,16 @@ impl HostedClient {
         Ok(decode_discussion(response))
     }
 
-    /// Fetch one hosted discussion by server id. `state_id` empty means HEAD.
-    /// Used by the live event consumer as the doorbell payload fetch.
+    /// Fetch one hosted discussion by server id. `state_id` empty means HEAD;
+    /// set it to recover a discussion on a prior state (32-byte `StateId`,
+    /// not the ChangeId used on OpenDiscussion/ListByState).
     pub async fn get_discussion(
         &mut self,
         repo_path: &str,
         discussion_id: &str,
+        state_id: Option<StateId>,
     ) -> Result<HostedDiscussion, ProtocolError> {
-        let request = GetDiscussionRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-            discussion_id: discussion_id.to_string(),
-            state_id: None,
-        };
+        let request = get_discussion_request(repo_path, discussion_id, state_id);
         let response = self
             .routes()
             .get_discussion(&request)
@@ -414,6 +428,17 @@ mod tests {
         let change = ChangeId::from_bytes([0x11; 16]);
         let field = change_id_state_field(change).expect("proto state wrapper");
         assert_eq!(field.value, change.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn get_discussion_request_uses_32_byte_state_id() {
+        let state = StateId::from_bytes([0xab; 32]);
+        let request = get_discussion_request("acme/widgets", "disc-1", Some(state));
+        assert_eq!(request.discussion_id, "disc-1");
+        let sent = request.state_id.expect("state_id should be set");
+        assert_eq!(sent.value, vec![0xab; 32]);
+        let head = get_discussion_request("acme/widgets", "disc-1", None);
+        assert!(head.state_id.is_none());
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -18,9 +18,10 @@
 
 use api::heddle::api::v1alpha1::{
     AppendTurnRequest, ContextAnnotationKind, Discussion as ProtoDiscussion, DiscussionKind,
-    DiscussionSeverity, DiscussionStatusFilter, ListDiscussionsByStateRequest,
-    OpenDiscussionRequest, PathSymbolRef, ResolveDiscussionRequest, StateId as ProtoStateId,
-    list_discussions_response, resolve_discussion_request,
+    DiscussionSeverity, DiscussionStatusFilter, GetDiscussionRequest,
+    ListDiscussionsByStateRequest, OpenDiscussionRequest, PathSymbolRef, ResolveDiscussionRequest,
+    StateId as ProtoStateId, discussion_resolution, list_discussions_response,
+    resolve_discussion_request,
 };
 use objects::object::{AnnotationKind, ChangeId, StateId};
 use wire::ProtocolError;
@@ -28,12 +29,35 @@ use wire::ProtocolError;
 use super::{HostedClient, helpers::hosted_to_protocol_error};
 
 /// One turn of a hosted discussion, decoded from the wire.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct HostedDiscussionTurn {
     pub author_name: String,
     pub author_email: String,
     pub body: String,
     pub posted_at_secs: i64,
+    /// Server-minted turn identity. Empty when the producer has not minted one
+    /// (ListByState snapshots on older weft); live events should carry it.
+    pub turn_id: String,
+    /// Per-discussion monotonic sequence. Zero means "not minted" — callers
+    /// then fall back to list order. Proto documents minted sequences as
+    /// 1-based (`turn_seq` is zero only before mint).
+    pub turn_seq: u64,
+}
+
+/// Hosted resolution decoded from the collaboration wire oneof.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum HostedResolution {
+    #[default]
+    Open,
+    IntoAnnotation {
+        annotation_id: String,
+    },
+    ByEdit {
+        state_id: Option<StateId>,
+    },
+    Dismissed {
+        reason: String,
+    },
 }
 
 /// A hosted discussion decoded from the `CollaborationService` wire types into
@@ -49,6 +73,7 @@ pub struct HostedDiscussion {
     pub visibility: String,
     pub thread_ref: Option<String>,
     pub turns: Vec<HostedDiscussionTurn>,
+    pub resolution: HostedResolution,
 }
 
 fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
@@ -70,8 +95,32 @@ fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
                 author_email: turn.author_email,
                 body: turn.body,
                 posted_at_secs: turn.posted_at.map(|ts| ts.seconds).unwrap_or(0),
+                turn_id: turn.turn_id,
+                turn_seq: turn.turn_seq,
             })
             .collect(),
+        resolution: decode_resolution(proto.resolution),
+    }
+}
+
+fn decode_resolution(
+    resolution: Option<api::heddle::api::v1alpha1::DiscussionResolution>,
+) -> HostedResolution {
+    match resolution.and_then(|resolution| resolution.state) {
+        Some(discussion_resolution::State::IntoAnnotation(annotation)) => {
+            HostedResolution::IntoAnnotation {
+                annotation_id: annotation.annotation_id,
+            }
+        }
+        Some(discussion_resolution::State::ByEdit(edit)) => HostedResolution::ByEdit {
+            state_id: edit
+                .state_id
+                .and_then(|state| StateId::try_from_slice(&state.value).ok()),
+        },
+        Some(discussion_resolution::State::Dismissed(dismissed)) => HostedResolution::Dismissed {
+            reason: dismissed.reason,
+        },
+        Some(discussion_resolution::State::Open(_)) | None => HostedResolution::Open,
     }
 }
 
@@ -176,6 +225,26 @@ impl HostedClient {
         let response = self
             .routes()
             .append_turn(&request)
+            .await
+            .map_err(hosted_to_protocol_error)?;
+        Ok(decode_discussion(response))
+    }
+
+    /// Fetch one hosted discussion by server id. `state_id` empty means HEAD.
+    /// Used by the live event consumer as the doorbell payload fetch.
+    pub async fn get_discussion(
+        &mut self,
+        repo_path: &str,
+        discussion_id: &str,
+    ) -> Result<HostedDiscussion, ProtocolError> {
+        let request = GetDiscussionRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            discussion_id: discussion_id.to_string(),
+            state_id: None,
+        };
+        let response = self
+            .routes()
+            .get_discussion(&request)
             .await
             .map_err(hosted_to_protocol_error)?;
         Ok(decode_discussion(response))
@@ -422,6 +491,7 @@ mod tests {
         assert_eq!(decoded.turns[0].author_name, "alice");
         assert_eq!(decoded.turns[0].body, "lgtm");
         assert_eq!(decoded.turns[0].posted_at_secs, 42);
+        assert!(matches!(decoded.resolution, HostedResolution::Open));
 
         // Missing optional fields collapse cleanly.
         let empty = decode_discussion(ProtoDiscussion {

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -78,6 +78,9 @@ pub struct HostedDiscussion {
     pub thread_ref: Option<String>,
     pub turns: Vec<HostedDiscussionTurn>,
     pub resolution: HostedResolution,
+    /// Wire `Discussion.kind`. Unspecified is treated as code-anchored when
+    /// file+symbol are present; Coordination has no `PathSymbolRef`.
+    pub kind: i32,
 }
 
 fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
@@ -91,6 +94,7 @@ fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
             .and_then(|state| StateId::try_from_slice(&state.value).ok()),
         visibility: proto.visibility,
         thread_ref: (!proto.thread_ref.is_empty()).then_some(proto.thread_ref),
+        kind: proto.kind,
         turns: proto
             .turns
             .into_iter()

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -76,6 +76,9 @@ pub struct HostedDiscussion {
     pub opened_against_state: Option<StateId>,
     pub visibility: String,
     pub thread_ref: Option<String>,
+    /// Wire `Discussion.thread_id`. Weft stamps the stable UUID here and the
+    /// renameable name in `thread_ref`.
+    pub thread_id: Option<String>,
     pub turns: Vec<HostedDiscussionTurn>,
     pub resolution: HostedResolution,
     /// Wire `Discussion.kind`. Unspecified is treated as code-anchored when
@@ -94,6 +97,7 @@ fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
             .and_then(|state| StateId::try_from_slice(&state.value).ok()),
         visibility: proto.visibility,
         thread_ref: (!proto.thread_ref.is_empty()).then_some(proto.thread_ref),
+        thread_id: (!proto.thread_id.is_empty()).then_some(proto.thread_id),
         kind: proto.kind,
         turns: proto
             .turns
@@ -516,6 +520,7 @@ mod tests {
         assert_eq!(decoded.opened_against_state, Some(state));
         assert_eq!(decoded.visibility, "team");
         assert_eq!(decoded.thread_ref, None);
+        assert_eq!(decoded.thread_id, None);
         assert_eq!(decoded.turns.len(), 1);
         assert_eq!(decoded.turns[0].author_name, "alice");
         assert_eq!(decoded.turns[0].body, "lgtm");
@@ -530,5 +535,15 @@ mod tests {
         assert!(empty.file.is_empty());
         assert!(empty.opened_against_state.is_none());
         assert!(empty.turns.is_empty());
+        assert!(empty.thread_id.is_none());
+
+        let stamped = decode_discussion(ProtoDiscussion {
+            id: "stamped".into(),
+            thread_ref: "old-name".into(),
+            thread_id: "thr-stable".into(),
+            ..Default::default()
+        });
+        assert_eq!(stamped.thread_ref.as_deref(), Some("old-name"));
+        assert_eq!(stamped.thread_id.as_deref(), Some("thr-stable"));
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/helpers.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/helpers.rs
@@ -296,9 +296,14 @@ pub(super) fn hosted_to_protocol_error(error: HostedError) -> ProtocolError {
             }
 
             match code {
-                CallFailureCode::Unauthenticated | CallFailureCode::PermissionDenied => {
-                    ProtocolError::AuthorizationFailed(message)
-                }
+                CallFailureCode::PermissionDenied => ProtocolError::AuthorizationFailed(message),
+                // Keep the CallFailureCode so doorbell fetch can treat
+                // expired/missing creds as fatal instead of a visibility skip.
+                CallFailureCode::Unauthenticated => ProtocolError::RemoteFailure {
+                    code: remote_failure_code(code),
+                    message,
+                    details: Vec::new(),
+                },
                 CallFailureCode::NotFound => ProtocolError::ObjectNotFound(message),
                 CallFailureCode::AlreadyExists => ProtocolError::AlreadyExists(message),
                 CallFailureCode::InvalidArgument | CallFailureCode::FailedPrecondition => {
@@ -543,7 +548,13 @@ mod tests {
             message: "invalid proof".to_string(),
             error: None,
         });
-        assert!(matches!(error, ProtocolError::AuthorizationFailed(_)));
+        assert!(matches!(
+            error,
+            ProtocolError::RemoteFailure {
+                code: wire::RemoteFailureCode::Unauthenticated,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -770,7 +781,10 @@ mod tests {
                 message: "nope".into(),
                 error: None,
             }),
-            ProtocolError::AuthorizationFailed(_)
+            ProtocolError::RemoteFailure {
+                code: wire::RemoteFailureCode::Unauthenticated,
+                ..
+            }
         ));
         assert!(matches!(
             hosted_to_protocol_error(HostedError::Call {

--- a/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
@@ -362,6 +362,13 @@ impl HostedRoutes<'_> {
         ResolveDiscussionRequest,
         Discussion
     );
+    unary_method!(
+        get_discussion,
+        "CollaborationService",
+        "GetDiscussion",
+        GetDiscussionRequest,
+        Discussion
+    );
     server_stream_method!(
         list_discussions_by_state,
         "CollaborationService",

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -47,7 +47,7 @@ pub use bootstrap::{
     fetch_signed_endpoint_descriptor,
 };
 pub use call::{BidirectionalRequestStream, BidirectionalStream, ServerStream, ServerStreamItem};
-pub use collaboration::{HostedDiscussion, HostedDiscussionTurn};
+pub use collaboration::{HostedDiscussion, HostedDiscussionTurn, HostedResolution};
 use config::ClientConfig;
 use connection::HostedConnection;
 pub use context::CallContextFactory;

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -65,6 +65,7 @@ pub(crate) struct CollaborationFixture {
     pub events: Vec<RepoEvent>,
     pub one_event_per_subscribe: bool,
     pub get_requests: Arc<Mutex<Vec<String>>>,
+    pub get_request_state_ids: Arc<Mutex<Vec<Option<Vec<u8>>>>>,
     pub list_requests: Arc<Mutex<usize>>,
     pub subscribe_after: Arc<Mutex<Vec<i64>>>,
 }
@@ -683,16 +684,24 @@ async fn serve_get_discussion(
     fixture: CollaborationFixture,
 ) {
     read_request_body(recv, request).await;
-    let discussion_id = decode_request_frame(request)
+    let request = decode_request_frame(request)
         .ok()
-        .and_then(|frame| GetDiscussionRequest::decode(frame.body).ok())
-        .map(|body| body.discussion_id)
+        .and_then(|frame| GetDiscussionRequest::decode(frame.body).ok());
+    let discussion_id = request
+        .as_ref()
+        .map(|body| body.discussion_id.clone())
         .unwrap_or_default();
+    let state_id = request.and_then(|body| body.state_id.map(|state| state.value));
     fixture
         .get_requests
         .lock()
         .unwrap_or_else(|poison| poison.into_inner())
         .push(discussion_id.clone());
+    fixture
+        .get_request_state_ids
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(state_id);
     if let Some(code) = fixture.hidden.get(&discussion_id).copied() {
         let failure = CallFailure {
             code: code as i32,

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -68,6 +68,7 @@ pub(crate) struct CollaborationFixture {
     pub get_request_state_ids: Arc<Mutex<Vec<Option<Vec<u8>>>>>,
     pub list_requests: Arc<Mutex<usize>>,
     pub subscribe_after: Arc<Mutex<Vec<i64>>>,
+    pub subscribe_thread: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
@@ -776,16 +777,26 @@ async fn serve_subscribe_repo_events(
     fixture: CollaborationFixture,
 ) {
     read_request_body(recv, request).await;
-    let after_event_id = decode_request_frame(request)
+    let subscribe = decode_request_frame(request)
         .ok()
-        .and_then(|frame| SubscribeRepoEventsRequest::decode(frame.body).ok())
+        .and_then(|frame| SubscribeRepoEventsRequest::decode(frame.body).ok());
+    let after_event_id = subscribe
+        .as_ref()
         .map(|body| body.after_event_id)
         .unwrap_or(0);
+    let thread_scope = subscribe
+        .map(|body| (body.thread, body.thread_id))
+        .unwrap_or_default();
     fixture
         .subscribe_after
         .lock()
         .unwrap_or_else(|poison| poison.into_inner())
         .push(after_event_id);
+    fixture
+        .subscribe_thread
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(thread_scope);
     let mut matching = fixture
         .events
         .into_iter()

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -280,6 +280,7 @@ async fn start_inner(
     (client, server_task)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn serve_call(
     mut send: iroh::endpoint::SendStream,
     mut recv: iroh::endpoint::RecvStream,

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -10,18 +10,20 @@ use api::{
     StreamingShape,
     framing::{
         StreamFrame, decode_request_frame, decode_request_prelude, decode_stream_frame,
-        encode_stream_message, encode_success_response,
+        encode_failure_response, encode_stream_message, encode_success_response,
     },
     heddle::api::v1alpha1::{
-        BlobResponse, CreateSpoolRequest, DeleteSpoolRequest, GetBlobRequest,
-        GetContextHistoryPageEnd, GetContextHistoryResponse, HostedSpool, ListContextPageEnd,
-        ListContextResponse, ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd,
-        ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind,
-        PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete, PushReady,
-        PushRequest, PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint,
-        TransportMode, UpdateSpoolRequest, get_context_history_response, list_context_response,
-        list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
-        push_client_frame, push_server_frame,
+        BlobResponse, CallFailure, CallFailureCode, CreateSpoolRequest, DeleteSpoolRequest,
+        Discussion, GetBlobRequest, GetContextHistoryPageEnd, GetContextHistoryResponse,
+        GetDiscussionRequest, HostedSpool, ListContextPageEnd, ListContextResponse,
+        ListDiscussionsByStateRequest, ListDiscussionsPageEnd, ListDiscussionsResponse,
+        ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk,
+        PackStreamKind, PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete,
+        PushReady, PushRequest, PushServerFrame, RepoEvent, SignedSpoolOwnerGenesis, StateId,
+        SubscribeRepoEventsRequest, TransferCheckpoint, TransportMode, UpdateSpoolRequest,
+        get_context_history_response, list_context_response, list_discussions_response,
+        list_refs_response, list_threads_response, pull_server_frame, push_client_frame,
+        push_server_frame,
     },
     method_descriptor,
 };
@@ -39,6 +41,10 @@ const GET_BLOB_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/GetBlob";
 const CREATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/CreateSpool";
 const DELETE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/DeleteSpool";
 const UPDATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/UpdateSpool";
+const GET_DISCUSSION_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/GetDiscussion";
+const LIST_BY_STATE_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/ListByState";
+const SUBSCRIBE_REPO_EVENTS_METHOD: &str =
+    "/heddle.api.v1alpha1.RepositoryService/SubscribeRepoEvents";
 
 #[derive(Default)]
 pub(crate) struct SpoolMutationCapture {
@@ -51,8 +57,36 @@ fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
     SignedSpoolOwnerGenesis::decode(bytes.as_slice()).expect("published v2 fixture genesis")
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct CollaborationFixture {
+    pub discussions: HashMap<String, Discussion>,
+    pub list: Vec<Discussion>,
+    pub hidden: HashMap<String, CallFailureCode>,
+    pub events: Vec<RepoEvent>,
+    pub one_event_per_subscribe: bool,
+    pub get_requests: Arc<Mutex<Vec<String>>>,
+    pub list_requests: Arc<Mutex<usize>>,
+    pub subscribe_after: Arc<Mutex<Vec<i64>>>,
+}
+
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None, BlobFixture::default(), None, None, None).await
+    start_inner(None, BlobFixture::default(), None, None, None, None).await
+}
+
+pub(crate) async fn start_with_collaboration(
+    fixture: CollaborationFixture,
+) -> (HostedClient, JoinHandle<()>, CollaborationFixture) {
+    let fixture_clone = fixture.clone();
+    let (client, server) = start_inner(
+        None,
+        BlobFixture::default(),
+        None,
+        None,
+        None,
+        Some(fixture),
+    )
+    .await;
+    (client, server, fixture_clone)
 }
 
 pub(crate) async fn start_recording_push()
@@ -64,6 +98,7 @@ pub(crate) async fn start_recording_push()
         None,
         None,
         Some(Arc::clone(&captured)),
+        None,
     )
     .await;
     (client, server, captured)
@@ -79,6 +114,7 @@ pub(crate) async fn start_recording_create_spool() -> (
         None,
         BlobFixture::default(),
         Some(Arc::clone(&captured)),
+        None,
         None,
         None,
     )
@@ -98,6 +134,7 @@ pub(crate) async fn start_recording_spool_mutations() -> (
         None,
         Some(Arc::clone(&captured)),
         None,
+        None,
     )
     .await;
     (client, server, captured)
@@ -112,6 +149,7 @@ pub(crate) async fn start_with_remote_state(
             pack: None,
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -130,6 +168,7 @@ pub(crate) async fn start_with_pull_pack(
             pack: Some((pack_data, index_data)),
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -168,7 +207,7 @@ async fn start_with_get_blob_contents_and_pull(
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(pull, fixture, None, None, None).await;
+    let (client, server) = start_inner(pull, fixture, None, None, None, None).await;
     (client, server, requested)
 }
 
@@ -190,6 +229,7 @@ async fn start_inner(
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
+    collaboration: Option<CollaborationFixture>,
 ) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
@@ -216,6 +256,7 @@ async fn start_inner(
                 create_spool.clone(),
                 spool_mutations.clone(),
                 push_requests.clone(),
+                collaboration.clone(),
             ));
         }
         server.close().await;
@@ -245,6 +286,7 @@ async fn serve_call(
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
+    collaboration: Option<CollaborationFixture>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -269,6 +311,14 @@ async fn serve_call(
                 serve_delete_spool(&mut send, &mut recv, &mut request, spool_mutations).await;
             } else if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
                 serve_get_blob(&mut send, &mut recv, &mut request, blobs).await;
+            } else if method == GET_DISCUSSION_METHOD {
+                if let Some(collaboration) = collaboration {
+                    serve_get_discussion(&mut send, &mut recv, &mut request, collaboration).await;
+                } else {
+                    send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+                        .await
+                        .unwrap();
+                }
             } else {
                 send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
                     .await
@@ -276,10 +326,29 @@ async fn serve_call(
             }
         }
         StreamingShape::ServerStreaming => {
-            let body = terminal_page(&method);
-            send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
-                .await
-                .unwrap();
+            if method == LIST_BY_STATE_METHOD {
+                if let Some(collaboration) = collaboration {
+                    serve_list_by_state(&mut send, &mut recv, &mut request, collaboration).await;
+                } else {
+                    let body = terminal_page(&method);
+                    send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+                        .await
+                        .unwrap();
+                }
+            } else if method == SUBSCRIBE_REPO_EVENTS_METHOD {
+                if let Some(collaboration) = collaboration {
+                    serve_subscribe_repo_events(&mut send, &mut recv, &mut request, collaboration)
+                        .await;
+                } else {
+                    send.finish().unwrap();
+                    return;
+                }
+            } else {
+                let body = terminal_page(&method);
+                send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+                    .await
+                    .unwrap();
+            }
         }
         StreamingShape::Bidirectional => {
             if method == "/heddle.api.v1alpha1.RepoSyncService/Push" {
@@ -599,6 +668,136 @@ async fn serve_get_blob(
     ))
     .await
     .unwrap();
+}
+
+async fn read_request_body(recv: &mut iroh::endpoint::RecvStream, request: &mut Vec<u8>) {
+    while let Ok(Some(chunk)) = recv.read_chunk(api::framing::MAX_CONTROL_BODY + 6).await {
+        request.extend_from_slice(&chunk);
+    }
+}
+
+async fn serve_get_discussion(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    fixture: CollaborationFixture,
+) {
+    read_request_body(recv, request).await;
+    let discussion_id = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| GetDiscussionRequest::decode(frame.body).ok())
+        .map(|body| body.discussion_id)
+        .unwrap_or_default();
+    fixture
+        .get_requests
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(discussion_id.clone());
+    if let Some(code) = fixture.hidden.get(&discussion_id).copied() {
+        let failure = CallFailure {
+            code: code as i32,
+            message: "discussion is not visible".to_string(),
+            error: None,
+        };
+        send.write_chunk(Bytes::from(encode_failure_response(&failure).unwrap()))
+            .await
+            .unwrap();
+        return;
+    }
+    let Some(discussion) = fixture.discussions.get(&discussion_id) else {
+        let failure = CallFailure {
+            code: CallFailureCode::NotFound as i32,
+            message: format!("discussion {discussion_id} not found"),
+            error: None,
+        };
+        send.write_chunk(Bytes::from(encode_failure_response(&failure).unwrap()))
+            .await
+            .unwrap();
+        return;
+    };
+    send.write_chunk(Bytes::from(
+        encode_success_response(&discussion.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_list_by_state(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    fixture: CollaborationFixture,
+) {
+    read_request_body(recv, request).await;
+    let _ = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| ListDiscussionsByStateRequest::decode(frame.body).ok());
+    *fixture
+        .list_requests
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner()) += 1;
+    for discussion in &fixture.list {
+        let body = ListDiscussionsResponse {
+            frame: Some(list_discussions_response::Frame::Item(Box::new(
+                discussion.clone(),
+            ))),
+        }
+        .encode_to_vec();
+        send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+            .await
+            .unwrap();
+    }
+    let end = ListDiscussionsResponse {
+        frame: Some(list_discussions_response::Frame::PageEnd(
+            ListDiscussionsPageEnd {
+                next_page_token: String::new(),
+            },
+        )),
+    }
+    .encode_to_vec();
+    send.write_chunk(Bytes::from(encode_stream_message(&end).unwrap()))
+        .await
+        .unwrap();
+}
+
+async fn serve_subscribe_repo_events(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    fixture: CollaborationFixture,
+) {
+    read_request_body(recv, request).await;
+    let after_event_id = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| SubscribeRepoEventsRequest::decode(frame.body).ok())
+        .map(|body| body.after_event_id)
+        .unwrap_or(0);
+    fixture
+        .subscribe_after
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(after_event_id);
+    let mut matching = fixture
+        .events
+        .into_iter()
+        .filter(|event| event.event_id > after_event_id);
+    if fixture.one_event_per_subscribe {
+        if let Some(event) = matching.next() {
+            send.write_chunk(Bytes::from(
+                encode_stream_message(&event.encode_to_vec()).unwrap(),
+            ))
+            .await
+            .unwrap();
+        }
+    } else {
+        for event in matching {
+            send.write_chunk(Bytes::from(
+                encode_stream_message(&event.encode_to_vec()).unwrap(),
+            ))
+            .await
+            .unwrap();
+        }
+    }
 }
 
 fn pack_frame(stream_kind: PackStreamKind, data: Vec<u8>) -> Vec<u8> {

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     net::Ipv4Addr,
     sync::{Arc, Mutex},
 };
@@ -10,7 +10,8 @@ use api::{
     StreamingShape,
     framing::{
         StreamFrame, decode_request_frame, decode_request_prelude, decode_stream_frame,
-        encode_failure_response, encode_stream_message, encode_success_response,
+        encode_failure_response, encode_stream_failure, encode_stream_message,
+        encode_success_response,
     },
     heddle::api::v1alpha1::{
         BlobResponse, CallFailure, CallFailureCode, CreateSpoolRequest, DeleteSpoolRequest,
@@ -64,10 +65,12 @@ pub(crate) struct CollaborationFixture {
     pub hidden: HashMap<String, CallFailureCode>,
     pub events: Vec<RepoEvent>,
     pub one_event_per_subscribe: bool,
+    pub unknown_repo_ids: HashSet<String>,
     pub get_requests: Arc<Mutex<Vec<String>>>,
     pub get_request_state_ids: Arc<Mutex<Vec<Option<Vec<u8>>>>>,
     pub list_requests: Arc<Mutex<usize>>,
     pub subscribe_after: Arc<Mutex<Vec<i64>>>,
+    pub subscribe_repo_ids: Arc<Mutex<Vec<String>>>,
     pub subscribe_thread: Arc<Mutex<Vec<(String, String)>>>,
 }
 
@@ -785,6 +788,10 @@ async fn serve_subscribe_repo_events(
         .as_ref()
         .map(|body| body.after_event_id)
         .unwrap_or(0);
+    let repo_id = subscribe
+        .as_ref()
+        .map(|body| body.repo_id.clone())
+        .unwrap_or_default();
     let thread_scope = subscribe
         .map(|body| (body.thread, body.thread_id))
         .unwrap_or_default();
@@ -794,10 +801,26 @@ async fn serve_subscribe_repo_events(
         .unwrap_or_else(|poison| poison.into_inner())
         .push(after_event_id);
     fixture
+        .subscribe_repo_ids
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(repo_id.clone());
+    fixture
         .subscribe_thread
         .lock()
         .unwrap_or_else(|poison| poison.into_inner())
         .push(thread_scope);
+    if fixture.unknown_repo_ids.contains(&repo_id) {
+        let failure = CallFailure {
+            code: CallFailureCode::NotFound as i32,
+            message: format!("repository {repo_id} not found"),
+            error: None,
+        };
+        send.write_chunk(Bytes::from(encode_stream_failure(&failure).unwrap()))
+            .await
+            .unwrap();
+        return;
+    }
     let mut matching = fixture
         .events
         .into_iter()

--- a/crates/repo/src/hooks.rs
+++ b/crates/repo/src/hooks.rs
@@ -29,7 +29,7 @@ fn hook_executable_busy(error: &std::io::Error) -> bool {
     }
 }
 
-fn spawn_payload_hook(command: &mut Command, hook: Hook) -> Result<std::process::Child> {
+fn spawn_hook(command: &mut Command, hook: Hook) -> Result<std::process::Child> {
     let mut attempt = 0;
     loop {
         match command.spawn() {
@@ -201,8 +201,11 @@ impl HookManager {
             cmd.env(key, value);
         }
 
-        let status = cmd
-            .status()
+        // Same ETXTBSY retry as `run_with_payload`: install-then-exec
+        // can race the just-written hook file under parallel tests.
+        let mut child = spawn_hook(&mut cmd, hook)?;
+        let status = child
+            .wait()
             .map_err(|e| anyhow!("Failed to execute hook {}: {}", hook.filename(), e))?;
 
         if !status.success() {
@@ -248,7 +251,7 @@ impl HookManager {
         for (key, value) in &ctx.env {
             cmd.env(key, value);
         }
-        let mut child = spawn_payload_hook(&mut cmd, hook)?;
+        let mut child = spawn_hook(&mut cmd, hook)?;
         let payload_bytes =
             serde_json::to_vec(payload).map_err(|e| anyhow!("encode hook payload: {e}"))?;
         if let Some(mut stdin) = child.stdin.take() {
@@ -413,11 +416,11 @@ mod tests {
     }
 
     #[test]
-    fn payload_hook_spawn_reports_non_busy_errors() {
+    fn hook_spawn_reports_non_busy_errors() {
         let temp = TempDir::new().unwrap();
         let mut command = Command::new(temp.path().join("missing-hook"));
 
-        let error = spawn_payload_hook(&mut command, Hook::PreSnapshot)
+        let error = spawn_hook(&mut command, Hook::PreSnapshot)
             .expect_err("missing hook executable should not spawn");
 
         assert!(
@@ -429,7 +432,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn payload_hook_spawn_retries_text_file_busy() {
+    fn hook_spawn_retries_text_file_busy() {
         use std::{fs::OpenOptions, os::unix::fs::PermissionsExt};
 
         let temp = TempDir::new().unwrap();
@@ -439,7 +442,7 @@ mod tests {
         let _write_guard = OpenOptions::new().write(true).open(&hook_path).unwrap();
         let mut command = Command::new(&hook_path);
 
-        let error = spawn_payload_hook(&mut command, Hook::PreSnapshot)
+        let error = spawn_hook(&mut command, Hook::PreSnapshot)
             .expect_err("an executable open for writing should stay busy");
 
         assert!(error.to_string().contains("Text file busy"));
@@ -493,9 +496,16 @@ printf '{"abort":"","custom":"%s","protocol":"%s","repo":"%s","payload":%s}
         let err = manager
             .run(Hook::PrePush, &HookContext::new(&repo))
             .unwrap_err();
+        let message = err.to_string();
 
-        assert!(err.to_string().contains("Hook pre-push failed"));
-        assert!(err.to_string().contains("Some(7)"));
+        assert!(
+            message.contains("Hook pre-push failed"),
+            "expected nonzero hook failure, got {message}"
+        );
+        assert!(
+            message.contains("Some(7)"),
+            "expected exit code 7, got {message}"
+        );
     }
 
     #[test]

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3478,6 +3478,18 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_list","discussions":[]}
 ```
 
+## `heddle discuss wait --output json`
+
+`discuss wait` emits JSONL: one object after subscribe, then one object per hosted event.
+
+```json
+{"output_kind":"discuss_wait","status":"listening","event_id":0,"event_type":"","discussion_id":null,"applied":false,"after_event_id":0}
+```
+
+```json
+{"output_kind":"discuss_wait","status":"applied","event_id":12,"event_type":"turn.appended","discussion_id":"disc-018f47ea-4a54-7c89-b012-3456789abcde","applied":true,"after_event_id":12}
+```
+
 `heddle maintenance fsck --output json` emits:
 
 ```json

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3490,6 +3490,10 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_wait","status":"applied","event_id":12,"event_type":"turn.appended","discussion_id":"disc-018f47ea-4a54-7c89-b012-3456789abcde","applied":true,"after_event_id":12}
 ```
 
+```json
+{"output_kind":"discuss_wait","status":"skipped","event_id":44,"event_type":"discussion.opened","discussion_id":null,"applied":false,"after_event_id":44,"skip_reason":"discussion disc-hidden is not visible to this caller"}
+```
+
 `heddle maintenance fsck --output json` emits:
 
 ```json

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7539,6 +7539,18 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_list","discussions":[]}
 ```
 
+## `heddle discuss wait --output json`
+
+`discuss wait` emits JSONL: one object after subscribe, then one object per hosted event.
+
+```json
+{"output_kind":"discuss_wait","status":"listening","event_id":0,"event_type":"","discussion_id":null,"applied":false,"after_event_id":0}
+```
+
+```json
+{"output_kind":"discuss_wait","status":"applied","event_id":12,"event_type":"turn.appended","discussion_id":"disc-018f47ea-4a54-7c89-b012-3456789abcde","applied":true,"after_event_id":12}
+```
+
 `heddle maintenance fsck --output json` emits:
 
 ```json

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7551,6 +7551,10 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_wait","status":"applied","event_id":12,"event_type":"turn.appended","discussion_id":"disc-018f47ea-4a54-7c89-b012-3456789abcde","applied":true,"after_event_id":12}
 ```
 
+```json
+{"output_kind":"discuss_wait","status":"skipped","event_id":44,"event_type":"discussion.opened","discussion_id":null,"applied":false,"after_event_id":44,"skip_reason":"discussion disc-hidden is not visible to this caller"}
+```
+
 `heddle maintenance fsck --output json` emits:
 
 ```json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live discussion events are doorbells. The authorized snapshot is always `GetDiscussion`; event JSON carries identity and routing only.

## Rebase + Fable follow-up

- Rebases onto `main` with #1645's client pack fallback.
- Clone/pull threads #1645's pulled-tip `against: Option<StateId>` through `pull_discussions_filtered` and `listed_hosted_discussions`. This avoids re-reading an unpublished or unrelated local HEAD. Scoped `discuss wait` bootstrap still requires the checked-out HEAD.
- Removes the already-mirrored append payload fast path. Every opened, appended, and resolved event now calls `GetDiscussion`, keeping visibility fail-closed at the authz RPC.
- Classifies deterministic collaboration codec validation failures as `Skipped { reason }` and advances the watermark. I/O, lock, corrupt-local-state, and no-HEAD failures remain `Err` and hold the watermark for retry.
- Adds `clone_discussion_sync_uses_against_before_head_is_published`, which stores the pulled state without publishing HEAD and proves discussion sync materializes one discussion instead of returning `Ok(0)`.

## Global error-mapping note

This PR changes shared hosted error mapping in `hosted_runtime/hosted/helpers.rs`: an unauthenticated call failure now maps to `ProtocolError::RemoteFailure { code: Unauthenticated, ... }` instead of `ProtocolError::AuthorizationFailed`. That affects all hosted callers, including making `review_sync::is_permanent` treat unauthenticated failures as transient. The live consumer needs the distinction so expired/missing credentials hold the cursor instead of being mistaken for a visibility skip.

## Preserved consumer design

- Bootstrap from pull-fold discussions when present, otherwise the existing `ListByState` RPC; no second view RPC and no `ListByThreadRef`.
- Thread-scoped wait filters the ListByState snapshot by thread name or stable wire thread id; clone/pull remains repo-wide.
- Principal/authority/thread-scoped durable watermarks, locked cursor and mirror RMW, bounded reconnect backoff, and stale hosted repo-id recovery remain intact.
- `discuss wait` alone bypasses legacy migration before hosted bootstrap; list/show still materialize legacy attachments.

## Proof

```text
cargo build
Finished dev profile successfully.

cargo clippy --workspace --all-targets -- -D warnings
Finished dev profile successfully with no warnings.

cargo test -p heddle-hosted-client --features client --lib -- discussion
69 passed; 0 failed; 0 ignored; 331 filtered out.

rustfmt +nightly --edition 2024 crates/hosted-client/src/client/discussion_live.rs crates/hosted-client/src/client/discussion_live_tests.rs crates/hosted-client/src/client/discussion_sync.rs
```

Closes HeddleCo/heddle#1644
<!-- CURSOR_AGENT_PR_BODY_END -->
