### PR TITLE
chore(release): don't publish parked treadle-schema to crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -74,8 +74,13 @@ env:
   # No auto-discovery (cargo metadata --workspace --no-deps): implicit
   # `publish = true` in Cargo.toml is invisible at PR review time, and
   # accidentally flipping it would silently expand the public surface.
+  #
+  # treadle-schema is intentionally NOT listed here: it's hosted in
+  # the workspace (release-plz.toml release = false, Cargo.toml
+  # publish = false) but parked, not published. Its first-publish
+  # 403'd on crates.io (new-crate permission) and blocked the 0.19
+  # release for the 29 crates below, none of which depend on it.
   PUBLISHABLE_CRATES: |
-    treadle-schema
     heddle-format
     heddle-object-model
     heddle-fs-prims

--- a/crates/treadle-schema/Cargo.toml
+++ b/crates/treadle-schema/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# Parked — not published to crates.io (see release-plz.toml). Belt-and-
+# suspenders: cargo refuses to publish this crate even if a publish
+# list drifts.
+publish = false
 
 [dependencies]
 blake3.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,8 +12,13 @@ publish_allow_dirty = false
 
 # Publishable OSS crates — all release = true.
 [[package]]
+# Parked — not published to crates.io until the treadle stack is
+# actually built. Nothing in the heddle graph depends on it; its
+# first-publish 403'd (crates.io token can update existing heddle-*
+# crates but can't create a new crate) and blocked the whole 0.19
+# release. Stays a hosted/buildable workspace member.
 name = "treadle-schema"
-release = true
+release = false
 
 [[package]]
 name = "heddle-format"

--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -439,7 +439,14 @@ for cm, toml in crates:
 # release-plz requires every [[package]] table to carry a package name. TOML
 # itself accepts an empty table, so parse and validate the typed shape here
 # rather than letting the next release run discover it.
+#
+# release_names covers every listed package (parked crates included) so
+# name/uniqueness/workspace-membership validation still applies to them.
+# publishable_release_names is the subset actually expected to reach
+# crates.io — it excludes `release = false` entries (parked: hosted in the
+# workspace, not published) — and is what PUBLISHABLE_CRATES must match.
 release_names = []
+publishable_release_names = []
 try:
     with open("release-plz.toml", "rb") as f:
         release_plz_toml = tomllib.load(f)
@@ -462,6 +469,8 @@ else:
                 errors.append(
                     f"release-plz.toml lists {name}, but no workspace package has that name"
                 )
+            if not (isinstance(package, dict) and package.get("release") is False):
+                publishable_release_names.append(name)
         if len(release_names) != len(set(release_names)):
             errors.append("release-plz.toml contains a duplicate package name")
         if release_names and not any(
@@ -493,12 +502,16 @@ if not publish_list:
     errors.append("could not parse PUBLISHABLE_CRATES from workflow")
 elif len(publish_positions) != len(publish_list):
     errors.append("PUBLISHABLE_CRATES contains a duplicate crate name")
-elif release_names != publish_list:
+elif publishable_release_names != publish_list:
     errors.append(
-        "release-plz.toml package order must exactly match PUBLISHABLE_CRATES"
+        "release-plz.toml's release = true package order must exactly match "
+        "PUBLISHABLE_CRATES (release = false parked crates are excluded from "
+        "both)"
     )
 else:
-    oks.append("release-plz.toml package order matches PUBLISHABLE_CRATES")
+    oks.append(
+        "release-plz.toml's release = true package order matches PUBLISHABLE_CRATES"
+    )
     dependency_pairs = 0
     order_pairs = 0
     # Versioned dev-dependencies are errors as well: they do not block


### PR DESCRIPTION
## Why

`treadle-schema` is parked, unfinished treadle work hosted in the heddle workspace (heddle#1635). Nothing in the heddle graph depends on it (`grep -rl treadle-schema crates/*/Cargo.toml` outside its own dir is empty). It's first in `release-plz.toml`'s `[[package]]` list, which put it first in `publish-crates.yml`'s ordered `PUBLISHABLE_CRATES` publish plan — and its first-publish to crates.io returned `403 Forbidden: this token does not have the required permissions` (the CI token can update existing `heddle-*` crates but can't create a brand-new crate). Since it's ordered first, that 403 blocked publish of all 29 real 0.19.0 crates.

## What

- `release-plz.toml`: `treadle-schema` `release = true` → `release = false`, with a comment explaining why. It stays a hosted/buildable workspace member — this only stops release-plz from treating it as release-managed.
- `crates/treadle-schema/Cargo.toml`: added `publish = false` — belt-and-suspenders so `cargo publish` refuses even if a list ever drifts.
- `.github/workflows/publish-crates.yml`: removed `treadle-schema` from the hardcoded `PUBLISHABLE_CRATES` env list (this list is NOT auto-derived from `release-plz.toml` despite the neighboring comment — it's a separately hand-maintained list, so it had to be edited directly).
- `scripts/check-publish-pipeline.sh`: this local asserter enforces exact order-equality between `release-plz.toml`'s `[[package]]` entries and `PUBLISHABLE_CRATES`. It never accounted for a `release = false` entry (every prior entry was `release = true`), so it false-failed on this change. Taught it to exclude parked (`release = false`) crates from that comparison. Note: this script isn't currently wired into any live GitHub Actions workflow (grep confirms no workflow invokes it) even though `RELEASING.md` says it runs in a "Rust Tests / Static contracts" job that doesn't exist in the current `rust-full-suite.yml` — pre-existing staleness, out of scope here, fixed the logic anyway since I was touching the exact code path it exercises.

Workspace version stays at 0.19.0 — not bumped. The 29 real crates are still unpublished at 0.19.0 and need to land at that version.

## Verify

- `cargo build --workspace` — clean, `treadle-schema` still compiles as a workspace member.
- `python3 scripts/check-dependency-version-bump.py origin/main HEAD` — passes (`ok: no publishable dependency contracts changed`).
- `bash scripts/check-publish-pipeline.sh` — passes after the fix above.
- Computed publish plan (release-plz.toml release=true entries and `PUBLISHABLE_CRATES` now agree exactly): 29 `heddle-*` crates, `treadle-schema` absent from both.

## Test plan

- [x] `cargo build --workspace`
- [x] `check-dependency-version-bump.py origin/main HEAD`
- [x] `check-publish-pipeline.sh`
- [ ] On merge, `publish-crates.yml` re-runs on main and should publish the 29 `heddle-*` crates at 0.19.0 (first-publish spacing applies since none exist on crates.io yet)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791062142&installation_model_id=21489&pr_number=1693&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1693&signature=25f8aa7e7b1285426dc43c56714dedd83fff9659e41008da9586db3209091c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->