### PR TITLE
fix(hosted-client): adopt hosted-canonical turn CollabOpIds on push/pull

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ An opaque stable UUIDv7 identifier for a discussion. Human-readable meaning belo
 _Avoid_: discussion slug, content-addressed discussion id
 
 **Collaboration Operation ID**:
-An opaque stable content-addressed identifier for a collaboration operation. It is distinct from a source history ChangeId even if it uses familiar Heddle short-prefix UX.
+An opaque stable content-addressed identifier for a collaboration operation. It is distinct from a source history ChangeId even if it uses familiar Heddle short-prefix UX. After a hosted push or pull, a published turn's id is the envelope a clone materializes from the hosted snapshot (author, timestamp, and `turn_op_key`); the originator's pre-push local-only id is retired so every machine agrees.
 _Avoid_: change id for collaboration
 
 **Collaboration Idempotency Key**:

--- a/crates/hosted-client/src/client/discussion_live_tests.rs
+++ b/crates/hosted-client/src/client/discussion_live_tests.rs
@@ -462,6 +462,8 @@ async fn bootstrap_marks_the_cursor_then_live_events_append() {
     server.await.unwrap();
 }
 
+// Clone/bootstrap materialization then doorbell replay. Originator
+// adopt-then-doorbell is `discussion_sync::tests::doorbell_after_adopt_does_not_duplicate_the_first_turn`.
 #[tokio::test]
 async fn replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn() {
     let (_temp, repo) = seed_repo();

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -3536,7 +3536,11 @@ mod tests {
             .into_values()
             .next()
             .unwrap();
-        assert_eq!(discussion.turns.len(), 1, "doorbell must not duplicate the first turn");
+        assert_eq!(
+            discussion.turns.len(),
+            1,
+            "doorbell must not duplicate the first turn"
+        );
         let mut after_doorbell: Vec<String> = originator_store
             .operation_ids()
             .unwrap()

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -48,7 +48,11 @@
 //! — and again on pull, when a linked local turn is not hosted-canonical —
 //! the originator **adopts** the same envelope a clone would materialize.
 //! The pre-push local-only op is retired (new bytes, new id; we do not
-//! rewrite bytes under the old id).
+//! rewrite bytes under the old id). Adopt remints only originator-local
+//! keys (v4 / `--op-id`). A turn already written with `turn_op_key` is
+//! left alone: a later GetDiscussion doorbell often lacks
+//! `opened_against_state` and must not rebuild a different Open than
+//! bootstrap/clone already stored (#1677/#1697).
 //! Resolve-into-annotation operations use the same durable mirror: their
 //! request identity is derived from `(hosted discussion id, server resolution
 //! key)` (see `resolve_op_key`) and is recorded only after `ResolveDiscussion`
@@ -1403,6 +1407,46 @@ fn parse_linked_op_id(local_turn_id: &str) -> Result<CollabOpId> {
         .map_err(|error| anyhow!("mirror turn link has an invalid CollabOpId {op:?}: {error}"))
 }
 
+/// True when every linked published turn already carries `turn_op_key` for
+/// its server ordinal — clone/bootstrap/prior-adopt materialization, not an
+/// originator-local v4 / `--op-id` key.
+fn linked_turns_already_use_hosted_keys(
+    store: &CollaborationStore,
+    hosted: &HostedDiscussion,
+    entry: &MirrorEntry,
+) -> Result<bool> {
+    if entry.links.is_empty() {
+        return Ok(false);
+    }
+    for link in &entry.links {
+        let op_id = parse_linked_op_id(&link.local_turn_id)?;
+        let Some(decoded) = store
+            .read_operation(&op_id)
+            .context("read linked op before hosted CollabOpId adoption")?
+        else {
+            return Ok(false);
+        };
+        let hosted_key = turn_op_key(&hosted.id, link.server_ordinal)?;
+        if decoded.operation.idempotency_key != hosted_key {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn fill_missing_server_turn_ids(entry: &mut MirrorEntry, hosted: &HostedDiscussion) {
+    for link in &mut entry.links {
+        if link.server_turn_id.is_some() {
+            continue;
+        }
+        link.server_turn_id = hosted.turns.iter().enumerate().find_map(|(index, turn)| {
+            (server_ordinal(turn, index) == link.server_ordinal)
+                .then(|| server_turn_id(turn))
+                .flatten()
+        });
+    }
+}
+
 /// The adopt `push_one` runs after keeping the last OpenDiscussion/AppendTurn
 /// echo. Weft echoes the **full** discussion (≥2 turns after append). Empty
 /// `turns` is a test-server / older-weft no-op. A short echo is refused so a
@@ -1428,8 +1472,11 @@ fn adopt_from_push_echo(
 }
 
 /// Replace local-only published turn ops with the envelopes a clone would
-/// materialize from `hosted`. No-op when the local linked ops already are
-/// those envelopes, or when unpublished local turns still parent the chain.
+/// materialize from `hosted`. No-op when the local linked ops already use
+/// hosted `turn_op_key`s (clone/bootstrap/prior adopt), or when unpublished
+/// local turns still parent the chain. A later doorbell GetDiscussion is
+/// often a thinner snapshot than the first hosted materialization; reminting
+/// from it would disagree with the live replay path.
 fn adopt_hosted_canonical_turns(
     store: &CollaborationStore,
     head_state: StateId,
@@ -1465,6 +1512,13 @@ fn adopt_hosted_canonical_turns(
         return Ok(false);
     }
 
+    if linked_turns_already_use_hosted_keys(store, hosted, entry)? {
+        // Already the hosted key space. Keep those envelopes — do not rebuild
+        // from this snapshot (GetDiscussion may omit opened_against_state).
+        fill_missing_server_turn_ids(entry, hosted);
+        return Ok(false);
+    }
+
     let mut parents = Vec::new();
     let mut canonical = Vec::with_capacity(hosted.turns.len());
     let mut new_links = Vec::with_capacity(hosted.turns.len());
@@ -1495,9 +1549,10 @@ fn adopt_hosted_canonical_turns(
     let already_canonical = linked_ops.len() == canonical.len()
         && canonical.iter().all(|(id, _)| linked_ops.contains(id));
     if already_canonical {
+        // Link metadata only (e.g. filling server_turn_id). The op-log is
+        // unchanged — doorbell replay must stay Unchanged.
         if entry.links != new_links {
             entry.links = new_links;
-            return Ok(true);
         }
         return Ok(false);
     }
@@ -1609,6 +1664,10 @@ fn parse_visibility_token(token: &str) -> VisibilityTier {
 
 #[cfg(test)]
 mod tests {
+    use api::heddle::api::v1alpha1::{
+        Discussion as ProtoDiscussion, DiscussionTurn as ProtoTurn, PathSymbolRef, RepoEvent,
+        StateId as ProtoStateId,
+    };
     use objects::object::{
         AnnotationKind, Attribution, CollaborationAnchor, CollaborationIdempotencyKey,
         CollaborationOperationBodyV1, CollaborationOperationEnvelope, CollaborationResolution,
@@ -1617,6 +1676,9 @@ mod tests {
         Principal, State, StateAttachmentId, StateId, SymbolAnchor, Tree, VisibilityTier,
     };
     use tempfile::TempDir;
+
+    use crate::client::discussion_live::{DiscussionEventOutcome, consume_discussion_event};
+    use crate::hosted_runtime::hosted::test_server::CollaborationFixture;
 
     use super::*;
 
@@ -3328,5 +3390,167 @@ mod tests {
             vec![originator_open.to_string()],
             "pull must retire the local-only open op, not keep it"
         );
+    }
+
+    // Cross-path for heddle#1695 + #1677/#1697: after the originator adopts
+    // the hosted-canonical Open, a live doorbell GetDiscussion (thinner
+    // snapshot: no opened_against_state, turn_id/turn_seq set) must not remint
+    // or duplicate the first turn. Adopt-in-isolation tests never hit this.
+    #[tokio::test]
+    async fn doorbell_after_adopt_does_not_duplicate_the_first_turn() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+        let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![TurnLink {
+                local_turn_id: turn_identity(&originator_open, 0),
+                server_ordinal: 0,
+                server_turn_id: None,
+            }],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap(),
+            "originator must adopt the hosted-canonical open before the doorbell"
+        );
+        let mut mirror = HostedMirror::default();
+        mirror
+            .repos
+            .entry("acme/widgets".to_string())
+            .or_default()
+            .discussions
+            .push(entry);
+        save_mirror(originator_repo.heddle_dir(), &mirror).unwrap();
+
+        let mut after_adopt: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        after_adopt.sort();
+        assert_eq!(after_adopt.len(), 1, "adopt must leave a single Open");
+        assert_ne!(
+            after_adopt[0],
+            originator_open.to_string(),
+            "adopt must retire the local-only open"
+        );
+
+        let mut fixture = CollaborationFixture::default();
+        fixture.discussions.insert(
+            wire_id.to_string(),
+            ProtoDiscussion {
+                id: wire_id.to_string(),
+                anchor: Some(PathSymbolRef {
+                    file: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                }),
+                visibility: "internal".to_string(),
+                turns: vec![ProtoTurn {
+                    author_name: "preview-user".to_string(),
+                    author_email: String::new(),
+                    body: "keep this invariant".to_string(),
+                    turn_id: "turn-open".to_string(),
+                    turn_seq: 1,
+                    posted_at: Some(prost_types::Timestamp {
+                        seconds: 1_700_000_042,
+                        nanos: 0,
+                    }),
+                    ..ProtoTurn::default()
+                }],
+                ..ProtoDiscussion::default()
+            },
+        );
+        let (mut client, server, _fixture) =
+            crate::hosted_runtime::hosted::test_server::start_with_collaboration(fixture).await;
+        let replay = consume_discussion_event(
+            &originator_repo,
+            &mut client,
+            "acme/widgets",
+            &RepoEvent {
+                event_id: 3,
+                repo_id: "repo-1".to_string(),
+                event_type: "discussion.opened".to_string(),
+                payload_json: serde_json::json!({
+                    "discussion_id": wire_id.to_string(),
+                    "turn_id": "turn-open",
+                    "turn_seq": 1,
+                })
+                .to_string(),
+                new_state: Some(ProtoStateId {
+                    value: vec![0x11; 32],
+                }),
+                ..RepoEvent::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(
+                replay,
+                DiscussionEventOutcome::Unchanged { discussion_id }
+                    if discussion_id == wire_id.to_string()
+            ),
+            "doorbell after adopt must not remint, got {replay:?}"
+        );
+
+        let discussion = originator_store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        assert_eq!(discussion.turns.len(), 1, "doorbell must not duplicate the first turn");
+        let mut after_doorbell: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        after_doorbell.sort();
+        assert_eq!(
+            after_doorbell, after_adopt,
+            "doorbell GetDiscussion must keep the adopted CollabOpId"
+        );
+
+        client.close().await;
+        server.await.unwrap();
     }
 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -467,6 +467,8 @@ async fn push_one(
                         }),
                     );
                 }
+                // OpenDiscussion / AppendTurn echo the full discussion (≥2 turns
+                // after append). Adopt uses this last snapshot.
                 (index, server_id, true, Some(hosted))
             }
             Some(index) => {
@@ -492,6 +494,9 @@ async fn push_one(
                             (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
                         }),
                     );
+                    // Weft AppendTurn/OpenDiscussion echoes the full discussion
+                    // (≥2 turns after append). Adopt uses this snapshot so a
+                    // last-turn-only echo cannot under-adopt.
                     hosted = Some(echoed);
                 }
                 (index, server_id, !candidates.is_empty(), hosted)
@@ -504,7 +509,7 @@ async fn push_one(
             .repos
             .get_mut(repo_path)
             .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
-            && adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)?
+            && adopt_from_push_echo(store, head_state, local_id, hosted, entry)?
         {
             changed = true;
         }
@@ -1396,6 +1401,30 @@ fn parse_linked_op_id(local_turn_id: &str) -> Result<CollabOpId> {
         .unwrap_or(local_turn_id);
     op.parse()
         .map_err(|error| anyhow!("mirror turn link has an invalid CollabOpId {op:?}: {error}"))
+}
+
+/// The adopt `push_one` runs after keeping the last OpenDiscussion/AppendTurn
+/// echo. Weft echoes the **full** discussion (≥2 turns after append). Empty
+/// `turns` is a test-server / older-weft no-op. A short echo is refused so a
+/// last-turn-only snapshot cannot retire local turns it cannot replace.
+fn adopt_from_push_echo(
+    store: &CollaborationStore,
+    head_state: StateId,
+    local_id: &str,
+    hosted: &HostedDiscussion,
+    entry: &mut MirrorEntry,
+) -> Result<bool> {
+    if hosted.turns.is_empty() {
+        return Ok(false);
+    }
+    if hosted.turns.len() < entry.links.len() {
+        return Err(anyhow!(
+            "hosted echo for {local_id} has {} turn(s) but this discussion has {} linked op(s); refusing adopt so a partial echo cannot drop local turns",
+            hosted.turns.len(),
+            entry.links.len(),
+        ));
+    }
+    adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)
 }
 
 /// Replace local-only published turn ops with the envelopes a clone would
@@ -2859,6 +2888,10 @@ mod tests {
             references: Vec::new(),
         });
         let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+        assert!(
+            hosted.turns.len() >= 2,
+            "AppendTurn/OpenDiscussion echo is the full discussion, not the last turn only"
+        );
 
         let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
         let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
@@ -2961,6 +2994,225 @@ mod tests {
             originator_ids, clone_ids,
             "after adopt, originator open+append CollabOpIds must equal the hosted clone"
         );
+    }
+
+    // The adopt `push_one` runs after `hosted = Some(echoed)`: a multi-turn
+    // AppendTurn echo is the full discussion, so both local ops adopt.
+    #[tokio::test]
+    async fn push_echo_adopt_uses_full_discussion() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+        hosted_snapshot.turns.push(DiscussionTurn {
+            author: Principal::new("preview-user", ""),
+            body: "and a follow-up".to_string(),
+            posted_at: 1_700_000_043,
+            references: Vec::new(),
+        });
+        let echo = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+        assert!(
+            echo.turns.len() >= 2,
+            "the AppendTurn echo push_one keeps must include every turn, not only the last"
+        );
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(&[hosted_snapshot]),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            echo.turns.len() >= entry.links.len(),
+            "full echo must cover every linked local turn"
+        );
+        assert!(
+            adopt_from_push_echo(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &echo,
+                &mut entry,
+            )
+            .unwrap(),
+            "push_one's adopt must consume the full multi-turn echo"
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "push_one adopt from a full echo must match the hosted clone"
+        );
+        assert_eq!(
+            originator_store.operation_ids().unwrap().len(),
+            2,
+            "full-echo adopt must keep both published turns"
+        );
+    }
+
+    // A last-turn-only echo must not retire the unpublished prefix.
+    #[test]
+    fn partial_push_echo_does_not_under_adopt() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let mut partial = hosted_discussion_from_bootstrap(bootstrap_discussion(
+            &wire_id.to_string(),
+            originator_state,
+        ));
+        partial.turns.truncate(1);
+        assert_eq!(partial.turns.len(), 1);
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        let before = originator_store.operation_ids().unwrap();
+        let error = adopt_from_push_echo(
+            &originator_store,
+            originator_state,
+            &wire_id.to_string(),
+            &partial,
+            &mut entry,
+        )
+        .expect_err("a one-turn echo must not adopt over two linked local turns");
+        assert!(
+            error.to_string().contains("partial echo"),
+            "refuse must name the partial-echo hazard, got: {error}"
+        );
+        let after = originator_store.operation_ids().unwrap();
+        assert_eq!(
+            after, before,
+            "partial echo must leave both local ops in place"
+        );
+        assert!(after.contains(&originator_open));
+        assert!(after.contains(&originator_append));
     }
 
     // The remint site on the hosted-clone/pull path: originator already

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -38,6 +38,17 @@
 //! ordinal)` (see `turn_op_key`) — never a random per-write nonce — so the same
 //! server turn earns the same `CollabOpId` on every clone and a retry replays
 //! instead of conflicting or duplicating.
+//!
+//! `CollabOpId` still hashes the **full** envelope, including author and
+//! `occurred_at_ms`. Weft restamps both on accept, so an originator's local
+//! `heddle discuss open` (local git author + wall-clock time + CLI `--op-id`
+//! / v4 key) cannot content-address to the hosted envelope. That is why
+//! clones agreed with each other after #1677/#1697 while the originator
+//! still printed a different `co-…` (heddle#1695). After a successful push
+//! — and again on pull, when a linked local turn is not hosted-canonical —
+//! the originator **adopts** the same envelope a clone would materialize.
+//! The pre-push local-only op is retired (new bytes, new id; we do not
+//! rewrite bytes under the old id).
 //! Resolve-into-annotation operations use the same durable mirror: their
 //! request identity is derived from `(hosted discussion id, server resolution
 //! key)` (see `resolve_op_key`) and is recorded only after `ResolveDiscussion`
@@ -137,7 +148,7 @@ struct MirrorEntry {
     pulled_resolution_key: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct TurnLink {
     /// Local turn id: `{CollabOpId}#{index-within-op}` — the stable turn
     /// identity (unique even when a `LegacyImported` op carries many turns).
@@ -399,7 +410,7 @@ async fn push_one(
             heddle_cli_render::cli::style::warn_marker(),
         );
     }
-    let (index, server_id, mut changed) =
+    let (index, server_id, mut changed, hosted) =
         match entry_index {
             None => {
                 if candidates.is_empty() {
@@ -407,7 +418,7 @@ async fn push_one(
                 }
                 let (open_turn_id, open_body) = candidates[0].clone();
                 let proposed_id = local_id.to_string();
-                let hosted = client
+                let mut hosted = client
                     .open_discussion(
                         repo_path,
                         change_id,
@@ -436,7 +447,7 @@ async fn push_one(
                 });
                 let index = repo_mirror.discussions.len() - 1;
                 for (turn_id, body) in &candidates[1..] {
-                    let hosted = client
+                    hosted = client
                         .append_turn(
                             repo_path,
                             &server_id,
@@ -456,12 +467,13 @@ async fn push_one(
                         }),
                     );
                 }
-                (index, server_id, true)
+                (index, server_id, true, Some(hosted))
             }
             Some(index) => {
                 let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
+                let mut hosted = None;
                 for (turn_id, body) in &candidates {
-                    let hosted = client
+                    let echoed = client
                         .append_turn(
                             repo_path,
                             &server_id,
@@ -475,15 +487,28 @@ async fn push_one(
                         repo_path,
                         index,
                         turn_id.clone(),
-                        hosted.turns.len().saturating_sub(1),
-                        hosted.turns.last().and_then(|turn| {
+                        echoed.turns.len().saturating_sub(1),
+                        echoed.turns.last().and_then(|turn| {
                             (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
                         }),
                     );
+                    hosted = Some(echoed);
                 }
-                (index, server_id, !candidates.is_empty())
+                (index, server_id, !candidates.is_empty(), hosted)
             }
         };
+
+    if let Some(hosted) = hosted.as_ref() {
+        let head_state = hosted_materialization_state(discussion, repo)?;
+        if let Some(entry) = mirror
+            .repos
+            .get_mut(repo_path)
+            .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+            && adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)?
+        {
+            changed = true;
+        }
+    }
 
     if push_into_annotation_resolution(client, repo_path, mirror, index, &server_id, discussion)
         .await?
@@ -878,10 +903,6 @@ fn pull_one(
             // discussion is addressable by the same id on every clone; fall back
             // to a deterministic derivation for legacy `hc-` ids.
             let local_id = adopt_or_derive_local_id(&discussion.id);
-            let anchor = hosted_open_anchor(discussion, head_state);
-            let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
-            let visibility = parse_visibility_token(&discussion.visibility);
-
             let first = &discussion.turns[0];
             let open_op = write_local_operation(
                 store,
@@ -889,13 +910,7 @@ fn pull_one(
                 Vec::new(),
                 turn_attribution(first),
                 turn_ms(first),
-                CollaborationOperationBodyV1::Open {
-                    title,
-                    anchor,
-                    visibility,
-                    turn: turn_body(first)?,
-                    thread_ref: discussion.thread_ref.clone(),
-                },
+                hosted_turn_body(discussion, first, 0, head_state)?,
                 turn_op_key(&discussion.id, server_ordinal(first, 0))?,
             )?;
             // Record the mapping immediately so a mid-materialization failure
@@ -923,9 +938,7 @@ fn pull_one(
                     heads.clone(),
                     turn_attribution(turn),
                     turn_ms(turn),
-                    CollaborationOperationBodyV1::AppendTurn {
-                        turn: turn_body(turn)?,
-                    },
+                    hosted_turn_body(discussion, turn, list_index, head_state)?,
                     turn_op_key(&discussion.id, ordinal)?,
                 )?;
                 heads = vec![op_id];
@@ -1024,6 +1037,22 @@ fn pull_one(
 
     if pull_resolution(store, repo_path, mirror, discussion)? {
         changed = true;
+    }
+    if let Some(index) = mirror.repos.get(repo_path).and_then(|repo_mirror| {
+        repo_mirror
+            .discussions
+            .iter()
+            .position(|entry| entry.server_id == discussion.id)
+    }) {
+        let local_id = mirror.repos[repo_path].discussions[index].local_id.clone();
+        if let Some(entry) = mirror
+            .repos
+            .get_mut(repo_path)
+            .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+            && adopt_hosted_canonical_turns(store, head_state, &local_id, discussion, entry)?
+        {
+            changed = true;
+        }
     }
     Ok(changed)
 }
@@ -1322,6 +1351,141 @@ fn resolve_op_key(
     .to_string();
     CollaborationIdempotencyKey::new(raw)
         .map_err(|error| anyhow!("invalid idempotency key: {error}"))
+}
+
+fn hosted_materialization_state(
+    discussion: &MaterializedDiscussion,
+    repo: &Repository,
+) -> Result<StateId> {
+    match &discussion.anchor {
+        CollaborationAnchor::Symbol { state_id, .. }
+        | CollaborationAnchor::State { state_id }
+        | CollaborationAnchor::Path { state_id, .. } => Ok(*state_id),
+        _ => repo
+            .head()
+            .context("resolve repository head for hosted turn adoption")?
+            .ok_or_else(|| anyhow!("cannot adopt hosted turn ops without an anchor state")),
+    }
+}
+
+fn hosted_turn_body(
+    discussion: &HostedDiscussion,
+    turn: &HostedDiscussionTurn,
+    index: usize,
+    head_state: StateId,
+) -> Result<CollaborationOperationBodyV1> {
+    if index == 0 {
+        Ok(CollaborationOperationBodyV1::Open {
+            title: derive_title(&turn.body, &discussion.symbol),
+            anchor: hosted_open_anchor(discussion, head_state),
+            visibility: parse_visibility_token(&discussion.visibility),
+            turn: turn_body(turn)?,
+            thread_ref: discussion.thread_ref.clone(),
+        })
+    } else {
+        Ok(CollaborationOperationBodyV1::AppendTurn {
+            turn: turn_body(turn)?,
+        })
+    }
+}
+
+fn parse_linked_op_id(local_turn_id: &str) -> Result<CollabOpId> {
+    let op = local_turn_id
+        .split_once('#')
+        .map(|(op, _)| op)
+        .unwrap_or(local_turn_id);
+    op.parse()
+        .map_err(|error| anyhow!("mirror turn link has an invalid CollabOpId {op:?}: {error}"))
+}
+
+/// Replace local-only published turn ops with the envelopes a clone would
+/// materialize from `hosted`. No-op when the local linked ops already are
+/// those envelopes, or when unpublished local turns still parent the chain.
+fn adopt_hosted_canonical_turns(
+    store: &CollaborationStore,
+    head_state: StateId,
+    local_id: &str,
+    hosted: &HostedDiscussion,
+    entry: &mut MirrorEntry,
+) -> Result<bool> {
+    if hosted.turns.is_empty() || hosted.id.is_empty() {
+        return Ok(false);
+    }
+    let local_record: DiscussionRecordId = local_id
+        .parse()
+        .map_err(|error| anyhow!("invalid local discussion id {local_id}: {error}"))?;
+    let Some(existing) = store
+        .materialize_discussion(&local_record)
+        .context("materialize discussion before hosted CollabOpId adoption")?
+    else {
+        return Ok(false);
+    };
+
+    let linked_ops: HashSet<CollabOpId> = entry
+        .links
+        .iter()
+        .map(|link| parse_linked_op_id(&link.local_turn_id))
+        .collect::<Result<HashSet<_>>>()?;
+    if existing
+        .turns
+        .iter()
+        .any(|(op_id, _)| !linked_ops.contains(op_id))
+    {
+        // An unpushed local turn still parents the published prefix. Rewriting
+        // the prefix would orphan that child; wait until it is published.
+        return Ok(false);
+    }
+
+    let mut parents = Vec::new();
+    let mut canonical = Vec::with_capacity(hosted.turns.len());
+    let mut new_links = Vec::with_capacity(hosted.turns.len());
+    for (index, turn) in hosted.turns.iter().enumerate() {
+        let ordinal = server_ordinal(turn, index);
+        let envelope = CollaborationOperationEnvelope::new(
+            local_record,
+            parents.clone(),
+            turn_op_key(&hosted.id, ordinal)?,
+            turn_attribution(turn),
+            turn_ms(turn),
+            hosted_turn_body(hosted, turn, index, head_state)?,
+        )
+        .context("build hosted-canonical collaboration operation")?;
+        let bytes = envelope
+            .encode()
+            .map_err(|error| anyhow!("encode hosted-canonical operation: {error}"))?;
+        let id = CollabOpId::for_bytes(&bytes);
+        new_links.push(TurnLink {
+            local_turn_id: turn_identity(&id, 0),
+            server_ordinal: ordinal,
+            server_turn_id: server_turn_id(turn),
+        });
+        canonical.push((id, envelope));
+        parents = vec![id];
+    }
+
+    let already_canonical = linked_ops.len() == canonical.len()
+        && canonical.iter().all(|(id, _)| linked_ops.contains(id));
+    if already_canonical {
+        if entry.links != new_links {
+            entry.links = new_links;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    let retire: Vec<CollabOpId> = linked_ops
+        .into_iter()
+        .filter(|id| !canonical.iter().any(|(canonical_id, _)| canonical_id == id))
+        .collect();
+    let write: Vec<CollaborationOperationEnvelope> = canonical
+        .into_iter()
+        .map(|(_, envelope)| envelope)
+        .collect();
+    store
+        .replace_operations(&retire, &write)
+        .context("adopt hosted-canonical collaboration operations")?;
+    entry.links = new_links;
+    Ok(true)
 }
 
 fn write_local_operation(
@@ -2210,9 +2374,15 @@ mod tests {
             let bootstrap = vec![bootstrap_discussion(&wire_id, state)];
             let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
             assert_eq!(
-                pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
-                    .await
-                    .unwrap(),
+                pull_discussions(
+                    &repo,
+                    &mut client,
+                    "acme/widgets",
+                    Some(&bootstrap),
+                    Some(state)
+                )
+                .await
+                .unwrap(),
                 1
             );
             client.close().await;
@@ -2224,8 +2394,13 @@ mod tests {
                 store.materialize_discussion(&originator).unwrap().is_some(),
                 "clone must be addressable by the originator's id {originator}"
             );
-            let ids: Vec<DiscussionRecordId> =
-                store.materialize().unwrap().discussions.keys().copied().collect();
+            let ids: Vec<DiscussionRecordId> = store
+                .materialize()
+                .unwrap()
+                .discussions
+                .keys()
+                .copied()
+                .collect();
             materialized_ids.push(ids);
         }
         assert_eq!(
@@ -2270,16 +2445,26 @@ mod tests {
         // A pulls its own discussion back — same id on the wire, mirror empty.
         let bootstrap = vec![bootstrap_discussion(&local_id.to_string(), state)];
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
-        pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
-            .await
-            .unwrap();
+        pull_discussions(
+            &repo,
+            &mut client,
+            "acme/widgets",
+            Some(&bootstrap),
+            Some(state),
+        )
+        .await
+        .unwrap();
         client.close().await;
         server.await.unwrap();
 
         // No duplicate `Open` root: exactly one discussion, still addressable, and
         // the single seeded turn reconciled rather than duplicated.
         let materialized = store.materialize().unwrap();
-        assert_eq!(materialized.discussions.len(), 1, "must not duplicate the discussion");
+        assert_eq!(
+            materialized.discussions.len(),
+            1,
+            "must not duplicate the discussion"
+        );
         assert!(materialized.discussions.contains_key(&local_id));
         assert_eq!(
             store.operation_ids().unwrap().len(),
@@ -2532,6 +2717,364 @@ mod tests {
             store.operation_ids().unwrap().len(),
             after_first,
             "a retry must dedupe, not append a duplicate op"
+        );
+    }
+
+    // heddle#1695: originator-local CollabOpId (random key + local author +
+    // wall-clock time) must become the hosted-canonical id a clone materializes
+    // from the same weft snapshot. Two clones already agreed after #1677/#1697;
+    // this is the hosted-clone path against an originator who opened locally.
+    #[tokio::test]
+    async fn originator_adopts_hosted_open_op_so_clone_agrees() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let hosted_snapshot = {
+            let mut discussion = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+            discussion.turns[0].author = Principal::new("preview-user", "");
+            discussion.turns[0].posted_at = 1_700_000_042;
+            discussion
+        };
+        let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+
+        let (originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let _ = originator_temp;
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "a title the clone will not see".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+
+        let (clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let _ = clone_temp;
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(std::slice::from_ref(&hosted_snapshot)),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_ne!(
+            vec![originator_open.to_string()],
+            clone_ids,
+            "pre-adopt originator CollabOpId must differ from the hosted clone (the remint this test exists to close)"
+        );
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![TurnLink {
+                local_turn_id: turn_identity(&originator_open, 0),
+                server_ordinal: 0,
+                server_turn_id: None,
+            }],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap(),
+            "originator must adopt the hosted-canonical open op"
+        );
+        assert!(
+            !adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap(),
+            "a second adopt must be a no-op"
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "after adopt, originator CollabOpId must equal the hosted clone"
+        );
+        assert_eq!(
+            originator_store.operation_ids().unwrap().len(),
+            1,
+            "adopt must retire the local-only open, not leave two Open roots"
+        );
+    }
+
+    // Same contract for open + append: the whole published chain adopts so
+    // parent pointers stay hosted-canonical.
+    #[tokio::test]
+    async fn originator_adopts_hosted_open_and_append_so_clone_agrees() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+        hosted_snapshot.turns.push(DiscussionTurn {
+            author: Principal::new("preview-user", ""),
+            body: "and a follow-up".to_string(),
+            posted_at: 1_700_000_043,
+            references: Vec::new(),
+        });
+        let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(&[hosted_snapshot]),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(clone_ids.len(), 2);
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap()
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "after adopt, originator open+append CollabOpIds must equal the hosted clone"
+        );
+    }
+
+    // The remint site on the hosted-clone/pull path: originator already
+    // published (mirror link exists) but still holds the local-only open op.
+    // pull_one must adopt the hosted-canonical envelope so the originator
+    // matches a fresh clone of the same snapshot.
+    #[tokio::test]
+    async fn pull_adopts_originator_local_open_to_match_clone() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let mut mirror = HostedMirror::default();
+        mirror
+            .repos
+            .entry("acme/widgets".to_string())
+            .or_default()
+            .discussions
+            .push(MirrorEntry {
+                local_id: wire_id.to_string(),
+                server_id: wire_id.to_string(),
+                links: vec![TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                }],
+                resolved_into_annotation_operation_id: None,
+                pulled_resolution_key: None,
+            });
+        save_mirror(originator_repo.heddle_dir(), &mirror).unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut clone_client, clone_server) =
+            crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut clone_client,
+            "acme/widgets",
+            Some(std::slice::from_ref(&hosted_snapshot)),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        clone_client.close().await;
+        clone_server.await.unwrap();
+
+        let (mut originator_client, originator_server) =
+            crate::hosted_runtime::hosted::test_server::start().await;
+        assert_eq!(
+            pull_discussions(
+                &originator_repo,
+                &mut originator_client,
+                "acme/widgets",
+                Some(&[hosted_snapshot]),
+                Some(originator_state),
+            )
+            .await
+            .unwrap(),
+            1,
+            "pull must adopt the hosted-canonical open op"
+        );
+        originator_client.close().await;
+        originator_server.await.unwrap();
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(
+            originator_ids, clone_ids,
+            "hosted pull must leave the originator with the same CollabOpId a clone materializes"
+        );
+        assert_ne!(
+            originator_ids,
+            vec![originator_open.to_string()],
+            "pull must retire the local-only open op, not keep it"
         );
     }
 }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -3521,13 +3521,12 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(
-            matches!(
-                replay,
-                DiscussionEventOutcome::Unchanged { discussion_id }
-                    if discussion_id == wire_id.to_string()
-            ),
-            "doorbell after adopt must not remint, got {replay:?}"
+        assert_eq!(
+            replay,
+            DiscussionEventOutcome::Unchanged {
+                discussion_id: wire_id.to_string(),
+            },
+            "doorbell after adopt must not remint"
         );
 
         let discussion = originator_store

--- a/crates/repo/src/collaboration_store.rs
+++ b/crates/repo/src/collaboration_store.rs
@@ -186,6 +186,10 @@ impl CollaborationStore {
     /// turn ops with the hosted-canonical envelopes a clone would materialize
     /// (heddle#1695). New ids are new envelopes; this does not rewrite bytes
     /// under an existing `CollabOpId`.
+    ///
+    /// Retire-then-write crash recovery is the existing pending-commit rebuild
+    /// (`stage_pending_commit_unlocked` → `pending-commit.msgpack` →
+    /// `rebuild_index_unlocked` on next `open`).
     pub fn replace_operations(
         &self,
         retire: &[CollabOpId],
@@ -262,7 +266,13 @@ impl CollaborationStore {
             let existed = path.exists();
             self.stage_pending_commit_unlocked(id)?;
             if !existed {
-                fs::create_dir_all(path.parent().expect("operation path has shard"))?;
+                let parent = path.parent().ok_or_else(|| {
+                    HeddleError::InvalidObject(format!(
+                        "collaboration operation path has no shard directory: {}",
+                        path.display()
+                    ))
+                })?;
+                fs::create_dir_all(parent)?;
                 write_file_atomic(&path, &bytes)?;
             }
             index.operations.insert(id);

--- a/crates/repo/src/collaboration_store.rs
+++ b/crates/repo/src/collaboration_store.rs
@@ -180,6 +180,112 @@ impl CollaborationStore {
         })
     }
 
+    /// Retire `retire` and write `write` under one lock.
+    ///
+    /// Hosted discussion sync uses this to replace an originator's local-only
+    /// turn ops with the hosted-canonical envelopes a clone would materialize
+    /// (heddle#1695). New ids are new envelopes; this does not rewrite bytes
+    /// under an existing `CollabOpId`.
+    pub fn replace_operations(
+        &self,
+        retire: &[CollabOpId],
+        write: &[CollaborationOperationEnvelope],
+    ) -> Result<Vec<CollaborationWriteOutcome>> {
+        if retire.is_empty() && write.is_empty() {
+            return Ok(Vec::new());
+        }
+        let decoded_writes = write
+            .iter()
+            .map(|operation| {
+                let bytes = operation.encode().map_err(codec_error)?;
+                let decoded =
+                    CollaborationOperationEnvelope::decode(&bytes).map_err(codec_error)?;
+                Ok((bytes, decoded))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let _guard = self.lock.write().map_err(lock_error)?;
+        if self.pending_commit_path().exists() {
+            let recovered = self.rebuild_index_unlocked()?;
+            self.write_index_unlocked(&recovered)?;
+            self.clear_pending_commit_unlocked()?;
+        }
+        let mut index = self.read_or_rebuild_index_unlocked()?;
+        let retire_set: BTreeSet<CollabOpId> = retire.iter().copied().collect();
+
+        for (bytes, decoded) in &decoded_writes {
+            let scope = idempotency_scope(&decoded.operation);
+            if let Some(existing) = index.idempotency.get(&scope)
+                && !retire_set.contains(existing)
+                && *existing != decoded.operation_id
+            {
+                return Err(HeddleError::InvalidObject(format!(
+                    "collaboration idempotency key already identifies {existing}"
+                )));
+            }
+            let path = self.operation_path(&decoded.operation_id);
+            match fs::read(&path) {
+                Ok(existing) if existing == *bytes => {}
+                Ok(_) => {
+                    return Err(HeddleError::InvalidObject(format!(
+                        "collaboration operation address collision at {}",
+                        decoded.operation_id
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        for id in &retire_set {
+            self.stage_pending_commit_unlocked(*id)?;
+            let path = self.operation_path(id);
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+            index.operations.remove(id);
+            for discussion_ops in index.discussions.values_mut() {
+                discussion_ops.remove(id);
+            }
+            index
+                .discussions
+                .retain(|_, discussion_ops| !discussion_ops.is_empty());
+            index.idempotency.retain(|_, existing| existing != id);
+        }
+
+        let mut outcomes = Vec::with_capacity(decoded_writes.len());
+        for (bytes, decoded) in decoded_writes {
+            let id = decoded.operation_id;
+            let scope = idempotency_scope(&decoded.operation);
+            let path = self.operation_path(&id);
+            let existed = path.exists();
+            self.stage_pending_commit_unlocked(id)?;
+            if !existed {
+                fs::create_dir_all(path.parent().expect("operation path has shard"))?;
+                write_file_atomic(&path, &bytes)?;
+            }
+            index.operations.insert(id);
+            index
+                .discussions
+                .entry(decoded.operation.discussion_id)
+                .or_default()
+                .insert(id);
+            index.idempotency.insert(scope, id);
+            outcomes.push(CollaborationWriteOutcome {
+                operation_id: id,
+                disposition: if existed {
+                    CollaborationWriteDisposition::ExistingOperation
+                } else {
+                    CollaborationWriteDisposition::Created
+                },
+            });
+        }
+        self.write_index_unlocked(&index)?;
+        self.clear_pending_commit_unlocked()?;
+        Ok(outcomes)
+    }
+
     pub fn read_operation(&self, id: &CollabOpId) -> Result<Option<DecodedCollaborationOperation>> {
         let _guard = self.lock.read().map_err(lock_error)?;
         self.read_operation_unlocked(id)
@@ -537,5 +643,35 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn replace_operations_retires_old_and_indexes_new() {
+        let temp = TempDir::new().unwrap();
+        let store = CollaborationStore::open(temp.path()).unwrap();
+        let first = operation("local-only");
+        let first_id = store.write_operation(&first).unwrap().operation_id;
+        let replacement = operation("hosted-canonical");
+        let outcomes = store
+            .replace_operations(&[first_id], std::slice::from_ref(&replacement))
+            .unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(
+            outcomes[0].disposition,
+            CollaborationWriteDisposition::Created
+        );
+        let ids = store.operation_ids().unwrap();
+        assert_eq!(ids, vec![outcomes[0].operation_id]);
+        assert!(store.read_operation(&first_id).unwrap().is_none());
+        assert_eq!(
+            store
+                .read_operation(&outcomes[0].operation_id)
+                .unwrap()
+                .unwrap()
+                .operation
+                .idempotency_key,
+            replacement.idempotency_key
+        );
+        assert!(store.verify_integrity().unwrap().index_current);
     }
 }

--- a/docs/adr/0026-content-addressed-collaboration-operation-ids.md
+++ b/docs/adr/0026-content-addressed-collaboration-operation-ids.md
@@ -26,6 +26,8 @@ Weft applies the same rule when validating hosted collaboration operations. A we
 
 Independent actors submitting the same visible content with the same anchor and causal parents still create distinct collaboration operations unless they share the same idempotency key and actor/capability scope. Heddle does not deduplicate collaboration by semantic content because repeated agreement, duplicate human comments, and parallel agent conclusions can be meaningful records.
 
+Hosted publish restamps author and timestamp, so the originator's local-only envelope cannot hash to the hosted `CollabOpId`. After a successful push or a later pull, Heddle retires that local-only operation and writes the hosted-canonical envelope a clone would materialize (heddle#1695). This creates a new operation id with a recorded mirror mapping; it does not rewrite bytes under the old id.
+
 Collaboration idempotency keys are operational metadata. Normal human-facing discussion output shows the resulting operation ID, actor, timestamp, turn kind, and content; idempotency keys appear only in verbose/debug JSON and `fsck`/`doctor` diagnostics.
 
 **Status:** proposed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- #1677/#1697 made clone materialization deterministic: two hosted clones already agree on turn `CollabOpId`s. The remaining remint was **originator-vs-hosted**.
- `CollabOpId` is content-addressed over the **full** envelope, including author and `occurred_at_ms`. Weft restamps both on accept, so a local `heddle discuss open` (git author + wall-clock + v4/`--op-id` key) cannot hash to the hosted envelope. That is the product contract, not a second derivation hole in `turn_op_key`.
- After a successful push (when the server echoes turns) and again on pull, the originator **adopts** the same envelopes a clone would materialize (`turn_op_key` + hosted author/timestamp + clone-path Open body). The local-only op is retired; we do not rewrite bytes under the old id.
- Adopt remints **only** originator-local keys. Linked turns that already carry `turn_op_key` (clone/bootstrap/prior adopt) are left alone. A later doorbell `GetDiscussion` often omits `opened_against_state`; rebuilding from it disagreed with the live replay path and broke `replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn`.
- Tests cover hosted-clone, not only the in-process key unit test: originator local open ≠ clone, then after adopt/pull they match; same for open+append. New cross-path: doorbell-after-adopt must stay `Unchanged` and keep the adopted `CollabOpId`.
- Review tightenings: `replace_operations` returns a shard-path error (no `expect`); retire-then-write points at the pending-commit rebuild; `push_one` adopt refuses a short Open/Append echo so a last-turn-only snapshot cannot under-adopt.

## Closes

Closes HeddleCo/heddle#1695

## Red commit

N/A — no separate red SHA. The new hosted-clone tests carry an in-test falsifier: they assert originator-local `co-…` ≠ clone **before** adopt, then equal after. That is the #1695 remint this PR closes. The doorbell-after-adopt test is the Zephyr regression (bootstrap+replay was RED on `11ec8493`).

## Test evidence

Proof on tip `ad120f76`:

```
$ cargo test -p heddle-hosted-client --features client --lib does_not_duplicate_the_first_turn -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/hosted_client-5ff98dd6b9a44fb2)

running 2 tests
test client::discussion_live::tests::replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn ... ok
test client::discussion_sync::tests::doorbell_after_adopt_does_not_duplicate_the_first_turn ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 423 filtered out; finished in 0.37s

$ cargo test -p heddle-hosted-client --features client --lib discussion_sync -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/hosted_client-5ff98dd6b9a44fb2)

running 27 tests
test client::discussion_sync::tests::doorbell_after_adopt_does_not_duplicate_the_first_turn ... ok
test client::discussion_sync::tests::originator_adopts_hosted_open_op_so_clone_agrees ... ok
test client::discussion_sync::tests::originator_adopts_hosted_open_and_append_so_clone_agrees ... ok
test client::discussion_sync::tests::pull_adopts_originator_local_open_to_match_clone ... ok
test client::discussion_sync::tests::push_echo_adopt_uses_full_discussion ... ok
test client::discussion_sync::tests::partial_push_echo_does_not_under_adopt ... ok
… (27 passed; 0 failed)

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 398 filtered out; finished in 3.88s

$ cargo test -p heddle-hosted-client --features client --lib discussion_live -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/hosted_client-5ff98dd6b9a44fb2)

running 46 tests
test client::discussion_live::tests::replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn ... ok
… (46 passed; 0 failed)

test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 379 filtered out; finished in 2.44s

$ cargo test -p heddle-repo replace_operations_retires_old_and_indexes_new -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/repo-58413e7e802e7543)

running 1 test
test collaboration_store::tests::replace_operations_retires_old_and_indexes_new ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out; finished in 0.38s
```

`cargo clippy -p heddle-repo -p heddle-hosted-client --features client --all-targets -- -D warnings` clean.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

Zephyr review: adopt-on-pull rewrote hosted-keyed ops so doorbell replay and adopt disagreed. Fixed by skipping remint when linked ops already use `turn_op_key`. Originator-local v4/`--op-id` keys still adopt (#1695).

## Surfaces

- **The verb:** no new clap flags; `discuss show` `operation_id` after push/pull is the hosted-canonical `co-…`.
- **Human and agent:** default JSON `operation_id` / `head_operation_ids` follow the adopted id.
- **Git interop:** none.
- **The wire:** no proto change; weft still restamps author/time. Client adopts the resulting envelope.
- **Reverse states:** way in = publish/pull adopt of originator-local keys; way out = unpublished local turns are left alone (parent chain not rewritten while unpushed children exist); already-hosted-keyed turns are not reminted on doorbell; way to see = `discuss show` / store `operation_ids`. Partial Open/Append echoes are refused so they cannot drop published local turns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8972895b-8bf9-471d-b386-eae5ddca13ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8972895b-8bf9-471d-b386-eae5ddca13ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791161134&installation_model_id=21489&pr_number=1703&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1703&signature=8df4d6ccf8e9c05c117d9e228eba973ccc3bfcfd6a5fdc74705d81473ec24723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->