### PR TITLE
storage: carry tree lineage depth in HDC1 v2

### DIFF
--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -27,10 +27,12 @@ pub const TREE_LEAN_MAGIC: &[u8; 4] = b"HLR1";
 pub const TREE_DELTA_MAGIC: &[u8; 4] = b"HDC1";
 /// Cursor version used by the HLR1 streaming reader.
 pub const TREE_LEAN_ENCODING_VERSION: u8 = 6;
-/// Current HDC1 body version.
-pub const TREE_DELTA_ENCODING_VERSION: u8 = 1;
-/// Fixed HDC1 header from the HTR4 radical spike.
-pub const TREE_DELTA_HEADER_LEN: usize = 59;
+/// Current HDC1 body version. Version 2 stores lineage depth in the header.
+pub const TREE_DELTA_ENCODING_VERSION: u8 = 2;
+/// Fixed HDC1 v2 header length.
+pub const TREE_DELTA_HEADER_LEN: usize = 60;
+const TREE_DELTA_V1_ENCODING_VERSION: u8 = 1;
+const TREE_DELTA_V1_HEADER_LEN: usize = 59;
 /// A lineage is refreshed after 127 delta descendants.
 pub const TREE_DELTA_ANCHOR_INTERVAL: u8 = 128;
 /// Cumulative deltas above this operation count become anchors.
@@ -657,6 +659,11 @@ impl TreeDeltaOp {
 /// Parsed HDC1 header, including its bounded first-entry and first-100 porch.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TreeDeltaHeader {
+    /// Delta depth within the anchor epoch. Version 1 did not store this hint;
+    /// callers must safely refresh the lineage when it is absent.
+    pub depth: Option<u8>,
+    /// Version-specific header length, and therefore the operation-body offset.
+    pub header_len: usize,
     pub anchor: ContentHash,
     pub result_count: usize,
     pub op_count: usize,
@@ -1071,10 +1078,16 @@ fn delta_prefix_counts(
 /// Encode a one-hop HDC1 body against `anchor`.
 pub fn encode_tree_delta(
     anchor_id: ContentHash,
+    depth: u8,
     anchor: &Tree,
     current: &Tree,
     ops: &[TreeDeltaOp],
 ) -> Result<Vec<u8>, TreeStreamError> {
+    if depth == 0 || depth >= TREE_DELTA_ANCHOR_INTERVAL {
+        return Err(TreeStreamError::Malformed(
+            "tree delta depth must be within its anchor epoch".into(),
+        ));
+    }
     anchor.validate()?;
     current.validate()?;
     if anchor.hash() != anchor_id {
@@ -1144,6 +1157,7 @@ pub fn encode_tree_delta(
     let mut out = Vec::with_capacity(TREE_DELTA_HEADER_LEN + body.len());
     out.extend_from_slice(TREE_DELTA_MAGIC);
     out.push(TREE_DELTA_ENCODING_VERSION);
+    out.push(depth);
     out.extend_from_slice(anchor_id.as_bytes());
     out.extend_from_slice(&result_count.to_le_bytes());
     out.extend_from_slice(&op_count.to_le_bytes());
@@ -1173,7 +1187,7 @@ pub fn decode_tree_delta_header_prefix(
     data: &[u8],
     object_len: usize,
 ) -> Result<TreeDeltaHeader, TreeStreamError> {
-    if data.len() < TREE_DELTA_HEADER_LEN {
+    if data.len() < TREE_DELTA_MAGIC.len() + 1 {
         return Err(TreeStreamError::TruncatedFrame { offset: 0 });
     }
     if !is_delta_tree(data) {
@@ -1181,29 +1195,42 @@ pub fn decode_tree_delta_header_prefix(
             "bytes are not an HDC1 tree delta".into(),
         ));
     }
-    if data[4] != TREE_DELTA_ENCODING_VERSION {
-        return Err(TreeStreamError::UnsupportedVersion { found: data[4] });
+    let (depth, header_len, anchor_offset) = match data[4] {
+        TREE_DELTA_V1_ENCODING_VERSION => (None, TREE_DELTA_V1_HEADER_LEN, 5),
+        TREE_DELTA_ENCODING_VERSION => (data.get(5).copied(), TREE_DELTA_HEADER_LEN, 6),
+        found => return Err(TreeStreamError::UnsupportedVersion { found }),
+    };
+    if data.len() < header_len {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    if depth.is_some_and(|depth| depth == 0 || depth >= TREE_DELTA_ANCHOR_INTERVAL) {
+        return Err(TreeStreamError::Malformed(
+            "invalid HDC1 lineage depth".into(),
+        ));
     }
     let anchor = ContentHash::from_bytes(
-        data[5..37]
+        data[anchor_offset..anchor_offset + 32]
             .try_into()
             .map_err(|_| TreeStreamError::Malformed("delta anchor hash is not 32 bytes".into()))?,
     );
+    let fields_offset = anchor_offset + 32;
     let header = TreeDeltaHeader {
+        depth,
+        header_len,
         anchor,
-        result_count: read_u32_at(data, 37)? as usize,
-        op_count: read_u16_at(data, 41)? as usize,
-        first_op_count: read_u16_at(data, 43)? as usize,
-        first_base_count: read_u16_at(data, 45)? as usize,
-        first_end: read_u32_at(data, 47)? as usize,
-        hundred_op_count: read_u16_at(data, 51)? as usize,
-        hundred_base_count: read_u16_at(data, 53)? as usize,
-        hundred_end: read_u32_at(data, 55)? as usize,
+        result_count: read_u32_at(data, fields_offset)? as usize,
+        op_count: read_u16_at(data, fields_offset + 4)? as usize,
+        first_op_count: read_u16_at(data, fields_offset + 6)? as usize,
+        first_base_count: read_u16_at(data, fields_offset + 8)? as usize,
+        first_end: read_u32_at(data, fields_offset + 10)? as usize,
+        hundred_op_count: read_u16_at(data, fields_offset + 14)? as usize,
+        hundred_base_count: read_u16_at(data, fields_offset + 16)? as usize,
+        hundred_end: read_u32_at(data, fields_offset + 18)? as usize,
     };
     if header.op_count > TREE_DELTA_MAX_OPS
         || header.first_op_count > header.op_count
         || header.hundred_op_count > header.op_count
-        || header.first_end < TREE_DELTA_HEADER_LEN
+        || header.first_end < header.header_len
         || header.hundred_end < header.first_end
         || header.hundred_end > object_len
     {
@@ -1235,7 +1262,7 @@ pub fn decode_tree_delta_ops_prefix(
             "partial delta operation count exceeds object".into(),
         ));
     }
-    let mut offset = TREE_DELTA_HEADER_LEN;
+    let mut offset = header.header_len;
     let mut previous = String::new();
     let mut ops = Vec::with_capacity(wanted);
     for _ in 0..wanted {

--- a/crates/objects/examples/htr4_measure.rs
+++ b/crates/objects/examples/htr4_measure.rs
@@ -38,7 +38,7 @@ const DEFAULT_REAL_TREE_LIMIT: usize = 4_000;
 const REAL_FILE_SAMPLE_LIMIT: usize = 64;
 const RADICAL_ANCHOR_INTERVAL: usize = 128;
 const RADICAL_MAX_OPS: usize = 512;
-const RADICAL_HEADER_LEN: usize = 59;
+const RADICAL_HEADER_LEN: usize = 60;
 const RADICAL_MAGIC: &[u8; 4] = b"HDC1";
 const LEAN_MAGIC: &[u8; 4] = b"HLR1";
 
@@ -867,6 +867,7 @@ fn encode_delta(anchor_id: ContentHash, anchor: &Tree, current: &Tree, ops: &[De
     };
     let mut out = Vec::with_capacity(RADICAL_HEADER_LEN + body.len());
     out.extend_from_slice(RADICAL_MAGIC);
+    out.push(2);
     out.push(1);
     out.extend_from_slice(anchor_id.as_bytes());
     out.extend_from_slice(&(current.len() as u32).to_le_bytes());
@@ -891,10 +892,11 @@ fn decode_delta_ops(
         "truncated radical delta header"
     );
     ensure!(bytes.starts_with(RADICAL_MAGIC), "not a radical tree delta");
-    ensure!(bytes[4] == 1, "unsupported radical delta version");
-    let anchor = ContentHash::from_bytes(bytes[5..37].try_into()?);
-    let result_count = read_u32(bytes, 37)? as usize;
-    let op_count = read_u16(bytes, 41)? as usize;
+    ensure!(bytes[4] == 2, "unsupported radical delta version");
+    ensure!(bytes[5] == 1, "unexpected radical delta depth");
+    let anchor = ContentHash::from_bytes(bytes[6..38].try_into()?);
+    let result_count = read_u32(bytes, 38)? as usize;
+    let op_count = read_u16(bytes, 42)? as usize;
     ensure!(wanted <= op_count, "partial delta op count exceeds object");
     let mut offset = RADICAL_HEADER_LEN;
     let mut previous = String::new();
@@ -928,7 +930,7 @@ fn decode_delta_ops(
 }
 
 fn decode_delta(bytes: &[u8], anchor: &Tree, expected: ContentHash) -> Result<Tree> {
-    let op_count = read_u16(bytes, 41)? as usize;
+    let op_count = read_u16(bytes, 42)? as usize;
     let (anchor_id, result_count, ops, consumed) = decode_delta_ops(bytes, op_count)?;
     ensure!(consumed == bytes.len(), "trailing radical delta bytes");
     ensure!(anchor.hash() == anchor_id, "radical delta anchor mismatch");
@@ -2279,7 +2281,7 @@ fn self_check(dictionary: Dictionary<'_>, block_entries: usize) -> Result<()> {
     let delta = encode_delta(tree.hash(), &tree, &changed, &ops);
     let production_ops = objects::object::tree_delta(&tree, &changed);
     let production_delta =
-        objects::object::encode_tree_delta(tree.hash(), &tree, &changed, &production_ops)?;
+        objects::object::encode_tree_delta(tree.hash(), 1, &tree, &changed, &production_ops)?;
     ensure!(
         production_delta == delta,
         "production HDC1 bytes drifted from the spike"

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -15,14 +15,6 @@ use crate::{
     store::{HeddleError, Result},
 };
 
-/// Store metadata needed to keep a future delta in the same bounded epoch.
-/// Losing this hint is safe: the next write falls back to a fresh HLR1 anchor.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TreeLineage {
-    pub anchor: ContentHash,
-    pub depth: u8,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TreeEncodingKind {
     Lean,
@@ -41,6 +33,8 @@ pub struct EncodedTree {
 }
 
 /// Materialized anchor information inherited from the immediate parent.
+/// A v1 HDC1 parent has no depth, so callers safely omit this hint and the
+/// next write falls back to a fresh HLR1 anchor.
 pub struct TreeDeltaBase<'a> {
     pub anchor_id: ContentHash,
     pub anchor: &'a Tree,
@@ -85,7 +79,7 @@ pub fn encode_tree_hot(tree: &Tree, base: Option<TreeDeltaBase<'_>>) -> Result<E
     if ops.len() > TREE_DELTA_MAX_OPS {
         return encode_tree_lean(tree, hash);
     }
-    let delta = encode_tree_delta(base.anchor_id, base.anchor, tree, &ops)?;
+    let delta = encode_tree_delta(base.anchor_id, depth, base.anchor, tree, &ops)?;
     let header = decode_tree_delta_header(&delta)?;
     let porch_is_bounded = header.first_base_count <= 1 && header.hundred_base_count <= 100;
     if !porch_is_bounded || delta.len() >= encoded_lean_size(tree) {
@@ -355,7 +349,7 @@ mod tests {
         );
         let ops = tree_delta(&anchor, &current);
         assert_eq!(ops.len(), 600);
-        assert!(encode_tree_delta(anchor.hash(), &anchor, &current, &ops).is_err());
+        assert!(encode_tree_delta(anchor.hash(), 1, &anchor, &current, &ops).is_err());
         let encoded = encode_tree_hot(
             &current,
             Some(TreeDeltaBase {
@@ -377,7 +371,7 @@ mod tests {
         assert!(decode_tree_with_key(&lean, wrong, None).is_err());
 
         let ops = tree_delta(&anchor, &current);
-        let delta = encode_tree_delta(anchor.hash(), &anchor, &current, &ops).unwrap();
+        let delta = encode_tree_delta(anchor.hash(), 1, &anchor, &current, &ops).unwrap();
         assert!(decode_tree_with_key(&delta, wrong, Some(&anchor)).is_err());
 
         let raw = current.encode_canonical().unwrap();

--- a/crates/objects/src/store/delta_source.rs
+++ b/crates/objects/src/store/delta_source.rs
@@ -32,7 +32,7 @@ impl DeltaTreeSource {
     ) -> Result<Self, TreeStreamError> {
         let delta_len = usize::try_from(delta.len())
             .map_err(|_| TreeStreamError::Malformed("HDC1 body exceeds usize".into()))?;
-        let mut header_bytes = [0u8; TREE_DELTA_HEADER_LEN];
+        let mut header_bytes = vec![0u8; delta_len.min(TREE_DELTA_HEADER_LEN)];
         delta.read_exact_at(0, &mut header_bytes)?;
         let header = decode_tree_delta_header_prefix(&header_bytes, delta_len)?;
         let mut body = Vec::new();

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -18,7 +18,7 @@ use super::{
         action_path, actions_dir, annotated_tags_dir, blobs_dir, hash_path, redaction_path,
         redactions_dir, state_attachment_index_lock_path, state_attachment_index_path,
         state_attachment_path, state_attachments_dir, state_path, state_visibility_dir,
-        state_visibility_path, states_dir, tree_lineage_path, trees_dir,
+        state_visibility_path, states_dir, trees_dir,
     },
 };
 use crate::{
@@ -31,7 +31,7 @@ use crate::{
     },
     store::{
         HeddleError, ObjectStore, Result, SidecarStore, SnapshotCommitDescriptor, TreeWrite, codec,
-        codec::{EncodedTree, TreeDeltaBase, TreeEncodingKind, TreeLineage},
+        codec::{EncodedTree, TreeDeltaBase},
         delta_source::DeltaTreeSource,
         pack::{ObjectType, PackManager, PackObjectId},
     },
@@ -700,7 +700,7 @@ impl FsStore {
     ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
         let object_len = usize::try_from(delta.len())
             .map_err(|_| HeddleError::InvalidObject("HDC1 body exceeds usize".to_string()))?;
-        let mut header_bytes = [0u8; TREE_DELTA_HEADER_LEN];
+        let mut header_bytes = vec![0u8; object_len.min(TREE_DELTA_HEADER_LEN)];
         delta.read_exact_at(0, &mut header_bytes)?;
         let header = decode_tree_delta_header_prefix(&header_bytes, object_len)?;
         let anchor = self
@@ -941,24 +941,18 @@ impl FsStore {
         };
         let base = if is_delta_tree(&parent_body) {
             let header = decode_tree_delta_header(&parent_body)?;
-            let Some(lineage) = self.read_tree_lineage(&parent)? else {
+            let Some(parent_depth) = header.depth else {
                 return codec::encode_tree_hot(&write.tree, None);
             };
-            if lineage.anchor != header.anchor || lineage.depth == 0 {
-                return codec::encode_tree_hot(&write.tree, None);
-            }
             let anchor = if let Some((_, anchor, _)) =
-                write
-                    .anchor
-                    .as_ref()
-                    .filter(|(anchor_id, _, parent_depth)| {
-                        *anchor_id == lineage.anchor && *parent_depth == lineage.depth
-                    }) {
+                write.anchor.as_ref().filter(|(anchor_id, _, hint_depth)| {
+                    *anchor_id == header.anchor && *hint_depth == parent_depth
+                }) {
                 anchor.clone()
-            } else if let Some(anchor) = self.recent_tree(&lineage.anchor) {
+            } else if let Some(anchor) = self.recent_tree(&header.anchor) {
                 anchor
             } else {
-                let Some(anchor_body) = self.try_get_tree_serialized_once(&lineage.anchor)? else {
+                let Some(anchor_body) = self.try_get_tree_serialized_once(&header.anchor)? else {
                     return codec::encode_tree_hot(&write.tree, None);
                 };
                 if is_delta_tree(&anchor_body) {
@@ -966,9 +960,9 @@ impl FsStore {
                         "HDC1 lineage points to another delta".to_string(),
                     ));
                 }
-                codec::decode_tree_serialized_with_key(&anchor_body, lineage.anchor, None)?
+                codec::decode_tree_serialized_with_key(&anchor_body, header.anchor, None)?
             };
-            Some((lineage.anchor, anchor, lineage.depth))
+            Some((header.anchor, anchor, parent_depth))
         } else {
             let anchor = match write.anchor.as_ref() {
                 Some((anchor_id, anchor, 0)) if *anchor_id == parent => anchor.clone(),
@@ -987,39 +981,6 @@ impl FsStore {
                 parent_depth,
             }),
         )
-    }
-
-    fn read_tree_lineage(&self, hash: &ContentHash) -> Result<Option<TreeLineage>> {
-        let Some(bytes) = read_file_bytes(&tree_lineage_path(&self.root, hash))? else {
-            return Ok(None);
-        };
-        let data = bytes.as_slice();
-        if data.len() != 33 {
-            return Ok(None);
-        }
-        let anchor = match data[..32].try_into() {
-            Ok(bytes) => ContentHash::from_bytes(bytes),
-            Err(_) => return Ok(None),
-        };
-        let depth = data[32];
-        if depth == 0 || depth >= crate::object::TREE_DELTA_ANCHOR_INTERVAL {
-            return Ok(None);
-        }
-        Ok(Some(TreeLineage { anchor, depth }))
-    }
-
-    pub(super) fn remember_tree_encoding(
-        &self,
-        hash: ContentHash,
-        kind: TreeEncodingKind,
-    ) -> Result<()> {
-        let TreeEncodingKind::Delta { anchor, depth, .. } = kind else {
-            return Ok(());
-        };
-        let mut bytes = Vec::with_capacity(33);
-        bytes.extend_from_slice(anchor.as_bytes());
-        bytes.push(depth);
-        self.write_reconstructible_cache(&tree_lineage_path(&self.root, &hash), &bytes)
     }
 
     fn try_has_tree_once(&self, hash: &ContentHash) -> Result<bool> {

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -210,7 +210,6 @@ impl FsStore {
 
         let tree_hash = tree.tree.hash();
         let mut staged_trees = Vec::with_capacity(trees.len() + 1);
-        let mut staged_encodings = Vec::with_capacity(trees.len() + 1);
         let mut seen_trees = std::collections::HashSet::with_capacity(trees.len() + 1);
         for authored_tree in trees {
             let authored_hash = authored_tree.tree.hash();
@@ -233,7 +232,6 @@ impl FsStore {
                     ));
                 }
                 builder.add(authored_hash, PackObjectType::Tree, encoded.data);
-                staged_encodings.push((authored_hash, encoded.kind));
                 staged_trees.push((authored_hash, authored_tree.tree));
             }
         }
@@ -255,7 +253,6 @@ impl FsStore {
                 ));
             }
             builder.add(tree_hash, PackObjectType::Tree, encoded.data);
-            staged_encodings.push((tree_hash, encoded.kind));
             staged_trees.push((tree_hash, tree.tree.clone()));
         }
 
@@ -326,9 +323,6 @@ impl FsStore {
             )?;
         }
         self.remember_pack_dir_modified()?;
-        for (hash, kind) in staged_encodings {
-            self.remember_tree_encoding(hash, kind)?;
-        }
         self.materialize_packed_attachment_index(&state_id, &attachment_ids, state_was_present)?;
 
         if let Ok(mut cache) = self.recent_blobs.write() {

--- a/crates/objects/src/store/fs/fs_paths.rs
+++ b/crates/objects/src/store/fs/fs_paths.rs
@@ -17,14 +17,6 @@ pub(super) fn trees_dir(root: &Path) -> PathBuf {
     objects_dir(root).join("trees")
 }
 
-pub(super) fn tree_lineage_dir(root: &Path) -> PathBuf {
-    objects_dir(root).join("tree-lineage")
-}
-
-pub(super) fn tree_lineage_path(root: &Path, hash: &ContentHash) -> PathBuf {
-    hash_path(&tree_lineage_dir(root), hash)
-}
-
 pub(super) fn annotated_tags_dir(root: &Path) -> PathBuf {
     objects_dir(root).join("annotated-tags")
 }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -18,7 +18,7 @@ use heddle_format::compression::CompressionConfig;
 
 use super::{
     fs_io::{AtomicWriteMode, write_atomic},
-    fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, tree_lineage_dir, trees_dir},
+    fs_paths::{actions_dir, blobs_dir, packs_dir, states_dir, trees_dir},
     npk1::Npk1Manager,
 };
 use crate::{
@@ -398,7 +398,6 @@ impl FsStore {
         // between mkdir and first object write (L6 residual migration).
         crate::fs_atomic::create_dir_all_durable(&blobs_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&trees_dir(&self.root))?;
-        crate::fs_atomic::create_dir_all_durable(&tree_lineage_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&states_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&actions_dir(&self.root))?;
         crate::fs_atomic::create_dir_all_durable(&packs_dir(&self.root))?;

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -639,7 +639,7 @@ fn install_pack_rejects_hdc1_stored_under_its_anchor_id() {
             .collect(),
     );
     let anchor_id = store.put_tree(&anchor).unwrap();
-    let self_delta = crate::object::encode_tree_delta(anchor_id, &anchor, &anchor, &[]).unwrap();
+    let self_delta = crate::object::encode_tree_delta(anchor_id, 1, &anchor, &anchor, &[]).unwrap();
     let mut builder = PackBuilder::new(CompressionConfig::disabled());
     builder.add(anchor_id, PackObjectType::Tree, self_delta);
     let (pack_data, index_data, _) = builder.build().unwrap();
@@ -1279,9 +1279,6 @@ fn direct_parent_hint_does_not_create_a_delta_chain() {
         .unwrap();
     store
         .put_tree_serialized(&first_encoded.data, first_encoded.hash)
-        .unwrap();
-    store
-        .remember_tree_encoding(first_encoded.hash, first_encoded.kind)
         .unwrap();
 
     let mut second_entries = first.entries().to_vec();

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1177,8 +1177,19 @@ fn loose_hlr1_open_is_file_backed_bounded_and_hashes() {
     ));
 }
 
+fn hdc1_v1_from_v2(mut data: Vec<u8>) -> Vec<u8> {
+    assert_eq!(data[4], 2);
+    for offset in [48, 56] {
+        let end = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+        data[offset..offset + 4].copy_from_slice(&(end - 1).to_le_bytes());
+    }
+    data[4] = 1;
+    data.remove(5);
+    data
+}
+
 #[test]
-fn loose_hdc1_reconstructs_from_one_materialized_anchor() {
+fn loose_hdc1_v1_and_v2_reconstruct_from_one_materialized_anchor() {
     use crate::object::{
         BytesTreeSource, TREE_DELTA_MAGIC, TreeEntryReader, TreePageLimits, is_delta_tree,
     };
@@ -1205,6 +1216,9 @@ fn loose_hdc1_reconstructs_from_one_materialized_anchor() {
         .encode_tree_write(&TreeWrite::descendant(current.clone(), anchor_id))
         .unwrap();
     assert!(is_delta_tree(&encoded.data));
+    let v2_header = decode_tree_delta_header(&encoded.data).unwrap();
+    assert_eq!(v2_header.depth, Some(1));
+    assert_eq!(v2_header.header_len, 60);
     store
         .put_tree_serialized(&encoded.data, encoded.hash)
         .unwrap();
@@ -1240,7 +1254,45 @@ fn loose_hdc1_reconstructs_from_one_materialized_anchor() {
         .unwrap();
     assert_eq!(rest.entries, current.entries()[100..]);
     reader.finish_and_verify().unwrap();
-    assert_eq!(reopened.get_tree(&encoded.hash).unwrap(), Some(current));
+    assert_eq!(
+        reopened.get_tree(&encoded.hash).unwrap(),
+        Some(current.clone())
+    );
+
+    let v1 = hdc1_v1_from_v2(encoded.data);
+    let v1_header = decode_tree_delta_header(&v1).unwrap();
+    assert_eq!(v1_header.depth, None);
+    assert_eq!(v1_header.header_len, 59);
+    assert_eq!(v2_header.first_end, v1_header.first_end + 1);
+    assert_eq!(v2_header.hundred_end, v1_header.hundred_end + 1);
+    std::fs::write(&path, v1).unwrap();
+
+    let reopened_v1 = FsStore::new(store.root());
+    let mut v1_reader = reopened_v1.open_tree(&encoded.hash, None).unwrap().unwrap();
+    let first = v1_reader
+        .next_page(TreePageLimits::new(100, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.entries, current.entries()[..100]);
+    let rest = v1_reader
+        .next_page(TreePageLimits::new(usize::MAX, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(rest.entries, current.entries()[100..]);
+    v1_reader.finish_and_verify().unwrap();
+    assert_eq!(
+        reopened_v1.get_tree(&encoded.hash).unwrap(),
+        Some(current.clone())
+    );
+
+    let mut next_entries = current.entries().to_vec();
+    next_entries[118] =
+        TreeEntry::file("module_0118.rs", ContentHash::compute(b"next"), false).unwrap();
+    let next = Tree::from_entries(next_entries);
+    let next_encoded = reopened_v1
+        .encode_tree_write(&TreeWrite::descendant(next, encoded.hash))
+        .unwrap();
+    assert_eq!(next_encoded.kind, TreeEncodingKind::Lean);
 }
 
 #[test]
@@ -1307,12 +1359,53 @@ fn direct_parent_hint_does_not_create_a_delta_chain() {
             ..
         } if anchor == anchor_id
     ));
-    assert_eq!(
-        decode_tree_delta_header(&second_encoded.data)
-            .unwrap()
-            .anchor,
-        anchor_id
+    let header = decode_tree_delta_header(&second_encoded.data).unwrap();
+    assert_eq!(header.anchor, anchor_id);
+    assert_eq!(header.depth, Some(2));
+    assert!(!store.root().join("objects/tree-lineage").exists());
+}
+
+#[test]
+fn packed_capture_stores_hdc1_depth_without_lineage_sidecar() {
+    let (_temp, store) = create_test_store();
+    let anchor = Tree::from_entries(
+        (0..240)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("module_{index:04}.rs"),
+                    ContentHash::compute(format!("anchor-{index}").as_bytes()),
+                    false,
+                )
+                .unwrap()
+            })
+            .collect(),
     );
+    let anchor_id = store.put_tree(&anchor).unwrap();
+    let mut entries = anchor.entries().to_vec();
+    entries[117] =
+        TreeEntry::file("module_0117.rs", ContentHash::compute(b"changed"), false).unwrap();
+    let descendant = Tree::from_entries(entries);
+    let descendant_id = descendant.hash();
+    let state = State::new(
+        descendant_id,
+        Vec::new(),
+        Attribution::human(Principal::new("Capture", "capture@example.com")),
+    );
+
+    store
+        .put_snapshot_objects_packed_impl(
+            Vec::new(),
+            Vec::new(),
+            &TreeWrite::descendant(descendant, anchor_id),
+            &state,
+            Vec::new(),
+            None,
+        )
+        .unwrap();
+
+    let body = store.get_tree_serialized(&descendant_id).unwrap().unwrap();
+    assert_eq!(decode_tree_delta_header(&body).unwrap().depth, Some(1));
+    assert!(!store.root().join("objects/tree-lineage").exists());
 }
 
 #[test]

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -728,7 +728,7 @@ mod tests {
         let current_hash = current.hash();
         let ops = objects::object::tree_delta(&anchor, &current);
         let delta_body =
-            objects::object::encode_tree_delta(anchor_hash, &anchor, &current, &ops).unwrap();
+            objects::object::encode_tree_delta(anchor_hash, 1, &anchor, &current, &ops).unwrap();
         write_loose_tree_bytes(&repo, current_hash, &delta_body);
 
         apply_pending(&repo).unwrap();


### PR DESCRIPTION
## Summary

- bump HDC1 tree deltas to v2 and store depth immediately after the version byte (60-byte header)
- dual-read v1 with unknown depth, preserving decode/seek behavior and safely refreshing the next write to HLR1
- remove the tree-lineage path, init directory, reads, and per-capture writes
- keep porch decoding version-aware through the parsed header length

## Test evidence

- cargo test -p heddle-objects hdc1 -- --nocapture: 5 passed, including v1/v2 paged reconstruction and packed capture without objects/tree-lineage
- cargo test -p heddle-objects direct_parent_hint_does_not_create_a_delta_chain -- --nocapture: passed; v2 child depth advances to 2
- cargo test -p heddle-repo tree_migrations_skip_hlr1_and_hdc1_bodies -- --nocapture: passed
- cargo build: clean
- cargo clippy --workspace --all-targets -- -D warnings: clean
- rustfmt +nightly --edition 2024 on every touched Rust file

Closes #1659
Refs #1652

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790969430&installation_model_id=21489&pr_number=1679&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1679&signature=77610a1a0b43dc5a3e7109c44ab1cde1e5a4ecfdacc2333c0a2c7589ecd79ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->