### PR TITLE
ci(rust): speed up fast lane + Quality (lld, pinned toolchain, richer cache)

### DIFF
--- a/.github/workflows/rust-full-suite.yml
+++ b/.github/workflows/rust-full-suite.yml
@@ -261,20 +261,41 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 60
+    env:
+      # Match the fast lane: LLVM lld for the link-heavy test builds. This job
+      # is Linux/ARM native and no heddle Rust job builds a wasm32 target, so
+      # the native-linker flag is safe. Kept byte-identical to the fast lane's
+      # fast-check job so the shared rust-cache slot stays coherent (rust-cache
+      # folds RUST* env vars into its key).
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
 
     steps:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          # Pin to match rust-toolchain.toml and the fast lane so a floating
+          # stable bump does not cold-invalidate the shared rust-cache.
+          toolchain: "1.98.0"
           components: clippy
+
+      - name: Ensure LLVM linker
+        run: |
+          if ! command -v ld.lld; then
+            sudo apt-get update
+            sudo apt-get install -y lld
+          fi
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: rust-tests-${{ runner.os }}
+          # Shared with the fast lane's fast-check job; see it for the key
+          # rationale. Both lanes are Linux/ARM so they land on one slot.
+          shared-key: rust-ws-${{ runner.os }}-${{ runner.arch }}
+          prefix-key: v1-rust-incr
           cache-on-failure: true
+          cache-all-crates: true
 
       - name: Rust source reachability and dead-code blankets
         if: needs.changes.outputs.skip_cargo != 'true'

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -43,6 +43,15 @@ jobs:
     name: fast-check
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 30
+    env:
+      # GNU ld dominates the tail of the workspace-wide, all-targets links
+      # this lane performs; LLVM lld is substantially faster. No heddle Rust
+      # job builds a wasm32 target, so this native-linker flag is safe
+      # workspace-wide here. Set at job scope so build, clippy, and the unit
+      # test link all use it. Kept identical to the full lane's Quality job so
+      # the two continue to share one rust-cache slot (rust-cache folds RUST*
+      # env into its key).
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
 
     steps:
       - name: Satisfy fast-check on the merge queue
@@ -55,7 +64,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: github.event_name == 'pull_request'
         with:
+          # Pin so a silent stable bump does not invalidate rust-cache. Matches
+          # rust-toolchain.toml, which already forces this channel at build
+          # time; pinning the installed default keeps rust-cache's rustc probe
+          # aligned with it so the cache stays warm across stable releases.
+          toolchain: "1.98.0"
           components: clippy
+
+      - name: Ensure LLVM linker
+        if: github.event_name == 'pull_request'
+        run: |
+          if ! command -v ld.lld; then
+            sudo apt-get update
+            sudo apt-get install -y lld
+          fi
 
       - uses: mozilla-actions/sccache-action@v0.0.9
         if: github.event_name == 'pull_request'
@@ -63,9 +85,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: github.event_name == 'pull_request'
         with:
-          # Shared with the full lane's default-feature Quality job.
-          shared-key: rust-tests-${{ runner.os }}
+          # Shared with the full lane's default-feature Quality job so both
+          # lanes reuse each other's dependency artifacts. Arch-qualified so an
+          # x86 and an arm runner never collide on one slot; prefix bumps the
+          # whole namespace when needed; cache-all-crates keeps registry deps
+          # warm across lanes.
+          shared-key: rust-ws-${{ runner.os }}-${{ runner.arch }}
+          prefix-key: v1-rust-incr
           cache-on-failure: true
+          cache-all-crates: true
 
       - name: Rust source reachability and dead-code blankets
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Adapts the portable CI wins from weft#2038 to heddle's Rust lanes. Every change is scoped to preserve coverage and gate integrity; nothing is renamed or dropped.

## Current bottleneck
On a normal PR push only `fast-check` (rust-tests.yml) runs, and its dominant cost is the cold-cache **`cargo build --locked --workspace --all-targets`** — it compiles every lib, bin, test, bench, and example target across the workspace, and the tail of those builds is GNU-ld link time. The full-suite `Quality` job has the same link-heavy shape. rust-cache also went cold on every silent stable release because `dtolnay/rust-toolchain@stable` floats.

## Changes and expected saving (estimated — CI not yet run)
1. **LLVM `lld` linker** on the two native Rust jobs (`fast-check`, `Quality`): job-level `RUSTFLAGS: -C link-arg=-fuse-ld=lld` + an "Ensure LLVM linker" apt step (same pattern weft#2038 runs on the identical Blacksmith arm image). Biggest win — link time on the large `--all-targets` / test builds. *Est. a few minutes off the link tail; magnitude unverified without a CI run.*
2. **Pinned toolchain `1.98.0`** on both cache-bearing jobs. `rust-toolchain.toml` already forces 1.98.0 at build time, but rust-cache probes the *installed default* (floating stable) for its key, so a stable release cold-invalidated the cache while builds still used 1.98.0. Pinning the installed default realigns them. *Est. eliminates periodic full cold rebuilds.*
3. **Richer shared cache key** — `shared-key: rust-ws-${{runner.os}}-${{runner.arch}}`, `prefix-key: v1-rust-incr`, `cache-all-crates: true`, applied identically to `fast-check` and `Quality` (the only two jobs that shared the old `rust-tests-${{runner.os}}` key). They keep sharing one slot, now arch-qualified with all registry crates cached. *Est. first run cold (new key); warm thereafter, better cross-lane reuse.*

## Coverage + gates preserved (what I checked)
- **No wasm32 anywhere.** `grep -r wasm32` across all workflows/crates/clients is empty and `rust-toolchain.toml` declares no extra `targets`, so lld cannot reach a wasm build. Still, lld is scoped to only `fast-check` and `Quality`; `worker`/wasm-style jobs don't exist here and no other job inherits the flag.
- **`--all-targets` kept in the fast lane (not trimmed).** Benches exist in cli/mount/objects/oplog/semantic(-recovery). full-suite `Quality` clippy is `--lib --bins --tests --examples` (no benches), so **benches are compile/clippy/`-D dead-code`-checked ONLY by the fast lane's `--all-targets`.** Trimming would drop that coverage into a void, so I left the invocation exactly as-is and instead made it cheaper via lld+cache. (Trim candidate noted below.)
- **No cargo invocation changed.** `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings -D dead-code`, `cargo test --workspace --lib --bins`, and Quality's affected-package build/clippy/test are byte-identical. No command silently narrows to 0 tests.
- **Aggregators / merge-queue gates intact.** `fast-check` is a single monolithic job whose name *is* the branch-protection + merge-queue status context — I did **not** rename or split it, so no `needs:`/branch-protection resync is required. All full-suite job names are unchanged, so `check-and-test.needs`, `full-suite.needs`, and every `needs: changes` output reference still resolve. The merge_group "Satisfy fast-check" echo path is untouched.
- **heddle-specific gates untouched:** source-reachability, `-D dead-code`, version-bump/docsgen/ts-types freshness workflows are not modified.
- Identical `RUSTFLAGS` on both shared-key jobs is deliberate: rust-cache folds `RUST*` env into its key, so matching them is what keeps the shared slot coherent.

## Candidates NOT shipped (coverage-safety uncertain / low ROI)
- **Trimming the fast lane off `--all-targets`** to move integration/bench/example compilation to full-suite: would drop bench `-D dead-code` coverage on PR pushes (benches aren't in Quality's clippy target set), so not done.
- **`cargo-nextest`** for unit tests: compilation dominates here, not test execution, and it adds an install step — no clear win.
- **lld/pin on the other cache-bearing jobs** (coverage, feature-contracts, cli-fault-injection): separate cache keys, so their warmth is independent; left out to keep blast radius small.

Estimates are labeled estimate-not-measured; a real measurement needs this to run in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058680&installation_model_id=21489&pr_number=1692&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1692&signature=05d7f46a3304a60543edcc14a2cbb9e2bd86526bb5f337c3aa47acb07acb4ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->