### PR TITLE
heddle 0.20: heddle-api 0.27 + cv 0.16 (weft#2047 cascade)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2141,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffb4e958804c0f94a7d2f5b2b107df045ea290c14e6c36d2ed2bfa21afc8ef"
+checksum = "02ca39fe24cc86e74825d513f5ccf29fbb5df80f1c347f1697147b0ad3975c4c"
 dependencies = [
  "blake3",
  "bytes",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2371,11 +2371,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "heddle-format"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2633,11 +2633,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2774,7 +2774,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2788,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "heddleco-capability-verifier"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dec352ce11fba30e5c360943878d983e2b06329d834e2f33776f95a09ccd280"
+checksum = "a342c0bf87836d4430c6eb51aed9a847df8e50af30d91217b643f014db3c970f"
 dependencies = [
  "biscuit-auth",
  "ed25519-dalek 3.0.0",
@@ -7557,7 +7557,7 @@ dependencies = [
 
 [[package]]
 name = "treadle-schema"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "blake3",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -47,7 +47,7 @@ categories = ["development-tools"]
 
 [workspace.dependencies]
 anyhow = "1"
-api = { package = "heddle-api", version = "0.26.0" }
+api = { package = "heddle-api", version = "0.27.0" }
 async-trait = "0.1"
 base32 = "0.5"
 base64 = "0.22"
@@ -160,34 +160,34 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-treadle-schema = { path = "crates/treadle-schema", version = "0.19.0" }
-heddle-cli-args = { path = "crates/cli-args", version = "0.19.0", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.19.0", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.19.0", default-features = false }
-heddle-format = { path = "crates/format", version = "0.19.0" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.19.0" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.19.0", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.19.0" }
-heddle-pack = { path = "crates/pack", version = "0.19.0" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.19.0" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.19.0", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.19.0" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.19.0" }
-config = { path = "crates/config", package = "heddle-config", version = "0.19.0" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.19.0" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.19.0", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.19.0", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.19.0" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.19.0" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.19.0" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.19.0", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.19.0" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.19.0", default-features = false }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.19.0" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.19.0" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.19.0" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.19.0", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.19.0", default-features = false }
+treadle-schema = { path = "crates/treadle-schema", version = "0.20.0" }
+heddle-cli-args = { path = "crates/cli-args", version = "0.20.0", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.20.0", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.20.0", default-features = false }
+heddle-format = { path = "crates/format", version = "0.20.0" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.20.0" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.20.0", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.20.0" }
+heddle-pack = { path = "crates/pack", version = "0.20.0" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.20.0" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.20.0", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.20.0" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.20.0" }
+config = { path = "crates/config", package = "heddle-config", version = "0.20.0" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.20.0" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.20.0", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.20.0", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.20.0" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.20.0" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.20.0" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.20.0", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.20.0" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.20.0", default-features = false }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.20.0" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.20.0" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.20.0" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.20.0", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.20.0", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.19.0",
+  "schemaVersion": "0.20.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.19.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.20.0" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -60,6 +60,10 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
     ),
     ("RotateCredential", AgentAuthOperationDisposition::Denied),
     ("RevokeCredential", AgentAuthOperationDisposition::Denied),
+    // Passkey-enrolled device-root revoke (weft#2047 C5). Modeled on
+    // RevokeCredential: derived agents must not drop a parent principal's
+    // registered device root.
+    ("RevokeDevice", AgentAuthOperationDisposition::Denied),
     (
         "CreateServiceAccount",
         AgentAuthOperationDisposition::Denied,

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,7 +16,7 @@ api = { workspace = true }
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddleco-capability-verifier = "0.15.0"
+heddleco-capability-verifier = "0.16.0"
 ignore.workspace = true
 heddle-perf-contract.workspace = true
 libc.workspace = true


### PR DESCRIPTION
## Summary

- Bumps `heddle-api` 0.26.0 → 0.27.0 and `heddleco-capability-verifier` 0.15.0 → 0.16.0 (both already published on crates.io) so weft can migrate off the heddle-* 0.17 / heddle-api 0.25 pin.
- Workspace / publish-set version 0.19.0 → 0.20.0. This is the repo's current release path: `scripts/check-dependency-version-bump.py` requires a workspace version increase when publishable dep contracts change; `publish-crates.yml` then publishes whatever is in `Cargo.toml` on merge to main. `cargo metadata` records `heddle-repo` 0.20.0 requiring `heddle-api ^0.27.0` and `heddleco-capability-verifier ^0.16.0`.
- heddle-api 0.27 is additive: `IdentityService/RevokeDevice`, `SubmitRecoveryProofRequest.new_device_proof_signature`, and the one-key / recovery signing consts (`ONE_KEY_DEVICE_BINDING_CHALLENGE_DOMAIN`, `RECOVERY_NEW_DEVICE_POP_V1_DOMAIN`). Production constructors compiled unchanged.
- The exhaustive IdentityService agent-policy table in `crates/hosted-client` is not source-additive: `AUTH_SERVICE_AGENT_POLICY` is compared against the shared descriptor, so `RevokeDevice` is classified `Denied` (same as `RevokeCredential`) — derived agents must not drop a parent principal's registered device root.
- Regenerated `clients/npm/generated/heddle-schemas.{ts,json}` via `scripts/gen-ts-types.sh` (version pin 0.19.0 → 0.20.0 only). `docs/llms-full.txt` is already fresh (`heddle-docsgen --check`).

On merge, `publish-crates` publishes heddle-repo and siblings at 0.20.0. Publish is merge-gated; this PR does not tag or publish.

## Closes

Part of HeddleCo/weft#2047

## Red commit

N/A — dependency republish. The IdentityService policy test failed locally against api 0.27 until `RevokeDevice` was classified `Denied`; that failure was not committed as a separate SHA.

## Test evidence
```
$ cargo build --workspace --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 21s

$ cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.61s

$ cargo test --locked --workspace --lib --bins
    (fast lane; hosted-client 418 passed / 1 ignored after classifying RevokeDevice)
    test result: ok. 418 passed; 0 failed; 1 ignored   # heddle-hosted-client
    test result: ok. 442 passed; 0 failed; 0 ignored   # heddle-cli
    test result: ok. 791 passed; 3 ignored             # heddle-repo
    test result: ok. 486 passed; 1 ignored             # heddle-verbs
    ALL workspace lib+bins packages: 0 failed

$ cargo test --locked -p heddle-cli --features git-overlay,native,semantic,zstd --test ts_types_in_sync
    test full_feature::generated_typescript_is_in_sync ... ok
    test full_feature::generated_json_is_in_sync ... ok
    test result: ok. 2 passed; 0 failed

$ cargo run --locked -p heddle-docsgen -- --check
    llms.txt / llms-full.txt are up to date

$ rustfmt +nightly --edition 2024 --check crates/hosted-client/src/hosted_runtime/device_flow.rs
    rustfmt_ok

$ python3 scripts/check-dependency-version-bump.py origin/main HEAD
    changed publishable dependency contracts:
      - Cargo.toml [workspace.dependencies]
      - crates/repo/Cargo.toml [dependencies] (heddle-repo)
    ok: workspace version increased from 0.19.0 to 0.20.0

$ cargo metadata --format-version 1 --no-deps  # heddle-repo
    heddle-repo version: 0.20.0
      heddle-api req=^0.27.0
      heddleco-capability-verifier req=^0.16.0
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791139662&installation_model_id=21489&pr_number=1700&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1700&signature=25b597dcb624eba1d15056d22ccdee330fc4eefb0941273bafd0683c0bc5fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->