### PR TITLE
perf(storage): stop re-hashing trees on capture

### DIFF
--- a/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
@@ -9,6 +9,7 @@ use super::measurement::{CaseKind, CaseResult, NegativeControl};
 const WARM_CLEAN_STATUS_100K_P95_MS: f64 = 50.0;
 const ONE_PATH_STATUS_100K_P95_MS: f64 = 75.0;
 const ONE_PATH_CAPTURE_100K_P95_MS: f64 = 100.0;
+const ONE_PATH_CAPTURE_100K_MAX_OBJECT_DECODES: f64 = 1_010.0;
 const BOUNDED_LOCAL_READ_P95_MS: f64 = 100.0;
 
 #[derive(Deserialize)]
@@ -174,10 +175,17 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
     if let Some(capture_100k) = find(results, CaseKind::CaptureOne, 100_000) {
         let dirs = capture_100k.counter(|counters| counters.directories_scanned);
         let hashes = capture_100k.counter(|counters| counters.files_hashed);
+        let decodes = capture_100k.counter(|counters| counters.object_decodes);
         if dirs.p95 > 20.0 || hashes.max > 1.0 {
             failures.push(format!(
                 "warm structural gate: one-path capture @ 100k dirs p95 {:.0} (<=20), files hashed max {:.0} (<=1)",
                 dirs.p95, hashes.max
+            ));
+        }
+        if decodes.max > ONE_PATH_CAPTURE_100K_MAX_OBJECT_DECODES {
+            failures.push(format!(
+                "warm structural gate: one-path capture @ 100k object decodes max {:.0} (<= {:.0})",
+                decodes.max, ONE_PATH_CAPTURE_100K_MAX_OBJECT_DECODES
             ));
         }
     }

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -161,8 +161,8 @@ pub use tree_canonical::{
     TREE_LEAN_ENCODING_VERSION, TREE_LEAN_MAGIC, TreeDeltaHeader, TreeDeltaOp, TreeHeader,
     apply_tree_delta, decode_header, decode_lean_prefix, decode_tree_delta,
     decode_tree_delta_header, decode_tree_delta_header_prefix, decode_tree_delta_ops,
-    decode_tree_delta_ops_prefix, encode_lean_entry, encode_tree_delta, is_canonical_tree,
-    is_delta_tree, is_lean_tree, is_streamable_tree, tree_delta,
+    decode_tree_delta_ops_prefix, encode_lean_entry, encode_tree_delta, encoded_lean_size,
+    is_canonical_tree, is_delta_tree, is_lean_tree, is_streamable_tree, tree_delta,
 };
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;

--- a/crates/object-model/src/object/tree.rs
+++ b/crates/object-model/src/object/tree.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tree types: entries, structure, and supporting enums.
 
-use std::{fmt, path::Path, sync::Arc};
+use std::{
+    fmt,
+    path::Path,
+    sync::{Arc, OnceLock},
+};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
@@ -19,6 +23,42 @@ const ENTRY_KIND_GITLINK: u8 = 3;
 const ENTRY_KIND_SPOOLLINK: u8 = 4;
 const GIT_OBJECT_FORMAT_SHA1: u8 = 1;
 const GIT_OBJECT_FORMAT_SHA256: u8 = 2;
+pub(crate) const TREE_HASH_SCRATCH_LEN: usize = 4 * 1024;
+
+struct TreeHashWriter<'a> {
+    hasher: &'a mut blake3::Hasher,
+    scratch: &'a mut [u8; TREE_HASH_SCRATCH_LEN],
+    len: usize,
+}
+
+impl TreeHashWriter<'_> {
+    fn push(&mut self, byte: u8) {
+        if self.len == self.scratch.len() {
+            self.flush();
+        }
+        self.scratch[self.len] = byte;
+        self.len += 1;
+    }
+
+    fn extend(&mut self, mut bytes: &[u8]) {
+        while !bytes.is_empty() {
+            if self.len == self.scratch.len() {
+                self.flush();
+            }
+            let count = bytes.len().min(self.scratch.len() - self.len);
+            self.scratch[self.len..self.len + count].copy_from_slice(&bytes[..count]);
+            self.len += count;
+            bytes = &bytes[count..];
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.len > 0 {
+            self.hasher.update(&self.scratch[..self.len]);
+            self.len = 0;
+        }
+    }
+}
 
 // ── TreeError ───────────────────────────────────────────────────────
 
@@ -217,23 +257,23 @@ impl TreeEntryTarget {
         }
     }
 
-    fn update_hasher(&self, hasher: &mut blake3::Hasher) {
-        hasher.update(&[self.mode().to_byte()]);
-        hasher.update(&[self.entry_type().to_byte()]);
+    fn append_hash_bytes(&self, bytes: &mut TreeHashWriter<'_>) {
+        bytes.push(self.mode().to_byte());
+        bytes.push(self.entry_type().to_byte());
         match self {
             TreeEntryTarget::Blob { hash, .. }
             | TreeEntryTarget::Tree { hash }
-            | TreeEntryTarget::Symlink { hash } => hasher.update(hash.as_bytes()),
+            | TreeEntryTarget::Symlink { hash } => bytes.extend(hash.as_bytes()),
             TreeEntryTarget::Gitlink { target } => {
-                hasher.update(&[git_format_to_tag(target.format())]);
-                hasher.update(target.as_bytes())
+                bytes.push(git_format_to_tag(target.format()));
+                bytes.extend(target.as_bytes());
             }
             TreeEntryTarget::Spoollink { spool_id, state_id } => {
-                hasher.update(&(spool_id.as_str().len() as u32).to_le_bytes());
-                hasher.update(spool_id.as_str().as_bytes());
-                hasher.update(state_id.as_bytes())
+                bytes.extend(&(spool_id.as_str().len() as u32).to_le_bytes());
+                bytes.extend(spool_id.as_str().as_bytes());
+                bytes.extend(state_id.as_bytes());
             }
-        };
+        }
     }
 }
 
@@ -459,27 +499,47 @@ impl TreeEntry {
         self.name.len() + self.target.encoded_payload_len()
     }
 
-    pub(crate) fn update_hasher(&self, hasher: &mut blake3::Hasher) {
-        self.target.update_hasher(hasher);
-        hasher.update(self.name.as_bytes());
-        hasher.update(&[0]);
+    pub(crate) fn update_hasher(
+        &self,
+        hasher: &mut blake3::Hasher,
+        scratch: &mut [u8; TREE_HASH_SCRATCH_LEN],
+    ) {
+        let mut writer = TreeHashWriter {
+            hasher,
+            scratch,
+            len: 0,
+        };
+        self.target.append_hash_bytes(&mut writer);
+        writer.extend(self.name.as_bytes());
+        writer.push(0);
+        writer.flush();
     }
 }
 
 // ── Tree ────────────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Tree {
     // Trees are immutable on every read path and only change while a caller is
     // constructing a replacement tree. Sharing the entry vector makes those
     // read-path clones O(1); insert/remove detach with copy-on-write.
     entries: Arc<Vec<TreeEntry>>,
+    hash: OnceLock<ContentHash>,
 }
+
+impl PartialEq for Tree {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+    }
+}
+
+impl Eq for Tree {}
 
 impl Tree {
     pub fn new() -> Self {
         Self {
             entries: Arc::new(Vec::new()),
+            hash: OnceLock::new(),
         }
     }
 
@@ -487,6 +547,7 @@ impl Tree {
         entries.sort_by(|a, b| a.name.cmp(&b.name));
         Self {
             entries: Arc::new(entries),
+            hash: OnceLock::new(),
         }
     }
 
@@ -498,6 +559,7 @@ impl Tree {
     pub fn try_from_decoded_entries(entries: Vec<TreeEntry>) -> Result<Self, TreeError> {
         let tree = Self {
             entries: Arc::new(entries),
+            hash: OnceLock::new(),
         };
         tree.validate()?;
         Ok(tree)
@@ -539,11 +601,14 @@ impl Tree {
             .position(|e| e.name > entry.name)
             .unwrap_or(entries.len());
         entries.insert(pos, entry);
+        self.hash = OnceLock::new();
     }
 
     pub fn remove(&mut self, name: &str) -> Option<TreeEntry> {
         let pos = self.entries.iter().position(|e| e.name == name)?;
-        Some(Arc::make_mut(&mut self.entries).remove(pos))
+        let removed = Arc::make_mut(&mut self.entries).remove(pos);
+        self.hash = OnceLock::new();
+        Some(removed)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -555,11 +620,14 @@ impl Tree {
     }
 
     pub fn hash(&self) -> ContentHash {
-        let total_len: usize = self.entries.iter().map(TreeEntry::encoded_len).sum();
-        ContentHash::compute_typed_with_len("tree", total_len as u64, |hasher| {
-            for entry in self.entries.iter() {
-                entry.update_hasher(hasher);
-            }
+        *self.hash.get_or_init(|| {
+            let total_len: usize = self.entries.iter().map(TreeEntry::encoded_len).sum();
+            ContentHash::compute_typed_with_len("tree", total_len as u64, |hasher| {
+                let mut scratch = [0; TREE_HASH_SCRATCH_LEN];
+                for entry in self.entries.iter() {
+                    entry.update_hasher(hasher, &mut scratch);
+                }
+            })
         })
     }
 
@@ -898,6 +966,32 @@ mod spoollink_tests {
 mod cow_tests {
     use super::*;
 
+    fn legacy_hash(tree: &Tree) -> ContentHash {
+        let total_len: usize = tree.entries.iter().map(TreeEntry::encoded_len).sum();
+        ContentHash::compute_typed_with_len("tree", total_len as u64, |hasher| {
+            for entry in tree.entries.iter() {
+                hasher.update(&[entry.mode().to_byte()]);
+                hasher.update(&[entry.entry_type().to_byte()]);
+                match entry.target() {
+                    TreeEntryTarget::Blob { hash, .. }
+                    | TreeEntryTarget::Tree { hash }
+                    | TreeEntryTarget::Symlink { hash } => hasher.update(hash.as_bytes()),
+                    TreeEntryTarget::Gitlink { target } => {
+                        hasher.update(&[git_format_to_tag(target.format())]);
+                        hasher.update(target.as_bytes())
+                    }
+                    TreeEntryTarget::Spoollink { spool_id, state_id } => {
+                        hasher.update(&(spool_id.as_str().len() as u32).to_le_bytes());
+                        hasher.update(spool_id.as_str().as_bytes());
+                        hasher.update(state_id.as_bytes())
+                    }
+                };
+                hasher.update(entry.name.as_bytes());
+                hasher.update(&[0]);
+            }
+        })
+    }
+
     fn fixture() -> Tree {
         Tree::from_entries(vec![
             TreeEntry::file("a", ContentHash::compute(b"a"), false).unwrap(),
@@ -930,6 +1024,29 @@ mod cow_tests {
         assert_eq!(original.hash(), original_hash);
         assert_eq!(rmp_serde::to_vec_named(&original).unwrap(), original_bytes);
         assert_ne!(clone.hash(), original_hash);
+    }
+
+    #[test]
+    fn cached_batched_hash_matches_legacy_hash_domain() {
+        let gitlink = GitObjectId::from_raw(GitObjectFormat::Sha1, &[7; 20]).unwrap();
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("a-file", ContentHash::compute(b"file"), false).unwrap(),
+            TreeEntry::file("b-executable", ContentHash::compute(b"executable"), true).unwrap(),
+            TreeEntry::directory("c-directory", ContentHash::compute(b"directory")).unwrap(),
+            TreeEntry::symlink("d-symlink", ContentHash::compute(b"symlink")).unwrap(),
+            TreeEntry::gitlink("e-gitlink", gitlink).unwrap(),
+            TreeEntry::spoollink(
+                "f-spoollink",
+                SpoolId::parse("acme/child").unwrap(),
+                StateId::from_bytes([9; 32]),
+            )
+            .unwrap(),
+            TreeEntry::file("g".repeat(5_000), ContentHash::compute(b"long-name"), false).unwrap(),
+        ]);
+
+        let expected = legacy_hash(&tree);
+        assert_eq!(tree.hash(), expected);
+        assert_eq!(tree.hash(), expected, "cached lookup must remain identical");
     }
 
     #[test]

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -9,7 +9,8 @@
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
-    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeEntryTarget,
+    TreeError,
     tree::{git_format_from_tag, git_format_to_tag},
     tree_stream::TreeStreamError,
 };
@@ -201,6 +202,30 @@ impl Tree {
             Ok(raw)
         }
     }
+}
+
+/// Exact byte length of the HLR1 body without constructing it.
+pub fn encoded_lean_size(tree: &Tree) -> usize {
+    let mut size = TREE_LEAN_MAGIC.len() + varint_len(tree.len());
+    let mut previous = "";
+    for entry in tree.entries() {
+        let prefix = shared_prefix(previous, entry.name());
+        let suffix_len = entry.name().len() - prefix;
+        let target_len = match entry.target() {
+            TreeEntryTarget::Blob { hash, .. }
+            | TreeEntryTarget::Tree { hash }
+            | TreeEntryTarget::Symlink { hash } => hash.as_bytes().len(),
+            TreeEntryTarget::Gitlink { target } => 1 + target.as_bytes().len(),
+            TreeEntryTarget::Spoollink { spool_id, state_id } => {
+                varint_len(spool_id.as_str().len())
+                    + spool_id.as_str().len()
+                    + state_id.as_bytes().len()
+            }
+        };
+        size += 1 + varint_len(prefix) + varint_len(suffix_len) + suffix_len + target_len;
+        previous = entry.name();
+    }
+    size
 }
 
 /// Parse the fixed HTR4 header. Does not read entry frames.
@@ -731,6 +756,15 @@ fn put_varint(mut value: usize, out: &mut Vec<u8>) {
     out.push(value as u8);
 }
 
+fn varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
 pub(crate) fn take_varint(bytes: &[u8], offset: &mut usize) -> Result<usize, TreeStreamError> {
     let mut value = 0usize;
     for shift in (0..usize::BITS).step_by(7) {
@@ -1055,10 +1089,13 @@ pub fn encode_tree_delta(
             ops.len()
         )));
     }
-    if apply_tree_delta(anchor, ops)? != *current {
-        return Err(TreeStreamError::Malformed(
-            "tree delta operations do not reconstruct the result".into(),
-        ));
+    #[cfg(debug_assertions)]
+    {
+        let reconstructed = apply_tree_delta(anchor, ops)?;
+        debug_assert_eq!(
+            reconstructed, *current,
+            "tree delta operations must reconstruct the result"
+        );
     }
     let result_count = u32::try_from(current.len())
         .map_err(|_| TreeStreamError::Malformed("delta result count exceeds u32".into()))?;

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -6,7 +6,7 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
     ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
-    tree::git_format_from_tag,
+    tree::{TREE_HASH_SCRATCH_LEN, git_format_from_tag},
     tree_canonical::{
         TREE_BLOCK_ENCODING_VERSION, TREE_BLOCK_INDEX_LEN, TREE_BLOCK_PREAMBLE_LEN,
         TREE_ENCODING_VERSION, TREE_HEADER_LEN, TREE_LEAN_ENCODING_VERSION, TREE_LEAN_MAGIC,
@@ -165,6 +165,7 @@ pub struct TreeEntryReader<S: TreeByteSource> {
     layout: TreeReaderLayout,
     cursor: TreeResumeCursor,
     hasher: Option<blake3::Hasher>,
+    hash_scratch: [u8; TREE_HASH_SCRATCH_LEN],
     lean_hash_entries: Option<Vec<TreeEntry>>,
     decoded_logical_len: u64,
     started_at_zero: bool,
@@ -256,6 +257,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
             layout,
             cursor,
             hasher,
+            hash_scratch: [0; TREE_HASH_SCRATCH_LEN],
             lean_hash_entries,
             decoded_logical_len: 0,
             started_at_zero,
@@ -714,7 +716,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
             .into());
         }
         if let Some(hasher) = &mut self.hasher {
-            entry.update_hasher(hasher);
+            entry.update_hasher(hasher, &mut self.hash_scratch);
         }
         if let Some(entries) = &mut self.lean_hash_entries {
             entries.push(entry.clone());

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -446,8 +446,9 @@ fn mismatched_logical_len_fails_eager_and_streamed() {
     let forged_logical = actual_logical.saturating_add(8);
     bytes[53..61].copy_from_slice(&forged_logical.to_le_bytes());
     let forged_id = ContentHash::compute_typed_with_len("tree", forged_logical, |hasher| {
+        let mut scratch = [0; crate::object::tree::TREE_HASH_SCRATCH_LEN];
         for entry in tree.entries() {
-            entry.update_hasher(hasher);
+            entry.update_hasher(hasher, &mut scratch);
         }
     });
     bytes[5..37].copy_from_slice(forged_id.as_bytes());

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -9,8 +9,8 @@ use heddle_format::compression::{
 use crate::{
     object::{
         Action, ActionId, ContentHash, State, TREE_DELTA_ANCHOR_INTERVAL, TREE_DELTA_MAX_OPS, Tree,
-        decode_tree_delta, decode_tree_delta_header, encode_tree_delta, is_canonical_tree,
-        is_delta_tree, is_lean_tree, tree_delta,
+        decode_tree_delta, decode_tree_delta_header, encode_tree_delta, encoded_lean_size,
+        is_canonical_tree, is_delta_tree, is_lean_tree, tree_delta,
     },
     store::{HeddleError, Result},
 };
@@ -69,52 +69,27 @@ pub fn encode_tree(tree: &Tree, _config: &CompressionConfig) -> Result<(ContentH
 /// eligible descendants are cumulative HDC1 deltas against the epoch anchor.
 pub fn encode_tree_hot(tree: &Tree, base: Option<TreeDeltaBase<'_>>) -> Result<EncodedTree> {
     let hash = tree.hash();
-    let lean = tree.encode_lean()?;
     let Some(base) = base else {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+        return encode_tree_lean(tree, hash);
     };
     if hash == base.anchor_id {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+        return encode_tree_lean(tree, hash);
     }
     let Some(depth) = base.parent_depth.checked_add(1) else {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+        return encode_tree_lean(tree, hash);
     };
     if depth >= TREE_DELTA_ANCHOR_INTERVAL {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+        return encode_tree_lean(tree, hash);
     }
     let ops = tree_delta(base.anchor, tree);
     if ops.len() > TREE_DELTA_MAX_OPS {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+        return encode_tree_lean(tree, hash);
     }
     let delta = encode_tree_delta(base.anchor_id, base.anchor, tree, &ops)?;
     let header = decode_tree_delta_header(&delta)?;
     let porch_is_bounded = header.first_base_count <= 1 && header.hundred_base_count <= 100;
-    if !porch_is_bounded || delta.len() >= lean.len() {
-        return Ok(EncodedTree {
-            hash,
-            data: lean,
-            kind: TreeEncodingKind::Lean,
-        });
+    if !porch_is_bounded || delta.len() >= encoded_lean_size(tree) {
+        return encode_tree_lean(tree, hash);
     }
     Ok(EncodedTree {
         hash,
@@ -124,6 +99,14 @@ pub fn encode_tree_hot(tree: &Tree, base: Option<TreeDeltaBase<'_>>) -> Result<E
             depth,
             op_count: ops.len(),
         },
+    })
+}
+
+fn encode_tree_lean(tree: &Tree, hash: ContentHash) -> Result<EncodedTree> {
+    Ok(EncodedTree {
+        hash,
+        data: tree.encode_lean()?,
+        kind: TreeEncodingKind::Lean,
     })
 }
 
@@ -272,6 +255,7 @@ mod tests {
         let anchor = tree_fixture(240, None);
         let current = tree_fixture(240, Some((117, b"changed")));
         let lean = encode_tree_hot(&anchor, None).unwrap();
+        assert_eq!(encoded_lean_size(&anchor), lean.data.len());
         assert_eq!(lean.kind, TreeEncodingKind::Lean);
         assert_eq!(
             decode_tree_with_key(&lean.data, anchor.hash(), None).unwrap(),

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -818,12 +818,6 @@ impl FsStore {
             let body = codec::decode_tree_body(data.as_slice())?;
             let tree = validate_loaded_tree(self.decode_tree_storage_body(*hash, &body)?)?;
             heddle_perf_contract::record_object_decode();
-            if tree.hash() != *hash {
-                return Err(HeddleError::Corruption {
-                    expected: *hash,
-                    found: tree.hash(),
-                });
-            }
             if let Ok(mut cache) = self.recent_trees.write() {
                 cache.insert(*hash, tree.clone());
             }
@@ -845,12 +839,6 @@ impl FsStore {
             trace!("Found tree in packfile");
             let tree = validate_loaded_tree(self.decode_tree_storage_body(*hash, &data)?)?;
             heddle_perf_contract::record_object_decode();
-            if tree.hash() != *hash {
-                return Err(HeddleError::Corruption {
-                    expected: *hash,
-                    found: tree.hash(),
-                });
-            }
             if let Ok(mut cache) = self.recent_trees.write() {
                 cache.insert(*hash, tree.clone());
             }
@@ -959,19 +947,33 @@ impl FsStore {
             if lineage.anchor != header.anchor || lineage.depth == 0 {
                 return codec::encode_tree_hot(&write.tree, None);
             }
-            let Some(anchor_body) = self.try_get_tree_serialized_once(&lineage.anchor)? else {
-                return codec::encode_tree_hot(&write.tree, None);
+            let anchor = if let Some((_, anchor, _)) =
+                write
+                    .anchor
+                    .as_ref()
+                    .filter(|(anchor_id, _, parent_depth)| {
+                        *anchor_id == lineage.anchor && *parent_depth == lineage.depth
+                    }) {
+                anchor.clone()
+            } else if let Some(anchor) = self.recent_tree(&lineage.anchor) {
+                anchor
+            } else {
+                let Some(anchor_body) = self.try_get_tree_serialized_once(&lineage.anchor)? else {
+                    return codec::encode_tree_hot(&write.tree, None);
+                };
+                if is_delta_tree(&anchor_body) {
+                    return Err(HeddleError::InvalidObject(
+                        "HDC1 lineage points to another delta".to_string(),
+                    ));
+                }
+                codec::decode_tree_serialized_with_key(&anchor_body, lineage.anchor, None)?
             };
-            if is_delta_tree(&anchor_body) {
-                return Err(HeddleError::InvalidObject(
-                    "HDC1 lineage points to another delta".to_string(),
-                ));
-            }
-            let anchor =
-                codec::decode_tree_serialized_with_key(&anchor_body, lineage.anchor, None)?;
             Some((lineage.anchor, anchor, lineage.depth))
         } else {
-            let anchor = codec::decode_tree_serialized_with_key(&parent_body, parent, None)?;
+            let anchor = match write.anchor.as_ref() {
+                Some((anchor_id, anchor, 0)) if *anchor_id == parent => anchor.clone(),
+                _ => codec::decode_tree_serialized_with_key(&parent_body, parent, None)?,
+            };
             Some((parent, anchor, 0))
         };
         let Some((anchor_id, anchor, parent_depth)) = base else {

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -17,10 +17,11 @@ use crate::{
     fs_atomic::temp_path,
     object::{
         Action, Agent, Attribution, Blob, ContentHash, Operation, Principal, State, StateId, Tree,
-        TreeEntry,
+        TreeEntry, decode_tree_delta_header,
     },
     store::{
         ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult, TreeWrite,
+        codec::TreeEncodingKind,
         pack::{
             ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId,
             decode_tagged_entry_header,
@@ -1221,6 +1222,81 @@ fn loose_hdc1_reconstructs_from_one_materialized_anchor() {
     assert_eq!(rest.entries, current.entries()[100..]);
     reader.finish_and_verify().unwrap();
     assert_eq!(reopened.get_tree(&encoded.hash).unwrap(), Some(current));
+}
+
+#[test]
+fn direct_parent_hint_does_not_create_a_delta_chain() {
+    let (_temp, store) = create_test_store();
+    let anchor = Tree::from_entries(
+        (0..240)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("anchor-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
+    );
+    let anchor_id = store.put_tree(&anchor).unwrap();
+
+    let mut first_entries = anchor.entries().to_vec();
+    first_entries[117] = TreeEntry::file(
+        "module_0117.rs",
+        ContentHash::compute(b"first change"),
+        false,
+    )
+    .unwrap();
+    let first = Tree::from_entries(first_entries);
+    let first_encoded = store
+        .encode_tree_write(
+            &TreeWrite::descendant(first.clone(), anchor_id).with_anchor(
+                anchor_id,
+                anchor.clone(),
+                0,
+            ),
+        )
+        .unwrap();
+    store
+        .put_tree_serialized(&first_encoded.data, first_encoded.hash)
+        .unwrap();
+    store
+        .remember_tree_encoding(first_encoded.hash, first_encoded.kind)
+        .unwrap();
+
+    let mut second_entries = first.entries().to_vec();
+    second_entries[118] = TreeEntry::file(
+        "module_0118.rs",
+        ContentHash::compute(b"second change"),
+        false,
+    )
+    .unwrap();
+    let second = Tree::from_entries(second_entries);
+    let second_encoded = store
+        .encode_tree_write(
+            &TreeWrite::descendant(second, first_encoded.hash).with_anchor(
+                first_encoded.hash,
+                first,
+                0,
+            ),
+        )
+        .unwrap();
+
+    assert!(matches!(
+        second_encoded.kind,
+        TreeEncodingKind::Delta {
+            anchor,
+            depth: 2,
+            ..
+        } if anchor == anchor_id
+    ));
+    assert_eq!(
+        decode_tree_delta_header(&second_encoded.data)
+            .unwrap()
+            .anchor,
+        anchor_id
+    );
 }
 
 #[test]

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -62,18 +62,31 @@ pub use writer_lease::{
 pub struct TreeWrite {
     pub tree: Tree,
     pub parent: Option<ContentHash>,
+    pub anchor: Option<(ContentHash, Tree, u8)>,
 }
 
 impl TreeWrite {
     pub fn anchor(tree: Tree) -> Self {
-        Self { tree, parent: None }
+        Self {
+            tree,
+            parent: None,
+            anchor: None,
+        }
     }
 
     pub fn descendant(tree: Tree, parent: ContentHash) -> Self {
         Self {
             tree,
             parent: Some(parent),
+            anchor: None,
         }
+    }
+
+    /// Supply a materialized delta anchor and the immediate parent's depth
+    /// within that anchor's epoch.
+    pub fn with_anchor(mut self, hash: ContentHash, tree: Tree, parent_depth: u8) -> Self {
+        self.anchor = Some((hash, tree, parent_depth));
+        self
     }
 }
 

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -381,11 +381,11 @@ impl SnapshotMutation<'_> {
         debug!("Building tree from worktree");
         let (tree, tree_profile, supplied_blobs) = match &self.source {
             SnapshotSource::Worktree => {
-                let (tree, profile, revalidation_files, blobs, trees, monitor_token) =
+                let (tree, profile, revalidation_files, blobs, trees, monitor_token, baseline_tree) =
                     self.build_worktree_tree()?;
                 self.worktree_revalidation_files = Some(revalidation_files);
                 self.worktree_monitor_token = monitor_token;
-                (tree, profile, Some((blobs, trees)))
+                (tree, profile, Some((blobs, trees, baseline_tree)))
             }
             SnapshotSource::SuppliedTree(tree) => (tree.clone(), TreeBuildProfile::default(), None),
             SnapshotSource::SuppliedTreeWithBlobs { tree, blobs } => (
@@ -397,6 +397,7 @@ impl SnapshotMutation<'_> {
                         .map(|blob| (blob.hash(), blob.content().to_vec()))
                         .collect(),
                     Vec::new(),
+                    None,
                 )),
             ),
         };
@@ -471,7 +472,7 @@ impl SnapshotMutation<'_> {
             };
             // Eager semantic index first so risk-signal prune can use merkle
             // digests (`semantic_changed`) instead of an empty SemanticContext.
-            let semantic_result = if let Some((blobs, trees)) = supplied_blobs.as_ref() {
+            let semantic_result = if let Some((blobs, trees, _)) = supplied_blobs.as_ref() {
                 let source_blobs = blobs
                     .iter()
                     .map(|(hash, bytes)| (*hash, bytes.as_slice()))
@@ -499,7 +500,7 @@ impl SnapshotMutation<'_> {
             match semantic_result {
                 Ok((Some(hash), pending)) => {
                     semantic_index = Some(hash);
-                    if let Some((blobs, _)) = supplied_blobs.as_mut() {
+                    if let Some((blobs, _, _)) = supplied_blobs.as_mut() {
                         blobs.extend(pending);
                     }
                 }
@@ -515,7 +516,7 @@ impl SnapshotMutation<'_> {
             // resolve new.tree without a store read.
             let mut source_blobs = std::collections::HashMap::new();
             let mut source_trees = std::collections::HashMap::new();
-            if let Some((blobs, trees)) = supplied_blobs.as_ref() {
+            if let Some((blobs, trees, _)) = supplied_blobs.as_ref() {
                 source_blobs.extend(blobs.iter().map(|(hash, bytes)| (*hash, bytes.as_slice())));
                 source_trees.extend(
                     trees
@@ -543,7 +544,7 @@ impl SnapshotMutation<'_> {
             }
 
             if let Some(parent_state) = prior_state.as_ref() {
-                let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
+                let source_blobs = supplied_blobs.as_ref().map(|(blobs, _, _)| {
                     blobs
                         .iter()
                         .map(|(hash, bytes)| (*hash, bytes.as_slice()))
@@ -632,10 +633,10 @@ impl SnapshotMutation<'_> {
         }
         let worktree_tree_chain = supplied_blobs
             .as_ref()
-            .filter(|(_, trees)| trees.len() <= 32)
-            .map(|(_, trees)| trees.iter().map(|write| write.tree.clone()).collect())
+            .filter(|(_, trees, _)| trees.len() <= 32)
+            .map(|(_, trees, _)| trees.iter().map(|write| write.tree.clone()).collect())
             .unwrap_or_default();
-        if let Some((blobs, trees)) = supplied_blobs {
+        if let Some((blobs, trees, baseline_tree)) = supplied_blobs {
             let parent_tree = self
                 .prev_head
                 .map(|id| self.repo.store.get_state(&id))
@@ -646,7 +647,11 @@ impl SnapshotMutation<'_> {
                 Some(parent)
                     if parent != tree_hash && !self.repo.store.has_tree_locally(&tree_hash)? =>
                 {
-                    TreeWrite::descendant(tree.clone(), parent)
+                    let write = TreeWrite::descendant(tree.clone(), parent);
+                    match baseline_tree.filter(|baseline| baseline.hash() == parent) {
+                        Some(baseline) => write.with_anchor(parent, baseline, 0),
+                        None => write,
+                    }
                 }
                 Some(_) | None => TreeWrite::anchor(tree.clone()),
             };

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -14,9 +14,8 @@ use objects::{
     util::gitlink_placeholder_bytes,
     worktree::WorktreeStatus,
 };
-use tracing::{debug, instrument, trace, warn};
-
 use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument, trace, warn};
 
 use super::{
     HeddleError, Repository, Result,
@@ -85,6 +84,7 @@ pub(crate) type SnapshotTreeBuildOutput = (
     Vec<(ContentHash, Vec<u8>)>,
     Vec<TreeWrite>,
     Option<ChangeMonitorToken>,
+    Option<Tree>,
 );
 
 #[derive(Debug, Clone, Default)]
@@ -160,7 +160,9 @@ fn rewrite_single_tracked_file(
             return Ok(None);
         };
         let updated_hash = updated_child.hash();
-        descendant_trees.push(TreeWrite::descendant(updated_child, child_hash));
+        descendant_trees.push(
+            TreeWrite::descendant(updated_child, child_hash).with_anchor(child_hash, child, 0),
+        );
         TreeEntry::directory((*name).to_string(), updated_hash)?
     };
     let mut updated = tree.clone();
@@ -291,6 +293,7 @@ impl Repository {
                 output.pending_blobs,
                 output.pending_trees,
                 output.monitor_token,
+                baseline_tree.cloned(),
             ));
         }
         // Capture preflight may have advanced an fsmonitor cursor while
@@ -316,6 +319,7 @@ impl Repository {
                     output.pending_blobs,
                     output.pending_trees,
                     output.monitor_token,
+                    baseline_tree.cloned(),
                 )
             })
     }
@@ -1507,8 +1511,10 @@ fn append_ignore_file_patterns(patterns: &mut Vec<String>, path: &Path) -> Resul
 mod tests {
     use std::path::Path;
 
-    use objects::object::{ContentHash, LeafPolicy, Tree, TreeEntry, resolve_tree_path};
-    use objects::store::ObjectStore;
+    use objects::{
+        object::{ContentHash, LeafPolicy, Tree, TreeEntry, resolve_tree_path},
+        store::ObjectStore,
+    };
     use tempfile::TempDir;
 
     use crate::{


### PR DESCRIPTION
Closes #1654
Refs #1652

## Summary

- cache each semantic tree hash and batch entry bytes through a reusable 4 KiB scratch buffer without changing the hash domain
- carry capture-owned parent trees into `TreeWrite`, reuse valid materialized anchors, and preserve the one-hop HDC1 lineage rule
- size HLR1 arithmetically before encoding it, omit the release hot-path delta reconstruction self-check, and avoid duplicate read hashing
- gate `CaptureOne` at no more than 1,010 object decodes

## Test evidence

- `cargo build`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `cargo test -p heddle-object-model`: 263 unit + 34 integration tests pass
- focused HDC1 lineage, external-key, and repository tree-chain tests: pass
- hash-domain invariance covers every entry kind plus a >4 KiB name: pass
- `cargo bench -p heddle-cli --bench capture_allocations`:
  - 1k paths: 4,443 -> 4,131 allocations (-312, -7.02%); 2,300,823 -> 2,242,928 bytes (-57,895, -2.52%)
  - 100k paths: 188,982 -> 168,865 allocations (-20,117, -10.65%); 59,046,023 -> 57,459,175 bytes (-1,586,848, -2.69%)
- release perf contract, 100k `CaptureOne`:
  - 5-sample `snapshot_ms` p95: 679 ms before -> 267 ms after (-60.7%)
  - final 20-sample wall p95: 267.511 ms; object decodes max: 1,009 (new gate: <=1,010)
  - the local AMD Ryzen 7 7700 runner remains above the existing <=100 ms wall gate, so the enforced local run is red despite the strictly positive delta; the benchmark itself reports allocation counts but has no internal latency timer

No on-disk format, hash bytes, or entry ordering changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905686&installation_model_id=21489&pr_number=1666&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1666&signature=07ed9475b913f2ed5660707cd5d3f631e5d4d969f8253288725176fa8227d07f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->