### PR TITLE
pull: fall back when packed context is unavailable

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1786,7 +1786,8 @@ async fn clone_network_connected(
             &local_repo,
             client,
             repo_path,
-            Some(bootstrap.context.as_slice()),
+            bootstrap.context.as_deref(),
+            Some(final_state),
         )
         .await
         {
@@ -2022,7 +2023,8 @@ async fn recover_interrupted_clone_connected(
         &repo,
         client,
         &intent.repository,
-        Some(bootstrap.context.as_slice()),
+        bootstrap.context.as_deref(),
+        Some(final_state),
     )
     .await
     {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1252,7 +1252,8 @@ async fn pull_network_connected(
                 repo_path,
                 bootstrap
                     .as_ref()
-                    .map(|metadata| metadata.context.as_slice()),
+                    .and_then(|metadata| metadata.context.as_deref()),
+                final_state_id,
             )
             .await
             {

--- a/crates/hosted-client/src/client/context_sync.rs
+++ b/crates/hosted-client/src/client/context_sync.rs
@@ -726,15 +726,21 @@ async fn first_server_revision_id(
 // Pull
 // =========================================================================
 
-/// Fetch hosted annotations for the head and reconcile them into the local
-/// `Context` attachment, rebuilding revision order to match the server.
+/// Fetch hosted annotations for `against` (or repository HEAD) and reconcile
+/// them into the local `Context` attachment, rebuilding revision order to
+/// match the server.
+///
+/// `against` is the pulled/cloned tip. Clone publishes HEAD only after this
+/// call, and `heddle pull feature --local-thread feature` leaves HEAD on the
+/// current checkout, so the fallback must not re-read HEAD.
 pub async fn pull_context(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
     bootstrap: Option<&[(ContextTarget, ContextBlob)]>,
+    against: Option<StateId>,
 ) -> Result<usize> {
-    let Some(head_id) = repo.head().context("resolve repository head")? else {
+    let Some(head_id) = context_sync_state(repo, against)? else {
         return Ok(0);
     };
     let Some(head_state) = repo
@@ -815,6 +821,15 @@ pub async fn pull_context(
         }
     }
     Ok(changed)
+}
+
+/// Prefer the pulled/cloned tip because clone has not published HEAD yet and a
+/// local-thread pull may target a thread other than the current checkout.
+fn context_sync_state(repo: &Repository, against: Option<StateId>) -> Result<Option<StateId>> {
+    match against {
+        Some(state) => Ok(Some(state)),
+        None => repo.head().context("resolve repository head"),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1361,6 +1376,116 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn clone_context_pack_fallback_uses_against_before_head_is_published() {
+        use api::heddle::api::v1alpha1::{AnnotatedFile, ContextAnnotation, ContextRevision};
+
+        use crate::hosted_runtime::hosted::{
+            PullBootstrapMetadata,
+            test_server::{ContextFixture, start_with_context},
+        };
+
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        let tree_id = repo
+            .store()
+            .put_tree(&objects::object::Tree::new())
+            .unwrap();
+        let state = State::new_snapshot(
+            tree_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        let against = state.id();
+        assert_eq!(
+            repo.head().unwrap(),
+            None,
+            "clone has not published HEAD yet"
+        );
+
+        // The server advertised a Context attachment, but the pull loop does
+        // not consume StateAttachment frames. Resolution must select the RPC
+        // fallback instead of clone-killing or treating it as an empty page.
+        let bootstrap = PullBootstrapMetadata {
+            discussions_from_pack: false,
+            discussions: Vec::new(),
+            context_from_pack: true,
+            context: Vec::new(),
+        }
+        .resolve(&repo, Some(against))
+        .expect("unconsumable packed context must fall back");
+        assert!(bootstrap.context.is_none());
+
+        let annotation_id = "server-context-before-head".to_string();
+        let fixture = ContextFixture {
+            files: vec![AnnotatedFile {
+                path: "lib.rs".to_string(),
+                annotations: vec![ContextAnnotation {
+                    id: annotation_id.clone(),
+                    status: ContextAnnotationStatus::Active as i32,
+                    kind: ContextAnnotationKind::Invariant as i32,
+                    ..ContextAnnotation::default()
+                }],
+            }],
+            histories: std::collections::HashMap::from([(
+                annotation_id.clone(),
+                vec![ContextRevision {
+                    revision_id: "server-context-revision".to_string(),
+                    kind: ContextAnnotationKind::Invariant as i32,
+                    content: "preserve this contract".to_string(),
+                    attribution: "reviewer <>".to_string(),
+                    created_at: Some(prost_types::Timestamp {
+                        seconds: 1_700_000_000,
+                        nanos: 0,
+                    }),
+                    ..ContextRevision::default()
+                }],
+            )]),
+            ..ContextFixture::default()
+        };
+        let (mut client, server, fixture) = start_with_context(fixture).await;
+
+        assert_eq!(
+            pull_context(
+                &repo,
+                &mut client,
+                "acme/widgets",
+                bootstrap.context.as_deref(),
+                Some(against),
+            )
+            .await
+            .unwrap(),
+            1,
+            "fallback must not return Ok(0) just because HEAD is unpublished"
+        );
+        assert_eq!(*fixture.list_requests.lock().unwrap(), 1);
+        assert_eq!(
+            fixture.history_requests.lock().unwrap().as_slice(),
+            [annotation_id]
+        );
+        assert_eq!(
+            repo.head().unwrap(),
+            None,
+            "sync must not publish clone HEAD"
+        );
+
+        let stored_state = repo.store().get_state(&against).unwrap().unwrap();
+        let root = context_root_for_state(&repo, &stored_state)
+            .unwrap()
+            .expect("fallback materialized a Context attachment");
+        let target = ContextTarget::file("lib.rs").unwrap();
+        let blob = repo.get_context_blob(&root, &target).unwrap().unwrap();
+        assert_eq!(blob.annotations.len(), 1);
+        assert_eq!(
+            blob.annotations[0].annotation_id,
+            "server-context-before-head"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn bootstrap_pull_materializes_context_once_and_persists_the_mirror() {
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
@@ -1389,13 +1514,13 @@ mod tests {
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
 
         assert_eq!(
-            pull_context(&repo, &mut client, "acme/widgets", Some(&bootstrap))
+            pull_context(&repo, &mut client, "acme/widgets", Some(&bootstrap), None,)
                 .await
                 .unwrap(),
             1
         );
         assert_eq!(
-            pull_context(&repo, &mut client, "acme/widgets", Some(&bootstrap))
+            pull_context(&repo, &mut client, "acme/widgets", Some(&bootstrap), None,)
                 .await
                 .unwrap(),
             0

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -68,6 +68,8 @@ use iroh::{Endpoint, EndpointAddr};
 pub use methods::HostedRoutes;
 use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
+#[cfg(test)]
+pub(crate) use sync::PullBootstrapMetadata;
 pub use sync::{HostedRefEntry, decode_pull_bootstrap, decode_pull_refs};
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -108,7 +108,13 @@ pub struct ResolvedPullBootstrapMetadata {
     /// packed attachment was unconsumable. Absent on the inline-bootstrap path
     /// and when the pack decoded.
     pub discussions_pack_fallback: Option<String>,
-    pub context: Vec<(ContextTarget, ContextBlob)>,
+    /// Packed or inline bootstrap context. `None` means the server advertised
+    /// `context_from_pack` and this client cannot consume the attachment, so
+    /// callers fall back to `ListContext`.
+    pub context: Option<Vec<(ContextTarget, ContextBlob)>>,
+    /// Human-facing reason when [`Self::context`] is `None`. Absent on the
+    /// inline-bootstrap path and when the packed attachment decoded.
+    pub context_pack_fallback: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -140,15 +146,25 @@ impl PullBootstrapMetadata {
         } else {
             (Some(self.discussions.clone()), None)
         };
-        let context = if self.context_from_pack {
-            context_from_pull_pack(repo, state_id)?
+        let (context, context_pack_fallback) = if self.context_from_pack {
+            match context_from_pull_pack(repo, state_id)? {
+                PackedContext::Ready(context) => (Some(context), None),
+                PackedContext::Unconsumable(reason) => {
+                    let warning = format!(
+                        "pull bootstrap advertised packed context but this client cannot consume it ({reason}); falling back to ListContext"
+                    );
+                    eprintln!("{} {warning}", heddle_cli_render::cli::style::warn_marker());
+                    (None, Some(warning))
+                }
+            }
         } else {
-            self.context.clone()
+            (Some(self.context.clone()), None)
         };
         Ok(ResolvedPullBootstrapMetadata {
             discussions,
             discussions_pack_fallback,
             context,
+            context_pack_fallback,
         })
     }
 }
@@ -302,21 +318,33 @@ fn named_map_version_skew(bytes: &[u8]) -> bool {
         .is_some_and(|version| version != DiscussionsBlob::FORMAT_VERSION)
 }
 
-pub(crate) fn context_from_pull_pack(
+enum PackedContext {
+    Ready(Vec<(ContextTarget, ContextBlob)>),
+    /// Server advertised a pack optimization this client cannot consume.
+    /// Clone/pull must ListContext instead of exiting 76.
+    Unconsumable(String),
+}
+
+fn context_from_pull_pack(
     repo: &Repository,
     state_id: StateId,
-) -> Result<Vec<(ContextTarget, ContextBlob)>, ProtocolError> {
+) -> Result<PackedContext, ProtocolError> {
     let Some(attachment) = repo.latest_state_attachment(&state_id, StateAttachmentKind::Context)?
     else {
-        return Err(ProtocolError::InvalidState(
-            "pull bootstrap advertised packed context but the attachment is missing".to_string(),
+        return Ok(PackedContext::Unconsumable(
+            "the attachment is missing".to_string(),
         ));
     };
     let StateAttachmentBody::Context(root) = attachment.body else {
-        return Err(ProtocolError::InvalidState(
-            "packed context attachment has the wrong kind".to_string(),
+        return Ok(PackedContext::Unconsumable(
+            "the attachment has the wrong kind".to_string(),
         ));
     };
+    if repo.store().get_tree(&root)?.is_none() {
+        return Ok(PackedContext::Unconsumable(format!(
+            "the context root {root} is missing"
+        )));
+    }
     let mut entries = repo
         .list_context_entries(&root, None)?
         .into_iter()
@@ -327,7 +355,7 @@ pub(crate) fn context_from_pull_pack(
             .retain(|annotation| annotation.status == AnnotationStatus::Active);
     }
     entries.retain(|(_, blob)| !blob.annotations.is_empty());
-    Ok(entries)
+    Ok(PackedContext::Ready(entries))
 }
 
 struct PullWantPlan {
@@ -2055,11 +2083,10 @@ impl HostedClient {
                 }
                 Some(pull_server_frame::Frame::StateAttachment(_)) => {
                     // Recognized and ignored. Weft streams attachments on this
-                    // frame, not in the native pack. Discussions are a v2
-                    // named-map chain; this client decodes v1 positional
-                    // DiscussionsBlob and must not treat the chain as
-                    // transport. resolve() ListByState-falls-back when
-                    // discussions_from_pack is advertised but unconsumable.
+                    // frame, not in the native pack. This client does not yet
+                    // consume that live transfer. resolve() falls back to the
+                    // hosted list RPC when discussions_from_pack or
+                    // context_from_pack is advertised but unconsumable.
                 }
                 Some(pull_server_frame::Frame::Complete(complete)) => {
                     tx.take();
@@ -3599,7 +3626,8 @@ mod pull_bootstrap_tests {
 
         assert_eq!(resolved.discussions, Some(vec![discussion]));
         assert!(resolved.discussions_pack_fallback.is_none());
-        assert_eq!(resolved.context, vec![(target, context_blob)]);
+        assert_eq!(resolved.context, Some(vec![(target, context_blob)]));
+        assert!(resolved.context_pack_fallback.is_none());
     }
 
     fn seed_snapshot() -> (TempDir, Repository, StateId) {
@@ -3641,6 +3669,61 @@ mod pull_bootstrap_tests {
             context_from_pack: false,
             context: Vec::new(),
         }
+    }
+
+    fn packed_context_metadata() -> PullBootstrapMetadata {
+        PullBootstrapMetadata {
+            discussions_from_pack: false,
+            discussions: Vec::new(),
+            context_from_pack: true,
+            context: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn packed_bootstrap_falls_back_when_context_attachment_is_missing() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let resolved = packed_context_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect("missing packed context must not clone-kill");
+        assert!(
+            resolved.context.is_none(),
+            "None means ListContext, not an empty inline set"
+        );
+        let warning = resolved.context_pack_fallback.expect("warned fallback");
+        assert!(warning.contains("the attachment is missing"), "{warning}");
+        assert!(warning.contains("falling back to ListContext"), "{warning}");
+    }
+
+    #[test]
+    fn packed_bootstrap_fail_closes_when_context_blob_is_corrupt() {
+        let (_temp, repo, state_id) = seed_snapshot();
+        let corrupt_hash = repo
+            .store()
+            .put_blob(&Blob::from(vec![0x80]))
+            .expect("store corrupt context blob");
+        let mut files = Tree::new();
+        files.insert(TreeEntry::file("lib.rs", corrupt_hash, false).expect("context file entry"));
+        let files_hash = repo.store().put_tree(&files).expect("store files tree");
+        let mut root = Tree::new();
+        root.insert(TreeEntry::directory("__files", files_hash).expect("context files root"));
+        let context_root = repo.store().put_tree(&root).expect("store context root");
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::Context(context_root),
+            attribution: Attribution::human(Principal::new("Ada", "ada@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach corrupt context");
+
+        let error = packed_context_metadata()
+            .resolve(&repo, Some(state_id))
+            .expect_err("present corrupt ContextBlob must fail closed");
+        assert!(
+            error.to_string().contains("invalid context blob"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -3860,6 +3943,8 @@ mod pull_bootstrap_tests {
         .expect("inline bootstrap");
         assert_eq!(resolved.discussions, Some(vec![discussion]));
         assert!(resolved.discussions_pack_fallback.is_none());
+        assert_eq!(resolved.context, Some(Vec::new()));
+        assert!(resolved.context_pack_fallback.is_none());
     }
 }
 

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -14,17 +14,18 @@ use api::{
         encode_success_response,
     },
     heddle::api::v1alpha1::{
-        BlobResponse, CallFailure, CallFailureCode, CreateSpoolRequest, DeleteSpoolRequest,
-        Discussion, GetBlobRequest, GetContextHistoryPageEnd, GetContextHistoryResponse,
-        GetDiscussionRequest, HostedSpool, ListContextPageEnd, ListContextResponse,
-        ListDiscussionsByStateRequest, ListDiscussionsPageEnd, ListDiscussionsResponse,
-        ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk,
-        PackStreamKind, PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete,
-        PushReady, PushRequest, PushServerFrame, RepoEvent, SignedSpoolOwnerGenesis, StateId,
-        SubscribeRepoEventsRequest, TransferCheckpoint, TransportMode, UpdateSpoolRequest,
-        get_context_history_response, list_context_response, list_discussions_response,
-        list_refs_response, list_threads_response, pull_server_frame, push_client_frame,
-        push_server_frame,
+        AnnotatedFile, BlobResponse, CallFailure, CallFailureCode, ContextRevision,
+        CreateSpoolRequest, DeleteSpoolRequest, Discussion, GetBlobRequest,
+        GetContextHistoryPageEnd, GetContextHistoryRequest, GetContextHistoryResponse,
+        GetDiscussionRequest, HostedSpool, ListContextPageEnd, ListContextRequest,
+        ListContextResponse, ListDiscussionsByStateRequest, ListDiscussionsPageEnd,
+        ListDiscussionsResponse, ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd,
+        ListThreadsResponse, PackChunk, PackStreamKind, PullComplete, PullReady, PullServerFrame,
+        PushClientFrame, PushComplete, PushReady, PushRequest, PushServerFrame, RepoEvent,
+        SignedSpoolOwnerGenesis, StateContextEntry, StateId, SubscribeRepoEventsRequest,
+        TransferCheckpoint, TransportMode, UpdateSpoolRequest, get_context_history_response,
+        list_context_response, list_discussions_response, list_refs_response,
+        list_threads_response, pull_server_frame, push_client_frame, push_server_frame,
     },
     method_descriptor,
 };
@@ -44,6 +45,8 @@ const DELETE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/DeleteSp
 const UPDATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/UpdateSpool";
 const GET_DISCUSSION_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/GetDiscussion";
 const LIST_BY_STATE_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/ListByState";
+const LIST_CONTEXT_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/ListContext";
+const GET_CONTEXT_HISTORY_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/GetContextHistory";
 const SUBSCRIBE_REPO_EVENTS_METHOD: &str =
     "/heddle.api.v1alpha1.RepositoryService/SubscribeRepoEvents";
 
@@ -74,8 +77,17 @@ pub(crate) struct CollaborationFixture {
     pub subscribe_thread: Arc<Mutex<Vec<(String, String)>>>,
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct ContextFixture {
+    pub files: Vec<AnnotatedFile>,
+    pub states: Vec<StateContextEntry>,
+    pub histories: HashMap<String, Vec<ContextRevision>>,
+    pub list_requests: Arc<Mutex<usize>>,
+    pub history_requests: Arc<Mutex<Vec<String>>>,
+}
+
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None, BlobFixture::default(), None, None, None, None).await
+    start_inner(None, BlobFixture::default(), None, None, None, None, None).await
 }
 
 pub(crate) async fn start_with_collaboration(
@@ -88,7 +100,25 @@ pub(crate) async fn start_with_collaboration(
         None,
         None,
         None,
+        None,
         Some(fixture),
+    )
+    .await;
+    (client, server, fixture_clone)
+}
+
+pub(crate) async fn start_with_context(
+    fixture: ContextFixture,
+) -> (HostedClient, JoinHandle<()>, ContextFixture) {
+    let fixture_clone = fixture.clone();
+    let (client, server) = start_inner(
+        None,
+        BlobFixture::default(),
+        None,
+        None,
+        None,
+        Some(fixture),
+        None,
     )
     .await;
     (client, server, fixture_clone)
@@ -103,6 +133,7 @@ pub(crate) async fn start_recording_push()
         None,
         None,
         Some(Arc::clone(&captured)),
+        None,
         None,
     )
     .await;
@@ -119,6 +150,7 @@ pub(crate) async fn start_recording_create_spool() -> (
         None,
         BlobFixture::default(),
         Some(Arc::clone(&captured)),
+        None,
         None,
         None,
         None,
@@ -140,6 +172,7 @@ pub(crate) async fn start_recording_spool_mutations() -> (
         Some(Arc::clone(&captured)),
         None,
         None,
+        None,
     )
     .await;
     (client, server, captured)
@@ -154,6 +187,7 @@ pub(crate) async fn start_with_remote_state(
             pack: None,
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -173,6 +207,7 @@ pub(crate) async fn start_with_pull_pack(
             pack: Some((pack_data, index_data)),
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -212,7 +247,7 @@ async fn start_with_get_blob_contents_and_pull(
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(pull, fixture, None, None, None, None).await;
+    let (client, server) = start_inner(pull, fixture, None, None, None, None, None).await;
     (client, server, requested)
 }
 
@@ -234,6 +269,7 @@ async fn start_inner(
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
+    context: Option<ContextFixture>,
     collaboration: Option<CollaborationFixture>,
 ) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
@@ -261,6 +297,7 @@ async fn start_inner(
                 create_spool.clone(),
                 spool_mutations.clone(),
                 push_requests.clone(),
+                context.clone(),
                 collaboration.clone(),
             ));
         }
@@ -292,6 +329,7 @@ async fn serve_call(
     create_spool: Option<Arc<Mutex<Vec<CreateSpoolRequest>>>>,
     spool_mutations: Option<Arc<Mutex<SpoolMutationCapture>>>,
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
+    context: Option<ContextFixture>,
     collaboration: Option<CollaborationFixture>,
 ) {
     let mut request = Vec::new();
@@ -332,7 +370,25 @@ async fn serve_call(
             }
         }
         StreamingShape::ServerStreaming => {
-            if method == LIST_BY_STATE_METHOD {
+            if method == LIST_CONTEXT_METHOD {
+                if let Some(context) = context {
+                    serve_list_context(&mut send, &mut recv, &mut request, context).await;
+                } else {
+                    let body = terminal_page(&method);
+                    send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+                        .await
+                        .unwrap();
+                }
+            } else if method == GET_CONTEXT_HISTORY_METHOD {
+                if let Some(context) = context {
+                    serve_get_context_history(&mut send, &mut recv, &mut request, context).await;
+                } else {
+                    let body = terminal_page(&method);
+                    send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+                        .await
+                        .unwrap();
+                }
+            } else if method == LIST_BY_STATE_METHOD {
                 if let Some(collaboration) = collaboration {
                     serve_list_by_state(&mut send, &mut recv, &mut request, collaboration).await;
                 } else {
@@ -680,6 +736,85 @@ async fn read_request_body(recv: &mut iroh::endpoint::RecvStream, request: &mut 
     while let Ok(Some(chunk)) = recv.read_chunk(api::framing::MAX_CONTROL_BODY + 6).await {
         request.extend_from_slice(&chunk);
     }
+}
+
+async fn serve_list_context(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    fixture: ContextFixture,
+) {
+    read_request_body(recv, request).await;
+    let _ = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| ListContextRequest::decode(frame.body).ok());
+    *fixture
+        .list_requests
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner()) += 1;
+    for file in &fixture.files {
+        let body = ListContextResponse {
+            frame: Some(list_context_response::Frame::Item(file.clone())),
+            states: Vec::new(),
+        }
+        .encode_to_vec();
+        send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+            .await
+            .unwrap();
+    }
+    let end = ListContextResponse {
+        frame: Some(list_context_response::Frame::PageEnd(ListContextPageEnd {
+            next_page_token: String::new(),
+            ..ListContextPageEnd::default()
+        })),
+        states: fixture.states.clone(),
+    }
+    .encode_to_vec();
+    send.write_chunk(Bytes::from(encode_stream_message(&end).unwrap()))
+        .await
+        .unwrap();
+}
+
+async fn serve_get_context_history(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    fixture: ContextFixture,
+) {
+    read_request_body(recv, request).await;
+    let annotation_id = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| GetContextHistoryRequest::decode(frame.body).ok())
+        .map(|body| body.annotation_id)
+        .unwrap_or_default();
+    fixture
+        .history_requests
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(annotation_id.clone());
+    if let Some(revisions) = fixture.histories.get(&annotation_id) {
+        for revision in revisions {
+            let body = GetContextHistoryResponse {
+                frame: Some(get_context_history_response::Frame::Item(revision.clone())),
+            }
+            .encode_to_vec();
+            send.write_chunk(Bytes::from(encode_stream_message(&body).unwrap()))
+                .await
+                .unwrap();
+        }
+    }
+    let end = GetContextHistoryResponse {
+        frame: Some(get_context_history_response::Frame::PageEnd(
+            GetContextHistoryPageEnd {
+                next_page_token: String::new(),
+                ..GetContextHistoryPageEnd::default()
+            },
+        )),
+    }
+    .encode_to_vec();
+    send.write_chunk(Bytes::from(encode_stream_message(&end).unwrap()))
+        .await
+        .unwrap();
 }
 
 async fn serve_get_discussion(

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -274,8 +274,10 @@ impl Repository {
                     }
                     if let Some(blob_hash) = entry.blob_hash()
                         && let Some(blob) = self.store.get_blob(&blob_hash)?
-                        && let Ok(context) = ContextBlob::decode(blob.content())
                     {
+                        let context = ContextBlob::decode(blob.content()).map_err(|error| {
+                            HeddleError::InvalidObject(format!("invalid context blob: {error}"))
+                        })?;
                         results.insert(context_entry_key(&target), (target, context));
                     }
                 }


### PR DESCRIPTION
## Summary

- treat an advertised but absent/unconsumable packed Context attachment as a `ListContext` fallback instead of a clone-killing protocol error
- pass the pulled state through Context sync so clone and local-thread pull do not re-read the wrong or unpublished HEAD
- keep present corrupt `ContextBlob` data fail-closed
- continue to recognize and ignore live `StateAttachment` frames; live consumption remains out of scope

Closes #1672

## Test evidence

- `cargo test -p heddle-hosted-client --features client clone_context_pack_fallback_uses_against_before_head_is_published -- --nocapture` — 1 passed; materialized one hosted annotation with HEAD still unpublished
- `cargo test -p heddle-hosted-client --features client packed_bootstrap_fail_closes_when_context_blob_is_corrupt -- --nocapture` — 1 passed
- `cargo test -p heddle-hosted-client --features client client::context_sync::tests -- --nocapture` — 12 passed
- `cargo test -p heddle-hosted-client --features client hosted_runtime::hosted::sync::pull_bootstrap_tests -- --nocapture` — 19 passed
- `cargo test -p heddle-repo repository_context -- --nocapture` — 11 passed
- `cargo build` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `rustfmt +nightly --edition 2024` on all touched Rust files — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790961158&installation_model_id=21489&pr_number=1674&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1674&signature=5f7b5494d0bb3aeacb74927fa3e8bc9cc67174b47b63f43c50ad8f5414e19ce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->