### PR TITLE
Deterministic collaboration op idempotency keys (heddle#1677)

### DIFF
--- a/crates/hosted-client/src/client/context_sync.rs
+++ b/crates/hosted-client/src/client/context_sync.rs
@@ -451,10 +451,12 @@ async fn push_one(
         // crash-retry replays with the same client_operation_id (P2-5).
         let op_id = {
             let entry = get_or_create_entry(mirror, repo_path, &annotation.annotation_id);
-            if entry.pending_create_op.is_none() {
-                entry.pending_create_op = Some(uuid::Uuid::new_v4().to_string());
-            }
-            entry.pending_create_op.clone().expect("just set")
+            entry
+                .pending_create_op
+                .get_or_insert_with(|| {
+                    create_op_id(repo_path, &annotation.annotation_id, &first.revision_id)
+                })
+                .clone()
         };
         save_mirror(heddle_dir, mirror)?;
 
@@ -1117,6 +1119,17 @@ fn revise_op_id(repo_path: &str, server_id: &str, revision_id: &str) -> String {
     uuid::Uuid::new_v5(
         &OP_NAMESPACE,
         format!("revise:{repo_path}:{server_id}:{revision_id}").as_bytes(),
+    )
+    .to_string()
+}
+
+/// Deterministic client-operation-id for the initial `create_on_server` call,
+/// derived from `(annotation id, first revision id)` so a crash-retry of the
+/// same create replays with the same id and dedupes instead of duplicating.
+fn create_op_id(repo_path: &str, annotation_id: &str, revision_id: &str) -> String {
+    uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("create:{repo_path}:{annotation_id}:{revision_id}").as_bytes(),
     )
     .to_string()
 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -33,11 +33,15 @@
 //! rest would be silently dropped on exactly the migrated repos.
 //!
 //! Push sends only turns that are self-authored AND unlinked; pull materializes
-//! only server ordinals not yet linked. Client operation ids are derived from
-//! the stable turn id, so a retry replays instead of conflicting.
+//! only server ordinals not yet linked. A materialized turn op's idempotency
+//! key is derived deterministically from `(hosted discussion id, server turn
+//! ordinal)` (see `turn_op_key`) — never a random per-write nonce — so the same
+//! server turn earns the same `CollabOpId` on every clone and a retry replays
+//! instead of conflicting or duplicating.
 //! Resolve-into-annotation operations use the same durable mirror: their
-//! request identity is derived from the complete resolution payload and is
-//! recorded only after `ResolveDiscussion` succeeds.
+//! request identity is derived from `(hosted discussion id, server resolution
+//! key)` (see `resolve_op_key`) and is recorded only after `ResolveDiscussion`
+//! succeeds.
 //!
 //! ## Reconciliation is author-aware, never body-alone
 //!
@@ -900,6 +904,7 @@ fn pull_one(
                     turn: turn_body(first)?,
                     thread_ref: discussion.thread_ref.clone(),
                 },
+                turn_op_key(&discussion.id, server_ordinal(first, 0))?,
             )?;
             // Record the mapping immediately so a mid-materialization failure
             // resumes into the `Some` arm instead of orphaning the written ops.
@@ -929,6 +934,7 @@ fn pull_one(
                     CollaborationOperationBodyV1::AppendTurn {
                         turn: turn_body(turn)?,
                     },
+                    turn_op_key(&discussion.id, ordinal)?,
                 )?;
                 heads = vec![op_id];
                 push_link(
@@ -1007,6 +1013,7 @@ fn pull_one(
                     CollaborationOperationBodyV1::AppendTurn {
                         turn: turn_body(server_turn)?,
                     },
+                    turn_op_key(&discussion.id, ordinal)?,
                 )?;
                 heads = vec![op_id];
                 push_link(
@@ -1101,6 +1108,7 @@ fn pull_resolution(
         hosted_resolution_author(),
         now_ms(),
         CollaborationOperationBodyV1::Resolve { resolution },
+        resolve_op_key(&discussion.id, &hosted_key)?,
     )?;
     mirror
         .repos
@@ -1281,6 +1289,49 @@ fn principals_match(a: &Principal, b: &Principal) -> bool {
     a.name == b.name && a.email == b.email
 }
 
+// --- deterministic idempotency keys for materialized hosted ops ---
+//
+// A `CollabOpId` is content-addressed OVER its idempotency key, so the key must
+// be identical across clones for the same turn to earn the same op id (and for
+// a retry to dedupe instead of duplicating). We derive it via UUIDv5 over the
+// module `OP_NAMESPACE` (shared with the push-side op-id helpers; the `turn:` /
+// `resolve:` descriptor prefixes keep the two spaces disjoint), purely from
+// hosted, server-assigned inputs — the hosted discussion id and either the
+// server turn ordinal or the server resolution key — never from local state.
+
+/// Idempotency key for a turn op (open / append) materialized from a hosted
+/// discussion. Derived from `(hosted discussion id, server turn ordinal)`, both
+/// of which are identical on every clone, so the same server turn yields the
+/// same `CollabOpId` everywhere.
+fn turn_op_key(
+    hosted_discussion_id: &str,
+    server_ordinal: usize,
+) -> Result<CollaborationIdempotencyKey> {
+    let raw = uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("turn:{hosted_discussion_id}:{server_ordinal}").as_bytes(),
+    )
+    .to_string();
+    CollaborationIdempotencyKey::new(raw)
+        .map_err(|error| anyhow!("invalid idempotency key: {error}"))
+}
+
+/// Idempotency key for a resolve op materialized from a hosted discussion.
+/// Derived from `(hosted discussion id, server resolution key)`, both hosted
+/// values, so a resolution pulled on two clones earns the same `CollabOpId`.
+fn resolve_op_key(
+    hosted_discussion_id: &str,
+    hosted_resolution_key: &str,
+) -> Result<CollaborationIdempotencyKey> {
+    let raw = uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("resolve:{hosted_discussion_id}:{hosted_resolution_key}").as_bytes(),
+    )
+    .to_string();
+    CollaborationIdempotencyKey::new(raw)
+        .map_err(|error| anyhow!("invalid idempotency key: {error}"))
+}
+
 fn write_local_operation(
     store: &CollaborationStore,
     discussion_id: DiscussionRecordId,
@@ -1288,9 +1339,8 @@ fn write_local_operation(
     author: Attribution,
     occurred_at_ms: i64,
     body: CollaborationOperationBodyV1,
+    key: CollaborationIdempotencyKey,
 ) -> Result<CollabOpId> {
-    let key = CollaborationIdempotencyKey::new(uuid::Uuid::new_v4().to_string())
-        .map_err(|error| anyhow!("invalid idempotency key: {error}"))?;
     let operation = CollaborationOperationEnvelope::new(
         discussion_id,
         parents,
@@ -1362,6 +1412,13 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    /// A stable per-turn idempotency key for tests that drive
+    /// `write_local_operation` directly (production callers derive theirs from
+    /// hosted ids via `turn_op_key`/`resolve_op_key`).
+    fn test_key(seed: &str) -> CollaborationIdempotencyKey {
+        CollaborationIdempotencyKey::new(format!("test-op:{seed}")).expect("valid test key")
+    }
 
     fn local(
         body: &str,
@@ -1720,6 +1777,7 @@ mod tests {
                 turn: DiscussionTurnV1::new("first turn").unwrap(),
                 thread_ref: Some("refs/heads/feature/run".to_string()),
             },
+            test_key("open-run-contract"),
         )
         .unwrap();
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
@@ -1739,6 +1797,7 @@ mod tests {
             CollaborationOperationBodyV1::AppendTurn {
                 turn: DiscussionTurnV1::new("second turn").unwrap(),
             },
+            test_key("append-second-turn"),
         )
         .unwrap();
         assert_eq!(
@@ -1761,6 +1820,7 @@ mod tests {
                     tags: vec!["cache".to_string()],
                 },
             },
+            test_key("resolve-into-annotation"),
         )
         .unwrap();
         assert_eq!(
@@ -1883,6 +1943,7 @@ mod tests {
                     reason: "local-only".to_string(),
                 },
             },
+            test_key("resolve-dismissed-local"),
         )
         .unwrap();
 
@@ -1979,6 +2040,7 @@ mod tests {
                     tags: vec!["cache".to_string()],
                 },
             },
+            test_key("resolve-into-annotation-local"),
         )
         .unwrap();
 
@@ -2186,6 +2248,7 @@ mod tests {
                 turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
                 thread_ref: None,
             },
+            test_key("open-keep-invariant"),
         )
         .unwrap();
         let ops_before = store.operation_ids().unwrap().len();
@@ -2208,6 +2271,118 @@ mod tests {
             store.operation_ids().unwrap().len(),
             ops_before,
             "resume must not write a duplicate Open root for the reconciled turn"
+        );
+    }
+
+    // Falsifier for heddle#1677: two clones must materialize the SAME
+    // `CollabOpId`s for the same server turns. The idempotency key is now
+    // derived from `(hosted discussion id, server turn ordinal)` — both
+    // identical on every clone — instead of a random `Uuid::new_v4()` per
+    // write. On the pre-change random key this assertion fails, the two clones
+    // producing disjoint `co-…` id sets.
+    #[tokio::test]
+    async fn two_clones_agree_on_turn_op_ids() {
+        // One server-side discussion, addressed by the originator's id and
+        // pinned to a single server `opened_against_state` — identical for every
+        // clone (the server sends the same value everywhere), so the Open op's
+        // anchor does not depend on any clone's local HEAD.
+        let wire_id = DiscussionRecordId::generate().to_string();
+        let (_temp0, _repo0, pinned_state) = seed_repo_with_state();
+        let mut discussion = bootstrap_discussion(&wire_id, pinned_state);
+        discussion.turns.push(DiscussionTurn {
+            author: Principal::new("Reviewer", "reviewer@example.com"),
+            body: "and here is a follow-up".to_string(),
+            posted_at: 1_700_000_002,
+            references: Vec::new(),
+        });
+
+        let mut op_id_sets = Vec::new();
+        for _ in 0..2 {
+            let (_temp, repo, head_state) = seed_repo_with_state();
+            let bootstrap = vec![discussion.clone()];
+            let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+            // `against` is this clone's own resolvable tip; the shared anchor
+            // rides on the discussion's pinned `opened_against_state`.
+            pull_discussions(
+                &repo,
+                &mut client,
+                "acme/widgets",
+                Some(&bootstrap),
+                Some(head_state),
+            )
+            .await
+            .unwrap();
+            client.close().await;
+            server.await.unwrap();
+
+            let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            assert_eq!(ids.len(), 2, "one Open + one AppendTurn materialized");
+            op_id_sets.push(ids);
+        }
+        assert_eq!(
+            op_id_sets[0], op_id_sets[1],
+            "two clones of one source must materialize the same CollabOpId set"
+        );
+    }
+
+    // A retried materialization re-derives the SAME idempotency key from the
+    // stable `(hosted discussion id, server turn ordinal)` tuple, so the op
+    // dedupes at the store instead of duplicating. On the pre-change random key
+    // the retry would mint a fresh `CollabOpId` and double the op count.
+    #[test]
+    fn rederived_turn_op_key_dedupes_on_retry() {
+        let (_temp, repo, state) = seed_repo_with_state();
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let discussion_id = DiscussionRecordId::generate();
+        let author = Attribution::human(Principal::new("Reviewer", "reviewer@example.com"));
+        let body = || CollaborationOperationBodyV1::Open {
+            title: "run contract".to_string(),
+            anchor: CollaborationAnchor::Symbol {
+                state_id: state,
+                path: "lib.rs".to_string(),
+                symbol: "run".to_string(),
+            },
+            visibility: VisibilityTier::Internal,
+            turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+            thread_ref: None,
+        };
+
+        let first = write_local_operation(
+            &store,
+            discussion_id,
+            Vec::new(),
+            author.clone(),
+            1_700_000_001_000,
+            body(),
+            turn_op_key("disc-xyz", 0).unwrap(),
+        )
+        .unwrap();
+        let after_first = store.operation_ids().unwrap().len();
+
+        // Retry: same stable inputs → `turn_op_key` returns the same key.
+        let second = write_local_operation(
+            &store,
+            discussion_id,
+            Vec::new(),
+            author,
+            1_700_000_001_000,
+            body(),
+            turn_op_key("disc-xyz", 0).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(first, second, "a retry must earn the same CollabOpId");
+        assert_eq!(
+            store.operation_ids().unwrap().len(),
+            after_first,
+            "a retry must dedupe, not append a duplicate op"
         );
     }
 }


### PR DESCRIPTION
## What

Follow-on to the client-sovereign-id work (weft#1991/#1992). The discussion id now agrees across clones, but turn-op `CollabOpId`s did not: a `CollabOpId` is content-addressed **over** its idempotency key, and that key was a per-write `Uuid::new_v4()`. So the same server turn earned a different `CollabOpId` on every clone, and a retried create duplicated instead of deduping.

This derives the materialization keys deterministically, via UUIDv5 over the module namespace (reusing the existing push-side op-id helper pattern; the `turn:` / `resolve:` descriptor prefixes keep the spaces disjoint from the existing `open:` / `append:` ones), from hosted, **server-assigned** inputs only:

- turn ops (open / append) — `(hosted discussion id, server turn ordinal)`
- resolve ops — `(hosted discussion id, server resolution key)`
- annotation create (`context_sync`) — `(annotation id, first revision id)`, so a crash-retry replays with the same `client_operation_id`

## Call-site dispositions

| Site | Disposition |
|---|---|
| `discussion_sync.rs` `write_local_operation` key | **Changed** — now takes a deterministic key from each caller (open / append / resolve) |
| `context_sync.rs` `pending_create_op` | **Changed** — `create_op_id(annotation_id, revision_id)`; also drops an `.expect` via `get_or_insert_with` |
| `operation_id.rs` `ClientOperationId::fresh` | **Reviewed, left** — the fresh-op fallback; callers supply determinism explicitly through `caller_or_fresh` |
| `cli discuss.rs` `idempotency_key` | **Reviewed, left** — a brand-new interactive authoring op; user passes `--op-id` for explicit idempotency. Determinism here would collide two distinct appends |

Security nonces (`auth.rs` agent-id, `auth_login_agent.rs`, `device_flow.rs`, `sync.rs` sync nonces) are deliberately untouched and still random.

## Verification

- `two_clones_agree_on_turn_op_ids` — two clones materialize an **identical** `co-…` `CollabOpId` set. Falsifier: on the pre-change random key the two clones produce disjoint sets and it fails.
- `rederived_turn_op_key_dedupes_on_retry` — a re-derived key dedupes at the store (`operation_ids().len()` unchanged, same `CollabOpId`). Fails pre-change.
- `heddle-hosted-client --features client --lib`: 405 passed, 0 failed, 1 ignored.
- `cargo clippy -p heddle-hosted-client --features client --all-targets -- -D warnings -D dead-code`: clean.
- No `unwrap`/`expect`/`Box` added in production code. No Cargo.toml / public-contract change → `check-dependency-version-bump.py` reports no bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791048854&installation_model_id=21489&pr_number=1685&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1685&signature=8c48713609807f3ae5987881200e0dc174c44f8158fdbb4794ea9fcec9804522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->