### PR TITLE
perf(storage): bound compact-frame point reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
  "heddle-format",
  "heddle-fs-prims",
  "heddle-object-model",
+ "heddle-perf-contract",
  "memmap2",
  "rmp-serde",
  "tempfile",

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -176,6 +176,16 @@ fn record_structural_counters() {
                 "git_reachable_copy_operations",
                 counters.git_reachable_copy_operations,
             ),
+            ProfileField::count(
+                "pack_frame_decompressions",
+                counters.pack_frame_decompressions,
+            ),
+            ProfileField::count("pack_frame_cache_hits", counters.pack_frame_cache_hits),
+            ProfileField::count("pack_blob_bodies_hashed", counters.pack_blob_bodies_hashed),
+            ProfileField::count(
+                "pack_state_frames_decoded",
+                counters.pack_state_frames_decoded,
+            ),
         ],
     );
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
@@ -141,6 +141,16 @@ impl PerfFixture {
         println!("SETUP additional_threads={count}");
     }
 
+    pub(super) fn repack(&self, binary: &Path) {
+        let start = Instant::now();
+        run_setup(
+            binary,
+            &["--output", "json", "maintenance", "repack"],
+            &self.root,
+        );
+        println!("SETUP repacked_ms={}", start.elapsed().as_millis());
+    }
+
     pub(super) fn prepare_full_scan_sample(&self) {
         let index = self.root.join(".heddle/state/index.bin");
         match fs::remove_file(index) {

--- a/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
@@ -205,10 +205,14 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
     for kind in [
         CaseKind::DiffOne,
         CaseKind::LogBounded,
+        CaseKind::DiffOneRepacked,
+        CaseKind::LogBoundedRepacked,
         CaseKind::ThreadListBounded,
     ] {
         enforce_absolute_p95(results, kind, BOUNDED_LOCAL_READ_P95_MS, &mut failures);
     }
+
+    enforce_repacked_reads(results, &mut failures);
 
     if !failures.is_empty() {
         eprintln!("PERF GATE RED");
@@ -216,6 +220,46 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
             eprintln!("  - {failure}");
         }
         panic!("{} core-loop performance gate(s) failed", failures.len());
+    }
+}
+
+fn enforce_repacked_reads(results: &[CaseResult], failures: &mut Vec<String>) {
+    let Some(diff) = find(results, CaseKind::DiffOneRepacked, 100_000) else {
+        failures.push("repacked read gate: missing diff_one_repacked @ 100000 paths".to_string());
+        return;
+    };
+    let diff_decompressions = diff.counter(|counters| counters.pack_frame_decompressions);
+    let diff_blob_hashes = diff.counter(|counters| counters.pack_blob_bodies_hashed);
+    let diff_state_decodes = diff.counter(|counters| counters.pack_state_frames_decoded);
+    println!(
+        "REPACKED_READ case=diff_one_repacked frame_decompressions={} blob_bodies_hashed={} state_frames_decoded={}",
+        diff_decompressions, diff_blob_hashes, diff_state_decodes
+    );
+    if diff_decompressions.max > 2.0 || diff_blob_hashes.max > 128.0 || diff_state_decodes.max > 1.0
+    {
+        failures.push(format!(
+            "repacked diff gate: frame decompressions max {:.0} (<=2), blob bodies hashed max {:.0} (<=128), state frames decoded max {:.0} (<=1)",
+            diff_decompressions.max, diff_blob_hashes.max, diff_state_decodes.max
+        ));
+    }
+
+    let Some(log) = find(results, CaseKind::LogBoundedRepacked, 100_000) else {
+        failures
+            .push("repacked read gate: missing log_bounded_repacked @ 100000 paths".to_string());
+        return;
+    };
+    let log_decompressions = log.counter(|counters| counters.pack_frame_decompressions);
+    let log_cache_hits = log.counter(|counters| counters.pack_frame_cache_hits);
+    let log_state_decodes = log.counter(|counters| counters.pack_state_frames_decoded);
+    println!(
+        "REPACKED_READ case=log_bounded_repacked frame_decompressions={} frame_cache_hits={} state_frames_decoded={}",
+        log_decompressions, log_cache_hits, log_state_decodes
+    );
+    if log_decompressions.max > 1.0 || log_state_decodes.max > 1.0 || log_cache_hits.p50 < 19.0 {
+        failures.push(format!(
+            "repacked log gate: frame decompressions max {:.0} (<=1), state frames decoded max {:.0} (<=1), frame cache hits p50 {:.0} (>=19)",
+            log_decompressions.max, log_state_decodes.max, log_cache_hits.p50
+        ));
     }
 }
 

--- a/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
@@ -46,6 +46,8 @@ pub(super) enum CaseKind {
     CaptureOne,
     DiffOne,
     LogBounded,
+    DiffOneRepacked,
+    LogBoundedRepacked,
     ThreadListBounded,
 }
 
@@ -59,6 +61,8 @@ impl CaseKind {
             Self::CaptureOne => "capture_one",
             Self::DiffOne => "diff_one",
             Self::LogBounded => "log_bounded",
+            Self::DiffOneRepacked => "diff_one_repacked",
+            Self::LogBoundedRepacked => "log_bounded_repacked",
             Self::ThreadListBounded => "thread_list_bounded",
         }
     }
@@ -69,8 +73,10 @@ impl CaseKind {
             Self::Help => &["help"],
             Self::StatusClean | Self::StatusDirty => &["--output", "json", "status"],
             Self::CaptureOne => &["--output", "json", "capture", "-m", "perf sample"],
-            Self::DiffOne => &["--output", "json", "diff"],
-            Self::LogBounded => &["--output", "json", "log", "--limit", "20"],
+            Self::DiffOne | Self::DiffOneRepacked => &["--output", "json", "diff"],
+            Self::LogBounded | Self::LogBoundedRepacked => {
+                &["--output", "json", "log", "--limit", "20"]
+            }
             Self::ThreadListBounded => &["--output", "json", "thread", "list"],
         }
     }
@@ -80,7 +86,11 @@ impl CaseKind {
             Self::Version | Self::Help => 0,
             Self::StatusClean | Self::StatusDirty => 1,
             Self::CaptureOne => 2,
-            Self::DiffOne | Self::LogBounded | Self::ThreadListBounded => 1,
+            Self::DiffOne
+            | Self::LogBounded
+            | Self::DiffOneRepacked
+            | Self::LogBoundedRepacked
+            | Self::ThreadListBounded => 1,
         }
     }
 }
@@ -141,6 +151,10 @@ pub(super) struct Counters {
     pub network_client_initialized: bool,
     pub ancestors_visited: u64,
     pub history_objects_decoded: u64,
+    pub pack_frame_decompressions: u64,
+    pub pack_frame_cache_hits: u64,
+    pub pack_blob_bodies_hashed: u64,
+    pub pack_state_frames_decoded: u64,
 }
 
 impl Sample {
@@ -203,6 +217,10 @@ impl Counters {
         self.network_client_initialized |= other.network_client_initialized;
         self.ancestors_visited += other.ancestors_visited;
         self.history_objects_decoded += other.history_objects_decoded;
+        self.pack_frame_decompressions += other.pack_frame_decompressions;
+        self.pack_frame_cache_hits += other.pack_frame_cache_hits;
+        self.pack_blob_bodies_hashed += other.pack_blob_bodies_hashed;
+        self.pack_state_frames_decoded += other.pack_state_frames_decoded;
     }
 }
 
@@ -278,7 +296,7 @@ impl CaseResult {
             self.metric(|sample| sample.network_ms),
         );
         println!(
-            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={} ancestors_visited={} history_objects_decoded={}",
+            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={} ancestors_visited={} history_objects_decoded={} pack_frame_decompressions={} pack_frame_cache_hits={} pack_blob_bodies_hashed={} pack_state_frames_decoded={}",
             self.kind.name(),
             self.path_count,
             self.counter(|value| value.directories_scanned),
@@ -294,6 +312,10 @@ impl CaseResult {
                 .any(|sample| sample.counters.network_client_initialized),
             self.counter(|value| value.ancestors_visited),
             self.counter(|value| value.history_objects_decoded),
+            self.counter(|value| value.pack_frame_decompressions),
+            self.counter(|value| value.pack_frame_cache_hits),
+            self.counter(|value| value.pack_blob_bodies_hashed),
+            self.counter(|value| value.pack_state_frames_decoded),
         );
     }
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
@@ -15,7 +15,7 @@ use super::*;
 
 const DEFAULT_SAMPLES: usize = 20;
 
-#[ignore = "release-only instant core-loop contract; run with `TMPDIR=/home/scratch cargo test --release -p heddle-cli --test cli_integration core_loop_release_contract -- --ignored --nocapture`"]
+#[ignore = "release-only instant core-loop contract; run with `TMPDIR=/home/scratch cargo test --release -p heddle-cli --test cli_basics core_loop_release_contract -- --ignored --nocapture`"]
 #[test]
 fn core_loop_release_contract() {
     if std::hint::black_box(cfg!(debug_assertions)) {
@@ -103,6 +103,21 @@ fn core_loop_release_contract() {
                         binary,
                         Some(&mut fixture),
                         CaseKind::LogBounded,
+                        samples,
+                        negative,
+                    ));
+                    fixture.repack(binary);
+                    results.push(measure_case(
+                        binary,
+                        Some(&mut fixture),
+                        CaseKind::DiffOneRepacked,
+                        samples,
+                        negative,
+                    ));
+                    results.push(measure_case(
+                        binary,
+                        Some(&mut fixture),
+                        CaseKind::LogBoundedRepacked,
                         samples,
                         negative,
                     ));

--- a/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
@@ -149,5 +149,9 @@ fn structural_counters(trace: &Value) -> Counters {
             .unwrap_or(true),
         ancestors_visited: count("ancestors_visited"),
         history_objects_decoded: count("history_objects_decoded"),
+        pack_frame_decompressions: count("pack_frame_decompressions"),
+        pack_frame_cache_hits: count("pack_frame_cache_hits"),
+        pack_blob_bodies_hashed: count("pack_blob_bodies_hashed"),
+        pack_state_frames_decoded: count("pack_state_frames_decoded"),
     }
 }

--- a/crates/object-model/src/compact/blob.rs
+++ b/crates/object-model/src/compact/blob.rs
@@ -49,6 +49,46 @@ pub fn encode_blob_frame(blobs: &[&[u8]]) -> Result<Vec<u8>> {
 
 /// Decode and whole-frame-verify every indexed blob slice.
 pub fn decode_blob_frame(bytes: &[u8]) -> Result<Vec<DecodedBlob<'_>>> {
+    let (mut input, lengths) = blob_frame_parts(bytes)?;
+    let mut blobs = Vec::with_capacity(lengths.len());
+    for len in lengths {
+        let body = input.take(len)?;
+        blobs.push((ContentHash::compute_typed("blob", body), body));
+    }
+    input.finish()?;
+    Ok(blobs)
+}
+
+/// Return one verified blob body without allocating or hashing later bodies.
+///
+/// HCB2 stores every body length before the concatenated bodies. After the
+/// whole-frame checksum and length table are validated, this walks bodies in
+/// frame order and stops at the first typed hash matching `expected`.
+pub fn extract_blob(bytes: &[u8], expected: ContentHash) -> Result<DecodedBlob<'_>> {
+    extract_blob_with_scan(bytes, expected).map(|(blob, _)| blob)
+}
+
+/// Point-read variant that also reports how many bodies were hashed.
+///
+/// This is exposed for the executable storage performance contract; callers
+/// serving objects should normally use [`extract_blob`].
+#[doc(hidden)]
+pub fn extract_blob_with_scan(
+    bytes: &[u8],
+    expected: ContentHash,
+) -> Result<(DecodedBlob<'_>, usize)> {
+    let (mut input, lengths) = blob_frame_parts(bytes)?;
+    for (ordinal, len) in lengths.into_iter().enumerate() {
+        let body = input.take(len)?;
+        let hash = ContentHash::compute_typed("blob", body);
+        if hash == expected {
+            return Ok(((hash, body), ordinal + 1));
+        }
+    }
+    Err(super::CompactError::Missing)
+}
+
+fn blob_frame_parts(bytes: &[u8]) -> Result<(Reader<'_>, Vec<usize>)> {
     let mut input = Reader::verified(bytes, BLOB_MAGIC)?;
     let count = input.get_count("blob frame", MIN_BLOB_ITEM_BYTES)?;
     let mut lengths = Vec::with_capacity(count);
@@ -78,13 +118,7 @@ pub fn decode_blob_frame(bytes: &[u8]) -> Result<Vec<DecodedBlob<'_>>> {
             input.remaining()
         )));
     }
-    let mut blobs = Vec::with_capacity(count);
-    for len in lengths {
-        let body = input.take(len)?;
-        blobs.push((ContentHash::compute_typed("blob", body), body));
-    }
-    input.finish()?;
-    Ok(blobs)
+    Ok((input, lengths))
 }
 
 fn checked_length(value: u64) -> Result<usize> {

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -10,7 +10,9 @@ mod state;
 mod state_decode;
 mod tree;
 
-pub use blob::{decode_blob_frame, encode_blob_frame, is_blob_frame};
+pub use blob::{
+    decode_blob_frame, encode_blob_frame, extract_blob, extract_blob_with_scan, is_blob_frame,
+};
 pub use extract::extract_state;
 pub use state::{encode_state_frame, is_state_frame};
 pub use state_decode::decode_state_frame;

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -7,7 +7,8 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
     CompactError, decode_blob_frame, decode_state_frame, decode_tree_frame, encode_blob_frame,
-    encode_state_frame, encode_tree_frame, extract_state, extract_tree, is_state_frame,
+    encode_state_frame, encode_tree_frame, extract_blob, extract_state, extract_tree,
+    is_state_frame,
     state::{STATE_MAGIC, STATE_MAGIC_V1, encode_state_frame_hcs1},
 };
 use crate::object::{
@@ -400,6 +401,26 @@ fn blob_frame_round_trips_offsets_lengths_and_typed_hashes() {
         assert_eq!(*actual, expected);
         assert_eq!(*hash, ContentHash::compute_typed("blob", expected));
     }
+}
+
+#[test]
+fn blob_frame_extracts_one_borrowed_body() {
+    let bodies = [
+        b"newest blob".as_slice(),
+        b"middle blob with a different length".as_slice(),
+        b"oldest".as_slice(),
+    ];
+    let encoded = encode_blob_frame(&bodies).unwrap();
+    for expected in bodies {
+        let expected_hash = ContentHash::compute_typed("blob", expected);
+        let (actual_hash, actual) = extract_blob(&encoded, expected_hash).unwrap();
+        assert_eq!(actual_hash, expected_hash);
+        assert_eq!(actual, expected);
+    }
+    assert!(matches!(
+        extract_blob(&encoded, ContentHash::from_bytes([0xff; 32])).unwrap_err(),
+        CompactError::Missing
+    ));
 }
 
 #[test]

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -1060,11 +1060,10 @@ impl FsStore {
         }
 
         if let Ok(manager) = self.pack_manager().read()
-            && let Some((obj_type, data)) = manager.get_object(&PackObjectId::StateId(*id))?
-            && obj_type == ObjectType::State
+            && let Some(state) = manager.get_state(id)?
         {
             trace!("Found state in packfile");
-            let state = validate_loaded_state(id, rmp_serde::from_slice(&data)?)?;
+            let state = validate_loaded_state(id, state)?;
             heddle_perf_contract::record_object_decode();
             if let Ok(mut cache) = self.recent_states.write() {
                 cache.insert(*id, state.clone());

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -15,6 +15,7 @@ bytes.workspace = true
 heddle-format.workspace = true
 heddle-fs-prims.workspace = true
 heddle-object-model.workspace = true
+heddle-perf-contract.workspace = true
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/pack/src/store/pack/decoded_frame_cache.rs
+++ b/crates/pack/src/store/pack/decoded_frame_cache.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{HashMap, VecDeque},
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use bytes::Bytes;
+use heddle_object_model::object::State;
+
+const DEFAULT_DECODED_FRAME_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub(super) struct DecodedFrameKey {
+    pack_path: Arc<PathBuf>,
+    record_offset: u64,
+}
+
+impl DecodedFrameKey {
+    pub(super) fn new(pack_path: Arc<PathBuf>, record_offset: usize) -> Self {
+        Self {
+            pack_path,
+            record_offset: record_offset as u64,
+        }
+    }
+}
+
+impl PartialEq for DecodedFrameKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_offset == other.record_offset && self.pack_path == other.pack_path
+    }
+}
+
+impl Eq for DecodedFrameKey {}
+
+impl Hash for DecodedFrameKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.pack_path.hash(state);
+        self.record_offset.hash(state);
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DecodedFrame {
+    pub(super) bytes: Bytes,
+    pub(super) states: Option<Vec<State>>,
+    resident_bytes: usize,
+}
+
+impl DecodedFrame {
+    pub(super) fn new(bytes: Bytes, states: Option<Vec<State>>) -> Self {
+        let state_bytes = states.as_ref().map_or(0, |values| {
+            values
+                .len()
+                .saturating_mul(std::mem::size_of::<State>())
+                // Compact columns hold the variable-width state data. Count
+                // one additional frame-sized allowance for the allocations
+                // materialised from those columns.
+                .saturating_add(bytes.len())
+        });
+        let resident_bytes = bytes.len().saturating_add(state_bytes);
+        Self {
+            bytes,
+            states,
+            resident_bytes,
+        }
+    }
+}
+
+/// Process-local LRU of decompressed compact frames.
+///
+/// Paths distinguish immutable packs while offsets distinguish physical
+/// records within a pack. The byte budget is global to a `PackManager`, so a
+/// repository with many packs cannot multiply the allowance per reader.
+#[derive(Debug)]
+pub(super) struct DecodedFrameCache {
+    entries: HashMap<DecodedFrameKey, Arc<DecodedFrame>>,
+    lru: VecDeque<DecodedFrameKey>,
+    resident_bytes: usize,
+    byte_budget: usize,
+}
+
+impl DecodedFrameCache {
+    pub(super) fn new() -> Self {
+        Self::with_byte_budget(DEFAULT_DECODED_FRAME_CACHE_BYTES)
+    }
+
+    fn with_byte_budget(byte_budget: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            resident_bytes: 0,
+            byte_budget,
+        }
+    }
+
+    pub(super) fn get(&mut self, key: &DecodedFrameKey) -> Option<Arc<DecodedFrame>> {
+        let frame = Arc::clone(self.entries.get(key)?);
+        self.promote(key);
+        Some(frame)
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        key: DecodedFrameKey,
+        frame: Arc<DecodedFrame>,
+    ) -> Arc<DecodedFrame> {
+        if frame.resident_bytes > self.byte_budget {
+            return frame;
+        }
+        if let Some(previous) = self.entries.remove(&key) {
+            self.resident_bytes = self.resident_bytes.saturating_sub(previous.resident_bytes);
+            self.lru.retain(|candidate| candidate != &key);
+        }
+        while self.resident_bytes.saturating_add(frame.resident_bytes) > self.byte_budget {
+            let Some(oldest) = self.lru.pop_front() else {
+                break;
+            };
+            if let Some(evicted) = self.entries.remove(&oldest) {
+                self.resident_bytes = self.resident_bytes.saturating_sub(evicted.resident_bytes);
+            }
+        }
+        self.resident_bytes = self.resident_bytes.saturating_add(frame.resident_bytes);
+        self.lru.push_back(key.clone());
+        self.entries.insert(key, Arc::clone(&frame));
+        frame
+    }
+
+    fn promote(&mut self, key: &DecodedFrameKey) {
+        self.lru.retain(|candidate| candidate != key);
+        self.lru.push_back(key.clone());
+    }
+}
+
+pub(super) fn in_memory_pack_path() -> Arc<PathBuf> {
+    Arc::new(Path::new("<memory-pack>").to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_budget_evicts_the_least_recently_used_frame() {
+        let path = Arc::new(PathBuf::from("pack"));
+        let keys = [
+            DecodedFrameKey::new(Arc::clone(&path), 1),
+            DecodedFrameKey::new(Arc::clone(&path), 2),
+            DecodedFrameKey::new(path, 3),
+        ];
+        let mut cache = DecodedFrameCache::with_byte_budget(8);
+        cache.insert(
+            keys[0].clone(),
+            Arc::new(DecodedFrame::new(Bytes::from_static(b"aaaa"), None)),
+        );
+        cache.insert(
+            keys[1].clone(),
+            Arc::new(DecodedFrame::new(Bytes::from_static(b"bbbb"), None)),
+        );
+        assert!(cache.get(&keys[0]).is_some());
+        cache.insert(
+            keys[2].clone(),
+            Arc::new(DecodedFrame::new(Bytes::from_static(b"cccc"), None)),
+        );
+
+        assert!(cache.get(&keys[0]).is_some());
+        assert!(cache.get(&keys[1]).is_none());
+        assert!(cache.get(&keys[2]).is_some());
+    }
+}

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -5,14 +5,15 @@ use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
-    sync::{OnceLock, RwLock},
+    sync::{Arc, Mutex, OnceLock, RwLock},
     time::SystemTime,
 };
 
 use tracing::{debug, instrument, trace};
 
+use super::decoded_frame_cache::DecodedFrameCache;
 use crate::{
-    object::ContentHash,
+    object::{ContentHash, State, StateId},
     store::{
         Result,
         pack::{ObjectType, PackObjectId, PackReadTier, PackReader},
@@ -25,6 +26,7 @@ use crate::{
 pub struct PackManager {
     packs_dir: PathBuf,
     packs: Vec<CachedPack>,
+    decoded_frames: Arc<Mutex<DecodedFrameCache>>,
     object_locations: RwLock<ObjectLocationIndex>,
     eager_object_locations: bool,
 }
@@ -44,51 +46,71 @@ struct ObjectLocation {
 struct CachedPack {
     pack_path: PathBuf,
     index_path: PathBuf,
+    decoded_frames: Arc<Mutex<DecodedFrameCache>>,
     reader: OnceLock<Option<PackReader<'static>>>,
 }
 
 impl CachedPack {
-    fn discovered(pack_path: PathBuf, index_path: PathBuf) -> Self {
+    fn discovered(
+        pack_path: PathBuf,
+        index_path: PathBuf,
+        decoded_frames: Arc<Mutex<DecodedFrameCache>>,
+    ) -> Self {
         Self {
             pack_path,
             index_path,
+            decoded_frames,
             reader: OnceLock::new(),
         }
     }
 
-    fn validated(pack_path: PathBuf, index_path: PathBuf, reader: PackReader<'static>) -> Self {
+    fn validated(
+        pack_path: PathBuf,
+        index_path: PathBuf,
+        decoded_frames: Arc<Mutex<DecodedFrameCache>>,
+        reader: PackReader<'static>,
+    ) -> Self {
         Self {
             pack_path,
             index_path,
+            decoded_frames,
             reader: OnceLock::from(Some(reader)),
         }
     }
 
     fn reader(&self) -> Option<&PackReader<'static>> {
         self.reader
-            .get_or_init(
-                || match PackReader::open_lazy(&self.pack_path, &self.index_path) {
+            .get_or_init(|| {
+                match PackReader::open_lazy_with_cache(
+                    &self.pack_path,
+                    &self.index_path,
+                    Arc::clone(&self.decoded_frames),
+                ) {
                     Ok(reader) => Some(reader),
                     Err(error) => {
                         debug!(pack = ?self.pack_path, %error, "Failed to open pack");
                         None
                     }
-                },
-            )
+                }
+            })
             .as_ref()
     }
 
     fn verified_reader(&self) -> Option<&PackReader<'static>> {
         self.reader
-            .get_or_init(
-                || match PackReader::open(&self.pack_path, &self.index_path) {
+            .get_or_init(|| {
+                match PackReader::open_with_cache(
+                    &self.pack_path,
+                    &self.index_path,
+                    Arc::clone(&self.decoded_frames),
+                ) {
                     Ok(reader) => Some(reader),
                     Err(error) => {
                         debug!(pack = ?self.pack_path, %error, "Failed to open pack");
                         None
                     }
-                },
-            )
+                }
+            })
             .as_ref()
     }
 }
@@ -99,11 +121,13 @@ impl PackManager {
     }
 
     fn new_with_index_mode(packs_dir: PathBuf, eager_object_locations: bool) -> Self {
-        let packs = Self::load_packs(&packs_dir).unwrap_or_default();
+        let decoded_frames = Arc::new(Mutex::new(DecodedFrameCache::new()));
+        let packs = Self::load_packs(&packs_dir, &decoded_frames).unwrap_or_default();
         let object_locations = Self::initial_object_locations(&packs, eager_object_locations);
         Self {
             packs_dir,
             packs,
+            decoded_frames,
             object_locations: RwLock::new(object_locations),
             eager_object_locations,
         }
@@ -143,15 +167,20 @@ impl PackManager {
         Ok(packs)
     }
 
-    fn load_packs(packs_dir: &Path) -> Result<Vec<CachedPack>> {
+    fn load_packs(
+        packs_dir: &Path,
+        decoded_frames: &Arc<Mutex<DecodedFrameCache>>,
+    ) -> Result<Vec<CachedPack>> {
         Ok(Self::discover_pack_paths(packs_dir)?
             .into_iter()
-            .map(|(pack_path, index_path)| CachedPack::discovered(pack_path, index_path))
+            .map(|(pack_path, index_path)| {
+                CachedPack::discovered(pack_path, index_path, Arc::clone(decoded_frames))
+            })
             .collect())
     }
 
     pub fn reload(&mut self) -> Result<()> {
-        self.packs = Self::load_packs(&self.packs_dir)?;
+        self.packs = Self::load_packs(&self.packs_dir, &self.decoded_frames)?;
         self.reset_object_locations();
         Ok(())
     }
@@ -252,10 +281,16 @@ impl PackManager {
         if self.packs.iter().any(|pack| pack.pack_path == pack_path) {
             return Ok(());
         }
-        let reader = PackReader::open(&pack_path, &index_path)?;
+        let reader =
+            PackReader::open_with_cache(&pack_path, &index_path, Arc::clone(&self.decoded_frames))?;
         let objects = reader.indexed_read_tiers()?;
         let pack_index = self.packs.len();
-        let cached = CachedPack::validated(pack_path, index_path, reader);
+        let cached = CachedPack::validated(
+            pack_path,
+            index_path,
+            Arc::clone(&self.decoded_frames),
+            reader,
+        );
         self.packs.push(cached);
         let mut index = self
             .object_locations
@@ -317,6 +352,19 @@ impl PackManager {
             trace!("Found object in pack");
         }
         Ok(object)
+    }
+
+    /// Return a typed state, preserving compact-frame decoding in the shared
+    /// frame cache instead of round-tripping through MessagePack.
+    pub fn get_state(&self, id: &StateId) -> Result<Option<State>> {
+        let object_id = PackObjectId::StateId(*id);
+        let Some(pack_index) = self.point_object_location(&object_id)? else {
+            return Ok(None);
+        };
+        let Some(reader) = self.packs[pack_index].reader() else {
+            return Ok(None);
+        };
+        reader.get_state(id)
     }
 
     /// Return the physical tier that will serve `id`.

--- a/crates/pack/src/store/pack/mod.rs
+++ b/crates/pack/src/store/pack/mod.rs
@@ -5,6 +5,7 @@
 //! achieving 50-70% space savings for repositories with many similar objects.
 
 mod compact_frame;
+mod decoded_frame_cache;
 mod manager;
 mod pack_builder;
 mod pack_identity;

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -7,7 +7,8 @@ use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs::File,
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
 use bytes::Bytes;
@@ -15,12 +16,15 @@ use heddle_format::delta::{DeltaDecoder, MAX_DELTA_OUTPUT_SIZE};
 
 use super::{
     ObjectType, PackLogicalId, PackObjectId, PackObjectRecord, PackRepresentationHash,
-    append_container_checksum, decode_tagged_entry_header, decompress_pack_payload, has_zstd_magic,
-    pack_container_spec, pack_identity::LogicalIdBuilder, pack_index::PackIndex, varint,
-    verify_supported_container, verify_supported_container_layout, write_container_header,
+    append_container_checksum, decode_tagged_entry_header,
+    decoded_frame_cache::{DecodedFrame, DecodedFrameCache, DecodedFrameKey, in_memory_pack_path},
+    decompress_pack_payload, has_zstd_magic, pack_container_spec,
+    pack_identity::LogicalIdBuilder,
+    pack_index::PackIndex,
+    varint, verify_supported_container, verify_supported_container_layout, write_container_header,
 };
 use crate::{
-    object::ContentHash,
+    object::{ContentHash, State, StateId},
     store::{Result, StoreError},
 };
 
@@ -105,8 +109,29 @@ pub struct PackReader<'a> {
     index: PackIndex,
     aliased_offsets: HashSet<u64>,
     content_end: usize,
+    pack_path: Arc<PathBuf>,
+    decoded_frames: Arc<Mutex<DecodedFrameCache>>,
     #[cfg(test)]
     compact_frame_reads: AtomicUsize,
+}
+
+enum NonDeltaPayload {
+    Ordinary(Vec<u8>),
+    Compact(Arc<DecodedFrame>),
+}
+
+struct PendingDelta {
+    data: Vec<u8>,
+    output_size: usize,
+}
+
+enum RecordStep {
+    Complete(PackObjectRecord),
+    Delta {
+        base_hash: ContentHash,
+        data: Vec<u8>,
+        output_size: usize,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -121,17 +146,34 @@ impl PackReader<'static> {
     /// to benefit (the same threshold the loose-blob path uses for
     /// its own mmap decision); read-into-heap otherwise.
     pub fn open(pack_path: &Path, index_path: &Path) -> Result<Self> {
-        Self::open_with_verification(pack_path, index_path, true)
+        Self::open_with_cache(
+            pack_path,
+            index_path,
+            Arc::new(Mutex::new(DecodedFrameCache::new())),
+        )
     }
 
-    pub(super) fn open_lazy(pack_path: &Path, index_path: &Path) -> Result<Self> {
-        Self::open_with_verification(pack_path, index_path, false)
+    pub(super) fn open_with_cache(
+        pack_path: &Path,
+        index_path: &Path,
+        decoded_frames: Arc<Mutex<DecodedFrameCache>>,
+    ) -> Result<Self> {
+        Self::open_with_verification(pack_path, index_path, true, decoded_frames)
+    }
+
+    pub(super) fn open_lazy_with_cache(
+        pack_path: &Path,
+        index_path: &Path,
+        decoded_frames: Arc<Mutex<DecodedFrameCache>>,
+    ) -> Result<Self> {
+        Self::open_with_verification(pack_path, index_path, false, decoded_frames)
     }
 
     fn open_with_verification(
         pack_path: &Path,
         index_path: &Path,
         verify_checksum: bool,
+        decoded_frames: Arc<Mutex<DecodedFrameCache>>,
     ) -> Result<Self> {
         let pack_bytes = read_file_bytes_for_pack(pack_path)?;
         let index_data = read_file_bytes_for_pack(index_path)?;
@@ -147,6 +189,8 @@ impl PackReader<'static> {
             index,
             aliased_offsets,
             content_end,
+            pack_path: Arc::new(pack_path.to_path_buf()),
+            decoded_frames,
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
         })
@@ -162,6 +206,8 @@ impl PackReader<'static> {
             index,
             aliased_offsets,
             content_end,
+            pack_path: in_memory_pack_path(),
+            decoded_frames: Arc::new(Mutex::new(DecodedFrameCache::new())),
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
         })
@@ -178,6 +224,8 @@ impl<'a> PackReader<'a> {
             index,
             aliased_offsets,
             content_end,
+            pack_path: in_memory_pack_path(),
+            decoded_frames: Arc::new(Mutex::new(DecodedFrameCache::new())),
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
         })
@@ -449,6 +497,42 @@ impl<'a> PackReader<'a> {
         self.get_object(&PackObjectId::Hash(*hash))
     }
 
+    /// Read a state as its domain type.
+    ///
+    /// Compact state frames keep their decoded state vector in the frame LRU,
+    /// so this path does not serialize one state to MessagePack merely for the
+    /// object store to parse it again.
+    pub fn get_state(&self, id: &StateId) -> Result<Option<State>> {
+        let requested_id = PackObjectId::StateId(*id);
+        let Some(offset) = self.index.find(&requested_id)? else {
+            return Ok(None);
+        };
+        let offset = checked_index_offset(offset)?;
+        let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+        if header.obj_type == ObjectType::State {
+            let data_start = checked_index_add(offset, header.header_len, "entry data start")?;
+            let data_end = checked_data_end(data_start, header.compressed_size, self.content_end)?;
+            let stored = &self.data.as_slice()[data_start..data_end];
+            return match self.read_non_delta_payload(offset, &header, stored)? {
+                NonDeltaPayload::Compact(frame) => state_from_decoded_frame(&frame, *id).map(Some),
+                NonDeltaPayload::Ordinary(data) => {
+                    verify_record_id_matches(&requested_id, &header.id)?;
+                    decode_serialized_state(&data, *id).map(Some)
+                }
+            };
+        }
+
+        let Some((obj_type, data)) = self.get_object(&requested_id)? else {
+            return Ok(None);
+        };
+        if obj_type != ObjectType::State {
+            return Err(StoreError::InvalidObject(format!(
+                "state index entry resolved to {obj_type:?}"
+            )));
+        }
+        decode_serialized_state(&data, *id).map(Some)
+    }
+
     /// Read an object's logical type from pack headers without reading or
     /// decoding its payload.
     ///
@@ -577,45 +661,104 @@ impl<'a> PackReader<'a> {
     fn read_object_type_at_depth(
         &self,
         requested_id: &PackObjectId,
-        offset: usize,
+        mut offset: usize,
         depth: usize,
     ) -> Result<ObjectType> {
-        if depth > MAX_DELTA_CHAIN_DEPTH {
-            return Err(StoreError::InvalidObject(format!(
-                "Delta chain depth {depth} exceeds max {MAX_DELTA_CHAIN_DEPTH}"
-            )));
+        let mut current_id = *requested_id;
+        let mut current_depth = depth;
+        loop {
+            verify_delta_depth(current_depth)?;
+            if offset >= self.content_end {
+                return Err(StoreError::InvalidObject(
+                    "Entry offset out of bounds".to_string(),
+                ));
+            }
+            let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+            if header.id != current_id {
+                return self
+                    .read_record_at_depth(&current_id, offset, current_depth)
+                    .map(|record| record.obj_type);
+            }
+            if header.obj_type != ObjectType::Delta {
+                return Ok(header.obj_type);
+            }
+            let base_hash = Self::require_delta_base_hash(header.delta_base)?;
+            current_id = PackObjectId::Hash(base_hash);
+            let base_offset = self
+                .index
+                .find(&current_id)?
+                .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
+            offset = checked_index_offset(base_offset)?;
+            current_depth = current_depth.checked_add(1).ok_or_else(|| {
+                StoreError::InvalidObject("Delta chain depth overflow".to_string())
+            })?;
         }
-        if offset >= self.content_end {
-            return Err(StoreError::InvalidObject(
-                "Entry offset out of bounds".to_string(),
-            ));
-        }
-
-        let header = decode_tagged_entry_header(self.content_from(offset)?)?;
-        if header.id != *requested_id {
-            return self
-                .read_record_at_depth(requested_id, offset, depth)
-                .map(|record| record.obj_type);
-        }
-        if header.obj_type != ObjectType::Delta {
-            return Ok(header.obj_type);
-        }
-
-        let base_hash = Self::require_delta_base_hash(header.delta_base)?;
-        let base_id = PackObjectId::Hash(base_hash);
-        let base_offset = self
-            .index
-            .find(&base_id)?
-            .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
-        self.read_object_type_at_depth(&base_id, checked_index_offset(base_offset)?, depth + 1)
     }
 
     fn read_record_at_depth(
         &self,
         requested_id: &PackObjectId,
-        offset: usize,
+        mut offset: usize,
         depth: usize,
     ) -> Result<PackObjectRecord> {
+        let mut current_id = *requested_id;
+        let mut pending = Vec::<PendingDelta>::new();
+        loop {
+            let current_depth = depth.checked_add(pending.len()).ok_or_else(|| {
+                StoreError::InvalidObject("Delta chain depth overflow".to_string())
+            })?;
+            verify_delta_depth(current_depth)?;
+            match self.read_record_step(&current_id, offset)? {
+                RecordStep::Complete(record) => {
+                    let mut data = record.data;
+                    while let Some(delta) = pending.pop() {
+                        data = DeltaDecoder::decode(&data, &delta.data, delta.output_size)
+                            .map_err(|error| {
+                                StoreError::InvalidObject(format!("Delta decode failed: {error}"))
+                            })?;
+                        if data.len() != delta.output_size {
+                            return Err(StoreError::InvalidObject(format!(
+                                "Size mismatch: expected {}, got {}",
+                                delta.output_size,
+                                data.len()
+                            )));
+                        }
+                    }
+                    return Ok(PackObjectRecord {
+                        id: *requested_id,
+                        obj_type: record.obj_type,
+                        data,
+                        delta_base: None,
+                        path_hint: None,
+                    });
+                }
+                RecordStep::Delta {
+                    base_hash,
+                    data,
+                    output_size,
+                } => {
+                    if output_size > MAX_PACK_DELTA_OUTPUT_SIZE {
+                        return Err(StoreError::InvalidObject(format!(
+                            "Delta output size {} exceeds max {}",
+                            output_size, MAX_PACK_DELTA_OUTPUT_SIZE
+                        )));
+                    }
+                    pending.push(PendingDelta { data, output_size });
+                    current_id = PackObjectId::Hash(base_hash);
+                    let base_offset = self
+                        .index
+                        .find(&current_id)?
+                        .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
+                    offset = checked_index_offset(base_offset)?;
+                }
+            }
+        }
+    }
+
+    /// Read one physical record. Delta base traversal deliberately lives in
+    /// the iterative caller above; #1670 can extend this step with cross-object
+    /// base lookup without introducing recursive or single-pack resolution.
+    fn read_record_step(&self, requested_id: &PackObjectId, offset: usize) -> Result<RecordStep> {
         if offset >= self.content_end {
             return Err(StoreError::InvalidObject(
                 "Entry offset out of bounds".to_string(),
@@ -652,60 +795,52 @@ impl<'a> PackReader<'a> {
 
         let stored_data = &self.data.as_slice()[data_start..data_end];
 
-        // Raw zstd (no wrapper). For non-delta entries, decompress
-        // if sizes differ. For delta entries, the stored data IS the delta
-        // payload (possibly zstd-compressed); check for zstd magic.
-        let decompressed = if obj_type == ObjectType::Delta {
-            if has_zstd_magic(stored_data) {
+        if obj_type == ObjectType::Delta {
+            verify_record_id_matches(requested_id, &id)?;
+            let data = if has_zstd_magic(stored_data) {
                 decompress_pack_payload(stored_data, 0)?
             } else {
                 stored_data.to_vec()
-            }
-        } else if compressed_size != uncompressed_size {
-            decompress_pack_payload(stored_data, uncompressed_size)?
-        } else {
-            stored_data.to_vec()
-        };
+            };
+            return Ok(RecordStep::Delta {
+                base_hash: Self::require_delta_base_hash(base_id)?,
+                data,
+                output_size: uncompressed_size,
+            });
+        }
 
         let shared_blob =
             obj_type == ObjectType::Blob && self.aliased_offsets.contains(&(offset as u64));
-        if obj_type != ObjectType::Delta && (shared_blob || is_compact_frame(&decompressed)) {
-            #[cfg(test)]
-            self.record_compact_frame_read();
-            if let Some(data) =
-                decode_compact_object(requested_id, obj_type, &decompressed, shared_blob)?
-            {
-                return Ok(PackObjectRecord {
+        match self.read_non_delta_payload_parts(
+            offset,
+            obj_type,
+            uncompressed_size,
+            compressed_size,
+            stored_data,
+            shared_blob,
+        )? {
+            NonDeltaPayload::Compact(frame) => {
+                let data = decode_compact_object(requested_id, obj_type, &frame, shared_blob)?
+                    .ok_or_else(|| compact_index_miss(requested_id))?;
+                Ok(RecordStep::Complete(PackObjectRecord {
                     id: *requested_id,
                     obj_type,
                     data,
                     delta_base: None,
                     path_hint: None,
-                });
+                }))
+            }
+            NonDeltaPayload::Ordinary(data) => {
+                verify_record_id_matches(requested_id, &id)?;
+                Ok(RecordStep::Complete(PackObjectRecord {
+                    id,
+                    obj_type,
+                    data,
+                    delta_base: None,
+                    path_hint: None,
+                }))
             }
         }
-        verify_record_id_matches(requested_id, &id)?;
-        let (resolved_type, final_data) = if obj_type == ObjectType::Delta {
-            self.read_delta_record(base_id, &decompressed, uncompressed_size, depth)?
-        } else {
-            (obj_type, decompressed)
-        };
-
-        if final_data.len() != uncompressed_size {
-            return Err(StoreError::InvalidObject(format!(
-                "Size mismatch: expected {}, got {}",
-                uncompressed_size,
-                final_data.len()
-            )));
-        }
-
-        Ok(PackObjectRecord {
-            id,
-            obj_type: resolved_type,
-            data: final_data,
-            delta_base: None,
-            path_hint: None,
-        })
     }
 
     fn read_compact_objects_at(&self, offset: usize) -> Result<Option<DecodedCompactObjects>> {
@@ -729,61 +864,101 @@ impl<'a> PackReader<'a> {
         let data_start = checked_index_add(offset, header.header_len, "entry data start")?;
         let data_end = checked_data_end(data_start, header.compressed_size, self.content_end)?;
         let stored = &self.data.as_slice()[data_start..data_end];
-        let data = if header.compressed_size != header.uncompressed_size {
-            decompress_pack_payload(stored, header.uncompressed_size)?
-        } else {
-            stored.to_vec()
-        };
-        if data.len() != header.uncompressed_size {
-            return Err(StoreError::InvalidObject(format!(
-                "Size mismatch: expected {}, got {}",
-                header.uncompressed_size,
-                data.len()
-            )));
+        match self.read_non_delta_payload(offset, &header, stored)? {
+            NonDeltaPayload::Compact(frame) => {
+                decode_compact_objects(header.obj_type, &frame, shared_blob)
+            }
+            NonDeltaPayload::Ordinary(_) => Ok(None),
         }
-        #[cfg(test)]
-        if shared_blob || is_compact_frame(&data) {
-            self.record_compact_frame_read();
-        }
-        decode_compact_objects(header.obj_type, &data, shared_blob)
     }
 
-    fn read_delta_record(
+    fn read_non_delta_payload(
         &self,
-        base_id: Option<PackObjectId>,
-        delta: &[u8],
+        offset: usize,
+        header: &super::PackEntryHeader,
+        stored_data: &[u8],
+    ) -> Result<NonDeltaPayload> {
+        let shared_blob =
+            header.obj_type == ObjectType::Blob && self.aliased_offsets.contains(&(offset as u64));
+        self.read_non_delta_payload_parts(
+            offset,
+            header.obj_type,
+            header.uncompressed_size,
+            header.compressed_size,
+            stored_data,
+            shared_blob,
+        )
+    }
+
+    fn read_non_delta_payload_parts(
+        &self,
+        offset: usize,
+        obj_type: ObjectType,
         uncompressed_size: usize,
-        depth: usize,
-    ) -> Result<(ObjectType, Vec<u8>)> {
-        if depth > MAX_DELTA_CHAIN_DEPTH {
+        compressed_size: usize,
+        stored_data: &[u8],
+        shared_blob: bool,
+    ) -> Result<NonDeltaPayload> {
+        let cache_key = DecodedFrameKey::new(Arc::clone(&self.pack_path), offset);
+        if let Some(frame) = self.cached_frame(&cache_key) {
+            heddle_perf_contract::record_pack_frame_cache_hit();
+            return Ok(NonDeltaPayload::Compact(frame));
+        }
+        let decompressed = if compressed_size != uncompressed_size {
+            decompress_pack_payload(stored_data, uncompressed_size)?
+        } else {
+            stored_data.to_vec()
+        };
+        if decompressed.len() != uncompressed_size {
             return Err(StoreError::InvalidObject(format!(
-                "Delta chain depth {} exceeds max {}",
-                depth, MAX_DELTA_CHAIN_DEPTH
+                "Size mismatch: expected {}, got {}",
+                uncompressed_size,
+                decompressed.len()
             )));
         }
-
-        if uncompressed_size > MAX_PACK_DELTA_OUTPUT_SIZE {
-            return Err(StoreError::InvalidObject(format!(
-                "Delta output size {} exceeds max {}",
-                uncompressed_size, MAX_PACK_DELTA_OUTPUT_SIZE
-            )));
+        if !shared_blob && (obj_type == ObjectType::Blob || !is_compact_frame(&decompressed)) {
+            return Ok(NonDeltaPayload::Ordinary(decompressed));
         }
+        if compressed_size != uncompressed_size {
+            heddle_perf_contract::record_pack_frame_decompression();
+        }
+        #[cfg(test)]
+        self.record_compact_frame_read();
+        let states = if obj_type == ObjectType::State
+            && heddle_object_model::compact::is_state_frame(&decompressed)
+        {
+            heddle_perf_contract::record_pack_state_frame_decode();
+            Some(
+                heddle_object_model::compact::decode_state_frame(&decompressed)
+                    .map_err(|error| StoreError::InvalidObject(error.to_string()))?,
+            )
+        } else {
+            None
+        };
+        let frame = Arc::new(DecodedFrame::new(Bytes::from(decompressed), states));
+        Ok(NonDeltaPayload::Compact(
+            self.insert_cached_frame(cache_key, frame),
+        ))
+    }
 
-        let base_hash = Self::require_delta_base_hash(base_id)?;
-        let base_offset = self
-            .index
-            .find(&PackObjectId::Hash(base_hash))?
-            .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
-        let base_offset = checked_index_offset(base_offset)?;
-        let base_id = PackObjectId::Hash(base_hash);
-        let base_record = self.read_record_at_depth(&base_id, base_offset, depth + 1)?;
-        let base_type = base_record.obj_type;
-        let base_data = base_record.data;
+    fn cached_frame(&self, key: &DecodedFrameKey) -> Option<Arc<DecodedFrame>> {
+        let mut cache = self
+            .decoded_frames
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.get(key)
+    }
 
-        let decoded = DeltaDecoder::decode(&base_data, delta, uncompressed_size)
-            .map_err(|error| StoreError::InvalidObject(format!("Delta decode failed: {error}")))?;
-
-        Ok((base_type, decoded))
+    fn insert_cached_frame(
+        &self,
+        key: DecodedFrameKey,
+        frame: Arc<DecodedFrame>,
+    ) -> Arc<DecodedFrame> {
+        let mut cache = self
+            .decoded_frames
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.insert(key, frame)
     }
 
     fn require_delta_base_hash(base_id: Option<PackObjectId>) -> Result<ContentHash> {
@@ -811,6 +986,15 @@ impl<'a> PackReader<'a> {
 fn checked_index_offset(offset: u64) -> Result<usize> {
     usize::try_from(offset)
         .map_err(|_| StoreError::InvalidObject("Entry offset exceeds platform limits".to_string()))
+}
+
+fn verify_delta_depth(depth: usize) -> Result<()> {
+    if depth > MAX_DELTA_CHAIN_DEPTH {
+        return Err(StoreError::InvalidObject(format!(
+            "Delta chain depth {depth} exceeds max {MAX_DELTA_CHAIN_DEPTH}"
+        )));
+    }
+    Ok(())
 }
 
 fn checked_decoded_size(field: &str, size: u64) -> Result<usize> {
@@ -893,10 +1077,18 @@ fn is_compact_frame(data: &[u8]) -> bool {
 fn decode_compact_object(
     requested_id: &PackObjectId,
     obj_type: ObjectType,
-    data: &[u8],
+    frame: &DecodedFrame,
     require_blob_frame: bool,
 ) -> Result<Option<Vec<u8>>> {
+    let data = frame.bytes.as_ref();
     match (obj_type, requested_id) {
+        (ObjectType::Blob, PackObjectId::Hash(hash)) if require_blob_frame => {
+            let ((_, body), hashed_bodies) =
+                heddle_object_model::compact::extract_blob_with_scan(data, *hash)
+                    .map_err(|error| compact_extract_error(requested_id, error))?;
+            heddle_perf_contract::record_pack_blob_bodies_hashed(hashed_bodies);
+            Ok(Some(body.to_vec()))
+        }
         (ObjectType::Tree, PackObjectId::Hash(hash))
             if heddle_object_model::compact::is_tree_frame(data) =>
         {
@@ -909,14 +1101,13 @@ fn decode_compact_object(
         (ObjectType::State, PackObjectId::StateId(id))
             if heddle_object_model::compact::is_state_frame(data) =>
         {
-            let state = heddle_object_model::compact::extract_state(data, *id)
-                .map_err(|error| compact_extract_error(requested_id, error))?;
+            let state = state_from_decoded_frame(frame, *id)?;
             rmp_serde::to_vec_named(&state)
                 .map(Some)
                 .map_err(|error| StoreError::InvalidObject(error.to_string()))
         }
         _ => {
-            let Some(objects) = decode_compact_objects(obj_type, data, require_blob_frame)? else {
+            let Some(objects) = decode_compact_objects(obj_type, frame, require_blob_frame)? else {
                 return Ok(None);
             };
             objects
@@ -941,9 +1132,10 @@ fn compact_extract_error(
 
 fn decode_compact_objects(
     obj_type: ObjectType,
-    data: &[u8],
+    frame: &DecodedFrame,
     require_blob_frame: bool,
 ) -> Result<Option<DecodedCompactObjects>> {
+    let data = frame.bytes.as_ref();
     match obj_type {
         ObjectType::Blob if require_blob_frame => {
             heddle_object_model::compact::decode_blob_frame(data)
@@ -968,24 +1160,60 @@ fn decode_compact_objects(
                 .collect::<Result<Vec<_>>>()
                 .map(Some)
         }
-        ObjectType::State if heddle_object_model::compact::is_state_frame(data) => {
-            heddle_object_model::compact::decode_state_frame(data)
-                .map_err(|error| StoreError::InvalidObject(error.to_string()))?
-                .into_iter()
-                .map(|state| {
-                    let id = PackObjectId::StateId(state.state_id);
-                    let bytes = rmp_serde::to_vec_named(&state)
-                        .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
-                    Ok((id, ObjectType::State, bytes))
-                })
-                .collect::<Result<Vec<_>>>()
-                .map(Some)
-        }
+        ObjectType::State if heddle_object_model::compact::is_state_frame(data) => frame
+            .states
+            .as_ref()
+            .ok_or_else(|| {
+                StoreError::InvalidObject(
+                    "compact state frame is missing its decoded state vector".into(),
+                )
+            })?
+            .iter()
+            .map(|state| {
+                let id = PackObjectId::StateId(state.state_id);
+                let bytes = rmp_serde::to_vec_named(&state)
+                    .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
+                Ok((id, ObjectType::State, bytes))
+            })
+            .collect::<Result<Vec<_>>>()
+            .map(Some),
         _ if is_compact_frame(data) => Err(StoreError::InvalidObject(
             "compact frame magic does not match its pack object type".into(),
         )),
         _ => Ok(None),
     }
+}
+
+fn state_from_decoded_frame(frame: &DecodedFrame, expected: StateId) -> Result<State> {
+    frame
+        .states
+        .as_ref()
+        .ok_or_else(|| {
+            StoreError::InvalidObject(
+                "compact state frame is missing its decoded state vector".into(),
+            )
+        })?
+        .iter()
+        .find(|state| state.accepts_stored_id(&expected))
+        .cloned()
+        .map(|mut state| {
+            state.state_id = expected;
+            state
+        })
+        .ok_or_else(|| compact_index_miss(&PackObjectId::StateId(expected)))
+}
+
+fn decode_serialized_state(data: &[u8], expected: StateId) -> Result<State> {
+    let mut state: State = rmp_serde::from_slice(data)
+        .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
+    if !state.accepts_stored_id(&expected) {
+        return Err(StoreError::InvalidObject(format!(
+            "state id mismatch: requested {expected}, computed {}",
+            state.id()
+        )));
+    }
+    state.state_id = expected;
+    Ok(state)
 }
 
 fn compact_index_miss(id: &PackObjectId) -> StoreError {

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -1097,6 +1097,39 @@ mod tests {
     }
 
     #[test]
+    fn shared_state_frame_returns_typed_states_from_one_decode() {
+        use crate::object::{Attribution, Principal, State};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let attribution = Attribution::human(Principal::new("Reader", "reader@example.com"));
+        let first = State::new(deterministic_hash(0x40), Vec::new(), attribution.clone())
+            .with_intent("first");
+        let second = State::new(deterministic_hash(0x41), vec![first.id()], attribution)
+            .with_intent("second");
+        let states = [first, second];
+        let ids = states
+            .iter()
+            .map(|state| PackObjectId::StateId(state.id()))
+            .collect::<Vec<_>>();
+        let frame = heddle_object_model::compact::encode_state_frame(&states).unwrap();
+        builder
+            .add_shared_frame(&ids, ObjectType::State, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, _) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        for state in &states {
+            assert_eq!(reader.get_state(&state.id()).unwrap(), Some(state.clone()));
+        }
+        assert_eq!(
+            reader.compact_frame_read_count(),
+            1,
+            "typed state reads must reuse the decoded state vector"
+        );
+    }
+
+    #[test]
     fn compact_tree_extraction_rejects_an_index_alias_with_the_wrong_typed_hash() {
         use crate::object::{Tree, TreeEntry};
 
@@ -1166,6 +1199,11 @@ mod tests {
                 Some(expected.len() as u64)
             );
         }
+        assert_eq!(
+            reader.compact_frame_read_count(),
+            1,
+            "sequential point reads must decompress a shared frame once"
+        );
     }
 
     #[test]

--- a/crates/perf-contract/src/lib.rs
+++ b/crates/perf-contract/src/lib.rs
@@ -20,6 +20,10 @@ static NETWORK_CLIENT_INITIALIZATIONS: AtomicU64 = AtomicU64::new(0);
 static ANCESTORS_VISITED: AtomicU64 = AtomicU64::new(0);
 static HISTORY_OBJECTS_DECODED: AtomicU64 = AtomicU64::new(0);
 static GIT_REACHABLE_COPY_OPERATIONS: AtomicU64 = AtomicU64::new(0);
+static PACK_FRAME_DECOMPRESSIONS: AtomicU64 = AtomicU64::new(0);
+static PACK_FRAME_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+static PACK_BLOB_BODIES_HASHED: AtomicU64 = AtomicU64::new(0);
+static PACK_STATE_FRAMES_DECODED: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct StructuralCounters {
@@ -36,6 +40,10 @@ pub struct StructuralCounters {
     pub ancestors_visited: u64,
     pub history_objects_decoded: u64,
     pub git_reachable_copy_operations: u64,
+    pub pack_frame_decompressions: u64,
+    pub pack_frame_cache_hits: u64,
+    pub pack_blob_bodies_hashed: u64,
+    pub pack_state_frames_decoded: u64,
 }
 
 fn enabled() -> bool {
@@ -101,6 +109,22 @@ pub fn record_git_reachable_copy_operation() {
     add(&GIT_REACHABLE_COPY_OPERATIONS, 1);
 }
 
+pub fn record_pack_frame_decompression() {
+    add(&PACK_FRAME_DECOMPRESSIONS, 1);
+}
+
+pub fn record_pack_frame_cache_hit() {
+    add(&PACK_FRAME_CACHE_HITS, 1);
+}
+
+pub fn record_pack_blob_bodies_hashed(count: usize) {
+    add(&PACK_BLOB_BODIES_HASHED, count as u64);
+}
+
+pub fn record_pack_state_frame_decode() {
+    add(&PACK_STATE_FRAMES_DECODED, 1);
+}
+
 pub fn snapshot() -> StructuralCounters {
     StructuralCounters {
         directories_scanned: DIRECTORIES_SCANNED.load(Ordering::Relaxed),
@@ -116,5 +140,9 @@ pub fn snapshot() -> StructuralCounters {
         ancestors_visited: ANCESTORS_VISITED.load(Ordering::Relaxed),
         history_objects_decoded: HISTORY_OBJECTS_DECODED.load(Ordering::Relaxed),
         git_reachable_copy_operations: GIT_REACHABLE_COPY_OPERATIONS.load(Ordering::Relaxed),
+        pack_frame_decompressions: PACK_FRAME_DECOMPRESSIONS.load(Ordering::Relaxed),
+        pack_frame_cache_hits: PACK_FRAME_CACHE_HITS.load(Ordering::Relaxed),
+        pack_blob_bodies_hashed: PACK_BLOB_BODIES_HASHED.load(Ordering::Relaxed),
+        pack_state_frames_decoded: PACK_STATE_FRAMES_DECODED.load(Ordering::Relaxed),
     }
 }


### PR DESCRIPTION
## Summary

- extract one HCB2 blob slice after whole-frame verification, hashing only through the requested body and copying only that body
- add a 64 MiB manager-wide decoded-frame LRU keyed by pack path and record offset; compact state frames retain their decoded `Vec<State>` in the same entry
- return typed packed states to `FsStore`, avoiding the compact-state MessagePack serialize/parse round trip
- keep delta-chain traversal iterative and isolate one-record reading as the extension seam for #1670
- add repacked `DiffOne` and `LogBounded` release perf-contract variants with structural counters

## Measured repacked reads

Five release samples (`HEDDLE_PERF_SAMPLES=5 HEDDLE_PERF_RECORD_ONLY=1`):

- `diff_one_repacked`: p50 61.426 ms, p95 70.374 ms; 2 frame decompressions, 1 blob body hashed, 1 state frame decoded per sample
- `log_bounded_repacked --limit 20`: p50 22.980 ms, p95 23.898 ms; 1 frame decompression, 19 frame-cache hits, 1 state-frame decode per sample

The structural gate caps repacked diff at 2 decompressions / 128 hashed bodies / 1 state decode, and requires repacked log to remain at 1 decompression / 1 state decode with at least 19 cache hits. This makes a regression to decode-every-state-per-read or hash-the-whole-blob-frame observable.

## Test evidence

- `cargo build`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p heddle-pack` (90 passed)
- `cargo test -p heddle-object-model compact::` (21 passed)
- `cargo test -p heddle-objects --test frame_reader --test hot_tier --test integrity` (12 passed)
- targeted compact blob extraction, shared blob/state frame caching, delta chain, and LRU eviction tests
- `HEDDLE_PERF_SAMPLES=5 HEDDLE_PERF_RECORD_ONLY=1 TMPDIR=/home/scratch cargo test --release -p heddle-cli --test cli_basics core_loop_release_contract -- --ignored --nocapture`
- nightly Rustfmt over every touched Rust file

Closes #1655
Refs #1652

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790939835&installation_model_id=21489&pr_number=1671&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1671&signature=c9a6e07377c3e673a6d750e7d1ff46b5caa1b7be03c00ca9ed028b111a824507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->