### PR TITLE
fix(clone): persist hosted thread stable id so clone→push is not exit 76

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -40,7 +40,7 @@ use objects::{
     store::ObjectStore,
     sync::LockExt,
 };
-use repo::{BlobHydrator, Repository};
+use repo::{BlobHydrator, Repository, ThreadManager};
 #[cfg(feature = "client")]
 use repo::{RepositorySourceAuthority, clone_intent::CloneIntent};
 #[cfg(feature = "client")]
@@ -1213,6 +1213,15 @@ async fn clone_local(
         let _ = fs::remove_dir_all(local_path);
         return Err(error);
     }
+    if let Some(metadata) =
+        ThreadManager::new(remote_repo.heddle_dir()).find_record_by_thread(&track_name)?
+    {
+        ThreadManager::new(local_repo.heddle_dir()).save_pulled_metadata(
+            &track_name,
+            &state_id,
+            metadata,
+        )?;
+    }
 
     let origin_url = configure_local_clone_origin(&local_repo, remote_path)?;
 
@@ -1837,6 +1846,15 @@ async fn clone_network_connected(
             checkout_clone_thread(&local_repo, &track_name, &final_state)
                 .context("failed to materialize hosted clone worktree")?;
         }
+        persist_hosted_clone_thread_identity(
+            &local_repo,
+            client,
+            repo_path,
+            &remote_refs,
+            &track_name,
+            &final_state,
+        )
+        .await?;
         CloneIntent::clear(local_path)?;
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(
@@ -2060,6 +2078,15 @@ async fn recover_interrupted_clone_connected(
     } else {
         checkout_clone_thread(&repo, &track_name, &final_state)?;
     }
+    persist_hosted_clone_thread_identity(
+        &repo,
+        client,
+        &intent.repository,
+        &remote_refs,
+        &track_name,
+        &final_state,
+    )
+    .await?;
     CloneIntent::clear(root)?;
     Ok(())
 }
@@ -2531,6 +2558,53 @@ fn clone_hosted_thread_not_found_advice(track_name: &str, remote_label: &str) ->
 }
 
 #[cfg(feature = "client")]
+#[cfg(feature = "client")]
+async fn persist_hosted_clone_thread_identity(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &objects::object::StateId,
+) -> Result<()> {
+    if let Some(metadata) = client
+        .try_get_thread_metadata(repo, repo_path, track_name, *final_state)
+        .await?
+    {
+        ThreadManager::new(repo.heddle_dir()).save_pulled_metadata(
+            track_name,
+            final_state,
+            metadata,
+        )?;
+        return Ok(());
+    }
+    persist_advertised_clone_thread_identity(repo, remote_refs, track_name, final_state)
+}
+
+#[cfg(feature = "client")]
+fn persist_advertised_clone_thread_identity(
+    repo: &Repository,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &objects::object::StateId,
+) -> Result<()> {
+    let Some(stable_id) = remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(());
+    };
+    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
+        repo,
+        track_name,
+        stable_id,
+        *final_state,
+    )?;
+    Ok(())
+}
+
 fn hosted_clone_thread_revision_address<'a>(
     remote_refs: &'a [HostedRefEntry],
     thread: &str,
@@ -2935,6 +3009,40 @@ mod tests {
 
         assert_eq!(repo.source_authority(), RepositorySourceAuthority::Native);
         assert!(!root.join(".git").exists());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_persists_advertised_thread_stable_id() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        std::fs::write(temp.path().join("tracked.txt"), b"cloned\n").unwrap();
+        let state = repo
+            .snapshot(Some("seed".into()), None)
+            .expect("snapshot")
+            .state_id;
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        let remote_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some("hosted-stable-main".to_string()),
+        )];
+
+        persist_advertised_clone_thread_identity(&repo, &remote_refs, "main", &state)
+            .expect("persist advertised identity");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, "hosted-stable-main");
+        assert_ne!(persisted.id, minted.id);
+        assert_ne!(persisted.id, "main");
     }
 
     #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -30,7 +30,8 @@ use heddle_git_projection::git_core::{
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
 use hosted_client::hosted_runtime::hosted::{
-    HostedClient, HostedRefEntry, PullMaterialization, persist_advertised_thread_identity,
+    HostedClient, HostedRefEntry, PullMaterialization, advertised_user_thread_id,
+    persist_advertised_thread_identity_with_live_fallback,
 };
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
@@ -2579,7 +2580,20 @@ async fn persist_hosted_clone_thread_identity(
         )?;
         return Ok(());
     }
-    persist_advertised_thread_identity(repo, remote_refs, track_name, final_state)?;
+    // Folded PullReady refs decode with `thread_id: None`. Refresh live
+    // ListRefs when the fold omitted the advertised stable id.
+    let live_refs = if advertised_user_thread_id(remote_refs, track_name).is_none() {
+        Some(client.list_refs_with_revision_addresses(repo_path).await?)
+    } else {
+        None
+    };
+    persist_advertised_thread_identity_with_live_fallback(
+        repo,
+        remote_refs,
+        live_refs.as_deref(),
+        track_name,
+        final_state,
+    )?;
     Ok(())
 }
 
@@ -3011,8 +3025,62 @@ mod tests {
             Some("hosted-stable-main".to_string()),
         )];
 
-        persist_advertised_thread_identity(&repo, &remote_refs, "main", &state)
-            .expect("persist advertised identity");
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &remote_refs,
+            None,
+            "main",
+            &state,
+        )
+        .expect("persist advertised identity");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, "hosted-stable-main");
+        assert_ne!(persisted.id, minted.id);
+        assert_ne!(persisted.id, "main");
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_refreshes_list_refs_when_folded_refs_omit_thread_id() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        std::fs::write(temp.path().join("tracked.txt"), b"cloned\n").unwrap();
+        let state = repo
+            .snapshot(Some("seed".into()), None)
+            .expect("snapshot")
+            .state_id;
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        let folded_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            None,
+        )];
+        let live_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some("hosted-stable-main".to_string()),
+        )];
+
+        assert!(advertised_user_thread_id(&folded_refs, "main").is_none());
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &folded_refs,
+            Some(&live_refs),
+            "main",
+            &state,
+        )
+        .expect("persist from live ListRefs when the fold omitted thread_id");
 
         let persisted = ThreadManager::new(repo.heddle_dir())
             .find_record_by_thread("main")

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -29,7 +29,9 @@ use heddle_git_projection::git_core::{
 };
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{HostedClient, HostedRefEntry, PullMaterialization};
+use hosted_client::hosted_runtime::hosted::{
+    HostedClient, HostedRefEntry, PullMaterialization, persist_advertised_thread_identity,
+};
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
 use objects::fs_atomic::CloneDurabilityBatch;
@@ -2558,7 +2560,6 @@ fn clone_hosted_thread_not_found_advice(track_name: &str, remote_label: &str) ->
 }
 
 #[cfg(feature = "client")]
-#[cfg(feature = "client")]
 async fn persist_hosted_clone_thread_identity(
     repo: &Repository,
     client: &mut HostedClient,
@@ -2578,30 +2579,7 @@ async fn persist_hosted_clone_thread_identity(
         )?;
         return Ok(());
     }
-    persist_advertised_clone_thread_identity(repo, remote_refs, track_name, final_state)
-}
-
-#[cfg(feature = "client")]
-fn persist_advertised_clone_thread_identity(
-    repo: &Repository,
-    remote_refs: &[HostedRefEntry],
-    track_name: &str,
-    final_state: &objects::object::StateId,
-) -> Result<()> {
-    let Some(stable_id) = remote_refs
-        .iter()
-        .find(|entry| entry.is_user_thread() && entry.name == track_name)
-        .and_then(|entry| entry.thread_id.as_deref())
-        .filter(|id| !id.is_empty())
-    else {
-        return Ok(());
-    };
-    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
-        repo,
-        track_name,
-        stable_id,
-        *final_state,
-    )?;
+    persist_advertised_thread_identity(repo, remote_refs, track_name, final_state)?;
     Ok(())
 }
 
@@ -3033,7 +3011,7 @@ mod tests {
             Some("hosted-stable-main".to_string()),
         )];
 
-        persist_advertised_clone_thread_identity(&repo, &remote_refs, "main", &state)
+        persist_advertised_thread_identity(&repo, &remote_refs, "main", &state)
             .expect("persist advertised identity");
 
         let persisted = ThreadManager::new(repo.heddle_dir())

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -43,6 +43,8 @@ use verbs::{
     plan_pull, pull_should_materialize, show_plain_git_remote, show_remote,
 };
 pub(crate) use verbs::{resolve_default_remote_name, resolved_default_remote_name};
+#[cfg(feature = "client")]
+use wire::ProtocolError;
 
 use super::super::{
     action_line::print_next,
@@ -1185,17 +1187,26 @@ async fn pull_network_connected(
                     {
                         Some(metadata) => Some(metadata),
                         None => {
-                            if let Ok(stable_id) = client
+                            match client
                                 .require_thread_id(repo_path, options.remote_thread)
                                 .await
                             {
-                                ThreadManager::new(repo.heddle_dir())
-                                    .adopt_stable_identity_for_thread(
-                                        repo,
-                                        track_to_update,
-                                        &stable_id,
-                                        final_state_id,
-                                    )?;
+                                Ok(stable_id) => {
+                                    ThreadManager::new(repo.heddle_dir())
+                                        .adopt_stable_identity_for_thread(
+                                            repo,
+                                            track_to_update,
+                                            &stable_id,
+                                            final_state_id,
+                                        )
+                                        .context(
+                                            "failed to persist hosted thread identity after pull",
+                                        )?;
+                                }
+                                Err(ProtocolError::ObjectNotFound(_)) => {
+                                    // Nothing advertised; first push may mint.
+                                }
+                                Err(error) => return Err(error.into()),
                             }
                             None
                         }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1174,7 +1174,32 @@ async fn pull_network_connected(
                             .await?,
                     )
                 } else {
-                    None
+                    match client
+                        .try_get_thread_metadata(
+                            repo,
+                            repo_path,
+                            options.remote_thread,
+                            final_state_id,
+                        )
+                        .await?
+                    {
+                        Some(metadata) => Some(metadata),
+                        None => {
+                            if let Ok(stable_id) = client
+                                .require_thread_id(repo_path, options.remote_thread)
+                                .await
+                            {
+                                ThreadManager::new(repo.heddle_dir())
+                                    .adopt_stable_identity_for_thread(
+                                        repo,
+                                        track_to_update,
+                                        &stable_id,
+                                        final_state_id,
+                                    )?;
+                            }
+                            None
+                        }
+                    }
                 };
                 let track_tn = ThreadName::new(track_to_update);
                 let pre_target = repo.refs().get_thread(&track_tn)?;
@@ -1317,17 +1342,14 @@ fn save_pulled_thread_metadata(
     pulled_state: &StateId,
     metadata: Option<SyncedThreadMetadata>,
 ) -> Result<()> {
-    let Some(mut metadata) = metadata else {
+    let Some(metadata) = metadata else {
         return Ok(());
     };
-    metadata.id = local_thread.to_string();
-    metadata.thread = local_thread.to_string();
-    metadata.current_state = Some(pulled_state.short());
-    metadata.shared_target_dir = None;
-    metadata
-        .integration_policy_result
-        .clear_untrusted_landing_fields();
-    ThreadManager::new(repo.heddle_dir()).save_record(&metadata)?;
+    ThreadManager::new(repo.heddle_dir()).save_pulled_metadata(
+        local_thread,
+        pulled_state,
+        metadata,
+    )?;
     Ok(())
 }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1309,7 +1309,11 @@ fn local_clone_persists_source_thread_stable_id() {
     let dest_parent = TempDir::new().unwrap();
     let clone = dest_parent.path().join("clone");
     heddle(
-        &["clone", source.path().to_str().unwrap(), clone.to_str().unwrap()],
+        &[
+            "clone",
+            source.path().to_str().unwrap(),
+            clone.to_str().unwrap(),
+        ],
         None,
     )
     .unwrap();

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1283,10 +1283,9 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
     assert_eq!(landed["status"], "landed", "{landed}");
 
     let source_id = thread_stable_id(&source, "shuttle/runner");
-    assert_ne!(source_id, "shuttle/runner");
     assert_eq!(
         managed.id, source_id,
-        "pulled managed metadata must keep the source stable id, not the thread name"
+        "pulled managed metadata must keep the source stable id"
     );
 }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1252,7 +1252,7 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
         repo.refs()
             .get_thread(&ThreadName::new("shuttle/runner"))
             .unwrap()
-            .map(|state| state.short())
+            .map(|state| state.to_string_full())
     );
 
     let listed = heddle(&["thread", "list", "--output", "json"], Some(&clone)).unwrap();

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -154,6 +154,15 @@ fn current_thread_state(cwd: &std::path::Path, thread: &str) -> String {
         .to_string()
 }
 
+fn thread_stable_id(cwd: &std::path::Path, thread: &str) -> String {
+    let repo = Repository::open(cwd).expect("open repository");
+    ThreadManager::new(repo.heddle_dir())
+        .find_record_by_thread(thread)
+        .expect("read thread records")
+        .unwrap_or_else(|| panic!("{thread} should have a persisted thread record"))
+        .id
+}
+
 fn log_head_state(cwd: &std::path::Path) -> String {
     let log_json =
         heddle(&["--output", "json", "log", "--limit", "1"], Some(cwd)).expect("log current state");
@@ -1272,6 +1281,78 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
     let landed: Value = serde_json::from_str(&landed).unwrap();
     assert_eq!(landed["output_kind"], "land", "{landed}");
     assert_eq!(landed["status"], "landed", "{landed}");
+
+    let source_id = thread_stable_id(&source, "shuttle/runner");
+    assert_ne!(source_id, "shuttle/runner");
+    assert_eq!(
+        managed.id, source_id,
+        "pulled managed metadata must keep the source stable id, not the thread name"
+    );
+}
+
+/// heddle#1701: a clean local clone must persist the source thread's stable
+/// identity. Hosted push (and weft `hosted_thread_records`) key on that id;
+/// minting a new UUIDv7 or filing the record under the ref name (`main`)
+/// is the clone→push exit-76 mismatch.
+#[test]
+fn local_clone_persists_source_thread_stable_id() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("main.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "source main"], Some(source.path())).unwrap();
+    let source_id = thread_stable_id(source.path(), "main");
+    assert!(
+        uuid::Uuid::parse_str(&source_id).is_ok(),
+        "source main must already carry a stable UUID, got {source_id}"
+    );
+
+    let dest_parent = TempDir::new().unwrap();
+    let clone = dest_parent.path().join("clone");
+    heddle(
+        &["clone", source.path().to_str().unwrap(), clone.to_str().unwrap()],
+        None,
+    )
+    .unwrap();
+
+    let cloned_id = thread_stable_id(&clone, "main");
+    assert_eq!(
+        cloned_id, source_id,
+        "clone must persist the source stable id, not mint a new one or use the ref name"
+    );
+    assert_ne!(cloned_id, "main");
+}
+
+/// heddle#1701: local pull must keep the source stable id. The previous
+/// `save_pulled_thread_metadata` stomped `metadata.id` to the local thread
+/// name (`main`), which cannot round-trip a hosted UUID.
+#[test]
+fn local_pull_preserves_source_thread_stable_id() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("main.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "source main"], Some(source.path())).unwrap();
+    let source_id = thread_stable_id(source.path(), "main");
+
+    let target = TempDir::new().unwrap();
+    heddle(&["init"], Some(target.path())).unwrap();
+    let target_id_before = thread_stable_id(target.path(), "main");
+    assert_ne!(
+        target_id_before, source_id,
+        "fixture: target init must mint its own main identity"
+    );
+
+    heddle(
+        &["pull", source.path().to_str().unwrap(), "--thread", "main"],
+        Some(target.path()),
+    )
+    .expect("pull main from the local source");
+
+    let pulled_id = thread_stable_id(target.path(), "main");
+    assert_eq!(
+        pulled_id, source_id,
+        "pull must adopt the source stable id, not keep the local init id or stomp to 'main'"
+    );
+    assert_ne!(pulled_id, "main");
 }
 
 #[test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -71,7 +71,8 @@ pub use session::{HostedAuthMode, HostedSession};
 #[cfg(test)]
 pub(crate) use sync::PullBootstrapMetadata;
 pub use sync::{
-    HostedRefEntry, decode_pull_bootstrap, decode_pull_refs, persist_advertised_thread_identity,
+    HostedRefEntry, advertised_user_thread_id, decode_pull_bootstrap, decode_pull_refs,
+    persist_advertised_thread_identity, persist_advertised_thread_identity_with_live_fallback,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -70,7 +70,9 @@ use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
 #[cfg(test)]
 pub(crate) use sync::PullBootstrapMetadata;
-pub use sync::{HostedRefEntry, decode_pull_bootstrap, decode_pull_refs};
+pub use sync::{
+    HostedRefEntry, decode_pull_bootstrap, decode_pull_refs, persist_advertised_thread_identity,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RenewableAuthorityCredential {

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -707,10 +707,34 @@ impl HostedClient {
         remote_thread: &str,
         pulled_state: StateId,
     ) -> Result<SyncedThreadMetadata, ProtocolError> {
+        self.try_get_thread_metadata(repo, repo_path, remote_thread, pulled_state)
+            .await?
+            .ok_or_else(|| {
+                ProtocolError::InvalidState(format!(
+                    "hosted thread '{remote_thread}' has no managed metadata; no local thread was created"
+                ))
+            })
+    }
+
+    /// Like [`get_thread_metadata`], but returns `None` when the remote has
+    /// no managed record yet. Clone/pull use this so a missing GetThread
+    /// can fall back to the advertised ListRefs stable id.
+    pub async fn try_get_thread_metadata(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        pulled_state: StateId,
+    ) -> Result<Option<SyncedThreadMetadata>, ProtocolError> {
+        let thread_id = match self.require_thread_id(repo_path, remote_thread).await {
+            Ok(thread_id) => thread_id,
+            Err(ProtocolError::ObjectNotFound(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
         let request = GetThreadRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             name: remote_thread.to_string(),
-            thread_id: self.require_thread_id(repo_path, remote_thread).await?,
+            thread_id,
         };
         let summary = match self.routes().get_thread(&request).await {
             Ok(summary) => summary,
@@ -724,14 +748,12 @@ impl HostedClient {
                             ..
                         }
                 ) {
-                    return Err(ProtocolError::InvalidState(format!(
-                        "hosted thread '{remote_thread}' has no managed metadata; no local thread was created"
-                    )));
+                    return Ok(None);
                 }
                 return Err(error);
             }
         };
-        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary)
+        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary).map(Some)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4326,6 +4348,81 @@ mod native_exchange_tests {
             .expect("legacy main metadata must be persisted after the first push");
         assert_eq!(persisted.id, first_metadata.name);
         assert_eq!(persisted.thread, "main");
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clone_like_push_reuses_adopted_hosted_thread_stable_id() {
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_push().await;
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let hosted_id = "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff";
+        save_thread_record(&repo, state, hosted_id, "main");
+
+        let _ = client
+            .push_with_expected_head_profiled(
+                &repo,
+                "acme/widgets",
+                state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "publish-thread-id-op".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let clone = TempDir::new().unwrap();
+        let (clone_repo, clone_state) = repository(&clone);
+        let manager = ThreadManager::new(clone_repo.heddle_dir());
+        let minted = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone init mints its own main identity");
+        assert_ne!(minted.id, hosted_id);
+
+        manager
+            .adopt_stable_identity_for_thread(&clone_repo, "main", hosted_id, clone_state)
+            .unwrap();
+
+        let _ = client
+            .push_with_expected_head_profiled(
+                &clone_repo,
+                "acme/widgets",
+                clone_state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "clone-push-thread-id-op".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let requests = captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0]
+                .thread_metadata
+                .as_ref()
+                .expect("publish must send thread metadata")
+                .name,
+            hosted_id
+        );
+        assert_eq!(
+            requests[1]
+                .thread_metadata
+                .as_ref()
+                .expect("clone push must send thread metadata")
+                .name,
+            hosted_id,
+            "push after adopting the hosted id must round-trip it, not mint a new UUIDv7"
+        );
 
         client.close().await;
         server.await.unwrap();

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -509,6 +509,18 @@ impl HostedRefEntry {
     }
 }
 
+/// Advertised ListRefs `thread_id` for a user thread, if present and non-empty.
+pub fn advertised_user_thread_id<'a>(
+    remote_refs: &'a [HostedRefEntry],
+    track_name: &str,
+) -> Option<&'a str> {
+    remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+}
+
 /// Persist the ListRefs-advertised stable id as the local thread identity.
 ///
 /// Clone uses this when GetThread is missing; tests drive the same helper so
@@ -519,12 +531,7 @@ pub fn persist_advertised_thread_identity(
     track_name: &str,
     final_state: &StateId,
 ) -> objects::error::Result<()> {
-    let Some(stable_id) = remote_refs
-        .iter()
-        .find(|entry| entry.is_user_thread() && entry.name == track_name)
-        .and_then(|entry| entry.thread_id.as_deref())
-        .filter(|id| !id.is_empty())
-    else {
+    let Some(stable_id) = advertised_user_thread_id(remote_refs, track_name) else {
         return Ok(());
     };
     ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
@@ -534,6 +541,27 @@ pub fn persist_advertised_thread_identity(
         *final_state,
     )?;
     Ok(())
+}
+
+/// Persist from folded PullReady refs when they advertise an id; otherwise
+/// from a live ListRefs advertisement. Folded refs currently decode with
+/// `thread_id: None`.
+pub fn persist_advertised_thread_identity_with_live_fallback(
+    repo: &Repository,
+    folded_refs: &[HostedRefEntry],
+    live_refs: Option<&[HostedRefEntry]>,
+    track_name: &str,
+    final_state: &StateId,
+) -> objects::error::Result<()> {
+    if advertised_user_thread_id(folded_refs, track_name).is_some() {
+        return persist_advertised_thread_identity(repo, folded_refs, track_name, final_state);
+    }
+    persist_advertised_thread_identity(
+        repo,
+        live_refs.unwrap_or(folded_refs),
+        track_name,
+        final_state,
+    )
 }
 
 impl PullObjectMix {
@@ -744,8 +772,9 @@ impl HostedClient {
     }
 
     /// Like [`get_thread_metadata`], but returns `None` when the remote has
-    /// no managed record yet. Clone/pull use this so a missing GetThread
-    /// can fall back to the advertised ListRefs stable id.
+    /// no managed record yet, including GetThread with an empty `thread_id`.
+    /// Clone/pull use this so a missing or empty-id GetThread can fall back
+    /// to the advertised ListRefs stable id.
     pub async fn try_get_thread_metadata(
         &mut self,
         repo: &Repository,
@@ -780,7 +809,7 @@ impl HostedClient {
                 return Err(error);
             }
         };
-        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary).map(Some)
+        super::thread_metadata::try_from_summary(repo, remote_thread, pulled_state, summary)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3399,6 +3428,10 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[0].state_id, main);
         assert_eq!(decoded.refs[0].kind, RefKind::Thread);
         assert_eq!(decoded.refs[0].revision_address, "git:0123456789abcdef");
+        assert!(
+            decoded.refs[0].thread_id.is_none(),
+            "folded PullReady refs currently decode without thread_id"
+        );
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert_eq!(decoded.refs[1].kind, RefKind::Marker);
@@ -4463,6 +4496,49 @@ mod native_exchange_tests {
 
         client.close().await;
         server.await.unwrap();
+    }
+
+    #[test]
+    fn persist_advertised_identity_uses_live_refs_when_folded_omit_thread_id() {
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let hosted_id = "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff";
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        assert_ne!(minted.id, hosted_id);
+
+        let folded = [HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            None,
+        )];
+        let live = [HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some(hosted_id.to_string()),
+        )];
+
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &folded,
+            Some(&live),
+            "main",
+            &state,
+        )
+        .expect("live ListRefs must supply the omitted folded thread_id");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, hosted_id);
+        assert_ne!(persisted.id, minted.id);
     }
 
     #[tokio::test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -509,6 +509,33 @@ impl HostedRefEntry {
     }
 }
 
+/// Persist the ListRefs-advertised stable id as the local thread identity.
+///
+/// Clone uses this when GetThread is missing; tests drive the same helper so
+/// a later push cannot mint a different UUIDv7.
+pub fn persist_advertised_thread_identity(
+    repo: &Repository,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &StateId,
+) -> objects::error::Result<()> {
+    let Some(stable_id) = remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(());
+    };
+    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
+        repo,
+        track_name,
+        stable_id,
+        *final_state,
+    )?;
+    Ok(())
+}
+
 impl PullObjectMix {
     fn record(&mut self, obj_type: ObjectType) {
         match obj_type.bucket() {
@@ -4384,9 +4411,19 @@ mod native_exchange_tests {
             .expect("clone init mints its own main identity");
         assert_ne!(minted.id, hosted_id);
 
-        manager
-            .adopt_stable_identity_for_thread(&clone_repo, "main", hosted_id, clone_state)
-            .unwrap();
+        persist_advertised_thread_identity(
+            &clone_repo,
+            &[HostedRefEntry::from_advertised(
+                "main".to_string(),
+                clone_state,
+                true,
+                format!("heddle:{}", clone_state.to_string_full()),
+                Some(hosted_id.to_string()),
+            )],
+            "main",
+            &clone_state,
+        )
+        .expect("clone path must adopt the advertised ListRefs thread_id");
 
         let _ = client
             .push_with_expected_head_profiled(

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_identity.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_identity.rs
@@ -4,7 +4,7 @@ use wire::ProtocolError;
 use super::{HostedClient, helpers::hosted_to_protocol_error};
 
 impl HostedClient {
-    pub(super) async fn require_thread_id(
+    pub async fn require_thread_id(
         &self,
         repo_path: &str,
         thread_name: &str,

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
@@ -9,6 +9,23 @@ use objects::{object::StateId, store::ObjectStore};
 use repo::{Repository, SyncedThreadMetadata};
 use wire::ProtocolError;
 
+/// Convert a GetThread summary, treating an empty `thread_id` as absent.
+///
+/// weft `native_thread_summary` historically hardcodes an empty
+/// `thread_id`. Clone/pull then fall back to ListRefs instead of failing
+/// with "metadata is missing its stable identity".
+pub(super) fn try_from_summary(
+    repo: &Repository,
+    remote_thread: &str,
+    pulled_state: StateId,
+    summary: ThreadSummary,
+) -> Result<Option<SyncedThreadMetadata>, ProtocolError> {
+    if summary.thread_id.is_empty() {
+        return Ok(None);
+    }
+    from_summary(repo, remote_thread, pulled_state, summary).map(Some)
+}
+
 pub(super) fn from_summary(
     repo: &Repository,
     remote_thread: &str,
@@ -200,7 +217,7 @@ mod tests {
     use repo::Repository;
     use tempfile::TempDir;
 
-    use super::from_summary;
+    use super::{from_summary, try_from_summary};
 
     #[test]
     fn hosted_thread_summary_rehydrates_managed_metadata_at_pulled_tip() {
@@ -231,5 +248,33 @@ mod tests {
         assert_eq!(metadata.state, repo::ThreadState::Ready);
         assert_eq!(metadata.current_state, Some(tip.state_id.short()));
         assert_eq!(metadata.changed_paths, vec!["runner.txt"]);
+    }
+
+    #[test]
+    fn empty_get_thread_thread_id_is_treated_as_absent() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let tip = repo
+            .refs()
+            .get_thread(&objects::object::ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let summary = ThreadSummary {
+            name: "main".to_string(),
+            thread_id: String::new(),
+            ..ThreadSummary::default()
+        };
+
+        let missing = try_from_summary(&repo, "main", tip, summary.clone()).unwrap();
+        assert!(
+            missing.is_none(),
+            "empty GetThread thread_id must fall through to ListRefs"
+        );
+
+        let err = from_summary(&repo, "main", tip, summary).unwrap_err();
+        assert!(
+            err.to_string().contains("missing its stable identity"),
+            "callers that require a summary still fail closed, got {err}"
+        );
     }
 }

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -557,7 +557,9 @@ impl ThreadManager {
             )));
         }
         metadata.thread = local_thread.to_string();
-        metadata.current_state = Some(pulled_state.short());
+        // Full encoding matches adopt_stable_identity_for_thread; shorts
+        // resolve, but the on-disk record should not depend on that.
+        metadata.current_state = Some(pulled_state.to_string_full());
         metadata.shared_target_dir = None;
         metadata
             .integration_policy_result
@@ -1101,6 +1103,10 @@ mod adopt_identity_tests {
         let saved = manager.find_record_by_thread("main").unwrap().unwrap();
         assert_eq!(saved.id, "source-stable-main");
         assert_eq!(saved.thread, "main");
+        assert_eq!(
+            saved.current_state.as_deref(),
+            Some(main_state.to_string_full().as_str())
+        );
         assert_ne!(saved.id, "main");
         assert!(
             saved

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -232,6 +232,49 @@ pub struct ThreadManager {
     lock_path: PathBuf,
 }
 
+fn materialized_thread_for_state(
+    repo: &crate::Repository,
+    thread: &str,
+    stable_id: String,
+    ref_state: StateId,
+) -> Result<Thread> {
+    let state = repo.store().get_state(&ref_state)?.ok_or_else(|| {
+        HeddleError::NotFound(format!(
+            "thread '{thread}' points to missing state {}",
+            ref_state.to_string_full()
+        ))
+    })?;
+    let now = Utc::now();
+    Ok(Thread {
+        id: stable_id,
+        thread: thread.to_string(),
+        target_thread: None,
+        parent_thread: None,
+        mode: ThreadMode::Materialized,
+        state: ThreadState::Active,
+        base_state: ref_state.to_string_full(),
+        base_root: state.tree.to_hex(),
+        current_state: Some(ref_state.to_string_full()),
+        merged_state: None,
+        task: None,
+        execution_path: repo.root().to_path_buf(),
+        materialized_path: None,
+        changed_paths: Vec::new(),
+        impact_categories: Vec::new(),
+        heavy_impact_paths: Vec::new(),
+        promotion_suggested: false,
+        freshness: ThreadFreshness::Current,
+        verification_summary: summarize_verification(state.verification.as_ref()),
+        confidence_summary: summarize_confidence(state.confidence),
+        integration_policy_result: ThreadIntegrationPolicy::default(),
+        created_at: now,
+        updated_at: now,
+        ephemeral: None,
+        auto: false,
+        shared_target_dir: None,
+    })
+}
+
 impl ThreadManager {
     pub fn new(heddle_dir: &Path) -> Self {
         Self {
@@ -450,47 +493,76 @@ impl ThreadManager {
         let Some(ref_state) = repo.refs().get_thread(&ThreadName::from(thread))? else {
             return Ok(None);
         };
-        let state = repo.store().get_state(&ref_state)?.ok_or_else(|| {
-            HeddleError::NotFound(format!(
-                "thread '{thread}' points to missing state {}",
-                ref_state.to_string_full()
-            ))
-        })?;
-        let now = Utc::now();
-        let materialized = Thread {
-            id: uuid::Uuid::now_v7().to_string(),
-            thread: thread.to_string(),
-            target_thread: None,
-            parent_thread: None,
-            mode: ThreadMode::Materialized,
-            state: ThreadState::Active,
-            base_state: ref_state.to_string_full(),
-            base_root: state.tree.to_hex(),
-            current_state: Some(ref_state.to_string_full()),
-            merged_state: None,
-            task: None,
-            execution_path: repo.root().to_path_buf(),
-            materialized_path: None,
-            changed_paths: Vec::new(),
-            impact_categories: Vec::new(),
-            heavy_impact_paths: Vec::new(),
-            promotion_suggested: false,
-            freshness: ThreadFreshness::Current,
-            verification_summary: summarize_verification(state.verification.as_ref()),
-            confidence_summary: summarize_confidence(state.confidence),
-            integration_policy_result: ThreadIntegrationPolicy::default(),
-            created_at: now,
-            updated_at: now,
-            ephemeral: None,
-            auto: false,
-            shared_target_dir: None,
-        };
+        let materialized = materialized_thread_for_state(
+            repo,
+            thread,
+            uuid::Uuid::now_v7().to_string(),
+            ref_state,
+        )?;
         let record = materialized.to_record();
         self.save_record_file(&record)?;
         objects::fault_inject::maybe_fail_at("thread_manager_save_before_workspace")?;
         self.save_workspace_file(&materialized.id, &materialized.workspace_state())?;
 
         SyncedThreadMetadata::from_record(repo, &record, current_state_override).map(Some)
+    }
+
+    /// Persist `stable_id` as the sole local identity for `thread`.
+    ///
+    /// Clone and pull call this with the hosted (or source) stable id so a
+    /// later push cannot mint a different UUIDv7. If a record already uses
+    /// `stable_id`, it is reused and pointed at `current_state`. Any other
+    /// same-name records are replaced via [`converge_records`].
+    pub fn adopt_stable_identity_for_thread(
+        &self,
+        repo: &crate::Repository,
+        thread: &str,
+        stable_id: &str,
+        current_state: StateId,
+    ) -> Result<SyncedThreadMetadata> {
+        if stable_id.is_empty() {
+            return Err(HeddleError::Config(format!(
+                "cannot adopt an empty stable identity for thread '{thread}'"
+            )));
+        }
+        if let Some(mut record) = self.find_record_by_thread(thread)? {
+            if record.id == stable_id {
+                record.current_state = Some(current_state.to_string_full());
+                record.updated_at = Utc::now();
+                self.save_record(&record)?;
+                return SyncedThreadMetadata::from_record(repo, &record, Some(current_state));
+            }
+        }
+
+        let adopted =
+            materialized_thread_for_state(repo, thread, stable_id.to_string(), current_state)?;
+        self.converge_records(thread, std::slice::from_ref(&adopted))?;
+        SyncedThreadMetadata::from_record(repo, &adopted.to_record(), Some(current_state))
+    }
+
+    /// Write pulled/cloned metadata as the sole record for `local_thread`.
+    ///
+    /// `metadata.id` is the stable identity and must be preserved — it is
+    /// not the thread ref name. Landing fields an unauthenticated peer can
+    /// forge are cleared before the record is filed.
+    pub fn save_pulled_metadata(
+        &self,
+        local_thread: &str,
+        pulled_state: &StateId,
+        mut metadata: SyncedThreadMetadata,
+    ) -> Result<()> {
+        if metadata.id.is_empty() {
+            return Err(HeddleError::Config(format!(
+                "pulled thread '{local_thread}' is missing its stable identity"
+            )));
+        }
+        metadata.thread = local_thread.to_string();
+        metadata.current_state = Some(pulled_state.short());
+        metadata.shared_target_dir = None;
+        metadata
+            .integration_policy_result
+            .clear_untrusted_landing_fields();
+        self.converge_records(local_thread, &[Thread::from_record(metadata)])
     }
 
     pub fn delete_record(&self, record_id: &str) -> Result<()> {
@@ -947,6 +1019,114 @@ updated_at = "2024-01-01T00:00:01Z"
         assert!(
             err.to_string().contains("missing field"),
             "strict reader should reject missing current fields, got: {err}",
+        );
+    }
+}
+
+#[cfg(test)]
+mod adopt_identity_tests {
+    use objects::object::ThreadName;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::Repository;
+
+    #[test]
+    fn adopt_stable_identity_replaces_local_id_and_reuses_matching_id() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let minted = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        assert_ne!(minted.id, "hosted-stable-main");
+
+        let adopted = manager
+            .adopt_stable_identity_for_thread(&repo, "main", "hosted-stable-main", main_state)
+            .unwrap();
+        assert_eq!(adopted.id, "hosted-stable-main");
+        assert_eq!(adopted.thread, "main");
+        assert_eq!(
+            manager.find_record_by_thread("main").unwrap().unwrap().id,
+            "hosted-stable-main"
+        );
+        assert!(manager.load_record(&minted.id).unwrap().is_none());
+
+        let reused = manager
+            .adopt_stable_identity_for_thread(&repo, "main", "hosted-stable-main", main_state)
+            .unwrap();
+        assert_eq!(reused.id, "hosted-stable-main");
+        assert_eq!(
+            manager
+                .list_records()
+                .unwrap()
+                .into_iter()
+                .filter(|record| record.thread == "main")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn save_pulled_metadata_keeps_stable_id_and_clears_forged_landing() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let local = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+
+        let mut pulled = local.clone();
+        pulled.id = "source-stable-main".to_string();
+        pulled.thread = "main".to_string();
+        pulled.integration_policy_result.manual_resolution_state = Some(main_state.short());
+        pulled.integration_policy_result.conflicts_resolved_manually = true;
+
+        manager
+            .save_pulled_metadata("main", &main_state, pulled)
+            .unwrap();
+
+        let saved = manager.find_record_by_thread("main").unwrap().unwrap();
+        assert_eq!(saved.id, "source-stable-main");
+        assert_eq!(saved.thread, "main");
+        assert_ne!(saved.id, "main");
+        assert!(
+            saved
+                .integration_policy_result
+                .manual_resolution_state
+                .is_none()
+        );
+        assert!(!saved.integration_policy_result.conflicts_resolved_manually);
+        assert!(manager.load_record(&local.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn adopt_stable_identity_rejects_an_empty_id() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let err = ThreadManager::new(repo.heddle_dir())
+            .adopt_stable_identity_for_thread(&repo, "main", "", main_state)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("empty stable identity"),
+            "empty id must fail closed, got {err}"
         );
     }
 }

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -525,13 +525,14 @@ impl ThreadManager {
                 "cannot adopt an empty stable identity for thread '{thread}'"
             )));
         }
-        if let Some(mut record) = self.find_record_by_thread(thread)? {
-            if record.id == stable_id {
+        match self.find_record_by_thread(thread)? {
+            Some(mut record) if record.id == stable_id => {
                 record.current_state = Some(current_state.to_string_full());
                 record.updated_at = Utc::now();
                 self.save_record(&record)?;
                 return SyncedThreadMetadata::from_record(repo, &record, Some(current_state));
             }
+            _ => {}
         }
 
         let adopted =
@@ -1108,12 +1109,10 @@ mod adopt_identity_tests {
             Some(main_state.to_string_full().as_str())
         );
         assert_ne!(saved.id, "main");
-        assert!(
-            saved
-                .integration_policy_result
-                .manual_resolution_state
-                .is_none()
-        );
+        assert!(saved
+            .integration_policy_result
+            .manual_resolution_state
+            .is_none());
         assert!(!saved.integration_policy_result.conflicts_resolved_manually);
         assert!(manager.load_record(&local.id).unwrap().is_none());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fresh hosted (and local) clones now persist the source/hosted thread **stable id** into `.heddle/thread_records` instead of leaving the record absent or filing it under the ref name (`main`).
- Pull no longer stomps `metadata.id` to the local thread name. Hosted pull adopts GetThread metadata when present, otherwise the ListRefs/ListThreads id.
- A later `heddle push` from that clone reuses the same UUIDv7, so weft `hosted_thread_records` no longer rejects the payload with exit 76.

AX follow-up in `898d3394` (client-only; weft persisted-id reject unchanged):

1. `try_get_thread_metadata` treats a successful GetThread with empty `thread_id` as absent (`Ok(None)`) so clone/pull can fall back to ListRefs. weft `native_thread_summary` historically hardcodes empty `thread_id`.
2. `persist_hosted_clone_thread_identity` refreshes live `list_refs_with_revision_addresses` when folded PullReady refs omit a non-empty `thread_id` (folded decode currently sets `thread_id: None`).

## Closes

Closes HeddleCo/heddle#1701

## Red commit
`e685568d61b4a0283c4d1c18b9bcf55f8e23f073`

## Test evidence

Re-run on HEAD `898d3394ec9db69d2793f23826b330616ef4211c`:

```
=== HEAD 898d3394ec9db69d2793f23826b330616ef4211c ===
=== heddle-repo adopt_identity ===
test thread_storage::adopt_identity_tests::adopt_stable_identity_rejects_an_empty_id ... ok
test thread_storage::adopt_identity_tests::adopt_stable_identity_replaces_local_id_and_reuses_matching_id ... ok
test thread_storage::adopt_identity_tests::save_pulled_metadata_keeps_stable_id_and_clears_forged_landing ... ok

=== heddle-repo init_default_persists ===
test repository::repository_tests::init_default_persists_and_reuses_stable_main_thread_record ... ok

=== heddle-hosted-client clone_like_push + AX hardenings ===
test hosted_runtime::hosted::sync::native_exchange_tests::clone_like_push_reuses_adopted_hosted_thread_stable_id ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::persist_advertised_identity_uses_live_refs_when_folded_omit_thread_id ... ok
test hosted_runtime::hosted::thread_metadata::tests::empty_get_thread_thread_id_is_treated_as_absent ... ok

=== heddle-cli advertised persist + ListRefs refresh ===
test cli::commands::clone::tests::hosted_clone_persists_advertised_thread_stable_id ... ok
test cli::commands::clone::tests::hosted_clone_refreshes_list_refs_when_folded_refs_omit_thread_id ... ok

=== heddle-cli overlay identity ===
test remotes::local_clone_persists_source_thread_stable_id ... ok
test remotes::local_pull_preserves_source_thread_stable_id ... ok
test remotes::pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land ... ok
test remotes::test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_target ... ok
```

## Manual verification

N/A — covered by tests. Local AX against weft @ `b9e44813` (plus a separate weft GetThread `thread_id: record.id` fix) proved clone→push exit 0.

## Blocked by → resolved

None

## Surfaces

- **The verb.** No new flags. Clone and pull now write the stable id; help/clap unchanged.
- **Human and agent.** Default text output unchanged; `--json` unchanged.
- **Git interop.** Native lane only. Git-overlay clone is unchanged except it can also adopt an advertised id when present.
- **The wire.** No proto change. ListRefs already advertises `thread_id`; the client now persists it. Folded PullReady refs still omit `thread_id`; live ListRefs supplies it.
- **Reverse states.** Way in: clone/pull persist the id. Way to see it: `thread_records` / `ThreadManager::find_record_by_thread`. Way out: push sends `metadata.name` as that same id.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b5f1b3c-59de-4730-844b-1fcc838cf35f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b5f1b3c-59de-4730-844b-1fcc838cf35f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791160705&installation_model_id=21489&pr_number=1702&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1702&signature=31639312d96fafb7d208fb06f14d7f9cc85de00b8d6d7313a5af53f6dab0e632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->