### PR TITLE
heddle: sign device-key registration for weft one-key contract (weft#2047)

### DIFF
--- a/crates/hosted-client/CHANGELOG.md
+++ b/crates/hosted-client/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Sign `CreateDeviceAuthorization` and `RegisterPublicKey` with the enrolling
+  device key (`principal:device-key:<hex>`) and send only
+  `device_proof_public_key` on RegisterPublicKey (weft#2047 one-key cutover).
 - Hash Push/Pull `StreamOpeningProof.stream_id` to 64-byte blake3 hex so weft admits the opening (the long transfer identity stays on the checkpoint).
 
 ## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-hosted-client-v0.15.2...heddle-hosted-client-v0.15.3) - 2026-08-28

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -29,8 +29,8 @@ use super::{
         attenuate_for_agent, effective_pop_public_key_hex,
     },
     hosted::{
-        HostedAuthMode, HostedClient, HostedError, HostedSession, ResolvedHostedCredential,
-        operation_id::ClientOperationId, resolve_hosted_credential,
+        CallContextFactory, HostedAuthMode, HostedClient, HostedError, HostedSession,
+        ResolvedHostedCredential, operation_id::ClientOperationId, resolve_hosted_credential,
     },
 };
 
@@ -835,8 +835,10 @@ pub(crate) async fn cmd_auth_login_browser(server: &str, open_browser: bool) -> 
         .to_pem()
         .map_err(|e| anyhow::anyhow!("failed to export private key: {e}"))?;
 
-    // 2. Connect to the auth service.
-    let mut auth_client = connect_auth_client(server).await?;
+    // 2. Connect as the enrolling device key. weft#2047 requires a Tier-1
+    // request PoP by this key on CreateDeviceAuthorization; an unsigned
+    // session is rejected with no fallback.
+    let mut auth_client = connect_enrolling_device_client(server, &signer).await?;
 
     // 3. Create device authorization.
     let hostname = std::env::var("HOSTNAME")
@@ -845,12 +847,10 @@ pub(crate) async fn cmd_auth_login_browser(server: &str, open_browser: bool) -> 
 
     let response: Result<DeviceAuthorizationResponse> = auth_client
         .routes()
-        .create_device_authorization(&CreateDeviceAuthorizationRequest {
-            device_name: hostname,
-            device_public_key: public_key_bytes.clone(),
-            scope: "repo:*".to_string(),
-            client_operation_id: String::new(),
-        })
+        .create_device_authorization(&create_device_authorization_request(
+            hostname,
+            &public_key_bytes,
+        ))
         .await
         .map_err(|error| anyhow::anyhow!("create_device_authorization failed: {error}"));
     let response = match response {
@@ -1333,14 +1333,42 @@ pub(crate) fn resolve_server(explicit: Option<&str>) -> Result<String> {
     Ok("api.heddle.sh".to_string())
 }
 
-/// Connect the unauthenticated login flow through the same signed descriptor
-/// bootstrap used by every other native hosted session.
-async fn connect_auth_client(server: &str) -> Result<HostedClient> {
+/// Connect the device-authorization login flow as the enrolling device key.
+///
+/// CreateDeviceAuthorization is possession-first (weft#2047): the request
+/// proof identity is `principal:device-key:<lowercase-hex>`. The proto field
+/// on this RPC remains `device_public_key` (heddle-api 0.26 has no
+/// `device_proof_public_key` on CreateDeviceAuthorizationRequest).
+fn enrolling_device_auth_mode(signer: &Ed25519Signer) -> Result<HostedAuthMode> {
+    Ok(HostedAuthMode::ProofOnly {
+        proof_key_pem: signer
+            .to_pem()
+            .map_err(|error| anyhow::anyhow!("failed to export private key: {error}"))?,
+        signing_identity: CallContextFactory::device_key_principal(signer.public_key()),
+    })
+}
+
+fn create_device_authorization_request(
+    device_name: impl Into<String>,
+    public_key: &[u8],
+) -> CreateDeviceAuthorizationRequest {
+    CreateDeviceAuthorizationRequest {
+        device_name: device_name.into(),
+        device_public_key: public_key.to_vec(),
+        scope: "repo:*".to_string(),
+        client_operation_id: String::new(),
+    }
+}
+
+async fn connect_enrolling_device_client(
+    server: &str,
+    signer: &Ed25519Signer,
+) -> Result<HostedClient> {
     let user_config = UserConfig::load_default()?;
     HostedSession::build(
         &user_config,
         Some(server.to_string()),
-        HostedAuthMode::Unauthenticated,
+        enrolling_device_auth_mode(signer)?,
     )?
     .connect(server)
     .await
@@ -2683,5 +2711,47 @@ mod tests {
                 "default server must be preserved so a no-arg retry re-targets the same server",
             );
         });
+    }
+
+    #[test]
+    fn device_authorization_session_signs_as_the_enrolling_device_key() {
+        use api::signing;
+        use prost::Message;
+
+        let signer = Ed25519Signer::generate().expect("device key");
+        match enrolling_device_auth_mode(&signer).expect("auth mode") {
+            HostedAuthMode::ProofOnly {
+                signing_identity, ..
+            } => {
+                assert_eq!(
+                    signing_identity,
+                    CallContextFactory::device_key_principal(signer.public_key())
+                );
+            }
+            _ => panic!("CreateDeviceAuthorization must use ProofOnly"),
+        }
+        let request = create_device_authorization_request("laptop", signer.public_key());
+        assert_eq!(request.device_public_key, signer.public_key());
+        assert_eq!(request.device_name, "laptop");
+        let encoded = request.encode_to_vec();
+        let signed = CallContextFactory::default()
+            .with_enrolling_device_key_pem(&signer.to_pem().expect("pem"))
+            .expect("factory")
+            .unary(
+                "/heddle.api.v1alpha1.IdentityService/CreateDeviceAuthorization",
+                &encoded,
+                "",
+            )
+            .expect("sign");
+        let proof = signed.context.request_proof.expect("request proof");
+        let canonical = signing::unary_bytes(
+            &proof.signing_identity,
+            "/heddle.api.v1alpha1.IdentityService/CreateDeviceAuthorization",
+            proof.timestamp_millis,
+            &proof.nonce,
+            &encoded,
+        );
+        Ed25519Signer::verify_with_public_key(&canonical, signer.public_key(), &proof.signature)
+            .expect("weft-verifiable enrollment PoP");
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/context.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/context.rs
@@ -140,6 +140,32 @@ impl CallContextFactory {
         Ok(self)
     }
 
+    /// Pre-account identity weft verifies for possession-first device enrollment.
+    ///
+    /// `hex::encode` is lowercase; weft compares this string exactly against
+    /// `principal:device-key:<lowercase-hex-of-device_proof_public_key>`.
+    pub fn device_key_principal(public_key: &[u8]) -> String {
+        format!("principal:device-key:{}", hex::encode(public_key))
+    }
+
+    /// Sign as the enrolling device key (weft#2047). Keeps any bearer; only
+    /// the request-proof identity becomes `principal:device-key:<hex>`.
+    pub fn as_enrolling_device_key(&self) -> Result<Self> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        let mut cloned = self.clone();
+        cloned.signing_identity = Some(Self::device_key_principal(signer.public_key()));
+        Ok(cloned)
+    }
+
+    pub fn with_enrolling_device_key_pem(self, pem: &str) -> Result<Self> {
+        let signer = Ed25519Signer::from_pem(pem)?;
+        let identity = Self::device_key_principal(signer.public_key());
+        self.with_signing_key_pem(pem, identity)
+    }
+
     pub fn from_client_config(config: &ClientConfig) -> Result<Self> {
         let signer = config
             .auth_proof_key_pem
@@ -619,6 +645,67 @@ mod tests {
             .mint_spool_owner_genesis()
             .expect_err("CreateSpool must not invent a throwaway owner key");
         assert!(matches!(error, HostedError::SigningIdentityRequired));
+    }
+
+    #[test]
+    fn enrolling_device_key_identity_is_lowercase_hex_principal() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let identity = CallContextFactory::device_key_principal(signer.public_key());
+        assert_eq!(
+            identity,
+            format!("principal:device-key:{}", hex::encode(signer.public_key()))
+        );
+        assert_eq!(identity, identity.to_ascii_lowercase());
+        let factory = CallContextFactory::default()
+            .with_enrolling_device_key_pem(&signer.to_pem().unwrap())
+            .unwrap();
+        assert_eq!(factory.signing_identity(), Some(identity.as_str()));
+        let request = b"device-enrollment";
+        let signed = factory
+            .unary(
+                "/heddle.api.v1alpha1.IdentityService/CreateDeviceAuthorization",
+                request,
+                "",
+            )
+            .unwrap();
+        let proof = signed.context.request_proof.unwrap();
+        assert_eq!(proof.algorithm, "ed25519");
+        assert_eq!(proof.signing_identity, identity);
+        let canonical = signing::unary_bytes(
+            &proof.signing_identity,
+            "/heddle.api.v1alpha1.IdentityService/CreateDeviceAuthorization",
+            proof.timestamp_millis,
+            &proof.nonce,
+            request,
+        );
+        Ed25519Signer::verify_with_public_key(&canonical, signer.public_key(), &proof.signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn as_enrolling_device_key_keeps_the_bearer_and_rewrites_request_identity() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let factory = CallContextFactory::default()
+            .with_bearer_capability(b"agent-root".to_vec())
+            .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:agent-key:abc")
+            .unwrap();
+        let enrollment = factory.as_enrolling_device_key().unwrap();
+        let expected = CallContextFactory::device_key_principal(signer.public_key());
+        assert_eq!(enrollment.bearer_capability(), b"agent-root");
+        assert_eq!(enrollment.signing_identity(), Some(expected.as_str()));
+        let signed = enrollment
+            .unary(
+                "/heddle.api.v1alpha1.IdentityService/RegisterPublicKey",
+                b"claim",
+                "op-1",
+            )
+            .unwrap();
+        let proof = signed.context.request_proof.unwrap();
+        assert_eq!(
+            proof.signing_identity,
+            CallContextFactory::device_key_principal(signer.public_key())
+        );
+        assert_eq!(signed.context.bearer_capability, b"agent-root");
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -177,6 +177,10 @@ impl HostedClient {
         self.context.proof_signer()
     }
 
+    pub(crate) fn enrolling_device_context(&self) -> Result<CallContextFactory> {
+        self.context.as_enrolling_device_key()
+    }
+
     pub async fn connect(descriptor: &VerifiedEndpointDescriptor) -> Result<Self> {
         let config = ClientConfig::default();
         Ok(Self {
@@ -349,13 +353,26 @@ impl HostedClient {
     where
         Response: Message + Default,
     {
+        self.call_unary_encoded_with(&self.context, method, encoded)
+            .await
+    }
+
+    pub(crate) async fn call_unary_encoded_with<Response>(
+        &self,
+        context: &CallContextFactory,
+        method: &str,
+        encoded: &[u8],
+    ) -> Result<Response>
+    where
+        Response: Message + Default,
+    {
         let descriptor = api::method_descriptor(method)
             .ok_or_else(|| HostedError::Framing(format!("unknown hosted method {method}")))?;
         let client_operation_id = descriptor.client_operation_id(encoded)?.unwrap_or_default();
         if descriptor.client_operation_id_required && client_operation_id.is_empty() {
             return Err(HostedError::MissingClientOperationId);
         }
-        let signed = self.context.unary(method, encoded, client_operation_id)?;
+        let signed = context.unary(method, encoded, client_operation_id)?;
         match call::unary_encoded(&self.connection, method, &signed.context, encoded).await {
             Ok(response) => Ok(response),
             Err(HostedError::Call {

--- a/crates/hosted-client/src/hosted_runtime/owner_root.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root.rs
@@ -91,6 +91,7 @@ pub(crate) fn encode_bootstrap_owner_root(
     encoded
 }
 
+#[allow(deprecated)]
 pub(crate) fn encode_register_public_key_claim(
     request: &RegisterPublicKeyRequest,
     transition: &SignedOwnerKeyTransition,
@@ -102,6 +103,19 @@ pub(crate) fn encode_register_public_key_claim(
         bail!(
             "RegisterPublicKey claim must not send owner_root, owner_root_proof_of_possession, or owner_key_binding; those replace sequence-0"
         );
+    }
+    if !request.device_public_key.is_empty() {
+        bail!(
+            "RegisterPublicKey must not send device_public_key; send only device_proof_public_key"
+        );
+    }
+    if !request.biscuit_authority_public_key.is_empty() {
+        bail!(
+            "RegisterPublicKey must not send biscuit_authority_public_key; send only device_proof_public_key"
+        );
+    }
+    if request.device_proof_public_key.len() != 32 {
+        bail!("RegisterPublicKey device_proof_public_key must be 32 bytes");
     }
     let kind = transition
         .transition
@@ -207,11 +221,34 @@ pub(crate) async fn send_pending_register_public_key_claim(
         identity_state::store_while_locked(&state)?;
         encoded
     };
+    let signer = client
+        .claim_proof_signer()
+        .context("RegisterPublicKey requires this device's proof key")?;
+    require_enrolling_device_proof_key(&encoded, signer)?;
+    let enrollment = client
+        .enrolling_device_context()
+        .context("signing RegisterPublicKey as the enrolling device key")?;
     Ok(Some(
         client
-            .call_unary_encoded(REGISTER_PUBLIC_KEY, &encoded)
+            .call_unary_encoded_with(&enrollment, REGISTER_PUBLIC_KEY, &encoded)
             .await?,
     ))
+}
+
+#[allow(deprecated)]
+pub(crate) fn require_enrolling_device_proof_key(
+    encoded: &[u8],
+    signer: &Ed25519Signer,
+) -> Result<()> {
+    let request = RegisterPublicKeyRequest::decode(encoded)
+        .context("decode pending RegisterPublicKey claim")?;
+    if !request.device_public_key.is_empty() || !request.biscuit_authority_public_key.is_empty() {
+        bail!("RegisterPublicKey must send only device_proof_public_key");
+    }
+    if request.device_proof_public_key != signer.public_key() {
+        bail!("RegisterPublicKey device_proof_public_key must be this device's proof key");
+    }
+    Ok(())
 }
 
 fn already_installed(message: &str) -> bool {

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -11,9 +11,9 @@ use config::credentials;
 use crypto::{Ed25519Signer, Signer as _};
 use prost::Message;
 use repo::{
-    OWNER_TRANSITION_DOMAIN, authorization_key_id, claim_deferred_human_transition,
-    ed25519_verification_key, owner_key_transition_body, seq0_authority_public_key,
-    sign_agent_claim_binding, sign_canonical,
+    authorization_key_id, claim_deferred_human_transition, ed25519_verification_key,
+    owner_key_transition_body, seq0_authority_public_key, sign_agent_claim_binding, sign_canonical,
+    OWNER_TRANSITION_DOMAIN,
 };
 
 fn build_with_browser_proofs(
@@ -71,9 +71,9 @@ use super::{
     hosted::{CallContextFactory, HostedError},
     identity_state,
     owner_root::{
-        BootstrapOwnerRootExtension, BrowserClaimDeferredHuman, RegisterPublicKeyClaimExtension,
         build_claim_deferred_human, encode_bootstrap_owner_root, encode_register_public_key_claim,
         load_recorded_root, prepare_register_public_key_claim, require_enrolling_device_proof_key,
+        BootstrapOwnerRootExtension, BrowserClaimDeferredHuman, RegisterPublicKeyClaimExtension,
     },
 };
 
@@ -567,13 +567,12 @@ fn pending_register_public_key_must_match_this_device_proof_key() {
             client_operation_id: "op-match".into(),
             ..Default::default()
         },
-        &{
-            let mut transition = SignedOwnerKeyTransition::default();
-            transition.transition = Some(api::heddle::api::v1alpha1::OwnerKeyTransition {
+        &SignedOwnerKeyTransition {
+            transition: Some(api::heddle::api::v1alpha1::OwnerKeyTransition {
                 kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
                 ..Default::default()
-            });
-            transition
+            }),
+            ..Default::default()
         },
     )
     .expect("one-key request");

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -73,7 +73,7 @@ use super::{
     owner_root::{
         BootstrapOwnerRootExtension, BrowserClaimDeferredHuman, RegisterPublicKeyClaimExtension,
         build_claim_deferred_human, encode_bootstrap_owner_root, encode_register_public_key_claim,
-        load_recorded_root, prepare_register_public_key_claim,
+        load_recorded_root, prepare_register_public_key_claim, require_enrolling_device_proof_key,
     },
 };
 
@@ -326,8 +326,6 @@ fn bootstrap_owner_root_wire_carries_agent_claim_binding_on_tag_5() {
 }
 
 #[test]
-// This deliberately exercises the legacy single-key device_public_key path.
-// Migrating CLI owner-root flows to the two-key model is a separate effort.
 #[allow(deprecated)]
 fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
     let _home = IsolatedHome::new();
@@ -377,7 +375,7 @@ fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
     );
     let request = RegisterPublicKeyRequest {
         challenge_id: "challenge-1".into(),
-        device_public_key: human.public_key().to_vec(),
+        device_proof_public_key: agent.public_key().to_vec(),
         client_operation_id: "op-claim-1".into(),
         ..Default::default()
     };
@@ -386,7 +384,9 @@ fn register_public_key_claim_sends_claim_deferred_human_on_tag_16() {
     assert!(official.owner_root.is_none());
     assert!(official.owner_root_proof_of_possession.is_none());
     assert!(official.owner_key_binding.is_none());
-    assert_eq!(official.device_public_key, human.public_key());
+    assert!(official.device_public_key.is_empty());
+    assert!(official.biscuit_authority_public_key.is_empty());
+    assert_eq!(official.device_proof_public_key, agent.public_key());
     let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
     let sent = extension
         .claim_deferred_human
@@ -440,8 +440,44 @@ fn register_public_key_claim_refuses_retired_device_public_key() {
 }
 
 #[test]
-// This deliberately exercises the legacy single-key device_public_key path.
-// Migrating CLI owner-root flows to the two-key model is a separate effort.
+fn register_public_key_claim_refuses_retired_biscuit_authority_public_key() {
+    let error = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            biscuit_authority_public_key: vec![0x11; 32],
+            device_proof_public_key: vec![0x22; 32],
+            client_operation_id: "op-authority".into(),
+            ..Default::default()
+        },
+        &Default::default(),
+    )
+    .expect_err("retired biscuit_authority_public_key must not be encoded");
+    assert!(
+        error
+            .to_string()
+            .contains("must not send biscuit_authority_public_key"),
+        "{error}"
+    );
+}
+
+#[test]
+fn register_public_key_claim_requires_device_proof_public_key() {
+    let error = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            client_operation_id: "op-empty".into(),
+            ..Default::default()
+        },
+        &Default::default(),
+    )
+    .expect_err("empty device_proof_public_key must not be encoded");
+    assert!(
+        error
+            .to_string()
+            .contains("device_proof_public_key must be 32 bytes"),
+        "{error}"
+    );
+}
+
+#[test]
 #[allow(deprecated)]
 fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
     let _home = IsolatedHome::new();
@@ -493,7 +529,7 @@ fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
         &mut state,
         RegisterPublicKeyRequest {
             challenge_id: "challenge-prepare".into(),
-            device_public_key: human.public_key().to_vec(),
+            device_proof_public_key: agent.public_key().to_vec(),
             client_operation_id: "op-prepare".into(),
             ..Default::default()
         },
@@ -507,6 +543,8 @@ fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
     let official = RegisterPublicKeyRequest::decode(encoded.as_slice()).expect("official");
     assert!(official.owner_root.is_none());
     assert!(official.owner_key_binding.is_none());
+    assert!(official.device_public_key.is_empty());
+    assert_eq!(official.device_proof_public_key, agent.public_key());
     let extension = RegisterPublicKeyClaimExtension::decode(encoded.as_slice()).expect("tag 16");
     assert_eq!(
         extension
@@ -516,5 +554,37 @@ fn claim_prepares_register_public_key_claim_deferred_human_for_send() {
             .expect("body")
             .kind(),
         OwnerKeyTransitionKind::ClaimDeferredHuman
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn pending_register_public_key_must_match_this_device_proof_key() {
+    let signer = Ed25519Signer::generate().expect("device");
+    let encoded = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            device_proof_public_key: signer.public_key().to_vec(),
+            client_operation_id: "op-match".into(),
+            ..Default::default()
+        },
+        &{
+            let mut transition = SignedOwnerKeyTransition::default();
+            transition.transition = Some(api::heddle::api::v1alpha1::OwnerKeyTransition {
+                kind: OwnerKeyTransitionKind::ClaimDeferredHuman as i32,
+                ..Default::default()
+            });
+            transition
+        },
+    )
+    .expect("one-key request");
+    require_enrolling_device_proof_key(&encoded, &signer).expect("matching device key");
+    let other = Ed25519Signer::generate().expect("other device");
+    let error = require_enrolling_device_proof_key(&encoded, &other)
+        .expect_err("a different device key must not prove this enrollment");
+    assert!(
+        error
+            .to_string()
+            .contains("must be this device's proof key"),
+        "{error}"
     );
 }

--- a/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/owner_root_tests.rs
@@ -419,6 +419,27 @@ fn register_public_key_claim_refuses_a_replacement_seq0() {
 }
 
 #[test]
+#[allow(deprecated)]
+fn register_public_key_claim_refuses_retired_device_public_key() {
+    let error = encode_register_public_key_claim(
+        &RegisterPublicKeyRequest {
+            device_public_key: vec![0x11; 32],
+            device_proof_public_key: vec![0x22; 32],
+            client_operation_id: "op-retired".into(),
+            ..Default::default()
+        },
+        &Default::default(),
+    )
+    .expect_err("retired device_public_key must not be encoded");
+    assert!(
+        error
+            .to_string()
+            .contains("must not send device_public_key"),
+        "{error}"
+    );
+}
+
+#[test]
 // This deliberately exercises the legacy single-key device_public_key path.
 // Migrating CLI owner-root flows to the two-key model is a separate effort.
 #[allow(deprecated)]


### PR DESCRIPTION
## Summary

- Sign `CreateDeviceAuthorization` with a Tier-1 request PoP by the enrolling device key (`principal:device-key:<lowercase-hex>`, `ed25519`, `unary_bytes` over the exact RPC path). An unsigned device-flow session is rejected once weft#2047 is deployed.
- Send only `device_proof_public_key` on `RegisterPublicKey`; refuse non-empty `device_public_key` and `biscuit_authority_public_key`. Sign the pending claim with the same device-key identity so weft can persist a `device_root` / `ed25519_request_pop` KeyBinding from `CallContext.request_proof`.
- `CreateDeviceAuthorizationRequest` in pinned heddle-api 0.26 still has `device_public_key` (tag 2) and no `device_proof_public_key`. weft#2047 still reads that field for this RPC, so the client keeps sending it. No api bump required.

## Closes

Part of HeddleCo/weft#2047

## Red commit
`234836c408cf2f501f8274bf76cde03b5df5cb09`

## Test evidence
```
$ cargo test -p heddle-hosted-client --features client --lib

running 419 tests
...
test hosted_runtime::auth::tests::device_authorization_session_signs_as_the_enrolling_device_key ... ok
test hosted_runtime::hosted::context::tests::as_enrolling_device_key_keeps_the_bearer_and_rewrites_request_identity ... ok
test hosted_runtime::hosted::context::tests::enrolling_device_key_identity_is_lowercase_hex_principal ... ok
test hosted_runtime::owner_root_tests::pending_register_public_key_must_match_this_device_proof_key ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_refuses_retired_biscuit_authority_public_key ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_refuses_retired_device_public_key ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_requires_device_proof_public_key ... ok
test hosted_runtime::owner_root_tests::register_public_key_claim_sends_claim_deferred_human_on_tag_16 ... ok
test hosted_runtime::owner_root_tests::claim_prepares_register_public_key_claim_deferred_human_for_send ... ok
...
test result: ok. 418 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 12.89s
```

Live weft enrollment (signup / add-device / agent-claim against a post-2047 weft) is not exercised in-repo. The tests above verify the request bytes and the Ed25519 request-proof weft re-checks at the storage boundary.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791130126&installation_model_id=21489&pr_number=1699&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1699&signature=51dd446b9bc6d41e2f435d034ca7948ccff952bffe33950e58933ecd3fc881e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->