### PR TITLE
perf(objects): reuse built ids for snapshot descriptors

### DIFF
--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -20,7 +20,7 @@ use crate::{
         FsRepackOperation, HeddleError, ObjectStore, RepackPolicy, RepackResourceLimits,
         RepackSchedule, RepackScheduler, Result, SnapshotCommitArtifact, SnapshotCommitDescriptor,
         TreeWrite, codec,
-        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId, PackReader},
+        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
         snapshot_commit::snapshot_commit_marker_path,
     },
 };
@@ -299,6 +299,14 @@ impl FsStore {
 
         let (pack_data, index_data, _stats, retained_objects) =
             builder.build_retaining_objects()?;
+        let object_ids = commit_artifact.as_ref().map(|_| {
+            let mut ids = retained_objects
+                .iter()
+                .map(|(id, _, _)| *id)
+                .collect::<Vec<_>>();
+            ids.sort_unstable();
+            ids
+        });
         let packs = packs_dir(&self.root);
         let installed_pack_name = if commit_artifact.is_some() {
             let (Some(artifact_id), Some(artifact_bytes)) = (artifact_id, artifact_bytes) else {
@@ -350,8 +358,11 @@ impl FsStore {
         }
         let descriptor = if let Some(artifact) = commit_artifact {
             let pack_path = packs.join(format!("{installed_pack_name}.pack"));
-            let index_path = packs.join(format!("{installed_pack_name}.idx"));
-            let object_ids = PackReader::open(&pack_path, &index_path)?.list_ids()?;
+            let object_ids = object_ids.ok_or_else(|| {
+                HeddleError::InvalidObject(
+                    "snapshot commit pack object ids were not retained".to_string(),
+                )
+            })?;
             Some(SnapshotCommitDescriptor {
                 artifact,
                 pack_name: installed_pack_name,

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -20,10 +20,11 @@ use crate::{
         TreeEntry, decode_tree_delta_header,
     },
     store::{
-        ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult, TreeWrite,
+        ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult,
+        SNAPSHOT_COMMIT_ARTIFACT_SCHEMA, SnapshotCommitArtifact, TreeWrite,
         codec::TreeEncodingKind,
         pack::{
-            ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId,
+            ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId, PackReader,
             decode_tagged_entry_header,
         },
     },
@@ -711,6 +712,62 @@ fn install_pack_accepts_valid_mixed_native_pack() {
         store.get_action(&action_id).unwrap().unwrap().description,
         "packed action",
     );
+}
+
+#[test]
+fn committed_snapshot_descriptor_reuses_built_ids_and_pack_remains_readable() {
+    let (_temp, store) = create_test_store();
+
+    let blob = Blob::from("committed snapshot blob");
+    let blob_hash = blob.hash();
+    let tree = Tree::from_entries(vec![TreeEntry::file("file.txt", blob_hash, false).unwrap()]);
+    let tree_hash = tree.hash();
+    let attribution = Attribution::human(Principal::new("Pack Test", "pack@example.com"));
+    let state = State::new(tree_hash, vec![], attribution).with_intent("committed snapshot");
+    let artifact = SnapshotCommitArtifact {
+        schema: SNAPSHOT_COMMIT_ARTIFACT_SCHEMA,
+        transaction_id: "tx-reader-reuse".to_string(),
+        scope: "snapshot".to_string(),
+        base_oplog_head_id: 0,
+        state: state.id(),
+        encoded_records: vec![vec![1]],
+    };
+
+    let descriptor = store
+        .put_committed_snapshot_objects_packed(
+            vec![(blob_hash, blob.clone().into_content())],
+            Vec::new(),
+            &TreeWrite::anchor(tree.clone()),
+            &state,
+            Vec::new(),
+            artifact.clone(),
+        )
+        .unwrap();
+
+    let reader = PackReader::open(
+        &descriptor.pack_path,
+        &descriptor.pack_path.with_extension("idx"),
+    )
+    .unwrap();
+    assert_eq!(descriptor.object_ids, reader.list_ids().unwrap());
+    let mut expected_ids = vec![
+        PackObjectId::Hash(blob_hash),
+        PackObjectId::Hash(tree_hash),
+        PackObjectId::Hash(artifact.id()),
+        PackObjectId::StateId(state.id()),
+    ];
+    expected_ids.sort_unstable();
+    assert_eq!(descriptor.object_ids, expected_ids);
+    assert_eq!(store.get_blob(&blob_hash).unwrap(), Some(blob));
+    assert_eq!(store.get_tree(&tree_hash).unwrap(), Some(tree));
+    assert_eq!(store.get_state(&state.id()).unwrap(), Some(state));
+
+    let indexed = store.snapshot_commit_descriptors().unwrap();
+    assert_eq!(indexed.len(), 1);
+    assert_eq!(indexed[0].object_ids, descriptor.object_ids);
+    let recovered = store.snapshot_commit_recovery_descriptors().unwrap();
+    assert_eq!(recovered.len(), 1);
+    assert_eq!(recovered[0].artifact, artifact);
 }
 
 #[cfg(feature = "zstd")]


### PR DESCRIPTION
Closes #1661
Refs #1652

## Summary
- derive committed snapshot descriptor IDs from the objects already retained by `PackBuilder`
- keep `PackManager::add_pack` as the single checksum-verifying open of the installed pack
- leave snapshot commit markers and journal recovery unchanged

The committed capture install path drops from two full pack opens and two index constructions to one full pack open and one index construction.

## Test evidence
- `rustfmt +nightly --edition 2024 crates/objects/src/store/fs/fs_pack.rs crates/objects/src/store/fs/fs_tests.rs`
- `cargo test -p heddle-objects committed_snapshot_descriptor_reuses_built_ids_and_pack_remains_readable -- --nocapture`
- `cargo test -p heddle-objects store::snapshot_commit::tests -- --nocapture`
- `cargo test -p heddle-objects --lib` (290 passed)
- `cargo build`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790969076&installation_model_id=21489&pr_number=1678&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1678&signature=2196f5a4ccb9acee948de1fdcb6a1d633f4e6effa2a5a80fad3d80c9b58afbba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->