### PR TITLE
chore(deps): heddle 0.16.0 onto api 0.24.0 + cv 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.15.8"
+version = "0.16.0"
 
 [[package]]
 name = "heddle-format"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2578,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.15.8"
+version = "0.16.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.15.8"
+version = "0.16.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -5087,7 +5087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5120,7 +5120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6898,7 +6898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e082bd2ce66eaf172ada9e6e44910c4ac69a507914121a03ab9f6b6e03c5b3ac"
+checksum = "c66a7868c6fdcb25b05d7b1a90008adeb21c30ccea387c3e7397af1c277704c0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57b537ef09cee99f292bd1a43640c3a1cdaeacb9e9eeed553c4b3355f81f057"
+checksum = "513d588f63cec67467e14b805feb1d7ba536cd8db58216f61f501a3fecf2bbc7"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.23.0" }
+api = { package = "heddle-api", version = "0.24.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.5", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.5", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.5", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.5" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.5" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.5", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.5" }
-heddle-pack = { path = "crates/pack", version = "0.15.5" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.5" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.5", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.5" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.5" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.5" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.5" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.5", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.5", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.5" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.5" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.5" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.5", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.5" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.5", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.5" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.5" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.5" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.5", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.5", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.15.8", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.8", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.15.8", default-features = false }
+heddle-format = { path = "crates/format", version = "0.15.8" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.8" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.15.8", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.15.8" }
+heddle-pack = { path = "crates/pack", version = "0.15.8" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.8" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.8", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.8" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.8" }
+config = { path = "crates/config", package = "heddle-config", version = "0.15.8" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.8" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.8", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.8", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.8" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.8" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.8" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.8", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.8" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.8", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.8" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.8" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.8" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.8", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.8", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.8"
+version = "0.16.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.15.8", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.15.8", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.15.8", default-features = false }
-heddle-format = { path = "crates/format", version = "0.15.8" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.15.8" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.15.8", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.15.8" }
-heddle-pack = { path = "crates/pack", version = "0.15.8" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.15.8" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.15.8", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.15.8" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.15.8" }
-config = { path = "crates/config", package = "heddle-config", version = "0.15.8" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.15.8" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.15.8", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.15.8", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.15.8" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.15.8" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.15.8" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.15.8", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.15.8" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.15.8", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.15.8" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.15.8" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.15.8" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.15.8", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.15.8", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.16.0", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.16.0", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.16.0", default-features = false }
+heddle-format = { path = "crates/format", version = "0.16.0" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.16.0" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.16.0", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.16.0" }
+heddle-pack = { path = "crates/pack", version = "0.16.0" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.16.0" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.16.0", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.16.0" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.16.0" }
+config = { path = "crates/config", package = "heddle-config", version = "0.16.0" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.16.0" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.16.0", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.16.0", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.16.0" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.16.0" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.16.0" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.16.0", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.16.0" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.16.0", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.16.0" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.16.0" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.16.0" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.16.0", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.16.0", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.15.8",
+  "schemaVersion": "0.16.0",
   "verbs": {
     "abort": {
       "$defs": {
@@ -24968,6 +24968,46 @@
         "bytes_reclaimed"
       ],
       "title": "MaintenanceRepackSchema",
+      "type": "object"
+    },
+    "netd serve": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "netd status": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "netd_status"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "netd stop": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "netd_stop"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
       "type": "object"
     },
     "pull": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.15.8" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.16.0" as const;
 
 export interface AbortSchema {
   action: OperatorAction;
@@ -1740,6 +1740,18 @@ export interface MaterializedThreadInfo {
   stale: boolean;
   state_id: string;
   tree_hash_short: string;
+}
+
+export type NetdServeSchema = Record<string, unknown>;
+
+export interface NetdStatusSchema {
+  output_kind: "netd_status";
+  [key: string]: unknown;
+}
+
+export interface NetdStopSchema {
+  output_kind: "netd_stop";
+  [key: string]: unknown;
 }
 
 /** The pending review state echoed under `review next`'s `next` field. */
@@ -3566,6 +3578,9 @@ export interface HeddleVerbOutputs {
   "maintenance oplog recover": MaintenanceOplogRecoverSchema;
   "maintenance refresh": MaintenanceRefreshSchema;
   "maintenance repack": MaintenanceRepackSchema;
+  "netd serve": NetdServeSchema;
+  "netd status": NetdStatusSchema;
+  "netd stop": NetdStopSchema;
   pull: PullOutput;
   push: PushOutput;
   query: QueryReport;
@@ -3730,6 +3745,9 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "maintenance oplog recover",
   "maintenance refresh",
   "maintenance repack",
+  "netd serve",
+  "netd status",
+  "netd stop",
   "pull",
   "push",
   "query",

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -326,6 +326,9 @@ fn bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5() {
 }
 
 #[test]
+// This deliberately exercises the legacy single-key device_public_key path.
+// Migrating CLI owner-root flows to the two-key model is a separate effort.
+#[allow(deprecated)]
 fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
     let _home = IsolatedHome::new();
     finish_invite_create_from_response(
@@ -416,6 +419,9 @@ fn register_public_key_claim_refuses_a_replacement_seq0() {
 }
 
 #[test]
+// This deliberately exercises the legacy single-key device_public_key path.
+// Migrating CLI owner-root flows to the two-key model is a separate effort.
+#[allow(deprecated)]
 fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
     let _home = IsolatedHome::new();
     finish_invite_create_from_response(

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.12"
+heddleco-capability-verifier = "0.13.0"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
Closes #1664

## Dep + version bumps
- `heddle-api` 0.23.0 → **0.24.0**
- `heddleco-capability-verifier` 0.12 → **0.13.0**
- workspace publish set and every internal inter-crate pin 0.15.8 → **0.16.0**
- `Cargo.lock` regenerated for the 0.16.0 graph

## Regenerated freshness artifacts
- `clients/npm/generated/heddle-schemas.json`
- `clients/npm/generated/heddle-schemas.ts`
- `llms.txt` / `llms-full.txt` checked fresh with no diff

## Deprecation compatibility
The existing first commit keeps the legacy single-key owner-root tests on the deprecated `device_public_key` path under documented `#[allow(deprecated)]` annotations. Migrating the CLI to the API 0.24 two-key model remains separate.

## Test evidence
- `cargo build --workspace` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `rustfmt +nightly --check` on the touched Rust test file — green
- `ts_types_in_sync` — green
- `heddle-docsgen --check` — green
- `check-dependency-version-bump.py origin/main HEAD` — green (0.15.8 → 0.16.0)
- `check-published-api-graph.py` — green (29/29 published crates, one API line)
- `cargo test --workspace` — reaches `cli_output_contracts`; 3 assertions reproduce individually in source paths unchanged from `main` (`native_capture_excludes_git_admin_storage_created_after_init` and two default-main `sync` tests). No out-of-scope source changes included.
- GitHub `fast-check` — green (build, strict clippy, workspace lib/bin unit tests)
- GitHub `Dependency change requires version bump` — green
- GitHub `Published crates use one heddle-api line` — green
- GitHub client-schema freshness coverage — green via `fast-check`
