### PR TITLE
Client-sovereign collaboration ids on heddle-api 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2086,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a7868c6fdcb25b05d7b1a90008adeb21c30ccea387c3e7397af1c277704c0"
+checksum = "62e8486926f5cafd3292428704df00061da5ee729ab4a24c29410baf284b0340"
 dependencies = [
  "blake3",
  "bytes",
@@ -2733,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513d588f63cec67467e14b805feb1d7ba536cd8db58216f61f501a3fecf2bbc7"
+checksum = "501f7b6f413dac4236c7d6b30242c798fa11bd06b0dcfa33728feb98c084324d"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",
@@ -5087,7 +5087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -5120,7 +5120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6898,7 +6898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2316,11 +2316,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "heddle-format"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2578,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.16.0"
+version = "0.17.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.24.0" }
+api = { package = "heddle-api", version = "0.25.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -159,33 +159,33 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-heddle-cli-args = { path = "crates/cli-args", version = "0.16.0", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.16.0", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.16.0", default-features = false }
-heddle-format = { path = "crates/format", version = "0.16.0" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.16.0" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.16.0", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.16.0" }
-heddle-pack = { path = "crates/pack", version = "0.16.0" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.16.0" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.16.0", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.16.0" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.16.0" }
-config = { path = "crates/config", package = "heddle-config", version = "0.16.0" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.16.0" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.16.0", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.16.0", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.16.0" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.16.0" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.16.0" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.16.0", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.16.0" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.16.0", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.16.0" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.16.0" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.16.0" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.16.0", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.16.0", default-features = false }
+heddle-cli-args = { path = "crates/cli-args", version = "0.17.0", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.17.0", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.17.0", default-features = false }
+heddle-format = { path = "crates/format", version = "0.17.0" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.17.0" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.17.0", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.17.0" }
+heddle-pack = { path = "crates/pack", version = "0.17.0" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.17.0" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.17.0", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.17.0" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.17.0" }
+config = { path = "crates/config", package = "heddle-config", version = "0.17.0" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.17.0" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.17.0", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.17.0", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.17.0" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.17.0" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.17.0" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.17.0", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.17.0" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.17.0", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.17.0" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.17.0" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.17.0" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.17.0", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.17.0", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.16.0",
+  "schemaVersion": "0.17.0",
   "verbs": {
     "abort": {
       "$defs": {
@@ -19294,6 +19294,58 @@
         "discussion"
       ],
       "title": "DiscussionShowSchema",
+      "type": "object"
+    },
+    "discuss wait": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "One `heddle discuss wait` JSONL line.",
+      "properties": {
+        "after_event_id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "applied": {
+          "type": "boolean"
+        },
+        "discussion_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "event_id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "event_type": {
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "discuss_wait"
+          ],
+          "type": "string"
+        },
+        "skip_reason": {
+          "description": "Present on `status = \"skipped\"` so a person (and JSONL) can see why.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "status",
+        "event_id",
+        "event_type",
+        "applied",
+        "after_event_id"
+      ],
+      "title": "DiscussWaitLineSchema",
       "type": "object"
     },
     "doctor": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.16.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.17.0" as const;
 
 export interface AbortSchema {
   action: OperatorAction;
@@ -1068,6 +1068,19 @@ export interface DiscussResolveSchema {
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "discuss_resolve";
   replayed?: boolean | null;
+}
+
+/** One `heddle discuss wait` JSONL line. */
+export interface DiscussWaitLineSchema {
+  after_event_id: number;
+  applied: boolean;
+  discussion_id?: string | null;
+  event_id: number;
+  event_type: string;
+  output_kind: "discuss_wait";
+  /** Present on `status = "skipped"` so a person (and JSONL) can see why. */
+  skip_reason?: string | null;
+  status: string;
 }
 
 export interface DiscussionListSchema {
@@ -3549,6 +3562,7 @@ export interface HeddleVerbOutputs {
   "discuss reopen": DiscussReopenSchema;
   "discuss resolve": DiscussResolveSchema;
   "discuss show": DiscussionShowSchema;
+  "discuss wait": DiscussWaitLineSchema;
   doctor: DoctorSchema;
   "doctor docs": DocsReport;
   "doctor schemas": SchemaReport;
@@ -3716,6 +3730,7 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "discuss reopen",
   "discuss resolve",
   "discuss show",
+  "discuss wait",
   "doctor",
   "doctor docs",
   "doctor schemas",

--- a/crates/hosted-client/src/client/context_sync.rs
+++ b/crates/hosted-client/src/client/context_sync.rs
@@ -74,7 +74,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
     AnnotationScope as ProtoScope, ContextAnnotation, ContextAnnotationKind,
     ContextAnnotationStatus, LineRange, SymbolScope, annotation_scope::Scope,
@@ -218,15 +218,6 @@ fn local_id_for_server(
         .map(|entry| entry.local_id.clone())
 }
 
-fn server_id_is_linked(mirror: &HostedContextMirror, repo_path: &str, server_id: &str) -> bool {
-    mirror.repos.get(repo_path).is_some_and(|repo_mirror| {
-        repo_mirror
-            .annotations
-            .iter()
-            .any(|entry| entry.server_id == server_id)
-    })
-}
-
 fn add_revision_link(
     mirror: &mut HostedContextMirror,
     repo_path: &str,
@@ -281,16 +272,6 @@ fn scope_from_proto(scope: Option<&ProtoScope>) -> AnnotationScope {
             },
         },
         Some(Scope::Lines(range)) => AnnotationScope::Lines(range.start, range.end),
-    }
-}
-
-/// Scope identity ignoring `resolved_lines` (the server may resolve a symbol's
-/// lines even when the local scope has none), for matching recovered annotations.
-fn scope_ident(scope: &AnnotationScope) -> String {
-    match scope {
-        AnnotationScope::File => "file".to_string(),
-        AnnotationScope::Symbol { name, .. } => format!("symbol:{name}"),
-        AnnotationScope::Lines(start, end) => format!("lines:{start}-{end}"),
     }
 }
 
@@ -484,8 +465,6 @@ async fn push_one(
             annotation,
             superseded_server.as_deref(),
             &op_id,
-            username,
-            mirror,
         )
         .await?;
 
@@ -530,8 +509,6 @@ async fn create_on_server(
     annotation: &Annotation,
     superseded_server: Option<&str>,
     op_id: &str,
-    username: Option<&str>,
-    mirror: &HostedContextMirror,
 ) -> Result<(String, String)> {
     let first = annotation
         .revisions
@@ -562,7 +539,9 @@ async fn create_on_server(
             .with_context(|| format!("supersede hosted annotation {superseded}"))?;
         response.new_annotation_id
     } else {
-        client
+        // Client-sovereign id: propose our local `ann-` id and take the server's
+        // authoritative echo from the response — no author+content recovery.
+        let response = client
             .set_context(
                 repo_path,
                 &path,
@@ -574,28 +553,17 @@ async fn create_on_server(
                 None,
                 None,
                 op_id.to_string(),
+                annotation.annotation_id.as_str(),
             )
             .await
             .with_context(|| format!("set hosted context for {}", annotation.annotation_id))?;
-
-        // Recover the minted id author-aware (weft returns only a count): the
-        // annotation at the target stamped with OUR hosted username, matching
-        // content + scope, whose id is not already linked (re-link safe).
-        let hosted = hosted_attribution(username);
-        list_server_targets(client, repo_path)
-            .await?
-            .into_iter()
-            .rev()
-            .find(|(candidate_target, candidate)| {
-                candidate_target == target
-                    && Some(candidate.attribution.as_str()) == hosted.as_deref()
-                    && candidate.content == first.content
-                    && scope_ident(&scope_from_proto(candidate.scope.as_ref()))
-                        == scope_ident(&annotation.scope)
-                    && !server_id_is_linked(mirror, repo_path, &candidate.id)
-            })
-            .map(|(_, candidate)| candidate.id)
-            .context("could not recover the minted annotation id (author + content)")?
+        if response.annotation_id.trim().is_empty() {
+            bail!(
+                "weft did not return an annotation id for {}",
+                annotation.annotation_id
+            );
+        }
+        response.annotation_id
     };
 
     let first_server_rev = first_server_revision_id(client, repo_path, &server_id).await?;
@@ -1183,19 +1151,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn scope_ident_ignores_resolved_lines() {
-        let a = AnnotationScope::Symbol {
-            name: "greet".to_string(),
-            resolved_lines: Some((1, 2)),
-        };
-        let b = AnnotationScope::Symbol {
-            name: "greet".to_string(),
-            resolved_lines: None,
-        };
-        assert_eq!(scope_ident(&a), scope_ident(&b));
-    }
-
     // P1-2: two clones concurrently revise one annotation. Alice already holds
     // r1 (pulled) and her own r3 (linked to server sA3); Bob's r2 arrives in the
     // middle. Pull must yield all three in SERVER order, keep Alice's local id
@@ -1348,16 +1303,6 @@ mod tests {
         get_or_create_entry(&mut mirror, "ns/repo", "in-flight").pending_create_op =
             Some("op".into());
         assert_eq!(server_id_for_local(&mirror, "ns/repo", "in-flight"), None);
-    }
-
-    // Minted-id recovery must not adopt a server id that is already linked to a
-    // different local annotation (the re-link-safe / concurrent-writer guard).
-    #[test]
-    fn server_id_is_linked_detects_prior_links() {
-        let mut mirror = HostedContextMirror::default();
-        get_or_create_entry(&mut mirror, "ns/repo", "local-a").server_id = "srv-1".into();
-        assert!(server_id_is_linked(&mirror, "ns/repo", "srv-1"));
-        assert!(!server_id_is_linked(&mirror, "ns/repo", "srv-2"));
     }
 
     #[tokio::test]

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -410,6 +410,7 @@ async fn push_one(
                     return Ok(false);
                 }
                 let (open_turn_id, open_body) = candidates[0].clone();
+                let proposed_id = local_id.to_string();
                 let hosted = client
                     .open_discussion(
                         repo_path,
@@ -420,6 +421,7 @@ async fn push_one(
                         &visibility,
                         discussion.thread_ref.as_deref(),
                         open_op_id(repo_path, local_id),
+                        &proposed_id,
                     )
                     .await
                     .with_context(|| format!("open hosted discussion for {local_id}"))?;
@@ -816,6 +818,16 @@ fn import_hosted_discussion(
     )
 }
 
+/// Choose the local `DiscussionRecordId` for a hosted discussion: adopt the id
+/// carried on the wire when it is a valid `disc-<UUIDv7>` (the client-sovereign
+/// id the originator minted), otherwise derive a deterministic id from the
+/// hosted id so every clone of a legacy `hc-` discussion still agrees.
+fn adopt_or_derive_local_id(hosted_id: &str) -> DiscussionRecordId {
+    hosted_id
+        .parse::<DiscussionRecordId>()
+        .unwrap_or_else(|_| DiscussionRecordId::for_hosted_source(hosted_id))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn pull_one(
     store: &CollaborationStore,
@@ -829,18 +841,47 @@ fn pull_one(
     if discussion.turns.is_empty() && matches!(discussion.resolution, HostedResolution::Open) {
         return Ok(false);
     }
-    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-    let entry_index = repo_mirror
+    let mut entry_index = mirror
+        .repos
+        .entry(repo_path.to_string())
+        .or_default()
         .discussions
         .iter()
         .position(|entry| entry.server_id == discussion.id);
+
+    // Client-sovereign id + resume guard: when there is no mirror entry yet but
+    // the op-log already holds this discussion under its adopted (or derived)
+    // local id — we pulled our own discussion back, or the mirror file was lost
+    // — re-establish the mirror link and resume into the `Some` arm instead of
+    // writing a duplicate `Open` root (materialize rejects a second root).
+    if entry_index.is_none() && !discussion.turns.is_empty() {
+        let candidate = adopt_or_derive_local_id(&discussion.id);
+        if store
+            .materialize_discussion(&candidate)
+            .context("check op-log for an existing discussion before pull")?
+            .is_some()
+        {
+            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+            repo_mirror.discussions.push(MirrorEntry {
+                local_id: candidate.to_string(),
+                server_id: discussion.id.clone(),
+                links: Vec::new(),
+                resolved_into_annotation_operation_id: None,
+                pulled_resolution_key: None,
+            });
+            entry_index = Some(repo_mirror.discussions.len() - 1);
+        }
+    }
 
     let mut changed = match entry_index {
         None => {
             if discussion.turns.is_empty() {
                 return Ok(false);
             }
-            let local_id = DiscussionRecordId::generate();
+            // Adopt the id the originator minted (carried on the wire) so the
+            // discussion is addressable by the same id on every clone; fall back
+            // to a deterministic derivation for legacy `hc-` ids.
+            let local_id = adopt_or_derive_local_id(&discussion.id);
             let anchor = hosted_open_anchor(discussion, head_state);
             let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
             let visibility = parse_visibility_token(&discussion.visibility);
@@ -902,6 +943,7 @@ fn pull_one(
             true
         }
         Some(index) => {
+            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
             let local_id: DiscussionRecordId = repo_mirror.discussions[index]
                 .local_id
                 .parse()
@@ -2028,5 +2070,144 @@ mod tests {
         );
         let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
         assert_eq!(store.materialize().unwrap().discussions.len(), 2);
+    }
+
+    #[test]
+    fn adopt_or_derive_local_id_adopts_valid_disc_and_derives_legacy() {
+        // A valid `disc-<UUIDv7>` on the wire is adopted verbatim (client-sovereign).
+        let minted = DiscussionRecordId::generate();
+        assert_eq!(adopt_or_derive_local_id(&minted.to_string()), minted);
+        // A legacy `hc-` id has no `disc-` form; it is derived deterministically.
+        let a = adopt_or_derive_local_id("hc-legacy-xyz");
+        assert_eq!(a, DiscussionRecordId::for_hosted_source("hc-legacy-xyz"));
+        assert_ne!(a, adopt_or_derive_local_id("hc-other"));
+    }
+
+    fn seed_repo_with_state() -> (TempDir, Repository, StateId) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        let state = repo
+            .snapshot_with_attribution(
+                Some("seed".to_string()),
+                None,
+                Attribution::human(Principal::new("Test", "test@example.com")),
+            )
+            .unwrap()
+            .id();
+        (temp, repo, state)
+    }
+
+    fn bootstrap_discussion(id: &str, state: StateId) -> Discussion {
+        Discussion {
+            id: id.to_string(),
+            anchor: SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: state,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: Principal::new("Reviewer", "reviewer@example.com"),
+                body: "keep this invariant".to_string(),
+                posted_at: 1_700_000_001,
+                references: Vec::new(),
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            anchor_ambiguous: false,
+            orphaned: false,
+            visibility: VisibilityTier::Internal,
+            resolved_annotation_id: None,
+        }
+    }
+
+    // Falsifier: the originator's `disc-` id must be the id every clone can
+    // address, and two clones of one source must agree. Pre-fix the pull path
+    // minted a fresh UUIDv7 per clone, so neither held.
+    #[tokio::test]
+    async fn pull_adopts_the_originators_disc_id_so_clones_agree() {
+        let originator = DiscussionRecordId::generate();
+        let wire_id = originator.to_string();
+
+        let mut materialized_ids = Vec::new();
+        for _ in 0..2 {
+            let (_temp, repo, state) = seed_repo_with_state();
+            let bootstrap = vec![bootstrap_discussion(&wire_id, state)];
+            let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+            assert_eq!(
+                pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
+                    .await
+                    .unwrap(),
+                1
+            );
+            client.close().await;
+            server.await.unwrap();
+
+            let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+            // Addressable by the ORIGINATOR's id on this clone.
+            assert!(
+                store.materialize_discussion(&originator).unwrap().is_some(),
+                "clone must be addressable by the originator's id {originator}"
+            );
+            let ids: Vec<DiscussionRecordId> =
+                store.materialize().unwrap().discussions.keys().copied().collect();
+            materialized_ids.push(ids);
+        }
+        assert_eq!(
+            materialized_ids[0], materialized_ids[1],
+            "two clones of one source must materialize the same discussion id set"
+        );
+    }
+
+    // Falsifier for the resume guard: if the op-log already holds the discussion
+    // (its own id came back over the wire) but the mirror has no entry, pull must
+    // resume rather than write a second `Open` root (materialize rejects two roots).
+    #[tokio::test]
+    async fn pull_resumes_when_oplog_has_it_but_mirror_is_missing() {
+        let (_temp, repo, state) = seed_repo_with_state();
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        // This discussion already exists in the op-log under its own id, with the
+        // open turn copied verbatim from the server (author + timestamp), so the
+        // resumed pull reconciles the one turn rather than appending a copy.
+        let local_id = DiscussionRecordId::generate();
+        write_local_operation(
+            &store,
+            local_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Reviewer", "reviewer@example.com")),
+            1_700_000_001_000,
+            CollaborationOperationBodyV1::Open {
+                title: "run contract".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+        )
+        .unwrap();
+        let ops_before = store.operation_ids().unwrap().len();
+
+        // A pulls its own discussion back — same id on the wire, mirror empty.
+        let bootstrap = vec![bootstrap_discussion(&local_id.to_string(), state)];
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
+            .await
+            .unwrap();
+        client.close().await;
+        server.await.unwrap();
+
+        // No duplicate `Open` root: exactly one discussion, still addressable, and
+        // the single seeded turn reconciled rather than duplicated.
+        let materialized = store.materialize().unwrap();
+        assert_eq!(materialized.discussions.len(), 1, "must not duplicate the discussion");
+        assert!(materialized.discussions.contains_key(&local_id));
+        assert_eq!(
+            store.operation_ids().unwrap().len(),
+            ops_before,
+            "resume must not write a duplicate Open root for the reconciled turn"
+        );
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/collaboration.rs
@@ -184,6 +184,7 @@ impl HostedClient {
         visibility: &str,
         thread_ref: Option<&str>,
         client_operation_id: String,
+        discussion_id: &str,
     ) -> Result<HostedDiscussion, ProtocolError> {
         let request = open_discussion_request(
             repo_path,
@@ -194,6 +195,7 @@ impl HostedClient {
             visibility,
             thread_ref,
             client_operation_id,
+            discussion_id,
         );
         let response = self
             .routes()
@@ -340,6 +342,7 @@ fn open_discussion_request(
     visibility: &str,
     thread_ref: Option<&str>,
     client_operation_id: String,
+    discussion_id: &str,
 ) -> OpenDiscussionRequest {
     OpenDiscussionRequest {
         repo_path: super::helpers::repository_ref(repo_path),
@@ -355,6 +358,7 @@ fn open_discussion_request(
         thread_id: String::new(),
         severity: DiscussionSeverity::Unspecified as i32,
         kind: DiscussionKind::CodeAnchored as i32,
+        discussion_id: discussion_id.to_string(),
     }
 }
 
@@ -461,12 +465,17 @@ mod tests {
             "internal",
             Some("refs/heads/feature/run"),
             "open-op".to_string(),
+            "disc-018f0000-0000-7000-8000-000000000000",
         );
         assert_eq!(request.thread_ref, "refs/heads/feature/run");
         assert_eq!(request.anchor.unwrap().file, "src/lib.rs");
         assert_eq!(request.body, "keep this stable");
         assert_eq!(request.severity, DiscussionSeverity::Unspecified as i32);
         assert_eq!(request.kind, DiscussionKind::CodeAnchored as i32);
+        assert_eq!(
+            request.discussion_id,
+            "disc-018f0000-0000-7000-8000-000000000000"
+        );
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/content.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/content.rs
@@ -114,6 +114,7 @@ impl HostedClient {
         agent_provider: Option<&str>,
         agent_model: Option<&str>,
         client_operation_id: String,
+        annotation_id: &str,
     ) -> Result<SetContextResponse, ProtocolError> {
         let operation_id =
             ClientOperationId::for_required_method(SET_CONTEXT, client_operation_id)?;
@@ -130,6 +131,7 @@ impl HostedClient {
                 .and_then(super::helpers::proto_state_id),
             kind: kind as i32,
             client_operation_id: operation_id.to_wire(),
+            annotation_id: annotation_id.to_string(),
         };
         self.routes()
             .set_context(&request)
@@ -375,6 +377,7 @@ mod tests {
                 Some("codex"),
                 Some("test"),
                 "set-context-op".to_string(),
+                "",
             )
             .await
             .unwrap();

--- a/crates/object-model/src/object/collaboration/ids.rs
+++ b/crates/object-model/src/object/collaboration/ids.rs
@@ -120,6 +120,20 @@ impl DiscussionRecordId {
         bytes[8] = (bytes[8] & 0x3f) | 0x80;
         Self(Uuid::from_bytes(bytes))
     }
+
+    /// Deterministic local id for a hosted discussion whose wire id is not a
+    /// `disc-<UUIDv7>` (a legacy `hc-` id opened before clients carried their
+    /// own id). Derived solely from the hosted id so every clone that pulls the
+    /// same discussion agrees on one id, and shaped as a valid UUIDv7 so
+    /// [`Self::from_uuid`] accepts it.
+    pub fn for_hosted_source(hosted_id: &str) -> Self {
+        let hash = ContentHash::compute_typed("hosted-discussion", hosted_id.as_bytes());
+        let mut bytes = [0; 16];
+        bytes.copy_from_slice(&hash.as_bytes()[..16]);
+        bytes[6] = (bytes[6] & 0x0f) | 0x70;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        Self(Uuid::from_bytes(bytes))
+    }
 }
 
 impl fmt::Display for DiscussionRecordId {
@@ -243,6 +257,21 @@ mod tests {
         let bytes = rmp_serde::to_vec_named("").unwrap();
         assert!(rmp_serde::from_slice::<CollaborationIdempotencyKey>(&bytes).is_err());
         assert!(rmp_serde::from_slice::<LegacyDiscussionId>(&bytes).is_err());
+    }
+
+    #[test]
+    fn for_hosted_source_is_deterministic_and_valid_v7() {
+        // Falsifier for the clone-agreement of the legacy `hc-` fallback: two
+        // clones deriving from the same hosted id must land on the same local id.
+        let a = DiscussionRecordId::for_hosted_source("hc-abc123");
+        let b = DiscussionRecordId::for_hosted_source("hc-abc123");
+        assert_eq!(a, b, "same hosted id must derive the same local id");
+        // Distinct hosted ids must not collide.
+        assert_ne!(a, DiscussionRecordId::for_hosted_source("hc-xyz789"));
+        // The derived id must round-trip through the `disc-<UUIDv7>` gate.
+        let text = a.to_string();
+        assert!(text.starts_with("disc-"));
+        assert_eq!(text.parse::<DiscussionRecordId>().unwrap(), a);
     }
 
     #[test]

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.13.0"
+heddleco-capability-verifier = "0.14.0"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true

--- a/docs/adr/0027-uuidv7-discussion-ids.md
+++ b/docs/adr/0027-uuidv7-discussion-ids.md
@@ -4,6 +4,8 @@ Discussion IDs are generated UUIDv7 record identifiers, while collaboration oper
 
 Migrated legacy state-attached discussions receive new UUIDv7 discussion IDs. Legacy IDs are preserved as source metadata or lookup aliases when useful, but they do not become canonical repository discussion identity.
 
-**Status:** proposed
+The client mints this UUIDv7 identity and carries it to the hosted service on open; the hosted service records the client-minted id, it does not mint its own. A discussion therefore has one identity that is stable across every clone — the id the originator printed is the id every other machine can address. (Before this, the hosted read path re-minted a fresh UUIDv7 per clone, so no clone could address the originator's id.) Legacy hosted discussions opened before clients carried their id have no `disc-<UUIDv7>` on the wire; those get a deterministic id derived from the hosted id, so clones still agree with each other.
+
+**Status:** accepted
 
 **Considered Options:** Content-addressing the opening operation could derive the discussion ID from immutable data, but it would make record identity depend on opening payload details. Random UUIDs would work, but UUIDv7 gives better ordering and locality for listings, indexes, and sync cursors while keeping the ID opaque.


### PR DESCRIPTION
## Summary

Hosted discussions were re-minted a fresh random UUIDv7 on every clone/pull (`DiscussionRecordId::generate()` in `pull_one`), so the `disc-…` id the originator printed was unreachable on every other machine, and two clones of one source disagreed on the id. This carries the client-minted id end to end so a discussion has one identity stable across every clone.

- **Deps:** `heddle-api` 0.24 → 0.25 (`Cargo.toml`) and `heddleco-capability-verifier` 0.13 → 0.14 (`crates/repo/Cargo.toml`). cv 0.14 is the first cv release built on api 0.25, so the api bump requires it; api 0.25 adds the additive `discussion_id` / `annotation_id` wire fields. Lockfile churn beyond api/cv (prost-build itertools, biscuit's syn, tempfile's getrandom) is the transitive fallout of that bump and resolves cleanly under `--locked`.
- **Discussions — push:** send the local `disc-<UUIDv7>` as `OpenDiscussionRequest.discussion_id` (`discussion_sync.rs` `push_one` → `open_discussion` → `open_discussion_request`).
- **Discussions — pull:** adopt the id on the wire when it is a valid `disc-<UUIDv7>`; otherwise derive a deterministic id from the hosted id via the new `DiscussionRecordId::for_hosted_source` (sibling of `for_legacy_source`) so legacy `hc-` discussions still agree across clones. Resume guard: when the op-log already holds the discussion but the mirror entry is missing (we pulled our own discussion back, or the mirror file was lost), re-link and resume into the existing-discussion path instead of writing a duplicate `Open` root.
- **Annotations — write side only:** send the local `ann-` id as `SetContextRequest.annotation_id` and use weft's echoed `SetContextResponse.annotation_id`, replacing the author+content-search recovery (and removing the now-dead `server_id_is_linked` / `scope_ident` helpers and their tests). Supersede already used the returned `new_annotation_id`; pull side already adopts the server id — unchanged.
- **ADR 0027** → `accepted`, with a line noting the hosted service records the client-minted id and does not mint its own.
- Owner Rust bar: no `unwrap`/`expect` added in prod paths, no `Box`/`dyn` introduced.

## Test evidence

Built and linted against api 0.25 (`CARGO_TARGET_DIR` isolated, `--locked`):

```
$ cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.73s
$ cargo clippy --locked -p heddle-hosted-client --features client --all-targets -- -D warnings -D dead-code
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

Suites:

```
$ cargo test --locked -p heddle-hosted-client --features client --lib
test result: ok. 400 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
$ cargo test --locked -p heddle-object-model -p heddle-repo --lib
test result: ok. 275 passed; 0 failed; 0 ignored ...   (object-model)
test result: ok. 739 passed; 0 failed; 3 ignored ...   (repo)
```

New falsifier tests (in `discussion_sync.rs` / `ids.rs`):
- `pull_adopts_the_originators_disc_id_so_clones_agree` — after clone, the discussion is addressable by the originator's `disc-` id, and two clones materialize an identical id set.
- `pull_resumes_when_oplog_has_it_but_mirror_is_missing` — pulling a discussion the op-log already holds does not write a second `Open` root.
- `adopt_or_derive_local_id_adopts_valid_disc_and_derives_legacy` / `for_hosted_source_is_deterministic_and_valid_v7` — adoption vs. deterministic fallback.

Negative case (proof the falsifiers can fail): reverting the pull-side adoption to `generate()` makes both pull tests fail:

```
---- pull_adopts_the_originators_disc_id_so_clones_agree ----
panicked: clone must be addressable by the originator's id disc-01a06421-...
---- pull_resumes_when_oplog_has_it_but_mirror_is_missing ----
assertion `left == right` failed: must not duplicate the discussion
  left: 2  right: 1
test result: FAILED. 0 passed; 2 failed
```

Tests requiring a live weft (end-to-end `clone` → `discuss show <A's id>` across machines, and weft honoring/echoing the proposed id) are deferred to CI / the weft leg (weft#1991); this unsandboxed env cannot reach a hosted weft.

Closes #1676, refs weft#1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790978645&installation_model_id=21489&pr_number=1680&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1680&signature=a6ab5c61dfea040066f065771db6d7300ef47d378743c32801cb1067a2ab3ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->