### PR TITLE
fix(ingest): propagate ShaMap lookup errors

### DIFF
--- a/crates/cli/src/bin/heddle-ingest.rs
+++ b/crates/cli/src/bin/heddle-ingest.rs
@@ -383,7 +383,7 @@ fn run_reason(args: ReasonArgs<'_>) -> Result<()> {
     // we take the default (every mapped commit), filter by `--since`,
     // and cap by `--limit`.
     let mut commits = if args.commits.is_empty() {
-        pipeline_default_commits(&map)
+        pipeline_default_commits(&map)?
     } else {
         args.commits.clone()
     };
@@ -536,22 +536,22 @@ fn run_map(path: &std::path::Path, action: MapAction) -> Result<()> {
     match action {
         MapAction::Stats => {
             println!("records: {}", map.len());
-            println!("commits: {}", map.commit_count());
+            println!("commits: {}", map.commit_count()?);
             println!("path: {}", path.display());
         }
         MapAction::LookupGit { sha } => {
-            if let Some(cid) = map.get_commit(&sha) {
+            if let Some(cid) = map.get_commit(&sha)? {
                 println!("commit {sha} → {}", cid.to_string_full());
-            } else if let Some(h) = map.get_tree(&sha) {
+            } else if let Some(h) = map.get_tree(&sha)? {
                 println!("tree   {sha} → {}", h.to_hex());
-            } else if let Some(h) = map.get_blob(&sha) {
+            } else if let Some(h) = map.get_blob(&sha)? {
                 println!("blob   {sha} → {}", h.to_hex());
             } else {
                 eprintln!("no mapping for git sha {sha}");
                 std::process::exit(1);
             }
         }
-        MapAction::LookupHeddle { heddle } => match map.get_git_for_heddle(&heddle) {
+        MapAction::LookupHeddle { heddle } => match map.get_git_for_heddle(&heddle)? {
             Some(sha) => println!("{heddle} → git {sha}"),
             None => {
                 eprintln!("no git sha mapped to {heddle}");

--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -743,7 +743,7 @@ fn run_reason(
     let transcripts = load_transcripts(git_path, &roots);
     println!("loaded {} transcripts", transcripts.len());
 
-    let mut commits = pipeline_default_commits(&map);
+    let mut commits = pipeline_default_commits(&map)?;
     if let Some(n) = limit {
         commits.truncate(n);
     }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -435,13 +435,16 @@ fn execute_authoritative_git_pull(
         import_progress.begin_ref_write();
         import_progress.finish();
     }
-    let new_state = mapping.get_commit(&new_oid.to_string()).ok_or_else(|| {
-        git_pull_import_advice(
-            remote_name,
-            remote_branch,
-            &"the fetched commit was not mapped",
-        )
-    })?;
+    let new_state = mapping
+        .get_commit(&new_oid.to_string())
+        .map_err(|error| git_pull_import_advice(remote_name, remote_branch, &error))?
+        .ok_or_else(|| {
+            git_pull_import_advice(
+                remote_name,
+                remote_branch,
+                &"the fetched commit was not mapped",
+            )
+        })?;
 
     let changed = old_oid != Some(new_oid);
     let materialized =

--- a/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
@@ -35,6 +35,7 @@ fn ingest_mapped_change(path: &std::path::Path, git_sha: &str) -> Option<String>
     let map_path = path.join(".heddle").join("ingest").join("sha_map.sqlite");
     let map = ingest::ShaMap::open(map_path).expect("open ingest SHA map");
     map.get_commit(git_sha)
+        .expect("read ingest SHA map")
         .map(|state_id| state_id.to_string_full())
 }
 
@@ -82,9 +83,11 @@ fn capture_persists_unchanged_git_subtree_and_blob_as_native_closure() {
     let map = ingest::ShaMap::open(work.join(".heddle/ingest/sha_map.sqlite")).unwrap();
     let stable_hash = map
         .get_tree(&stable_git_tree)
+        .expect("read unchanged Git subtree mapping")
         .expect("unchanged Git subtree must retain its identity mapping");
     let stable_blob_hash = map
         .get_blob(&stable_git_blob)
+        .expect("read unchanged Git blob mapping")
         .expect("unchanged Git blob must retain its identity mapping");
     let captured_repo = repo::Repository::open(&work).unwrap();
     let captured = captured_repo

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -382,19 +382,18 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
         let overlay_descriptor_dir = staging_dir
             .parent()
             .map(|parent| parent.join("overlay-states"));
-        let descriptor_commits = commits
-            .iter()
-            .filter_map(|commit| {
-                let state = self.map.get_commit(&commit.sha)?;
-                overlay_descriptor_dir
-                    .as_ref()
-                    .is_some_and(|dir| {
-                        dir.join(format!("{}.state", state.to_string_full()))
-                            .is_file()
-                    })
-                    .then(|| (commit.sha.clone(), state))
-            })
-            .collect::<Vec<_>>();
+        let mut descriptor_commits = Vec::new();
+        for commit in &commits {
+            let Some(state) = self.map.get_commit(&commit.sha)? else {
+                continue;
+            };
+            if overlay_descriptor_dir.as_ref().is_some_and(|dir| {
+                dir.join(format!("{}.state", state.to_string_full()))
+                    .is_file()
+            }) {
+                descriptor_commits.push((commit.sha.clone(), state));
+            }
+        }
         let repair_mapped_objects = !descriptor_commits.is_empty();
 
         self.map.begin_append_batch()?;
@@ -477,15 +476,14 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             }
         };
 
-        let descriptor_state_remaps = descriptor_commits
-            .iter()
-            .filter_map(|(git_sha, old_state)| {
-                self.map
-                    .get_commit(git_sha)
-                    .filter(|new_state| new_state != old_state)
-                    .map(|new_state| (*old_state, new_state))
-            })
-            .collect::<Vec<_>>();
+        let mut descriptor_state_remaps = Vec::new();
+        for (git_sha, old_state) in &descriptor_commits {
+            if let Some(new_state) = self.map.get_commit(git_sha)?
+                && new_state != *old_state
+            {
+                descriptor_state_remaps.push((*old_state, new_state));
+            }
+        }
 
         let ref_stats = RefEmitter::new(self.refs, self.store, self.map)
             .with_state_remaps(descriptor_state_remaps)
@@ -757,7 +755,7 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
         git_tree_sha: &str,
         path_prefix: &str,
     ) -> crate::Result<ContentHash> {
-        if let Some(hash) = self.map.get_tree(git_tree_sha)
+        if let Some(hash) = self.map.get_tree(git_tree_sha)?
             && (!self.repair_mapped_objects
                 || !self.materialized_trees.insert(git_tree_sha.to_string()))
         {
@@ -885,7 +883,7 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
     }
 
     fn translate_blob(&mut self, git_blob_sha: &str) -> crate::Result<ContentHash> {
-        if let Some(hash) = self.map.get_blob(git_blob_sha)
+        if let Some(hash) = self.map.get_blob(git_blob_sha)?
             && (!self.repair_mapped_objects
                 || !self.materialized_blobs.insert(git_blob_sha.to_string()))
         {
@@ -912,7 +910,7 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
         for head in heads.iter().filter(|head| {
             head.namespace == RefNamespace::Tag && head.object_sha != head.target_sha
         }) {
-            let peeled_state = self.map.get_commit(&head.target_sha).ok_or_else(|| {
+            let peeled_state = self.map.get_commit(&head.target_sha)?.ok_or_else(|| {
                 IngestError::Other(format!(
                     "annotated tag {} peels to unmapped commit {}",
                     head.full_name, head.target_sha
@@ -955,13 +953,13 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
         git_lossy: bool,
         parent_policy: ParentMapPolicy,
     ) -> crate::Result<objects::object::StateId> {
-        if let Some(cid) = self.map.get_commit(&commit.sha) {
+        if let Some(cid) = self.map.get_commit(&commit.sha)? {
             return Ok(cid);
         }
 
         let mut parents = Vec::with_capacity(commit.parents.len());
         for p in &commit.parents {
-            match self.map.get_commit(p) {
+            match self.map.get_commit(p)? {
                 Some(cid) => parents.push(cid),
                 None => match parent_policy {
                     ParentMapPolicy::RequireMapped => {
@@ -1141,7 +1139,7 @@ pub fn import_single_git_commit_into(
 
     let map_path = repo.heddle_dir().join("ingest").join("sha_map.sqlite");
     let mut map = ShaMap::open(&map_path)?;
-    if let Some(existing) = map.get_commit(git_sha) {
+    if let Some(existing) = map.get_commit(git_sha)? {
         // Already bound — still verify the state object is present.
         if repo.store().get_state(&existing)?.is_some() {
             return Ok(existing);
@@ -1247,7 +1245,7 @@ pub fn bind_single_git_commit_overlay(
     let repo = repo::Repository::open(root)?;
     let map_path = repo.heddle_dir().join("ingest").join("sha_map.sqlite");
     let mut map = ShaMap::open(&map_path)?;
-    if let Some(existing) = map.get_commit(git_sha) {
+    if let Some(existing) = map.get_commit(git_sha)? {
         if repo.store().get_state(&existing)?.is_some() {
             return Ok(existing);
         }
@@ -2056,7 +2054,10 @@ mod tests {
         let tip = git_output(&source, &["rev-parse", "HEAD"], None);
 
         let (_, source_map) = import_git_into(&source, &native).expect("import source graph");
-        let source_id = source_map.get_commit(&tip).expect("mapped source tip");
+        let source_id = source_map
+            .get_commit(&tip)
+            .expect("read source mapping")
+            .expect("mapped source tip");
         let source_repo = repo::Repository::open(&native).expect("open source Heddle repo");
         let source_state = source_repo
             .store()
@@ -2127,7 +2128,7 @@ mod tests {
 
         let (_, repaired_map) =
             import_git_into(&clone, &clone).expect("materialize full noted parent graph");
-        assert_eq!(repaired_map.get_commit(&tip), Some(source_id));
+        assert_eq!(repaired_map.get_commit(&tip).unwrap(), Some(source_id));
         let repaired = repo::Repository::open(&clone).expect("open repaired clone");
         let repaired_state = repaired
             .store()
@@ -2380,7 +2381,7 @@ mod tests {
         let (stats, map) = import_git_into(gitdir.path(), gitdir.path()).unwrap();
 
         assert!(stats.commits_imported >= 2);
-        assert_eq!(stats.states_created, map.commit_shas().len());
+        assert_eq!(stats.states_created, map.commit_shas().unwrap().len());
         let map_path = gitdir
             .path()
             .join(".heddle")
@@ -2388,9 +2389,15 @@ mod tests {
             .join("sha_map.sqlite");
         assert!(map_path.is_file(), "ingest SHA map is missing");
         let reloaded = ShaMap::open(&map_path).unwrap();
-        assert_eq!(reloaded.commit_shas().len(), map.commit_shas().len());
-        for git_oid in map.commit_shas() {
-            assert_eq!(reloaded.get_commit(&git_oid), map.get_commit(&git_oid));
+        assert_eq!(
+            reloaded.commit_shas().unwrap().len(),
+            map.commit_shas().unwrap().len()
+        );
+        for git_oid in map.commit_shas().unwrap() {
+            assert_eq!(
+                reloaded.get_commit(&git_oid).unwrap(),
+                map.get_commit(&git_oid).unwrap()
+            );
         }
 
         let git_projection_mapping_path = gitdir
@@ -2443,9 +2450,9 @@ mod tests {
         .expect("single-tip import");
 
         let map = ShaMap::open(gitdir.path().join(".heddle/ingest/sha_map.sqlite")).unwrap();
-        assert_eq!(map.get_commit(&tip), Some(change_id));
+        assert_eq!(map.get_commit(&tip).unwrap(), Some(change_id));
         // Only the tip — not the parent commit.
-        assert_eq!(map.commit_shas().len(), 1);
+        assert_eq!(map.commit_shas().unwrap().len(), 1);
 
         let repo = repo::Repository::open(gitdir.path()).unwrap();
         let state = repo
@@ -2471,6 +2478,7 @@ mod tests {
             ShaMap::open(gitdir.path().join(".heddle/ingest/sha_map.sqlite"))
                 .unwrap()
                 .commit_shas()
+                .unwrap()
                 .len(),
             1
         );

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -119,11 +119,13 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
 
         for entry in entries {
             match classify(&entry.ref_name) {
-                RefKind::Head => self.emit_head(entry, scope, &mut groups, &mut stats),
+                RefKind::Head => self.emit_head(entry, scope, &mut groups, &mut stats)?,
                 RefKind::Branch(name) => {
-                    self.emit_branch(entry, &name, scope, &mut groups, &mut stats)
+                    self.emit_branch(entry, &name, scope, &mut groups, &mut stats)?
                 }
-                RefKind::Tag(name) => self.emit_tag(entry, &name, scope, &mut groups, &mut stats),
+                RefKind::Tag(name) => {
+                    self.emit_tag(entry, &name, scope, &mut groups, &mut stats)?
+                }
                 RefKind::Other => {
                     stats.skipped_noop += 1;
                 }
@@ -149,30 +151,32 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
         scope: Option<&'g str>,
         groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) {
+    ) -> crate::Result<()> {
         // Only `checkout:` is a pure navigation event; other HEAD movements
         // are handled from the corresponding branch reflog.
         if !entry.message.starts_with("checkout:") {
             stats.skipped_noop += 1;
-            return;
+            return Ok(());
         }
         let Some(new_sha) = &entry.new_sha else {
             stats.skipped_noop += 1;
-            return;
+            return Ok(());
         };
-        let Some(cid) = self.map.get_commit(new_sha) else {
+        let Some(cid) = self.map.get_commit(new_sha)? else {
             warn!(
                 ref_name = %entry.ref_name,
                 sha = %new_sha,
                 "dropping HEAD checkout — target commit not in sha map",
             );
             stats.skipped_unmapped += 1;
-            return;
+            return Ok(());
         };
         let prev_cid = entry
             .previous_sha
             .as_deref()
-            .and_then(|s| self.map.get_commit(s));
+            .map(|sha| self.map.get_commit(sha))
+            .transpose()?
+            .flatten();
         // Mirrors `OpLogRecorder::record_goto`: the `head` field is the goto
         // target. Pushed as its own group so it stays an independent undo
         // unit (one `record_goto` == one batch).
@@ -185,6 +189,7 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
             scope,
         ));
         stats.gotos += 1;
+        Ok(())
     }
 
     fn emit_branch<'g>(
@@ -194,15 +199,15 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
         scope: Option<&'g str>,
         groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) {
+    ) -> crate::Result<()> {
         match (&entry.previous_sha, &entry.new_sha) {
             (None, None) => {
                 stats.skipped_noop += 1;
             }
             (None, Some(new_sha)) => {
-                let Some(cid) = self.map.get_commit(new_sha) else {
+                let Some(cid) = self.map.get_commit(new_sha)? else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 // Git-history ingest does not write a ThreadManager
                 // record — those exist for native heddle threads. Pass
@@ -220,9 +225,9 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 stats.thread_creates += 1;
             }
             (Some(prev_sha), None) => {
-                let Some(cid) = self.map.get_commit(prev_sha) else {
+                let Some(cid) = self.map.get_commit(prev_sha)? else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 // Mirrors `record_thread_delete`.
                 groups.push((
@@ -241,10 +246,10 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
             }
             (Some(prev), Some(new)) => {
                 let (Some(old_cid), Some(new_cid)) =
-                    (self.map.get_commit(prev), self.map.get_commit(new))
+                    (self.map.get_commit(prev)?, self.map.get_commit(new)?)
                 else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 groups.push((
                     vec![OpRecord::ThreadUpdate {
@@ -258,6 +263,7 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 stats.thread_updates += 1;
             }
         }
+        Ok(())
     }
 
     fn emit_tag<'g>(
@@ -267,12 +273,12 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
         scope: Option<&'g str>,
         groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) {
+    ) -> crate::Result<()> {
         match (&entry.previous_sha, &entry.new_sha) {
             (None, Some(new)) => {
-                let Some(cid) = self.map.get_commit(new) else {
+                let Some(cid) = self.map.get_commit(new)? else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 // Mirrors `record_marker_create`, which records with scope
                 // `None` (it goes through `record_batch`, not the scoped
@@ -287,9 +293,9 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 stats.marker_creates += 1;
             }
             (Some(prev), None) => {
-                let Some(cid) = self.map.get_commit(prev) else {
+                let Some(cid) = self.map.get_commit(prev)? else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 // Mirrors `record_marker_delete` — scope `None`.
                 groups.push((
@@ -312,10 +318,10 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 // This arm uses the emitter scope (it always did, via the
                 // earlier inline `record_batch_scoped(_, self.scope)`).
                 let (Some(old_cid), Some(new_cid)) =
-                    (self.map.get_commit(prev), self.map.get_commit(new))
+                    (self.map.get_commit(prev)?, self.map.get_commit(new)?)
                 else {
                     stats.skipped_unmapped += 1;
-                    return;
+                    return Ok(());
                 };
                 groups.push((
                     vec![
@@ -337,6 +343,7 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 stats.skipped_noop += 1;
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/ingest/src/reasoning_emit.rs
+++ b/crates/ingest/src/reasoning_emit.rs
@@ -114,7 +114,7 @@ impl<'a> ReasoningEmitter<'a> {
         // Resolve the git commit to its Heddle state_id. If the ShaMap
         // doesn't know this SHA, the commit wasn't imported; count the
         // whole batch as unmapped and bail.
-        let Some(state_id) = self.sha_map.get_commit(git_sha) else {
+        let Some(state_id) = self.sha_map.get_commit(git_sha)? else {
             self.stats.skipped_unmapped += clean.len();
             return Ok(None);
         };

--- a/crates/ingest/src/reasoning_pipeline.rs
+++ b/crates/ingest/src/reasoning_pipeline.rs
@@ -282,6 +282,7 @@ impl<'a> ReasoningPipeline<'a> {
                     self.stats.skipped_untranslated_tree += 1;
                     continue;
                 }
+                Err(PipelineFileError::ShaMap(error)) => return Err(error.into()),
                 Err(PipelineFileError::Other(e)) => {
                     warn!(sha, error = %e, "diff_trees failed, skipping");
                     self.stats.skipped_git_errors += 1;
@@ -511,6 +512,7 @@ impl<'a> ReasoningPipeline<'a> {
         let to_hash = self
             .sha_map
             .get_tree(&commit.tree_sha)
+            .map_err(PipelineFileError::ShaMap)?
             .ok_or(PipelineFileError::UntranslatedTree)?;
 
         let from_hash = if let Some(parent) = commit.parents.first() {
@@ -527,6 +529,7 @@ impl<'a> ReasoningPipeline<'a> {
             let from_hash = self
                 .sha_map
                 .get_tree(&parent_commit.tree_sha)
+                .map_err(PipelineFileError::ShaMap)?
                 .ok_or(PipelineFileError::UntranslatedTree)?;
             Some(from_hash)
         } else {
@@ -1047,15 +1050,16 @@ fn walk_tree<S: ObjectSource + ?Sized>(
 /// exploded" (unexpected — log and move on).
 enum PipelineFileError {
     UntranslatedTree,
+    ShaMap(crate::ShaMapError),
     Other(String),
 }
 
 /// Convenience: return every git commit SHA currently in the map.
 /// Useful for the default "process all imported commits" policy.
-pub fn pipeline_default_commits(map: &ShaMap) -> Vec<String> {
-    let mut v = map.commit_shas();
+pub fn pipeline_default_commits(map: &ShaMap) -> crate::Result<Vec<String>> {
+    let mut v = map.commit_shas()?;
     v.sort();
-    v
+    Ok(v)
 }
 
 #[cfg(test)]
@@ -1370,7 +1374,10 @@ mod tests {
         // Verify the annotation surface: the state for head_sha should
         // now have a context blob at __files/src/auth.rs with an
         // Invariant-kind annotation.
-        let state_id = map.get_commit(&head_sha).unwrap();
+        let state_id = map
+            .get_commit(&head_sha)
+            .unwrap()
+            .expect("head commit mapping");
         let attachment = repo
             .latest_state_attachment(&state_id, StateAttachmentKind::Context)
             .unwrap()
@@ -1714,7 +1721,7 @@ mod tests {
         map.insert_commit(&"b".repeat(40), test_state_id()).unwrap();
         map.insert_commit(&"a".repeat(40), test_state_id()).unwrap();
         map.insert_commit(&"c".repeat(40), test_state_id()).unwrap();
-        let got = pipeline_default_commits(&map);
+        let got = pipeline_default_commits(&map).unwrap();
         let want: Vec<String> = vec!["a".repeat(40), "b".repeat(40), "c".repeat(40)];
         assert_eq!(got, want);
     }

--- a/crates/ingest/src/ref_emit.rs
+++ b/crates/ingest/src/ref_emit.rs
@@ -98,7 +98,7 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
         let mut markers = Vec::new();
 
         for head in heads {
-            let Some(cid) = self.map.get_commit(&head.target_sha) else {
+            let Some(cid) = self.map.get_commit(&head.target_sha)? else {
                 warn!(
                     ref_name = %head.full_name,
                     target = %head.target_sha,
@@ -416,6 +416,25 @@ mod tests {
         let stats = pollster::block_on(RefEmitter::new(&mgr, &store, &map).emit(&heads)).unwrap();
         assert_eq!(stats.threads_written, 0);
         assert_eq!(stats.skipped_unmapped, 1);
+        assert_eq!(mgr.get_thread(&ThreadName::new("orphan")).unwrap(), None);
+    }
+
+    #[test]
+    fn sqlite_lookup_error_fails_emit_instead_of_skipping_ref() {
+        let (_tmp, mgr) = fresh_ref_manager();
+        let store = InMemoryStore::new();
+        let map_dir = TempDir::new().unwrap();
+        let map_path = map_dir.path().join("sha_map.sqlite");
+        let map = ShaMap::open(&map_path).unwrap();
+        let conn = rusqlite::Connection::open(&map_path).unwrap();
+        conn.execute("DROP TABLE sha_map", []).unwrap();
+
+        let git_sha = "c".repeat(40);
+        let heads = vec![sample_head("orphan", RefNamespace::Branch, &git_sha)];
+        let error = pollster::block_on(RefEmitter::new(&mgr, &store, &map).emit(&heads))
+            .expect_err("a sha-map query error must fail ref emission");
+
+        assert!(matches!(error, IngestError::ShaMap(_)));
         assert_eq!(mgr.get_thread(&ThreadName::new("orphan")).unwrap(), None);
     }
 

--- a/crates/ingest/src/sha_map.rs
+++ b/crates/ingest/src/sha_map.rs
@@ -121,6 +121,13 @@ pub enum ShaMapError {
     },
     #[error("serialize lossy tree entries: {0}")]
     LossySerialize(#[from] serde_json::Error),
+    #[error("corrupt stored {kind:?} mapping for git={git}: {heddle_repr:?}: {reason}")]
+    CorruptStoredValue {
+        git: String,
+        kind: MapKind,
+        heddle_repr: String,
+        reason: String,
+    },
 }
 
 impl Default for ShaMap {
@@ -394,15 +401,33 @@ impl ShaMap {
     }
 
     /// Look up the Heddle `StateId` for a git commit SHA.
-    pub fn get_commit(&self, git_sha: &str) -> Option<StateId> {
-        let heddle = self.get_for_kind(git_sha, MapKind::Commit)?;
-        StateId::parse(&heddle).ok()
+    pub fn get_commit(&self, git_sha: &str) -> Result<Option<StateId>, ShaMapError> {
+        let Some(heddle) = self.get_for_kind(git_sha, MapKind::Commit)? else {
+            return Ok(None);
+        };
+        StateId::parse(&heddle)
+            .map(Some)
+            .map_err(|error| ShaMapError::CorruptStoredValue {
+                git: git_sha.to_string(),
+                kind: MapKind::Commit,
+                heddle_repr: heddle,
+                reason: error.to_string(),
+            })
     }
 
     /// Look up the Heddle `ContentHash` for a git tree SHA.
-    pub fn get_tree(&self, git_sha: &str) -> Option<ContentHash> {
-        let heddle = self.get_for_kind(git_sha, MapKind::Tree)?;
-        ContentHash::from_hex(&heddle).ok()
+    pub fn get_tree(&self, git_sha: &str) -> Result<Option<ContentHash>, ShaMapError> {
+        let Some(heddle) = self.get_for_kind(git_sha, MapKind::Tree)? else {
+            return Ok(None);
+        };
+        ContentHash::from_hex(&heddle)
+            .map(Some)
+            .map_err(|error| ShaMapError::CorruptStoredValue {
+                git: git_sha.to_string(),
+                kind: MapKind::Tree,
+                heddle_repr: heddle,
+                reason: error.to_string(),
+            })
     }
 
     /// Look up persisted lossy entries for a git tree SHA.
@@ -432,64 +457,60 @@ impl ShaMap {
     }
 
     /// Look up the Heddle `ContentHash` for a git blob SHA.
-    pub fn get_blob(&self, git_sha: &str) -> Option<ContentHash> {
-        let heddle = self.get_for_kind(git_sha, MapKind::Blob)?;
-        ContentHash::from_hex(&heddle).ok()
+    pub fn get_blob(&self, git_sha: &str) -> Result<Option<ContentHash>, ShaMapError> {
+        let Some(heddle) = self.get_for_kind(git_sha, MapKind::Blob)? else {
+            return Ok(None);
+        };
+        ContentHash::from_hex(&heddle)
+            .map(Some)
+            .map_err(|error| ShaMapError::CorruptStoredValue {
+                git: git_sha.to_string(),
+                kind: MapKind::Blob,
+                heddle_repr: heddle,
+                reason: error.to_string(),
+            })
     }
 
-    fn get_for_kind(&self, git_sha: &str, want: MapKind) -> Option<String> {
-        let git_sha = normalize_git_sha(git_sha).ok()?;
+    fn get_for_kind(&self, git_sha: &str, want: MapKind) -> Result<Option<String>, ShaMapError> {
+        let git_sha = normalize_git_sha(git_sha)?;
         let mut stmt = self
             .conn
-            .prepare_cached("SELECT heddle_repr FROM sha_map WHERE git_sha = ? AND kind = ?")
-            .ok()?;
-        stmt.query_row(params![git_sha, want.as_i64()], |r| r.get(0))
-            .optional()
-            .ok()?
+            .prepare_cached("SELECT heddle_repr FROM sha_map WHERE git_sha = ? AND kind = ?")?;
+        Ok(stmt
+            .query_row(params![git_sha, want.as_i64()], |r| r.get(0))
+            .optional()?)
     }
 
     /// Reverse lookup: the git SHA that produced a given Heddle repr.
     /// Returns `None` if no record matches; the secondary index makes
     /// this an O(log n) lookup against `heddle_repr`.
-    pub fn get_git_for_heddle(&self, heddle_repr: &str) -> Option<String> {
+    pub fn get_git_for_heddle(&self, heddle_repr: &str) -> Result<Option<String>, ShaMapError> {
         let mut stmt = self
             .conn
-            .prepare_cached("SELECT git_sha FROM sha_map WHERE heddle_repr = ?")
-            .ok()?;
-        stmt.query_row(params![heddle_repr], |r| r.get(0))
-            .optional()
-            .ok()?
+            .prepare_cached("SELECT git_sha FROM sha_map WHERE heddle_repr = ?")?;
+        Ok(stmt
+            .query_row(params![heddle_repr], |r| r.get(0))
+            .optional()?)
     }
 
     /// How many commits have been mapped (used for progress reporting).
-    pub fn commit_count(&self) -> usize {
-        self.conn
-            .query_row(
-                "SELECT COUNT(*) FROM sha_map WHERE kind = ?",
-                params![MapKind::Commit.as_i64()],
-                |r| r.get::<_, i64>(0),
-            )
-            .map(|n| n as usize)
-            .unwrap_or(0)
+    pub fn commit_count(&self) -> Result<usize, ShaMapError> {
+        Ok(self.conn.query_row(
+            "SELECT COUNT(*) FROM sha_map WHERE kind = ?",
+            params![MapKind::Commit.as_i64()],
+            |r| r.get::<_, i64>(0),
+        )? as usize)
     }
 
     /// Every git commit SHA currently in the map. Order is unspecified
     /// (B-tree iteration on `git_sha`); callers that want a stable
     /// order should sort.
-    pub fn commit_shas(&self) -> Vec<String> {
-        let mut stmt = match self
+    pub fn commit_shas(&self) -> Result<Vec<String>, ShaMapError> {
+        let mut stmt = self
             .conn
-            .prepare_cached("SELECT git_sha FROM sha_map WHERE kind = ?")
-        {
-            Ok(s) => s,
-            Err(_) => return Vec::new(),
-        };
-        let rows =
-            match stmt.query_map(params![MapKind::Commit.as_i64()], |r| r.get::<_, String>(0)) {
-                Ok(r) => r,
-                Err(_) => return Vec::new(),
-            };
-        rows.filter_map(|r| r.ok()).collect()
+            .prepare_cached("SELECT git_sha FROM sha_map WHERE kind = ?")?;
+        let rows = stmt.query_map(params![MapKind::Commit.as_i64()], |r| r.get::<_, String>(0))?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     /// Every mapped Heddle content hash of the requested source kind.
@@ -609,9 +630,9 @@ mod tests {
         let sha = "ca1af22000000000000000000000000000000000";
         let cid = test_state_id();
         m.insert_commit(sha, cid).unwrap();
-        assert_eq!(m.get_commit(sha), Some(cid));
+        assert_eq!(m.get_commit(sha).unwrap(), Some(cid));
         assert_eq!(m.len(), 1);
-        assert_eq!(m.commit_count(), 1);
+        assert_eq!(m.commit_count().unwrap(), 1);
     }
 
     #[test]
@@ -623,9 +644,9 @@ mod tests {
 
         // Same git sha looked up as commit/blob must miss because kind
         // is part of the semantic identity.
-        assert!(m.get_commit(sha).is_none());
-        assert!(m.get_blob(sha).is_none());
-        assert_eq!(m.get_tree(sha), Some(tree_hash));
+        assert!(m.get_commit(sha).unwrap().is_none());
+        assert!(m.get_blob(sha).unwrap().is_none());
+        assert_eq!(m.get_tree(sha).unwrap(), Some(tree_hash));
     }
 
     #[test]
@@ -647,6 +668,28 @@ mod tests {
         m.insert_commit(sha, cid1).unwrap();
         let err = m.insert_commit(sha, cid2).unwrap_err();
         assert!(matches!(err, ShaMapError::Conflict { .. }));
+    }
+
+    #[test]
+    fn corrupt_stored_commit_is_an_error_not_a_miss() {
+        let mut m = ShaMap::new();
+        let sha = "ca1af22000000000000000000000000000000000";
+        m.insert_commit(sha, test_state_id()).unwrap();
+        m.conn
+            .execute(
+                "UPDATE sha_map SET heddle_repr = 'not-a-state-id' WHERE git_sha = ?",
+                params![sha],
+            )
+            .unwrap();
+
+        let error = m.get_commit(sha).unwrap_err();
+        assert!(matches!(
+            error,
+            ShaMapError::CorruptStoredValue {
+                kind: MapKind::Commit,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -673,9 +716,9 @@ mod tests {
         // Reopen — every record must round-trip.
         let reloaded = ShaMap::open(&path).unwrap();
         assert_eq!(reloaded.len(), 3);
-        assert_eq!(reloaded.get_commit(sha1), Some(cid));
-        assert_eq!(reloaded.get_tree(sha2), Some(tree_h));
-        assert_eq!(reloaded.get_blob(sha3), Some(blob_h));
+        assert_eq!(reloaded.get_commit(sha1).unwrap(), Some(cid));
+        assert_eq!(reloaded.get_tree(sha2).unwrap(), Some(tree_h));
+        assert_eq!(reloaded.get_blob(sha3).unwrap(), Some(blob_h));
     }
 
     #[test]
@@ -697,7 +740,7 @@ mod tests {
         }
 
         let reloaded = ShaMap::open(&path).unwrap();
-        assert_eq!(reloaded.get_tree(sha), Some(tree_h));
+        assert_eq!(reloaded.get_tree(sha).unwrap(), Some(tree_h));
         assert_eq!(
             reloaded.get_tree_lossy_entries(sha).unwrap().unwrap(),
             entries
@@ -756,8 +799,8 @@ mod tests {
 
         let reloaded = ShaMap::open(&path).unwrap();
         assert_eq!(reloaded.len(), 2);
-        assert_eq!(reloaded.get_commit(sha1), Some(cid));
-        assert_eq!(reloaded.get_tree(sha2), Some(tree_h));
+        assert_eq!(reloaded.get_commit(sha1).unwrap(), Some(cid));
+        assert_eq!(reloaded.get_tree(sha2).unwrap(), Some(tree_h));
     }
 
     #[test]
@@ -767,7 +810,9 @@ mod tests {
         let cid = test_state_id();
         m.insert_commit(sha, cid).unwrap();
         assert_eq!(
-            m.get_git_for_heddle(&cid.to_string_full()).as_deref(),
+            m.get_git_for_heddle(&cid.to_string_full())
+                .unwrap()
+                .as_deref(),
             Some(sha)
         );
     }
@@ -796,23 +841,26 @@ mod tests {
         m.abort_append_batch();
 
         assert_eq!(m.len(), 1, "batch inserts must be rolled back");
-        assert_eq!(m.get_commit(pre_sha), Some(pre_cid));
+        assert_eq!(m.get_commit(pre_sha).unwrap(), Some(pre_cid));
         assert_eq!(
-            m.get_commit(in_batch_sha),
+            m.get_commit(in_batch_sha).unwrap(),
             None,
             "aborted commit must not survive"
         );
         assert!(
-            m.get_tree(in_batch_tree_sha).is_none(),
+            m.get_tree(in_batch_tree_sha).unwrap().is_none(),
             "aborted tree must not survive"
         );
         assert!(
             m.get_git_for_heddle(&in_batch_cid.to_string_full())
+                .unwrap()
                 .is_none(),
             "aborted commit must not survive in reverse lookup"
         );
         assert!(
-            m.get_git_for_heddle(&in_batch_tree.to_hex()).is_none(),
+            m.get_git_for_heddle(&in_batch_tree.to_hex())
+                .unwrap()
+                .is_none(),
             "aborted tree must not survive in reverse lookup"
         );
     }
@@ -846,7 +894,7 @@ mod tests {
         // Reopen. Only the original record should survive.
         let reloaded = ShaMap::open(&path).unwrap();
         assert_eq!(reloaded.len(), 1);
-        assert_eq!(reloaded.get_commit(pre_sha), Some(pre_cid));
+        assert_eq!(reloaded.get_commit(pre_sha).unwrap(), Some(pre_cid));
     }
 
     #[test]
@@ -868,7 +916,7 @@ mod tests {
         m.abort_append_batch();
 
         assert_eq!(m.len(), 1);
-        assert_eq!(m.get_commit(sha), Some(cid));
+        assert_eq!(m.get_commit(sha).unwrap(), Some(cid));
         assert_eq!(ShaMap::open(&path).unwrap().len(), 1);
     }
 
@@ -890,14 +938,14 @@ mod tests {
         m.begin_append_batch().unwrap();
         m.insert_commit(inner_sha, inner_cid).unwrap();
         m.abort_append_batch(); // rolls back inner only
-        assert_eq!(m.get_commit(inner_sha), None);
-        assert_eq!(m.get_commit(outer_sha), Some(outer_cid));
+        assert_eq!(m.get_commit(inner_sha).unwrap(), None);
+        assert_eq!(m.get_commit(outer_sha).unwrap(), Some(outer_cid));
         m.flush_append_batch().unwrap();
         drop(m);
 
         let reloaded = ShaMap::open(&path).unwrap();
         assert_eq!(reloaded.len(), 1);
-        assert_eq!(reloaded.get_commit(outer_sha), Some(outer_cid));
+        assert_eq!(reloaded.get_commit(outer_sha).unwrap(), Some(outer_cid));
     }
 
     #[test]
@@ -920,11 +968,14 @@ mod tests {
             m.insert_commit(&sha, cid).unwrap();
         }
         m.flush_append_batch().unwrap();
-        assert_eq!(m.commit_count(), 10_000);
+        assert_eq!(m.commit_count().unwrap(), 10_000);
         // Spot-check round-trip across the range.
         for i in [0u32, 1, 99, 1_234, 5_000, 9_999] {
             let sha = format!("{:040x}", i);
-            assert!(m.get_commit(&sha).is_some(), "missing commit {sha}");
+            assert!(
+                m.get_commit(&sha).unwrap().is_some(),
+                "missing commit {sha}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- return Result<Option<T>, ShaMapError> from SHA-map lookups, reverse lookup, commit count, and commit enumeration
- reserve None for real SQLite optional misses and report corrupt stored StateId or ContentHash values as errors
- propagate lookup failures through import, ref/reasoning/oplog emission, reasoning pipeline, Git pull, and ingest CLI callers

## Test evidence
- pre-fix negative: cargo test -p heddle-ingest sqlite_lookup_error_fails_emit_instead_of_skipping_ref -- --nocapture failed because emission returned Ok with skipped_unmapped = 1 after the sha_map table was dropped
- post-fix negative: the same test passes and ref emission returns IngestError::ShaMap
- corrupt value: cargo test -p heddle-ingest corrupt_stored_commit_is_an_error_not_a_miss -- --nocapture passes
- cargo build -p heddle-ingest -p heddle-cli --all-targets
- cargo test -p heddle-ingest: 201 passed, 0 failed, 1 ignored
- cargo test -p heddle-cli --lib remote_ops: 2 passed
- cargo test -p heddle-cli --test cli_overlay_remote capture_persists_unchanged_git_subtree_and_blob_as_native_closure: 1 passed
- cargo clippy --workspace --all-targets -- -D warnings
- rustfmt +nightly --edition 2024 on all touched Rust files

Closes #1647

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790902145&installation_model_id=21489&pr_number=1651&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1651&signature=beacd739dc58f5ff575cba1bc445258782123b4efb3f2bc59903fa68fc032259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->