### PR TITLE
feat(objects): train per-pack NPK1 record dictionary

### DIFF
--- a/crates/objects/src/store/fs/npk1/builder.rs
+++ b/crates/objects/src/store/fs/npk1/builder.rs
@@ -12,7 +12,10 @@ use super::{
     CHECKSUM_CHUNK_BYTES, EXACT_CANDIDATES, HEADER_LEN, INDEX_MAGIC, LARGE_OFFSET_FLAG, MAGIC,
     MAX_CHAIN_DEPTH, RECORD_BLOCK_ENTRIES, TRAILER_HEADER_LEN, TRAILER_MAGIC, VERSION,
     WINDOW_BUCKET_LIMIT,
-    codec::{Dictionary, encode_anchor, encode_delta, note_tree_dictionary_rows},
+    codec::{
+        Dictionary, RawRecord, RecordEncoder, encode_anchor, encode_delta,
+        note_tree_dictionary_rows,
+    },
     invalid,
 };
 use crate::{
@@ -216,12 +219,38 @@ struct Plan {
 struct CandidateRecord {
     base: usize,
     depth: usize,
-    bytes: Vec<u8>,
+    encoded_len: usize,
+    record: RawRecord,
 }
 
 fn load_tree(store: &FsStore, hash: ContentHash) -> Result<Tree> {
     ObjectStore::get_tree(store, &hash)?
         .ok_or_else(|| invalid(format!("tree disappeared while packing: {hash}")))
+}
+
+fn train_record_dictionary(records: &[RawRecord]) -> Result<Vec<u8>> {
+    #[cfg(feature = "zstd")]
+    {
+        let samples = records
+            .iter()
+            .flat_map(RawRecord::samples)
+            .filter(|sample| !sample.is_empty())
+            .collect::<Vec<_>>();
+        let total_bytes = samples
+            .iter()
+            .fold(0usize, |total, sample| total.saturating_add(sample.len()));
+        let dictionary_bytes = (total_bytes / 8).min(super::RECORD_DICTIONARY_MAX_BYTES);
+        if samples.len() < 8 || dictionary_bytes < super::RECORD_DICTIONARY_MIN_BYTES {
+            return Ok(Vec::new());
+        }
+        zstd::dict::from_samples(&samples, dictionary_bytes)
+            .map_err(|error| HeddleError::Compression(error.to_string()))
+    }
+    #[cfg(not(feature = "zstd"))]
+    {
+        let _ = records;
+        Ok(Vec::new())
+    }
 }
 
 pub(crate) fn build_npk1_pack(
@@ -273,25 +302,12 @@ pub(crate) fn build_npk1_pack(
     let name_bytes = dictionary.encode_names()?;
     let target_bytes = dictionary.encode_targets()?;
 
-    let file = OpenOptions::new()
-        .create_new(true)
-        .read(true)
-        .write(true)
-        .open(output)?;
-    let mut writer = BufWriter::new(file);
-    writer.write_all(&[0u8; HEADER_LEN])?;
-    let name_offset = HEADER_LEN as u64;
-    writer.write_all(&name_bytes)?;
-    let target_offset = name_offset.saturating_add(name_bytes.len() as u64);
-    writer.write_all(&target_bytes)?;
-    let records_offset = target_offset.saturating_add(target_bytes.len() as u64);
-
     let mut plans = vec![None::<Plan>; hashes.len()];
     let mut ordinals = vec![usize::MAX; hashes.len()];
     let mut order = Vec::with_capacity(hashes.len());
-    let mut record_offsets = Vec::with_capacity(hashes.len() + 1);
-    let mut record_position = 0u64;
+    let mut records = Vec::with_capacity(hashes.len());
     let mut window = CandidateWindow::default();
+    let mut selector_encoder = RecordEncoder::new(&[])?;
 
     for start in 0..hashes.len() {
         if plans[start].is_some() {
@@ -315,6 +331,7 @@ pub(crate) fn build_npk1_pack(
             ordinals[index] = ordinal;
             let current = load_tree(store, hashes[index])?;
             let anchor = encode_anchor(&current, &dictionary)?;
+            let anchor_len = anchor.encode(&mut selector_encoder)?.len();
             let candidate_indexes =
                 window.candidates(sketches[index], &sketches, parent_indexes[index], &ordinals);
             let mut candidates = Vec::with_capacity(candidate_indexes.len());
@@ -331,25 +348,27 @@ pub(crate) fn build_npk1_pack(
                 }
                 let base_tree = load_tree(store, hashes[base])?;
                 let ops = tree_delta(&base_tree, &current);
-                let bytes = encode_delta(ordinal - base_ordinal, &current, &ops, &dictionary)?;
+                let record = encode_delta(ordinal - base_ordinal, &current, &ops, &dictionary)?;
+                let encoded_len = record.encode(&mut selector_encoder)?.len();
                 context
-                    .checkpoint(bytes.len() as u64)
+                    .checkpoint(encoded_len as u64)
                     .map_err(Npk1BuildError::Cancelled)?;
-                candidates.push(CandidateRecord { base, depth, bytes });
+                candidates.push(CandidateRecord {
+                    base,
+                    depth,
+                    encoded_len,
+                    record,
+                });
             }
             let selected = candidates
                 .into_iter()
-                .filter(|candidate| candidate.bytes.len() < anchor.len())
-                .min_by_key(|candidate| (candidate.bytes.len(), Reverse(ordinals[candidate.base])));
+                .filter(|candidate| candidate.encoded_len < anchor_len)
+                .min_by_key(|candidate| (candidate.encoded_len, Reverse(ordinals[candidate.base])));
             let (record, depth) = match selected {
-                Some(candidate) => (candidate.bytes, candidate.depth),
+                Some(candidate) => (candidate.record, candidate.depth),
                 None => (anchor, 0),
             };
-            record_offsets.push(record_position);
-            writer.write_all(&record)?;
-            record_position = record_position
-                .checked_add(record.len() as u64)
-                .ok_or_else(|| invalid("record section exceeds u64"))?;
+            records.push(record);
             plans[index] = Some(Plan { depth });
             order.push(index);
             window.insert(index, sketches[index]);
@@ -357,6 +376,33 @@ pub(crate) fn build_npk1_pack(
     }
     if order.len() != hashes.len() {
         return Err(invalid("not every input tree received a record").into());
+    }
+
+    let record_dictionary = train_record_dictionary(&records)?;
+    let mut record_encoder = RecordEncoder::new(&record_dictionary)?;
+    let file = OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(output)?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(&[0u8; HEADER_LEN])?;
+    let name_offset = HEADER_LEN as u64;
+    writer.write_all(&name_bytes)?;
+    let target_offset = name_offset.saturating_add(name_bytes.len() as u64);
+    writer.write_all(&target_bytes)?;
+    let record_dictionary_offset = target_offset.saturating_add(target_bytes.len() as u64);
+    writer.write_all(&record_dictionary)?;
+    let records_offset = record_dictionary_offset.saturating_add(record_dictionary.len() as u64);
+    let mut record_offsets = Vec::with_capacity(records.len() + 1);
+    let mut record_position = 0u64;
+    for record in &records {
+        let encoded = record.encode(&mut record_encoder)?;
+        record_offsets.push(record_position);
+        writer.write_all(&encoded)?;
+        record_position = record_position
+            .checked_add(encoded.len() as u64)
+            .ok_or_else(|| invalid("record section exceeds u64"))?;
     }
     record_offsets.push(record_position);
     let index_offset = records_offset
@@ -373,6 +419,7 @@ pub(crate) fn build_npk1_pack(
         hashes.len(),
         name_offset,
         target_offset,
+        record_dictionary_offset,
         records_offset,
         index_offset,
         trailer_offset,
@@ -392,6 +439,7 @@ fn encode_header(
     object_count: usize,
     name_offset: u64,
     target_offset: u64,
+    record_dictionary_offset: u64,
     records_offset: u64,
     index_offset: u64,
     trailer_offset: u64,
@@ -409,6 +457,7 @@ fn encode_header(
     header[32..40].copy_from_slice(&records_offset.to_le_bytes());
     header[40..48].copy_from_slice(&index_offset.to_le_bytes());
     header[48..56].copy_from_slice(&trailer_offset.to_le_bytes());
+    header[56..64].copy_from_slice(&record_dictionary_offset.to_le_bytes());
     Ok(header)
 }
 

--- a/crates/objects/src/store/fs/npk1/codec.rs
+++ b/crates/objects/src/store/fs/npk1/codec.rs
@@ -8,6 +8,8 @@ use super::{
     NAME_MAGIC, NAME_RESTART, RECORD_BLOCK_ENTRIES, TARGET_MAGIC, checked_slice, invalid,
     put_varint, read_u16, read_u32, shared_prefix, take_varint,
 };
+#[cfg(feature = "zstd")]
+use crate::store::HeddleError;
 use crate::{
     object::{
         ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeDeltaOp, TreeEntry,
@@ -15,6 +17,11 @@ use crate::{
     },
     store::Result,
 };
+
+#[cfg(test)]
+thread_local! {
+    static DECODED_RECORD_BLOCKS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[derive(Debug)]
 pub(super) struct Dictionary {
@@ -389,6 +396,127 @@ pub(super) struct RecordHeader {
     pub(super) blocks: Vec<BlockDescriptor>,
 }
 
+pub(super) struct RawRecord {
+    tag: u8,
+    prefix: Vec<usize>,
+    blocks: Vec<(u32, Vec<u8>)>,
+}
+
+impl RawRecord {
+    pub(super) fn encode(&self, encoder: &mut RecordEncoder) -> Result<Vec<u8>> {
+        let mut stored_blocks = Vec::with_capacity(self.blocks.len());
+        for (first_name, raw) in &self.blocks {
+            let encoded = encoder.compress_block(raw)?;
+            stored_blocks.push((*first_name, raw.len(), encoded));
+        }
+        let mut out = Vec::new();
+        out.push(self.tag);
+        for value in &self.prefix {
+            put_varint(*value, &mut out);
+        }
+        put_varint(stored_blocks.len(), &mut out);
+        for (first_name, raw_len, stored) in &stored_blocks {
+            put_varint(*first_name as usize, &mut out);
+            put_varint(*raw_len, &mut out);
+            put_varint(stored.len(), &mut out);
+        }
+        for (_, _, stored) in stored_blocks {
+            out.extend_from_slice(&stored);
+        }
+        Ok(out)
+    }
+
+    #[cfg(feature = "zstd")]
+    pub(super) fn samples(&self) -> impl Iterator<Item = &[u8]> {
+        self.blocks.iter().map(|(_, raw)| raw.as_slice())
+    }
+}
+
+pub(super) struct RecordEncoder {
+    #[cfg(feature = "zstd")]
+    compressor: zstd::bulk::Compressor<'static>,
+}
+
+impl RecordEncoder {
+    pub(super) fn new(dictionary: &[u8]) -> Result<Self> {
+        #[cfg(feature = "zstd")]
+        {
+            let compressor =
+                zstd::bulk::Compressor::with_dictionary(super::RECORD_LEVEL, dictionary)
+                    .map_err(|error| HeddleError::Compression(error.to_string()))?;
+            Ok(Self { compressor })
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            let _ = dictionary;
+            Ok(Self {})
+        }
+    }
+
+    fn compress_block(&mut self, raw: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "zstd")]
+        {
+            let candidate = self
+                .compressor
+                .compress(raw)
+                .map_err(|error| HeddleError::Compression(error.to_string()))?;
+            if candidate.len() < raw.len() {
+                return Ok(candidate);
+            }
+        }
+        Ok(raw.to_vec())
+    }
+}
+
+pub(super) struct RecordDecoder {
+    #[cfg(feature = "zstd")]
+    dictionary: Option<zstd::dict::DecoderDictionary<'static>>,
+}
+
+impl RecordDecoder {
+    pub(super) fn new(dictionary: &[u8]) -> Self {
+        #[cfg(feature = "zstd")]
+        {
+            Self {
+                dictionary: (!dictionary.is_empty())
+                    .then(|| zstd::dict::DecoderDictionary::copy(dictionary)),
+            }
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            let _ = dictionary;
+            Self {}
+        }
+    }
+
+    fn decompress(&self, stored: &[u8], raw_len: usize) -> Result<Vec<u8>> {
+        #[cfg(feature = "zstd")]
+        {
+            let decoded = match &self.dictionary {
+                Some(dictionary) => {
+                    let mut decompressor =
+                        zstd::bulk::Decompressor::with_prepared_dictionary(dictionary)
+                            .map_err(|error| HeddleError::Compression(error.to_string()))?;
+                    decompressor.decompress(stored, raw_len)
+                }
+                None => zstd::bulk::decompress(stored, raw_len),
+            }
+            .map_err(|error| HeddleError::Compression(error.to_string()))?;
+            if decoded.len() != raw_len {
+                return Err(invalid("decoded block length mismatch"));
+            }
+            Ok(decoded)
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            let _ = (stored, raw_len);
+            Err(invalid(
+                "compressed record requires a build with zstd support",
+            ))
+        }
+    }
+}
+
 pub(super) fn parse_record_header(bytes: &[u8]) -> Result<RecordHeader> {
     let tag = *bytes.first().ok_or_else(|| invalid("empty record"))?;
     if tag != b'A' && tag != b'D' {
@@ -441,19 +569,13 @@ pub(super) fn parse_record_header(bytes: &[u8]) -> Result<RecordHeader> {
     })
 }
 
-fn compress_block(raw: &[u8]) -> Result<Vec<u8>> {
-    #[cfg(feature = "zstd")]
-    {
-        let candidate = zstd::bulk::compress(raw, super::RECORD_LEVEL)
-            .map_err(|error| crate::store::HeddleError::Compression(error.to_string()))?;
-        if candidate.len() < raw.len() {
-            return Ok(candidate);
-        }
-    }
-    Ok(raw.to_vec())
-}
-
-pub(super) fn decode_block(bytes: &[u8], block: &BlockDescriptor) -> Result<Vec<u8>> {
+pub(super) fn decode_block(
+    bytes: &[u8],
+    block: &BlockDescriptor,
+    decoder: &RecordDecoder,
+) -> Result<Vec<u8>> {
+    #[cfg(test)]
+    DECODED_RECORD_BLOCKS.with(|count| count.set(count.get().saturating_add(1)));
     let stored = checked_slice(
         bytes,
         block.payload_offset,
@@ -463,48 +585,10 @@ pub(super) fn decode_block(bytes: &[u8], block: &BlockDescriptor) -> Result<Vec<
     if block.stored_len == block.raw_len {
         return Ok(stored.to_vec());
     }
-    #[cfg(feature = "zstd")]
-    {
-        let decoded = zstd::bulk::decompress(stored, block.raw_len)
-            .map_err(|error| crate::store::HeddleError::Compression(error.to_string()))?;
-        if decoded.len() != block.raw_len {
-            return Err(invalid("decoded block length mismatch"));
-        }
-        Ok(decoded)
-    }
-    #[cfg(not(feature = "zstd"))]
-    {
-        let _ = stored;
-        Err(invalid(
-            "compressed record requires a build with zstd support",
-        ))
-    }
+    decoder.decompress(stored, block.raw_len)
 }
 
-fn finish_record(tag: u8, prefix: &[usize], raw_blocks: Vec<(u32, Vec<u8>)>) -> Result<Vec<u8>> {
-    let mut stored_blocks = Vec::with_capacity(raw_blocks.len());
-    for (first_name, raw) in raw_blocks {
-        let encoded = compress_block(&raw)?;
-        stored_blocks.push((first_name, raw.len(), encoded));
-    }
-    let mut out = Vec::new();
-    out.push(tag);
-    for value in prefix {
-        put_varint(*value, &mut out);
-    }
-    put_varint(stored_blocks.len(), &mut out);
-    for (first_name, raw_len, stored) in &stored_blocks {
-        put_varint(*first_name as usize, &mut out);
-        put_varint(*raw_len, &mut out);
-        put_varint(stored.len(), &mut out);
-    }
-    for (_, _, stored) in stored_blocks {
-        out.extend_from_slice(&stored);
-    }
-    Ok(out)
-}
-
-pub(super) fn encode_anchor(tree: &Tree, dictionary: &Dictionary) -> Result<Vec<u8>> {
+pub(super) fn encode_anchor(tree: &Tree, dictionary: &Dictionary) -> Result<RawRecord> {
     let mut blocks = Vec::new();
     for entries in tree.entries().chunks(RECORD_BLOCK_ENTRIES) {
         let first_name = entries
@@ -528,7 +612,11 @@ pub(super) fn encode_anchor(tree: &Tree, dictionary: &Dictionary) -> Result<Vec<
         }
         blocks.push((first_name, raw));
     }
-    finish_record(b'A', &[tree.len()], blocks)
+    Ok(RawRecord {
+        tag: b'A',
+        prefix: vec![tree.len()],
+        blocks,
+    })
 }
 
 pub(super) fn encode_delta(
@@ -536,7 +624,7 @@ pub(super) fn encode_delta(
     current: &Tree,
     ops: &[TreeDeltaOp],
     dictionary: &Dictionary,
-) -> Result<Vec<u8>> {
+) -> Result<RawRecord> {
     if base_distance == 0 {
         return Err(invalid("delta base distance is zero"));
     }
@@ -569,7 +657,11 @@ pub(super) fn encode_delta(
         }
         blocks.push((first_name, raw));
     }
-    finish_record(b'D', &[base_distance, current.len(), ops.len()], blocks)
+    Ok(RawRecord {
+        tag: b'D',
+        prefix: vec![base_distance, current.len(), ops.len()],
+        blocks,
+    })
 }
 
 pub(super) fn record_base_distance(bytes: &[u8]) -> Result<Option<usize>> {
@@ -587,11 +679,12 @@ fn decode_rows(
     bytes: &[u8],
     header: &RecordHeader,
     dictionary: &Dictionary,
+    decoder: &RecordDecoder,
 ) -> Result<Vec<TreeDeltaOp>> {
     let mut ops = Vec::new();
     let mut previous_global = None;
     for block in &header.blocks {
-        let raw = decode_block(bytes, block)?;
+        let raw = decode_block(bytes, block, decoder)?;
         let mut offset = 0usize;
         let mut name_id = 0u32;
         let mut ordinal = 0usize;
@@ -637,13 +730,17 @@ fn decode_rows(
     Ok(ops)
 }
 
-pub(super) fn decode_anchor(bytes: &[u8], dictionary: &Dictionary) -> Result<Tree> {
+pub(super) fn decode_anchor(
+    bytes: &[u8],
+    dictionary: &Dictionary,
+    decoder: &RecordDecoder,
+) -> Result<Tree> {
     let header = parse_record_header(bytes)?;
     if header.tag != b'A' {
         return Err(invalid("anchor record expected"));
     }
     let expected_entries = header.prefix[0];
-    let ops = decode_rows(bytes, &header, dictionary)?;
+    let ops = decode_rows(bytes, &header, dictionary, decoder)?;
     if ops.len() != expected_entries {
         return Err(invalid("anchor entry count mismatch"));
     }
@@ -657,14 +754,19 @@ pub(super) fn decode_anchor(bytes: &[u8], dictionary: &Dictionary) -> Result<Tre
     Ok(Tree::try_from_decoded_entries(entries)?)
 }
 
-pub(super) fn decode_delta(bytes: &[u8], base: &Tree, dictionary: &Dictionary) -> Result<Tree> {
+pub(super) fn decode_delta(
+    bytes: &[u8],
+    base: &Tree,
+    dictionary: &Dictionary,
+    decoder: &RecordDecoder,
+) -> Result<Tree> {
     let header = parse_record_header(bytes)?;
     if header.tag != b'D' {
         return Err(invalid("delta record expected"));
     }
     let result_entries = header.prefix[1];
     let expected_ops = header.prefix[2];
-    let ops = decode_rows(bytes, &header, dictionary)?;
+    let ops = decode_rows(bytes, &header, dictionary, decoder)?;
     if ops.len() != expected_ops {
         return Err(invalid("delta operation count mismatch"));
     }
@@ -686,6 +788,7 @@ pub(super) fn lookup_record(
     bytes: &[u8],
     dictionary: &Dictionary,
     wanted_name: u32,
+    decoder: &RecordDecoder,
 ) -> Result<(LookupState, Option<TreeEntry>)> {
     let header = parse_record_header(bytes)?;
     let Some(block_index) = header
@@ -695,7 +798,7 @@ pub(super) fn lookup_record(
     else {
         return Ok((LookupState::Missing, None));
     };
-    let raw = decode_block(bytes, &header.blocks[block_index])?;
+    let raw = decode_block(bytes, &header.blocks[block_index], decoder)?;
     let mut offset = 0usize;
     let mut name_id = 0u32;
     let mut ordinal = 0usize;
@@ -744,6 +847,16 @@ pub(super) fn lookup_record(
         ordinal += 1;
     }
     Ok((LookupState::Missing, None))
+}
+
+#[cfg(test)]
+pub(super) fn reset_decoded_record_blocks() {
+    DECODED_RECORD_BLOCKS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn decoded_record_blocks() -> usize {
+    DECODED_RECORD_BLOCKS.with(std::cell::Cell::get)
 }
 
 pub(super) fn note_tree_dictionary_rows(

--- a/crates/objects/src/store/fs/npk1/mod.rs
+++ b/crates/objects/src/store/fs/npk1/mod.rs
@@ -24,18 +24,22 @@ const INDEX_MAGIC: &[u8; 4] = b"NPI1";
 const NAME_MAGIC: &[u8; 4] = b"NDI1";
 const TARGET_MAGIC: &[u8; 4] = b"TDI1";
 const TRAILER_MAGIC: &[u8; 4] = b"NPT1";
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
 const HEADER_LEN: usize = 64;
 const CHECKSUM_LEN: usize = 32;
 const CHECKSUM_CHUNK_BYTES: usize = 64 * 1024;
 const TRAILER_HEADER_LEN: usize = 16;
 const NAME_RESTART: usize = 128;
 const RECORD_BLOCK_ENTRIES: usize = 128;
+#[cfg(feature = "zstd")]
+const RECORD_DICTIONARY_MAX_BYTES: usize = 32 * 1024;
+#[cfg(feature = "zstd")]
+const RECORD_DICTIONARY_MIN_BYTES: usize = 16 * 1024;
 const WINDOW_BUCKET_LIMIT: usize = 64;
 const EXACT_CANDIDATES: usize = 16;
 const MAX_CHAIN_DEPTH: usize = 16;
 #[cfg(feature = "zstd")]
-const RECORD_LEVEL: i32 = 3;
+const RECORD_LEVEL: i32 = 10;
 const LARGE_OFFSET_FLAG: u32 = 1 << 31;
 
 fn invalid(message: impl Into<String>) -> HeddleError {

--- a/crates/objects/src/store/fs/npk1/reader.rs
+++ b/crates/objects/src/store/fs/npk1/reader.rs
@@ -16,8 +16,8 @@ use super::{
     MAX_CHAIN_DEPTH, RECORD_BLOCK_ENTRIES, TRAILER_HEADER_LEN, TRAILER_MAGIC, VERSION,
     checked_slice,
     codec::{
-        Dictionary, LookupState, decode_anchor, decode_delta, lookup_record, parse_record_header,
-        record_base_distance,
+        Dictionary, LookupState, RecordDecoder, decode_anchor, decode_delta, lookup_record,
+        parse_record_header, record_base_distance,
     },
     invalid, read_u16, read_u32, read_u64, usize_from_u64,
 };
@@ -31,6 +31,7 @@ type DecodedIndex = (Vec<([u8; 32], u32)>, Vec<u64>);
 pub(crate) struct Npk1Pack {
     mmap: Mmap,
     dictionary: Dictionary,
+    record_decoder: RecordDecoder,
     records_offset: usize,
     record_offsets: Vec<u64>,
     object_index: Vec<([u8; 32], u32)>,
@@ -67,18 +68,21 @@ impl Npk1Pack {
             return Err(invalid("invalid pack magic"));
         }
         let version = read_u32(bytes, 4, "pack version")?;
-        if version != VERSION {
+        if version > VERSION {
             return Err(HeddleError::StorageFormatTooNew {
                 storage: path.display().to_string(),
                 found: version,
                 supported: VERSION,
             });
         }
+        if version == 0 {
+            return Err(invalid("unsupported pack version"));
+        }
         let object_count = read_u32(bytes, 8, "object count")? as usize;
         if bytes[12] as usize != MAX_CHAIN_DEPTH {
             return Err(invalid("unsupported chain-depth contract"));
         }
-        if bytes[13] != 0 || bytes[56..64].iter().any(|byte| *byte != 0) {
+        if bytes[13] != 0 {
             return Err(invalid("non-zero reserved header field"));
         }
         if read_u16(bytes, 14, "record block size")? as usize != RECORD_BLOCK_ENTRIES {
@@ -91,9 +95,22 @@ impl Npk1Pack {
         let index_offset = usize_from_u64(read_u64(bytes, 40, "index offset")?, "index offset")?;
         let trailer_offset =
             usize_from_u64(read_u64(bytes, 48, "trailer offset")?, "trailer offset")?;
+        let dictionary_field = usize_from_u64(
+            read_u64(bytes, 56, "record dictionary offset")?,
+            "record dictionary offset",
+        )?;
+        let record_dictionary_offset = if version == 1 {
+            if dictionary_field != 0 {
+                return Err(invalid("non-zero reserved header field"));
+            }
+            records_offset
+        } else {
+            dictionary_field
+        };
         if name_offset != HEADER_LEN
             || !(name_offset <= target_offset
-                && target_offset <= records_offset
+                && target_offset <= record_dictionary_offset
+                && record_dictionary_offset <= records_offset
                 && records_offset <= index_offset
                 && index_offset <= trailer_offset)
             || trailer_offset >= len
@@ -128,8 +145,9 @@ impl Npk1Pack {
         )?;
         let dictionary = Dictionary::decode(
             &bytes[name_offset..target_offset],
-            &bytes[target_offset..records_offset],
+            &bytes[target_offset..record_dictionary_offset],
         )?;
+        let record_decoder = RecordDecoder::new(&bytes[record_dictionary_offset..records_offset]);
         let (object_index, record_offsets) = decode_index(
             &bytes[index_offset..trailer_offset],
             object_count,
@@ -138,6 +156,7 @@ impl Npk1Pack {
         let pack = Self {
             mmap,
             dictionary,
+            record_decoder,
             records_offset,
             record_offsets,
             object_index,
@@ -261,9 +280,14 @@ impl Npk1Pack {
         let anchor = chain
             .pop()
             .ok_or_else(|| invalid("empty resolution chain"))?;
-        let mut tree = decode_anchor(self.record(anchor)?, &self.dictionary)?;
+        let mut tree = decode_anchor(self.record(anchor)?, &self.dictionary, &self.record_decoder)?;
         while let Some(delta) = chain.pop() {
-            tree = decode_delta(self.record(delta)?, &tree, &self.dictionary)?;
+            tree = decode_delta(
+                self.record(delta)?,
+                &tree,
+                &self.dictionary,
+                &self.record_decoder,
+            )?;
         }
         let found = tree.hash();
         if found != *expected {
@@ -307,7 +331,8 @@ impl Npk1Pack {
                     block.stored_len,
                 )?;
             }
-            let (state, entry) = lookup_record(record, &self.dictionary, wanted_name)?;
+            let (state, entry) =
+                lookup_record(record, &self.dictionary, wanted_name, &self.record_decoder)?;
             match state {
                 LookupState::Found => return Ok(entry),
                 LookupState::Removed => return Ok(None),

--- a/crates/objects/src/store/fs/npk1/tests.rs
+++ b/crates/objects/src/store/fs/npk1/tests.rs
@@ -5,7 +5,10 @@ use std::{num::NonZeroUsize, sync::Arc};
 use proptest::prelude::*;
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
-use super::{CHECKSUM_CHUNK_BYTES, CHECKSUM_LEN, MAX_CHAIN_DEPTH, Npk1Pack, TRAILER_HEADER_LEN};
+use super::{
+    CHECKSUM_CHUNK_BYTES, CHECKSUM_LEN, MAX_CHAIN_DEPTH, Npk1Pack, TRAILER_HEADER_LEN, VERSION,
+    codec::{decoded_record_blocks, reset_decoded_record_blocks},
+};
 use crate::{
     object::{Attribution, ContentHash, Principal, SpoolId, State, StateId, Tree, TreeEntry},
     store::{
@@ -131,6 +134,51 @@ fn pack_roundtrip_direct_lookup_and_loose_coexistence() {
             .expect("read old packed tree"),
         Some(trees[3].clone())
     );
+}
+
+#[test]
+fn version_one_pack_without_a_record_dictionary_still_roundtrips() {
+    let (_temp, store) = store();
+    let tree = related_tree(3, 16);
+    store.put_tree(&tree).expect("put v1 fixture tree");
+    repack(&store);
+    let path = only_npk1_path(&store);
+    let mut bytes = std::fs::read(&path).expect("read v2 fixture pack");
+    let records_offset =
+        u64::from_le_bytes(bytes[32..40].try_into().expect("records offset")) as usize;
+    let dictionary_offset =
+        u64::from_le_bytes(bytes[56..64].try_into().expect("record dictionary offset")) as usize;
+    assert_eq!(
+        dictionary_offset, records_offset,
+        "fixture has no dictionary"
+    );
+    bytes[4..8].copy_from_slice(&1u32.to_le_bytes());
+    bytes[56..64].fill(0);
+    let trailer_offset =
+        u64::from_le_bytes(bytes[48..56].try_into().expect("trailer offset")) as usize;
+    refresh_checksum_manifest(&mut bytes, trailer_offset);
+    std::fs::write(&path, bytes).expect("write checksummed v1 fixture");
+
+    let pack = Npk1Pack::open(&path).expect("open v1 pack");
+    assert_eq!(pack.resolve(&tree.hash()).expect("resolve v1 tree"), tree);
+}
+
+#[test]
+fn direct_lookup_decodes_only_the_selected_record_block() {
+    let (_temp, store) = store();
+    let tree = related_tree(7, 300);
+    store.put_tree(&tree).expect("put multi-block tree");
+    repack(&store);
+    let pack = Npk1Pack::open(&only_npk1_path(&store)).expect("open multi-block pack");
+    let wanted = tree.entries()[200].clone();
+
+    reset_decoded_record_blocks();
+    assert_eq!(
+        pack.lookup(&tree.hash(), wanted.name())
+            .expect("direct block lookup"),
+        Some(wanted)
+    );
+    assert_eq!(decoded_record_blocks(), 1);
 }
 
 #[test]
@@ -386,10 +434,23 @@ fn direct_lookup_verifies_only_the_touched_record_chunks() {
 
     let path = only_npk1_path(&store);
     let mut bytes = std::fs::read(&path).expect("read NPK1");
+    assert_eq!(
+        u32::from_le_bytes(bytes[4..8].try_into().expect("pack version")),
+        VERSION
+    );
     let object_count = u32::from_le_bytes(bytes[8..12].try_into().expect("object count")) as usize;
     let records_offset =
         u64::from_le_bytes(bytes[32..40].try_into().expect("records offset")) as usize;
     let index_offset = u64::from_le_bytes(bytes[40..48].try_into().expect("index offset")) as usize;
+    let dictionary_offset =
+        u64::from_le_bytes(bytes[56..64].try_into().expect("record dictionary offset")) as usize;
+    #[cfg(feature = "zstd")]
+    assert!(
+        dictionary_offset < records_offset,
+        "large v2 fixture must carry a trained record dictionary"
+    );
+    #[cfg(not(feature = "zstd"))]
+    assert_eq!(dictionary_offset, records_offset);
     let entries_start = index_offset + 16 + 256 * 4;
     let offsets_start = entries_start + object_count * 36;
     let indexed_hash = |ordinal: u32| {


### PR DESCRIPTION
Closes #1656
Refs #1652

## Summary

- raise independent NPK1 record-block compression from zstd level 3 to level 10
- retain selected raw anchor/delta blocks until the pack plan is complete, then train a 16–32 KiB per-pack zstd dictionary and encode every block independently
- write format v2 as `header | names | targets | record dictionary | records | index | checksum trailer`, with bytes 56–63 holding the record-dictionary offset
- keep v1 readable: a zero field means no record dictionary and the target section continues directly to records

## Test evidence

- `cargo build` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p heddle-objects npk1 --features zstd` — 13 passed
- `cargo test -p heddle-objects npk1` — 13 passed without zstd
- v2 round-trip: the repack staged verifier resolved all 9,270 NPK1 trees before publication; `heddle maintenance fsck --full --output json` then reported `valid: true`, 21,205 objects checked, no errors or warnings
- dual-version: the v2 reader consumed the real 9,270-tree v1 corpus to build v2; the checksummed v1 fixture test also resolves its tree through `Npk1Pack`
- seekability: `direct_lookup_decodes_only_the_selected_record_block` instruments decode and observes exactly one decoded block
- capture isolation: `build_npk1_pack` has one production caller, `fs/repack/operation.rs`; capture does not call it

### Real-corpus size

Corpus: all 804 commits from the storage-staging ancestry, 9,270 unique trees / 21,206 repacked objects.

| Encoding | Dictionary bytes | Record-section bytes | Dictionary + records | Delta vs v1 level 3 |
| --- | ---: | ---: | ---: | ---: |
| v1, level 3 | 0 | 536,876 | 536,876 | baseline |
| v1, level 10 only | 0 | 536,872 | 536,872 | -4 bytes (-0.000745%) |
| v2, level 10 + trained dictionary | 32,768 | 500,866 | 533,634 | -3,242 bytes net (-0.6039%) |

The dictionary reduces the record section itself by 36,010 bytes (6.7073%); after its 32 KiB section is included, the whole NPK1 pack falls from 1,277,575 to 1,274,333 bytes.

External falsifier: dumped all 9,270 raw blocks from the level-10 v1 pack and ran zstd 1.5.7 `--train --maxdict=32768`. Retained block payloads were 458,277 bytes at level 10 without a dictionary versus 416,717 with the trained dictionary (41,560 bytes gross; 8,792 bytes after dictionary cost). The table above reports the actual builder result, including record framing and the stored dictionary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905518&installation_model_id=21489&pr_number=1665&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1665&signature=0cdc2baa7089b94586ba840c52edbae2d90c45aad9f8892962e4e7224a577a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->