### PR TITLE
ci(release): poll the sparse index instead of a fixed 60s/600s inter-crate sleep

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -341,6 +341,60 @@ jobs:
             exit 1
           fi
 
+          # Poll the crates.io sparse index until a just-published
+          # version is visible, then return — replacing the old fixed
+          # inter-crate sleep. crates.io propagates the sparse index in
+          # seconds, so the next crate (which may depend on this one)
+          # can usually publish almost immediately instead of waiting a
+          # blanket 60s/600s.
+          #
+          # Best-effort by design: on timeout it logs a warning and
+          # returns 0 rather than failing. The next crate's
+          # `cargo publish` already retries with exponential backoff if
+          # a dependency is not yet visible (see the transient-failure
+          # branch below), so a propagation race is caught there. This
+          # poll is a latency optimization, not a correctness gate. The
+          # new-crate 1-per-10-minute quota is still enforced by the
+          # 429-retry branch, never here.
+          #
+          # Sparse-index path convention (https://index.crates.io/):
+          #   1-char name        -> 1/<name>
+          #   2-char name        -> 2/<name>
+          #   3-char name        -> 3/<c1>/<name>
+          #   4+ char name       -> <c1c2>/<c3c4>/<name>   e.g. he/dd/heddle-repo
+          # The response is JSON-lines; each line is a version record
+          # with a "vers" field. We look for a line whose vers == target.
+          wait_for_index() {
+            local crate="$1" version="$2"
+            local len=${#crate} path
+            case "$len" in
+              1) path="1/${crate}" ;;
+              2) path="2/${crate}" ;;
+              3) path="3/${crate:0:1}/${crate}" ;;
+              *) path="${crate:0:2}/${crate:2:2}/${crate}" ;;
+            esac
+            local url="https://index.crates.io/${path}"
+            local deadline
+            deadline=$(( $(date +%s) + 120 ))
+            echo "=== waiting for ${crate}@${version} to appear in the sparse index (${url}) ==="
+            while true; do
+              local body
+              if body=$(curl -sS --max-time 15 \
+                          -H 'User-Agent: heddle-publish-workflow (https://github.com/HeddleCo/heddle)' \
+                          "$url" 2>/dev/null); then
+                if printf '%s\n' "$body" | jq -e --arg v "$version" 'select(.vers == $v)' >/dev/null 2>&1; then
+                  echo "=== index: ${crate}@${version} visible ==="
+                  return 0
+                fi
+              fi
+              if (( $(date +%s) >= deadline )); then
+                echo "::warning::${crate}@${version} not visible in the sparse index after 120s — proceeding anyway (next publish retries with backoff if the dep is missing)"
+                return 0
+              fi
+              sleep 3
+            done
+          }
+
           # Pretty-print the publish plan up front so the workflow log
           # has a clean record before any side effects.
           echo "Publish plan:"
@@ -355,7 +409,6 @@ jobs:
             [[ -z "$line" ]] && continue
             crate=$(echo "$line" | cut -f1)
             version=$(echo "$line" | cut -f2)
-            first_publish=$(echo "$line" | cut -f3)
             publish_idx=$((publish_idx+1))
 
             attempt=0
@@ -425,17 +478,16 @@ jobs:
               exit 1
             done
 
-            # Space publishes to match crates.io quotas and give the
-            # sparse index a moment to see the crate the next publish
-            # may depend on. Skip the pause after the last crate.
+            # Before publishing the next crate (which may depend on the
+            # one we just shipped), poll the sparse index until this
+            # version is visible instead of sleeping a fixed 60s/600s.
+            # This typically returns in a few seconds. It is best-effort:
+            # on timeout it proceeds, since the next `cargo publish` has
+            # retry-with-backoff. The genuine new-crate 1-per-10-min
+            # quota is still guarded by the 429-retry branch above, not
+            # here. Skip the wait after the last crate.
             if (( publish_idx < publish_count )); then
-              if [[ "$first_publish" == "true" ]]; then
-                sleep_for=600
-              else
-                sleep_for=60
-              fi
-              echo "=== waiting ${sleep_for}s before next publish ==="
-              sleep "$sleep_for"
+              wait_for_index "$crate" "$version"
             fi
           done
 


### PR DESCRIPTION
## Problem

The `Publish each crate` step in `publish-crates.yml` sleeps a **fixed** delay after every successful `cargo publish` before the next crate: `600s` for a first-publish, `60s` otherwise. For the ~29-crate update graph that's **~28 minutes of pure sleeping** per release.

The comment justified this as letting the sparse index "see the crate the next publish needs" — but crates.io propagates the sparse index in **seconds**. crates.io only rate-limits *new-crate* first-publishes (1 per 10 min); *updates* burst (~30), so an all-updates graph has no rate reason to throttle at all. The 600s is only justified by the new-crate quota — and that quota is already independently guarded by the 429-retry branch.

## Change

Replace the unconditional fixed inter-crate sleep with a **poll-the-sparse-index-until-visible** wait:

- New `wait_for_index(crate, version)` bash function polls `https://index.crates.io/<c1c2>/<c3c4>/<crate>` (with correct short-name fallbacks: `1/<n>`, `2/<n>`, `3/<c1>/<n>`) every 3s, up to a 120s timeout, checking each JSON-lines record's `vers` field via `jq -e`. It returns as soon as the version is visible.
- After each successful `cargo publish` (and the idempotent "already on crates.io" branch — both reach the same post-loop code), we call `wait_for_index "$crate" "$version"` instead of `sleep 60`/`sleep 600`.

## Why it's safe

- **Propagation races are backstopped by the existing retry logic.** On timeout, `wait_for_index` logs a `::warning::` and returns 0 rather than failing — the next crate's `cargo publish` already retries with exponential backoff (the transient-failure branch) if a dependency isn't yet visible. The poll is a latency optimization, not a correctness gate.
- **The genuine new-crate 1-per-10-min quota is still guarded.** The 429-retry branch (`sleep 600` on a rate-limit response, then retry) is **untouched** — a first-publish that hits the quota still waits 600s and retries. No new unconditional 600s is introduced.
- **No other behavior changed**: `--no-verify`, idempotent "already exists" handling, transient exponential backoff, non-retriable fail-loud, `max_attempts`, crate ordering, and the final step-summary are all preserved. (The now-dead `first_publish` bash extraction, which only fed the removed sleep, was dropped; the JSON `.first_publish` field still feeds the publish-plan printout.)

## Offline verification (can't run a real publish)

- `bash -n` on the extracted step script: **SYNTAX OK**. YAML parses.
- `wait_for_index heddle-repo 0.19.0` → returns in **0s** (`=== index: heddle-repo@0.19.0 visible ===`; live in the index).
- `wait_for_index heddle-repo 99.99.99` → hits the timeout, emits the `::warning::`, returns rc=0 and continues (proven with a shortened 9s deadline; does not hang).
- URL spot-checks: `a`→`1/a`, `ab`→`2/ab`, `abc`→`3/a/abc`, `heddle-repo`→`he/dd/heddle-repo`, `serde`→`se/rd/serde`.
- Confirmed the 429/transient retry branches and `PUBLISHABLE_CRATES` ordering are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791065218&installation_model_id=21489&pr_number=1694&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1694&signature=264049ed5b6a3f5d8bb89d0d0336f56ff3063d41465789dd7f8ba77e4a59ba17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->