### PR TITLE
CI: route Linux jobs to heddleco runner

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   criterion:
     name: Criterion suite
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   coverage:
     name: Coverage
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 60
     env:
       HAVE_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}

--- a/.github/workflows/perf-core-loop.yml
+++ b/.github/workflows/perf-core-loop.yml
@@ -33,7 +33,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/project-card-sync.yml
+++ b/.github/workflows/project-card-sync.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   add-issue-to-project:
     if: github.event_name == 'issues'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     steps:
       - name: Add issue to project
         uses: actions/add-to-project@v1.0.2
@@ -72,7 +72,7 @@ jobs:
     if: |
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     env:
       GH_TOKEN: ${{ secrets.PROJECT_PAT }}
     steps:

--- a/.github/workflows/rust-full-suite.yml
+++ b/.github/workflows/rust-full-suite.yml
@@ -51,7 +51,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 5
 
     steps:
@@ -79,7 +79,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci')
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 10
     outputs:
       rust: ${{ steps.decide.outputs.rust }}
@@ -259,7 +259,7 @@ jobs:
     name: Quality
     needs: changes
     if: needs.changes.outputs.rust == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 60
     env:
       # Match the fast lane: LLVM lld for the link-heavy test builds. This job
@@ -362,7 +362,7 @@ jobs:
     name: Feature contracts
     needs: changes
     if: needs.changes.outputs.cli_checks == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 30
 
     steps:
@@ -428,7 +428,7 @@ jobs:
       always() &&
       (github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 5
     steps:
       - name: Require every extracted quality gate
@@ -491,7 +491,7 @@ jobs:
     name: CLI fault-injection tests
     needs: changes
     if: needs.changes.outputs.fault_tests == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -540,7 +540,7 @@ jobs:
     name: FUSE mount smoke (Linux)
     needs: changes
     if: needs.changes.outputs.mount == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -707,7 +707,7 @@ jobs:
     name: Coverage
     needs: changes
     if: needs.changes.outputs.coverage == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 60
 
     steps:
@@ -848,7 +848,7 @@ jobs:
       github.event_name != 'schedule' &&
       (github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'full-ci'))
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 5
     steps:
       - name: Require every full-suite gate

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   fast-check:
     name: fast-check
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: [self-hosted, linux, x64, heddleco]
     timeout-minutes: 30
     env:
       # GNU ld dominates the tail of the workspace-wide, all-targets links


### PR DESCRIPTION
Routes Linux x64 CI jobs to the org-level heddleco self-hosted runner and moves generic ARM-labeled Linux jobs to x64 where applicable. Platform-specific Windows, macOS, and ARM release lanes remain unchanged. This is a single persistent runner, so concurrent jobs will queue; review runner-group policy before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791086783&installation_model_id=21489&pr_number=1698&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1698&signature=3f189fcb6a5aabdc838ce0d7a1494b4a3a6c8f4ed180e9dbfbab9cfe3680be5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->