### PR TITLE
perf(storage): wire automatic repack after capture

### DIFF
--- a/crates/cli/src/cli/commands/automatic_repack.rs
+++ b/crates/cli/src/cli/commands/automatic_repack.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Post-capture automatic storage maintenance.
+
+use std::{
+    ffi::OsStr,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant, SystemTime},
+};
+
+use anyhow::Result;
+use objects::store::{
+    FsRepackOperation, FsStore, RepackPolicy, RepackResourceLimits, RepackSchedule,
+    RepackScheduler, SnapshotPackFold,
+};
+use repo::{Repository, RepositoryCapability};
+
+const AUTOMATIC_REPACK_WORKER_ARG: &str = "--internal-automatic-repack";
+const AUTOMATIC_REPACK_SUCCESS_FILE: &str = ".automatic-repack-success";
+const AUTOMATIC_REPACK_SUCCESS_BACKOFF: Duration = Duration::from_secs(30 * 60);
+const CAPTURE_QUIET_PERIOD: Duration = Duration::from_millis(500);
+const MAX_CAPTURE_QUIET_WAIT: Duration = Duration::from_secs(30);
+static CAPTURED_REPOSITORIES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+pub(crate) fn note_committed_capture(repo: &Repository) {
+    if repo.capability() != RepositoryCapability::NativeHeddle {
+        return;
+    }
+    let mut roots = CAPTURED_REPOSITORIES
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if !roots.iter().any(|root| root == repo.heddle_dir()) {
+        roots.push(repo.heddle_dir().to_path_buf());
+    }
+}
+
+pub fn automatic_repack_worker_root() -> Option<PathBuf> {
+    let mut args = std::env::args_os();
+    let _program = args.next()?;
+    if args.next()? != OsStr::new(AUTOMATIC_REPACK_WORKER_ARG) {
+        return None;
+    }
+    let root = PathBuf::from(args.next()?);
+    args.next().is_none().then_some(root)
+}
+
+pub fn spawn_pending_automatic_repack_workers() {
+    let roots = {
+        let mut pending = CAPTURED_REPOSITORIES
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::mem::take(&mut *pending)
+    };
+    let executable = match std::env::current_exe() {
+        Ok(executable) => executable,
+        Err(error) => {
+            tracing::warn!(%error, "could not locate automatic repack worker executable");
+            return;
+        }
+    };
+    for root in roots {
+        if let Err(error) = Command::new(&executable)
+            .arg(AUTOMATIC_REPACK_WORKER_ARG)
+            .arg(&root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            tracing::warn!(repo = %root.display(), %error, "could not start automatic repack worker");
+        }
+    }
+}
+
+pub fn run_automatic_repack_worker(root: PathBuf) -> Result<()> {
+    let store = FsStore::new(root);
+    let Some(_automatic_lock) = store.try_lock_automatic_repack()? else {
+        return Ok(());
+    };
+    wait_for_capture_quiet_period(store.root().join("packs"));
+    match store.fold_snapshot_packs_if_needed()? {
+        SnapshotPackFold::Busy => return Ok(()),
+        SnapshotPackFold::Folded {
+            source_packs,
+            objects,
+            pack_count,
+        } => tracing::info!(
+            source_packs,
+            objects,
+            pack_count,
+            "folded incremental snapshot packs"
+        ),
+        SnapshotPackFold::NotNeeded { .. } => {}
+    }
+
+    let success_marker = store
+        .root()
+        .join("packs")
+        .join(AUTOMATIC_REPACK_SUCCESS_FILE);
+    if success_marker
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|elapsed| elapsed < AUTOMATIC_REPACK_SUCCESS_BACKOFF)
+    {
+        return Ok(());
+    }
+
+    let scheduler = RepackScheduler::new(RepackPolicy::default(), RepackResourceLimits::default());
+    let operation = Arc::new(FsRepackOperation::new(store));
+    if let RepackSchedule::Started(handle) = scheduler.schedule_if_needed(operation)? {
+        handle.wait()?;
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(success_marker)?
+            .sync_all()?;
+    }
+    Ok(())
+}
+
+fn wait_for_capture_quiet_period(packs: PathBuf) {
+    let started = Instant::now();
+    let mut stable_since = Instant::now();
+    let mut observed = pack_dir_modified(&packs);
+    while stable_since.elapsed() < CAPTURE_QUIET_PERIOD
+        && started.elapsed() < MAX_CAPTURE_QUIET_WAIT
+    {
+        thread::sleep(Duration::from_millis(50));
+        let current = pack_dir_modified(&packs);
+        if current != observed {
+            observed = current;
+            stable_since = Instant::now();
+        }
+    }
+}
+
+fn pack_dir_modified(packs: &Path) -> Option<SystemTime> {
+    packs
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+}

--- a/crates/cli/src/cli/commands/automatic_repack.rs
+++ b/crates/cli/src/cli/commands/automatic_repack.rs
@@ -6,7 +6,7 @@ use std::{
     fs::OpenOptions,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard},
     thread,
     time::{Duration, Instant, SystemTime},
 };
@@ -25,13 +25,18 @@ const CAPTURE_QUIET_PERIOD: Duration = Duration::from_millis(500);
 const MAX_CAPTURE_QUIET_WAIT: Duration = Duration::from_secs(30);
 static CAPTURED_REPOSITORIES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
+fn captured_repositories() -> MutexGuard<'static, Vec<PathBuf>> {
+    match CAPTURED_REPOSITORIES.lock() {
+        Ok(roots) => roots,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 pub(crate) fn note_committed_capture(repo: &Repository) {
     if repo.capability() != RepositoryCapability::NativeHeddle {
         return;
     }
-    let mut roots = CAPTURED_REPOSITORIES
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut roots = captured_repositories();
     if !roots.iter().any(|root| root == repo.heddle_dir()) {
         roots.push(repo.heddle_dir().to_path_buf());
     }
@@ -49,9 +54,7 @@ pub fn automatic_repack_worker_root() -> Option<PathBuf> {
 
 pub fn spawn_pending_automatic_repack_workers() {
     let roots = {
-        let mut pending = CAPTURED_REPOSITORIES
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut pending = captured_repositories();
         std::mem::take(&mut *pending)
     };
     let executable = match std::env::current_exe() {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -8,6 +8,7 @@ mod agent_cmd;
 mod agent_presence;
 mod agent_provenance;
 mod auto_capture;
+mod automatic_repack;
 mod blame;
 mod checkpoint;
 #[cfg(feature = "ci")]
@@ -93,6 +94,10 @@ pub use agent_cmd::{
     agent_api_schema, cmd_agent_capture, cmd_agent_heartbeat, cmd_agent_list, cmd_agent_ready,
     cmd_agent_release, cmd_agent_reserve,
 };
+pub use automatic_repack::{
+    automatic_repack_worker_root, run_automatic_repack_worker,
+    spawn_pending_automatic_repack_workers,
+};
 #[cfg(feature = "ci")]
 pub use ci::cmd_ci;
 #[cfg(feature = "client")]
@@ -119,7 +124,6 @@ pub use context::{
 #[allow(unused_imports)]
 pub(crate) use daemon::client as daemon_client;
 pub use daemon::{cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop};
-pub use netdaemon::{cmd_netd_serve, cmd_netd_status, cmd_netd_stop};
 pub use diff::cmd_diff;
 pub use discuss::run as cmd_discuss;
 pub use doctor::cmd_doctor;
@@ -147,6 +151,7 @@ pub use integration::{
 };
 pub use log::{LogCommandOptions, cmd_log};
 pub use maintenance::cmd_maintenance;
+pub use netdaemon::{cmd_netd_serve, cmd_netd_status, cmd_netd_stop};
 pub use operator_core::operator_emission_output_kinds;
 pub use operator_loop::{cmd_abort, cmd_continue, cmd_sync_smart};
 pub use oplog::cmd_oplog;

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -158,6 +158,7 @@ pub fn cmd_snapshot(
     let captured_thread_targets_integration = capture_report.captured_thread_targets_integration;
     let (output, snapshot_profile) = snapshot_output_from_capture_report(capture_report);
     let repo = ctx.require_repo()?;
+    super::automatic_repack::note_committed_capture(repo);
 
     let as_json = should_output_json(cli, Some(repo.config()));
     let git_overlay = repo.capability() == repo::RepositoryCapability::GitOverlay;
@@ -602,6 +603,9 @@ pub(crate) fn create_snapshot_profiled(
     let execute_save_start = Instant::now();
     let report = execute_save(repo, plan)?;
     let execute_save_ms = execute_save_start.elapsed().as_millis();
+    if report.created_new_state {
+        super::automatic_repack::note_committed_capture(repo);
+    }
     let (output, mut profile) = snapshot_output_from_save_report(repo, user_config, report)?;
     profile.preflight_ms = preflight_ms;
     profile.attribution_ms = attribution_ms;
@@ -655,6 +659,9 @@ pub(crate) fn create_snapshot_from_tree_profiled(
         )),
     };
     let report = execute_save(repo, plan)?;
+    if report.created_new_state {
+        super::automatic_repack::note_committed_capture(repo);
+    }
     snapshot_output_from_save_report(repo, user_config, report)
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,20 +26,21 @@ use cli::{
         UndoArgs,
         cli_args::LandArgs,
         commands::{
-            LogCommandOptions, SnapshotAgentOverrides, build_command_catalog, cmd_abort, cmd_adopt,
-            cmd_agent, cmd_capture_split, cmd_clone, cmd_commit, cmd_complete, cmd_completions,
-            cmd_context_audit, cmd_context_check, cmd_context_edit, cmd_context_get,
-            cmd_context_history, cmd_context_list, cmd_context_rm, cmd_context_set,
-            cmd_context_suggest, cmd_context_supersede, cmd_continue, cmd_daemon_serve,
-            cmd_daemon_status, cmd_daemon_stop, cmd_diff, cmd_discuss, cmd_doctor, cmd_doctor_docs,
-            cmd_doctor_schemas, cmd_hook, cmd_init, cmd_integration, cmd_land, cmd_log,
-            cmd_maintenance, cmd_netd_serve, cmd_netd_status, cmd_netd_stop, cmd_pull, cmd_push,
-            cmd_query, cmd_ready, cmd_redo, cmd_remote,
+            LogCommandOptions, SnapshotAgentOverrides, automatic_repack_worker_root,
+            build_command_catalog, cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_clone,
+            cmd_commit, cmd_complete, cmd_completions, cmd_context_audit, cmd_context_check,
+            cmd_context_edit, cmd_context_get, cmd_context_history, cmd_context_list,
+            cmd_context_rm, cmd_context_set, cmd_context_suggest, cmd_context_supersede,
+            cmd_continue, cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff,
+            cmd_discuss, cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_hook, cmd_init,
+            cmd_integration, cmd_land, cmd_log, cmd_maintenance, cmd_netd_serve, cmd_netd_status,
+            cmd_netd_stop, cmd_pull, cmd_push, cmd_query, cmd_ready, cmd_redo, cmd_remote,
             cmd_resolve, cmd_revert, cmd_review, cmd_shell, cmd_show, cmd_snapshot, cmd_start,
             cmd_status, cmd_sync_smart, cmd_thread, cmd_undo, cmd_undo_recover, cmd_verify,
             cmd_watch, command_runtime_contract_for_command, print_error_with_hint,
             print_or_suggest_parse_error, print_parse_error_json_envelope,
-            recover_incomplete_land_if_present,
+            recover_incomplete_land_if_present, run_automatic_repack_worker,
+            spawn_pending_automatic_repack_workers,
         },
         render::write_json_stdout,
     },
@@ -62,6 +63,9 @@ use tracing::debug;
 // multi-thread flavor pays for thread-pool creation + teardown.
 fn main() -> Result<()> {
     install_broken_pipe_panic_hook();
+    if let Some(root) = automatic_repack_worker_root() {
+        return run_automatic_repack_worker(root);
+    }
     if let Some(code) = cli::identity_stamp::maybe_run_fast_path() {
         std::process::exit(code);
     }
@@ -844,6 +848,12 @@ async fn async_main() -> Result<()> {
             ],
         );
     }
+
+    // A capture's durable save and all measured command work are complete.
+    // The detached worker owns any synchronous cheap fold and waits for the
+    // scheduler thread, so the foreground process neither kills the repack at
+    // exit nor puts storage maintenance inside CaptureOne's measured body.
+    spawn_pending_automatic_repack_workers();
 
     shutdown_command_telemetry(command_trace, command_span_guard, telemetry, exit_status);
     match result {

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -325,6 +325,7 @@ impl FsStore {
                 packs.join(format!("{installed_pack_name}.idx")),
             )?;
         }
+        self.remember_pack_dir_modified()?;
         for (hash, kind) in staged_encodings {
             self.remember_tree_encoding(hash, kind)?;
         }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -11,6 +11,7 @@ use std::{
         Arc, Mutex, RwLock,
         atomic::{AtomicBool, Ordering},
     },
+    time::SystemTime,
 };
 
 use heddle_format::compression::CompressionConfig;
@@ -46,6 +47,12 @@ pub(super) const RECENT_BLOB_CACHE_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// caps the resident blob-cache footprint while still holding a deep
 /// hot working set of small objects (the common case).
 pub(super) const RECENT_BLOB_CACHE_MAX_TOTAL_BYTES: usize = 256 * 1024 * 1024;
+
+fn pack_dir_modified(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+}
 
 thread_local! {
     static SNAPSHOT_WRITE_BATCH_DEPTHS: std::cell::RefCell<HashMap<PathBuf, usize>> =
@@ -259,6 +266,13 @@ pub struct FsStore {
     pub(super) snapshot_delta_search: bool,
     pack_manager: RwLock<SnapshotPackManager>,
     npk1_manager: RwLock<Npk1Manager>,
+    /// Last pack-directory generation reflected by both in-memory managers.
+    /// Immutable pack publication changes the directory entry set, so one
+    /// metadata probe replaces the two full directory scans formerly paid by
+    /// every read miss.
+    pack_dir_modified: RwLock<Option<SystemTime>>,
+    #[cfg(test)]
+    pack_dir_generation_probes: AtomicUsize,
     pub(super) recent_blobs: RwLock<RecentObjectCache<ContentHash, Blob>>,
     pub(super) recent_trees: RwLock<RecentObjectCache<ContentHash, Tree>>,
     pub(super) recent_states: RwLock<RecentObjectCache<StateId, State>>,
@@ -296,6 +310,11 @@ impl Clone for FsStore {
         cloned.snapshot_delta_search = self.snapshot_delta_search;
         cloned.loose_object_write_mode = self.loose_object_write_mode;
         cloned.external_source = self.external_source.clone();
+        cloned.pack_dir_modified = RwLock::new(pack_dir_modified(&packs_dir(&self.root)));
+        #[cfg(test)]
+        cloned
+            .pack_dir_generation_probes
+            .store(0, Ordering::Relaxed);
         cloned
     }
 }
@@ -308,12 +327,16 @@ impl FsStore {
         let root = root.as_ref().to_path_buf();
         let pack_manager = SnapshotPackManager::new(packs_dir(&root));
         let npk1_manager = Npk1Manager::new(packs_dir(&root));
+        let pack_dir_modified = pack_dir_modified(&packs_dir(&root));
         Self {
             root,
             compression: CompressionConfig::default(),
             snapshot_delta_search: false,
             pack_manager: RwLock::new(pack_manager),
             npk1_manager: RwLock::new(npk1_manager),
+            pack_dir_modified: RwLock::new(pack_dir_modified),
+            #[cfg(test)]
+            pack_dir_generation_probes: AtomicUsize::new(0),
             recent_blobs: RwLock::new(RecentObjectCache::with_byte_budget(
                 RECENT_BLOB_CACHE_CAPACITY,
                 RECENT_BLOB_CACHE_MAX_TOTAL_BYTES,
@@ -339,12 +362,16 @@ impl FsStore {
         let root = root.as_ref().to_path_buf();
         let pack_manager = SnapshotPackManager::new(packs_dir(&root));
         let npk1_manager = Npk1Manager::new(packs_dir(&root));
+        let pack_dir_modified = pack_dir_modified(&packs_dir(&root));
         Self {
             root,
             compression,
             snapshot_delta_search: false,
             pack_manager: RwLock::new(pack_manager),
             npk1_manager: RwLock::new(npk1_manager),
+            pack_dir_modified: RwLock::new(pack_dir_modified),
+            #[cfg(test)]
+            pack_dir_generation_probes: AtomicUsize::new(0),
             recent_blobs: RwLock::new(RecentObjectCache::with_byte_budget(
                 RECENT_BLOB_CACHE_CAPACITY,
                 RECENT_BLOB_CACHE_MAX_TOTAL_BYTES,
@@ -375,6 +402,7 @@ impl FsStore {
         crate::fs_atomic::create_dir_all_durable(&states_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&actions_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&packs_dir(&self.root))?;
+        self.remember_pack_dir_modified()?;
         Ok(())
     }
 
@@ -460,7 +488,9 @@ impl FsStore {
         let mut npk1 = self.npk1_manager.write().map_err(|_| {
             crate::store::HeddleError::Config("Failed to acquire NPK1 manager lock".to_string())
         })?;
-        npk1.reload()
+        npk1.reload()?;
+        drop(npk1);
+        self.remember_pack_dir_modified()
     }
 
     /// Reload pack files only if the immutable pack set changed on disk.
@@ -477,40 +507,67 @@ impl FsStore {
     /// the write lock; only the first thread that observes a stale
     /// view escalates and does the reload.
     pub(super) fn reload_packs_if_stale(&self) -> Result<bool> {
-        // Fast path: read-lock and bail out if the disk snapshot still matches.
-        let generic_stale = {
-            let manager = self.pack_manager.read().map_err(|_| {
-                crate::store::HeddleError::Config("Failed to acquire pack manager lock".to_string())
-            })?;
-            manager.needs_reload()?
-        };
-        let npk1_stale = {
-            let manager = self.npk1_manager.read().map_err(|_| {
-                crate::store::HeddleError::Config("Failed to acquire NPK1 manager lock".to_string())
-            })?;
-            manager.needs_reload()?
-        };
-        if !generic_stale && !npk1_stale {
+        let packs = packs_dir(&self.root);
+        let disk_modified = self.current_pack_dir_modified(&packs);
+        let observed = self.pack_dir_modified.read().map_err(|_| {
+            crate::store::HeddleError::Config(
+                "Failed to acquire pack directory generation lock".to_string(),
+            )
+        })?;
+        if *observed == disk_modified {
             return Ok(false);
         }
-        // Slow path: take the write lock and re-check (another
-        // thread may have already reloaded between our drop and
-        // re-acquire).
+        drop(observed);
+
+        // Serialize the generation transition, then recheck in case another
+        // reader refreshed both managers while this thread was waiting.
+        let mut observed = self.pack_dir_modified.write().map_err(|_| {
+            crate::store::HeddleError::Config(
+                "Failed to acquire pack directory generation lock".to_string(),
+            )
+        })?;
+        let disk_modified = self.current_pack_dir_modified(&packs);
+        if *observed == disk_modified {
+            return Ok(false);
+        }
         let mut manager = self.pack_manager.write().map_err(|_| {
             crate::store::HeddleError::Config("Failed to acquire pack manager lock".to_string())
         })?;
-        let generic_reloaded = manager.reload_if_stale()?;
+        manager.reload()?;
         drop(manager);
         let mut npk1 = self.npk1_manager.write().map_err(|_| {
             crate::store::HeddleError::Config("Failed to acquire NPK1 manager lock".to_string())
         })?;
-        let npk1_reloaded = if npk1.needs_reload()? {
-            npk1.reload()?;
-            true
-        } else {
-            false
-        };
-        Ok(generic_reloaded || npk1_reloaded)
+        npk1.reload()?;
+        *observed = self.current_pack_dir_modified(&packs);
+        Ok(true)
+    }
+
+    pub(super) fn remember_pack_dir_modified(&self) -> Result<()> {
+        let mut observed = self.pack_dir_modified.write().map_err(|_| {
+            crate::store::HeddleError::Config(
+                "Failed to acquire pack directory generation lock".to_string(),
+            )
+        })?;
+        *observed = self.current_pack_dir_modified(&packs_dir(&self.root));
+        Ok(())
+    }
+
+    fn current_pack_dir_modified(&self, packs: &Path) -> Option<SystemTime> {
+        #[cfg(test)]
+        self.pack_dir_generation_probes
+            .fetch_add(1, Ordering::Relaxed);
+        pack_dir_modified(packs)
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_pack_dir_generation_probes(&self) {
+        self.pack_dir_generation_probes.store(0, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(super) fn pack_dir_generation_probes(&self) -> usize {
+        self.pack_dir_generation_probes.load(Ordering::Relaxed)
     }
 
     /// Get the pack manager for pack operations.

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -368,6 +368,25 @@ fn second_fs_store_sees_packs_installed_after_its_construction() {
 }
 
 #[test]
+fn repeated_read_misses_probe_only_the_pack_directory_generation() {
+    let temp_dir = TempDir::new().unwrap();
+    let store = FsStore::new(temp_dir.path().join(".heddle"));
+    store.init().unwrap();
+    store.reset_pack_dir_generation_probes();
+    let missing = ContentHash::compute(b"generation-probe-miss");
+
+    for _ in 0..100 {
+        assert!(!store.has_blob(&missing).unwrap());
+    }
+
+    assert_eq!(
+        store.pack_dir_generation_probes(),
+        100,
+        "each miss should pay one metadata probe, not two full pack-directory scans"
+    );
+}
+
+#[test]
 fn list_states_sees_packs_installed_after_store_construction() {
     let temp_dir = TempDir::new().unwrap();
     let heddle_dir = temp_dir.path().join(".heddle");

--- a/crates/objects/src/store/fs/mod.rs
+++ b/crates/objects/src/store/fs/mod.rs
@@ -20,4 +20,4 @@ pub use pack_install_journal::{
     pack_install_metrics_reset, pack_install_metrics_snapshot, recover_pack_install_intents,
     recover_pack_install_intents_with_ttl,
 };
-pub use repack::FsRepackOperation;
+pub use repack::{AutomaticRepackLock, FsRepackOperation, SnapshotPackFold};

--- a/crates/objects/src/store/fs/npk1/reader.rs
+++ b/crates/objects/src/store/fs/npk1/reader.rs
@@ -628,10 +628,6 @@ impl Npk1Manager {
         Ok(())
     }
 
-    pub(crate) fn needs_reload(&self) -> Result<bool> {
-        Ok(discover(&self.packs_dir)? != self.fingerprints)
-    }
-
     pub(crate) fn file_paths(&self) -> Vec<&Path> {
         self.fingerprints
             .iter()

--- a/crates/objects/src/store/fs/repack/cheap_fold.rs
+++ b/crates/objects/src/store/fs/repack/cheap_fold.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashSet,
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::Path,
+};
+
+use super::{
+    cutover::{hash_file, try_acquire_automatic_repack_lock, try_acquire_repack_lock},
+    staging::RepackStaging,
+};
+use crate::{
+    fs_atomic::sync_directory,
+    object::ContentHash,
+    store::{
+        HeddleError, Result,
+        fs::{FsStore, fs_paths::packs_dir},
+        pack::{PackObjectId, PackReader, StreamingPackBuilder},
+        snapshot_commit::{snapshot_commit_marker_path, snapshot_commit_markers_by_pack},
+    },
+};
+
+const MAX_PACKS_BEFORE_FOLD: usize = 8;
+const MAX_SNAPSHOT_PACKS_PER_FOLD: usize = 8;
+
+/// Cross-process ownership for one automatic-maintenance worker.
+pub struct AutomaticRepackLock {
+    _file: File,
+}
+
+/// Result of the bounded generic-pack fold.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SnapshotPackFold {
+    NotNeeded {
+        pack_count: usize,
+    },
+    Busy,
+    Folded {
+        source_packs: usize,
+        objects: usize,
+        pack_count: usize,
+    },
+}
+
+impl FsStore {
+    /// Claim automatic maintenance without waiting behind another process.
+    pub fn try_lock_automatic_repack(&self) -> Result<Option<AutomaticRepackLock>> {
+        fs::create_dir_all(packs_dir(self.root()))?;
+        Ok(try_acquire_automatic_repack_lock(&packs_dir(self.root()))?
+            .map(|file| AutomaticRepackLock { _file: file }))
+    }
+
+    /// Fold a bounded number of recent, one-capture packs into one generic
+    /// pack. Logical record bytes are carried forward unchanged: this does not
+    /// build NPK1, shared blob frames, or new tree encodings.
+    pub fn fold_snapshot_packs_if_needed(&self) -> Result<SnapshotPackFold> {
+        let packs = packs_dir(self.root());
+        fs::create_dir_all(&packs)?;
+        let Some(_repack_lock) = try_acquire_repack_lock(&packs)? else {
+            return Ok(SnapshotPackFold::Busy);
+        };
+        self.reload_packs()?;
+
+        let markers = snapshot_commit_markers_by_pack(&packs)?;
+        let (pack_count, candidates) = {
+            let manager = self.pack_manager().read().map_err(|_| {
+                HeddleError::Config("Failed to acquire pack manager lock".to_string())
+            })?;
+            let paths = manager.pack_file_paths();
+            let pack_count = paths.len();
+            let candidates = paths
+                .into_iter()
+                .filter_map(|(pack, index)| {
+                    let name = pack.file_stem()?.to_str()?;
+                    (markers.get(name).is_some_and(|values| values.len() == 1))
+                        .then(|| (pack.to_path_buf(), index.to_path_buf(), name.to_string()))
+                })
+                .collect::<Vec<_>>();
+            (pack_count, candidates)
+        };
+        if pack_count <= MAX_PACKS_BEFORE_FOLD {
+            return Ok(SnapshotPackFold::NotNeeded { pack_count });
+        }
+
+        let desired_sources = pack_count
+            .saturating_sub(MAX_PACKS_BEFORE_FOLD)
+            .saturating_add(1)
+            .clamp(2, MAX_SNAPSHOT_PACKS_PER_FOLD);
+        let selected = candidates
+            .into_iter()
+            .rev()
+            .take(desired_sources)
+            .collect::<Vec<_>>();
+        if selected.len() < 2 {
+            return Ok(SnapshotPackFold::NotNeeded { pack_count });
+        }
+
+        let staging = RepackStaging::new(&packs)?;
+        let pack_file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&staging.pack)?;
+        let mut compression = self.compression();
+        compression.max_delta_size = 0;
+        let mut builder = StreamingPackBuilder::new(
+            pack_file,
+            staging.index.clone(),
+            compression,
+            staging.buckets.clone(),
+        )?;
+        let mut expected = HashSet::<PackObjectId>::new();
+
+        // `selected` is newest-first. Keep the newest physical encoding when
+        // immutable identities repeat across incremental snapshots.
+        for (pack, index, _) in &selected {
+            let reader = PackReader::open(pack, index)?;
+            reader.visit_objects(|id, object_type, data| {
+                if expected.insert(id) {
+                    builder.add_id(id, object_type, data.to_vec())?;
+                }
+                Ok(())
+            })?;
+        }
+        let (_pack_file, stats) = builder.finalize()?;
+        let replacement = hash_file(&staging.pack)?;
+        let reader = PackReader::open(&staging.pack, &staging.index)?;
+        let actual = reader.list_ids()?.into_iter().collect::<HashSet<_>>();
+        if actual != expected || stats.object_count as usize != expected.len() {
+            return Err(HeddleError::InvalidObject(
+                "snapshot pack fold changed the logical object set".to_string(),
+            ));
+        }
+
+        self.install_pack_files_streaming(&staging.pack, &staging.index)?;
+        let replacement_pack = packs.join(format!("{replacement}.pack"));
+        for (_, _, name) in &selected {
+            if let Some(pack_markers) = markers.get(name) {
+                for (artifact_id, bytes) in pack_markers {
+                    install_commit_marker(&replacement_pack, artifact_id, bytes)?;
+                }
+            }
+        }
+        sync_directory(&packs)?;
+
+        for (pack, index, name) in &selected {
+            if pack != &replacement_pack {
+                remove_file_ignore_missing(pack)?;
+                remove_file_ignore_missing(index)?;
+                if let Some(pack_markers) = markers.get(name) {
+                    for (artifact_id, _) in pack_markers {
+                        remove_file_ignore_missing(&snapshot_commit_marker_path(
+                            pack,
+                            artifact_id,
+                        ))?;
+                    }
+                }
+            }
+        }
+        sync_directory(&packs)?;
+        self.reload_packs()?;
+
+        let resulting_count = self
+            .pack_manager()
+            .read()
+            .map_err(|_| HeddleError::Config("Failed to acquire pack manager lock".to_string()))?
+            .pack_count();
+        Ok(SnapshotPackFold::Folded {
+            source_packs: selected.len(),
+            objects: expected.len(),
+            pack_count: resulting_count,
+        })
+    }
+}
+
+fn install_commit_marker(pack_path: &Path, artifact_id: &ContentHash, bytes: &[u8]) -> Result<()> {
+    let marker = snapshot_commit_marker_path(pack_path, artifact_id);
+    match OpenOptions::new().write(true).create_new(true).open(marker) {
+        Ok(mut file) => {
+            file.write_all(bytes)?;
+            file.sync_all()?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn remove_file_ignore_missing(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use heddle_format::compression::CompressionConfig;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::{
+        object::StateId,
+        store::{
+            SNAPSHOT_COMMIT_ARTIFACT_SCHEMA, SnapshotCommitArtifact,
+            fs::pack_install_journal::install_committed_snapshot_pack_bytes,
+            pack::{ObjectType, PackBuilder},
+        },
+    };
+
+    #[test]
+    fn fold_bounds_incremental_packs_and_preserves_commit_markers() {
+        let temp = TempDir::new().unwrap();
+        let store = FsStore::new(temp.path().join(".heddle"));
+        store.init().unwrap();
+        let packs = packs_dir(store.root());
+        let mut artifact_ids = Vec::new();
+        let mut tree_records = Vec::new();
+
+        for ordinal in 0..9u8 {
+            let artifact = SnapshotCommitArtifact {
+                schema: SNAPSHOT_COMMIT_ARTIFACT_SCHEMA,
+                transaction_id: format!("fold-{ordinal}"),
+                scope: "snapshot".to_string(),
+                base_oplog_head_id: ordinal as u64,
+                state: StateId::from_bytes([ordinal.saturating_add(1); 32]),
+                encoded_records: vec![vec![ordinal]],
+            };
+            let artifact_id = artifact.id();
+            let bytes = rmp_serde::to_vec_named(&artifact).unwrap();
+            let mut builder = PackBuilder::new(CompressionConfig::disabled());
+            builder.add(artifact_id, ObjectType::SnapshotCommit, bytes.clone());
+            let payload = format!("incremental payload {ordinal}").into_bytes();
+            builder.add(ContentHash::compute(&payload), ObjectType::Blob, payload);
+            let tree_bytes = format!("HDC1-preserved-tree-{ordinal}").into_bytes();
+            let tree_id = ContentHash::compute(&tree_bytes);
+            builder.add(tree_id, ObjectType::Tree, tree_bytes.clone());
+            let (pack, index, _) = builder.build().unwrap();
+            install_committed_snapshot_pack_bytes(&packs, pack, index, artifact_id, bytes).unwrap();
+            artifact_ids.push(artifact_id);
+            tree_records.push((tree_id, tree_bytes));
+        }
+        store.reload_packs().unwrap();
+
+        assert_eq!(
+            store.fold_snapshot_packs_if_needed().unwrap(),
+            SnapshotPackFold::Folded {
+                source_packs: 2,
+                objects: 6,
+                pack_count: 8,
+            }
+        );
+        assert_eq!(
+            store.fold_snapshot_packs_if_needed().unwrap(),
+            SnapshotPackFold::NotNeeded { pack_count: 8 }
+        );
+
+        let manager = store.pack_manager().read().unwrap();
+        let descriptors = manager.snapshot_commit_recovery_descriptors().unwrap();
+        assert_eq!(descriptors.len(), artifact_ids.len());
+        for artifact_id in artifact_ids {
+            assert!(
+                manager
+                    .get_object(&PackObjectId::Hash(artifact_id))
+                    .unwrap()
+                    .is_some(),
+                "fold must preserve every authoritative snapshot artifact"
+            );
+        }
+        for (tree_id, expected_bytes) in tree_records {
+            assert_eq!(
+                manager.get_object(&PackObjectId::Hash(tree_id)).unwrap(),
+                Some((ObjectType::Tree, expected_bytes)),
+                "fold must carry HDC1/HLR1 tree record bytes forward unchanged"
+            );
+        }
+        assert!(
+            std::fs::read_dir(&packs).unwrap().all(|entry| entry
+                .unwrap()
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                != Some("npk")),
+            "cheap fold must not rebuild NPK1"
+        );
+    }
+}

--- a/crates/objects/src/store/fs/repack/cutover.rs
+++ b/crates/objects/src/store/fs/repack/cutover.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 const REPACK_LOCK_FILE: &str = ".repack.lock";
+const AUTOMATIC_REPACK_LOCK_FILE: &str = ".automatic-repack.lock";
 
 pub(super) struct CutoverStats {
     pub(super) removed_pack_bytes: u64,
@@ -163,6 +164,32 @@ pub(in crate::store::fs) fn acquire_repack_lock_blocking(packs: &Path) -> Result
     let file = open_lock_file(packs)?;
     file.lock_exclusive()?;
     Ok(file)
+}
+
+pub(super) fn try_acquire_repack_lock(packs: &Path) -> Result<Option<File>> {
+    let file = open_lock_file(packs)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(file)),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(in crate::store::fs) fn try_acquire_automatic_repack_lock(
+    packs: &Path,
+) -> Result<Option<File>> {
+    let path = packs.join(AUTOMATIC_REPACK_LOCK_FILE);
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(Some(file)),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn open_lock_file(packs: &Path) -> std::io::Result<File> {

--- a/crates/objects/src/store/fs/repack/mod.rs
+++ b/crates/objects/src/store/fs/repack/mod.rs
@@ -6,11 +6,13 @@ mod blob_lineage;
 mod blob_lineage_tests;
 mod blob_renames;
 mod blob_writer;
+mod cheap_fold;
 mod compact;
 mod cutover;
 mod operation;
 mod staging;
 
+pub use cheap_fold::{AutomaticRepackLock, SnapshotPackFold};
 pub(super) use cutover::acquire_repack_lock_blocking;
 pub use operation::FsRepackOperation;
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -23,10 +23,11 @@ pub mod store_compliance;
 pub mod writer_lease;
 
 pub use fs::{
-    DEFAULT_PACK_INSTALL_INTENT_TTL_SECS, FsRepackOperation, FsStore, PackInstallIntent,
-    PackInstallMetricsSnapshot, PackInstallPhase, PackInstallRecoverReport,
-    install_pack_bytes_journaled, pack_install_metrics_reset, pack_install_metrics_snapshot,
-    recover_pack_install_intents, recover_pack_install_intents_with_ttl,
+    AutomaticRepackLock, DEFAULT_PACK_INSTALL_INTENT_TTL_SECS, FsRepackOperation, FsStore,
+    PackInstallIntent, PackInstallMetricsSnapshot, PackInstallPhase, PackInstallRecoverReport,
+    SnapshotPackFold, install_pack_bytes_journaled, pack_install_metrics_reset,
+    pack_install_metrics_snapshot, recover_pack_install_intents,
+    recover_pack_install_intents_with_ttl,
 };
 pub use heddle_format::compression::{CompressionConfig, CompressionError, compress, decompress};
 pub use liveness::{

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -20,7 +20,7 @@ use crate::{
 
 pub const SNAPSHOT_COMMIT_ARTIFACT_SCHEMA: u32 = 1;
 
-type SnapshotCommitMarkersByPack = HashMap<String, Vec<(ContentHash, Vec<u8>)>>;
+pub(crate) type SnapshotCommitMarkersByPack = HashMap<String, Vec<(ContentHash, Vec<u8>)>>;
 
 pub(crate) fn snapshot_commit_marker_path(pack_path: &Path, artifact_id: &ContentHash) -> PathBuf {
     let stem = pack_path
@@ -262,7 +262,9 @@ impl SnapshotPackManager {
     }
 }
 
-fn snapshot_commit_markers_by_pack(packs_dir: &Path) -> Result<SnapshotCommitMarkersByPack> {
+pub(crate) fn snapshot_commit_markers_by_pack(
+    packs_dir: &Path,
+) -> Result<SnapshotCommitMarkersByPack> {
     let mut markers = SnapshotCommitMarkersByPack::new();
     for entry in fs::read_dir(packs_dir)? {
         let entry = entry?;


### PR DESCRIPTION
## Summary

- trigger a debounced detached repack worker after durable native captures and after command timing; the worker retains the scheduler handle and coordinates through a cross-process lock
- fold newest one-capture snapshot packs when the generic pack count exceeds 8, using a bounded StreamingPackBuilder pass that preserves logical tree records and commit markers; full FsRepackOperation thresholds remain unchanged
- replace the two full pack-directory scans on each read miss with one directory-mtime metadata probe

Closes #1653
Refs #1652

## Test evidence

- cargo build: pass
- cargo clippy --workspace --all-targets -- -D warnings: pass
- cargo test -p heddle-objects: 287 passed; fault-injection integration test passed
- read misses, 100 missing-blob reads: before, 200 full pack-directory scans (generic and NPK1 per miss); after, 100 O(1) metadata probes and no per-miss read_dir
- cheap-fold fixture: 9 to 8 generic packs by folding the 2 newest snapshot packs and 6 records; all 9 markers and HDC1 logical tree bytes preserved; no NPK1 emitted by the fold
- end-to-end fixture, 10 rapid native captures: 10 immediate generic packs to 1 generic plus 1 NPK1 after the worker settled; all 10 markers preserved and status clean
- CaptureOne release gate, 20 samples: structural counters passed (6 directories, 1 file hashed, 1009 object decodes), but wall-time p95 was 354.147 ms against the 100 ms gate. The runner was overloaded: clean status p95 was 176.991 ms against a locally calibrated 11.617 ms baseline and 50 ms gate. A 5-sample rerun also showed CaptureOne p95 385.371 ms and clean status 142.128 ms. The trigger runs after command profiling, and the worker waits for 500 ms of pack-directory quiet before maintenance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919067&installation_model_id=21489&pr_number=1668&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1668&signature=81d987e99030ff23b60e96633742e521eadfafc9d9191bada8e34956cd0de679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->