### PR TITLE
staging: clone→push thread identity + CollabOpId adopt

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,7 +77,7 @@ An opaque stable UUIDv7 identifier for a discussion. Human-readable meaning belo
 _Avoid_: discussion slug, content-addressed discussion id
 
 **Collaboration Operation ID**:
-An opaque stable content-addressed identifier for a collaboration operation. It is distinct from a source history ChangeId even if it uses familiar Heddle short-prefix UX.
+An opaque stable content-addressed identifier for a collaboration operation. It is distinct from a source history ChangeId even if it uses familiar Heddle short-prefix UX. After a hosted push or pull, a published turn's id is the envelope a clone materializes from the hosted snapshot (author, timestamp, and `turn_op_key`); the originator's pre-push local-only id is retired so every machine agrees.
 _Avoid_: change id for collaboration
 
 **Collaboration Idempotency Key**:

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -40,7 +40,7 @@ use objects::{
     store::ObjectStore,
     sync::LockExt,
 };
-use repo::{BlobHydrator, Repository};
+use repo::{BlobHydrator, Repository, ThreadManager};
 #[cfg(feature = "client")]
 use repo::{RepositorySourceAuthority, clone_intent::CloneIntent};
 #[cfg(feature = "client")]
@@ -1213,6 +1213,15 @@ async fn clone_local(
         let _ = fs::remove_dir_all(local_path);
         return Err(error);
     }
+    if let Some(metadata) =
+        ThreadManager::new(remote_repo.heddle_dir()).find_record_by_thread(&track_name)?
+    {
+        ThreadManager::new(local_repo.heddle_dir()).save_pulled_metadata(
+            &track_name,
+            &state_id,
+            metadata,
+        )?;
+    }
 
     let origin_url = configure_local_clone_origin(&local_repo, remote_path)?;
 
@@ -1837,6 +1846,15 @@ async fn clone_network_connected(
             checkout_clone_thread(&local_repo, &track_name, &final_state)
                 .context("failed to materialize hosted clone worktree")?;
         }
+        persist_hosted_clone_thread_identity(
+            &local_repo,
+            client,
+            repo_path,
+            &remote_refs,
+            &track_name,
+            &final_state,
+        )
+        .await?;
         CloneIntent::clear(local_path)?;
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(
@@ -2060,6 +2078,15 @@ async fn recover_interrupted_clone_connected(
     } else {
         checkout_clone_thread(&repo, &track_name, &final_state)?;
     }
+    persist_hosted_clone_thread_identity(
+        &repo,
+        client,
+        &intent.repository,
+        &remote_refs,
+        &track_name,
+        &final_state,
+    )
+    .await?;
     CloneIntent::clear(root)?;
     Ok(())
 }
@@ -2531,6 +2558,53 @@ fn clone_hosted_thread_not_found_advice(track_name: &str, remote_label: &str) ->
 }
 
 #[cfg(feature = "client")]
+#[cfg(feature = "client")]
+async fn persist_hosted_clone_thread_identity(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &objects::object::StateId,
+) -> Result<()> {
+    if let Some(metadata) = client
+        .try_get_thread_metadata(repo, repo_path, track_name, *final_state)
+        .await?
+    {
+        ThreadManager::new(repo.heddle_dir()).save_pulled_metadata(
+            track_name,
+            final_state,
+            metadata,
+        )?;
+        return Ok(());
+    }
+    persist_advertised_clone_thread_identity(repo, remote_refs, track_name, final_state)
+}
+
+#[cfg(feature = "client")]
+fn persist_advertised_clone_thread_identity(
+    repo: &Repository,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &objects::object::StateId,
+) -> Result<()> {
+    let Some(stable_id) = remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(());
+    };
+    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
+        repo,
+        track_name,
+        stable_id,
+        *final_state,
+    )?;
+    Ok(())
+}
+
 fn hosted_clone_thread_revision_address<'a>(
     remote_refs: &'a [HostedRefEntry],
     thread: &str,
@@ -2935,6 +3009,40 @@ mod tests {
 
         assert_eq!(repo.source_authority(), RepositorySourceAuthority::Native);
         assert!(!root.join(".git").exists());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_persists_advertised_thread_stable_id() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        std::fs::write(temp.path().join("tracked.txt"), b"cloned\n").unwrap();
+        let state = repo
+            .snapshot(Some("seed".into()), None)
+            .expect("snapshot")
+            .state_id;
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        let remote_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some("hosted-stable-main".to_string()),
+        )];
+
+        persist_advertised_clone_thread_identity(&repo, &remote_refs, "main", &state)
+            .expect("persist advertised identity");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, "hosted-stable-main");
+        assert_ne!(persisted.id, minted.id);
+        assert_ne!(persisted.id, "main");
     }
 
     #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -29,10 +29,7 @@ use heddle_git_projection::git_core::{
 };
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{
-    HostedClient, HostedRefEntry, PullMaterialization, advertised_user_thread_id,
-    persist_advertised_thread_identity_with_live_fallback,
-};
+use hosted_client::hosted_runtime::hosted::{HostedClient, HostedRefEntry, PullMaterialization};
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
 use objects::fs_atomic::CloneDurabilityBatch;
@@ -2569,31 +2566,9 @@ async fn persist_hosted_clone_thread_identity(
     track_name: &str,
     final_state: &objects::object::StateId,
 ) -> Result<()> {
-    if let Some(metadata) = client
-        .try_get_thread_metadata(repo, repo_path, track_name, *final_state)
-        .await?
-    {
-        ThreadManager::new(repo.heddle_dir()).save_pulled_metadata(
-            track_name,
-            final_state,
-            metadata,
-        )?;
-        return Ok(());
-    }
-    // Folded PullReady refs decode with `thread_id: None`. Refresh live
-    // ListRefs when the fold omitted the advertised stable id.
-    let live_refs = if advertised_user_thread_id(remote_refs, track_name).is_none() {
-        Some(client.list_refs_with_revision_addresses(repo_path).await?)
-    } else {
-        None
-    };
-    persist_advertised_thread_identity_with_live_fallback(
-        repo,
-        remote_refs,
-        live_refs.as_deref(),
-        track_name,
-        final_state,
-    )?;
+    client
+        .adopt_advertised_thread_identity(repo, repo_path, remote_refs, track_name, *final_state)
+        .await?;
     Ok(())
 }
 
@@ -2864,6 +2839,10 @@ pub fn register_git_overlay_factory() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "client")]
+    use hosted_client::hosted_runtime::hosted::{
+        advertised_user_thread_id, persist_advertised_thread_identity,
+    };
 
     #[test]
     fn heddle_clone_output_uses_native_repository_capability() {
@@ -3025,14 +3004,8 @@ mod tests {
             Some("hosted-stable-main".to_string()),
         )];
 
-        persist_advertised_thread_identity_with_live_fallback(
-            &repo,
-            &remote_refs,
-            None,
-            "main",
-            &state,
-        )
-        .expect("persist advertised identity");
+        persist_advertised_thread_identity(&repo, &remote_refs, "main", &state)
+            .expect("persist advertised identity");
 
         let persisted = ThreadManager::new(repo.heddle_dir())
             .find_record_by_thread("main")
@@ -3073,14 +3046,10 @@ mod tests {
         )];
 
         assert!(advertised_user_thread_id(&folded_refs, "main").is_none());
-        persist_advertised_thread_identity_with_live_fallback(
-            &repo,
-            &folded_refs,
-            Some(&live_refs),
-            "main",
-            &state,
-        )
-        .expect("persist from live ListRefs when the fold omitted thread_id");
+        persist_advertised_thread_identity(&repo, &folded_refs, "main", &state)
+            .expect("omitted folded advertisement is a no-op");
+        persist_advertised_thread_identity(&repo, &live_refs, "main", &state)
+            .expect("persist from live ListRefs when the fold omitted thread_id");
 
         let persisted = ThreadManager::new(repo.heddle_dir())
             .find_record_by_thread("main")

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -30,7 +30,8 @@ use heddle_git_projection::git_core::{
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
 use hosted_client::hosted_runtime::hosted::{
-    HostedClient, HostedRefEntry, PullMaterialization, persist_advertised_thread_identity,
+    HostedClient, HostedRefEntry, PullMaterialization, advertised_user_thread_id,
+    persist_advertised_thread_identity_with_live_fallback,
 };
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
@@ -2579,7 +2580,20 @@ async fn persist_hosted_clone_thread_identity(
         )?;
         return Ok(());
     }
-    persist_advertised_thread_identity(repo, remote_refs, track_name, final_state)?;
+    // Folded PullReady refs decode with `thread_id: None`. Refresh live
+    // ListRefs when the fold omitted the advertised stable id.
+    let live_refs = if advertised_user_thread_id(remote_refs, track_name).is_none() {
+        Some(client.list_refs_with_revision_addresses(repo_path).await?)
+    } else {
+        None
+    };
+    persist_advertised_thread_identity_with_live_fallback(
+        repo,
+        remote_refs,
+        live_refs.as_deref(),
+        track_name,
+        final_state,
+    )?;
     Ok(())
 }
 
@@ -3011,8 +3025,62 @@ mod tests {
             Some("hosted-stable-main".to_string()),
         )];
 
-        persist_advertised_thread_identity(&repo, &remote_refs, "main", &state)
-            .expect("persist advertised identity");
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &remote_refs,
+            None,
+            "main",
+            &state,
+        )
+        .expect("persist advertised identity");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, "hosted-stable-main");
+        assert_ne!(persisted.id, minted.id);
+        assert_ne!(persisted.id, "main");
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_refreshes_list_refs_when_folded_refs_omit_thread_id() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        std::fs::write(temp.path().join("tracked.txt"), b"cloned\n").unwrap();
+        let state = repo
+            .snapshot(Some("seed".into()), None)
+            .expect("snapshot")
+            .state_id;
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        let folded_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            None,
+        )];
+        let live_refs = vec![HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some("hosted-stable-main".to_string()),
+        )];
+
+        assert!(advertised_user_thread_id(&folded_refs, "main").is_none());
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &folded_refs,
+            Some(&live_refs),
+            "main",
+            &state,
+        )
+        .expect("persist from live ListRefs when the fold omitted thread_id");
 
         let persisted = ThreadManager::new(repo.heddle_dir())
             .find_record_by_thread("main")

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -29,7 +29,9 @@ use heddle_git_projection::git_core::{
 };
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{HostedClient, HostedRefEntry, PullMaterialization};
+use hosted_client::hosted_runtime::hosted::{
+    HostedClient, HostedRefEntry, PullMaterialization, persist_advertised_thread_identity,
+};
 use ingest::ImportOptions;
 #[cfg(feature = "client")]
 use objects::fs_atomic::CloneDurabilityBatch;
@@ -2558,7 +2560,6 @@ fn clone_hosted_thread_not_found_advice(track_name: &str, remote_label: &str) ->
 }
 
 #[cfg(feature = "client")]
-#[cfg(feature = "client")]
 async fn persist_hosted_clone_thread_identity(
     repo: &Repository,
     client: &mut HostedClient,
@@ -2578,30 +2579,7 @@ async fn persist_hosted_clone_thread_identity(
         )?;
         return Ok(());
     }
-    persist_advertised_clone_thread_identity(repo, remote_refs, track_name, final_state)
-}
-
-#[cfg(feature = "client")]
-fn persist_advertised_clone_thread_identity(
-    repo: &Repository,
-    remote_refs: &[HostedRefEntry],
-    track_name: &str,
-    final_state: &objects::object::StateId,
-) -> Result<()> {
-    let Some(stable_id) = remote_refs
-        .iter()
-        .find(|entry| entry.is_user_thread() && entry.name == track_name)
-        .and_then(|entry| entry.thread_id.as_deref())
-        .filter(|id| !id.is_empty())
-    else {
-        return Ok(());
-    };
-    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
-        repo,
-        track_name,
-        stable_id,
-        *final_state,
-    )?;
+    persist_advertised_thread_identity(repo, remote_refs, track_name, final_state)?;
     Ok(())
 }
 
@@ -3033,7 +3011,7 @@ mod tests {
             Some("hosted-stable-main".to_string()),
         )];
 
-        persist_advertised_clone_thread_identity(&repo, &remote_refs, "main", &state)
+        persist_advertised_thread_identity(&repo, &remote_refs, "main", &state)
             .expect("persist advertised identity");
 
         let persisted = ThreadManager::new(repo.heddle_dir())

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1781,6 +1781,7 @@ async fn auto_provision_hosted_repo(
             provisioned_repo.status_verb(),
             style::bold(&display_full_path)
         );
+        let (scheme, host) = user_facing_hosted_authority(options.remote_arg, options.authority);
         if let Some(remote_name) = configured_remote {
             println!(
                 "{}",
@@ -1789,17 +1790,13 @@ async fn auto_provision_hosted_repo(
                     &format!(
                         "{} -> {}",
                         style::bold(&remote_name),
-                        style::dim(&format!(
-                            "heddle://{}/{}",
-                            options.authority, display_full_path
-                        ))
+                        style::dim(&format!("{scheme}://{host}/{display_full_path}"))
                     )
                 )
             );
         } else {
             print_next(&format!(
-                "heddle remote add origin heddle://{}/{}",
-                options.authority, display_full_path
+                "heddle remote add origin {scheme}://{host}/{display_full_path}"
             ));
         }
     }
@@ -1866,15 +1863,90 @@ fn persist_auto_provisioned_remote(
         return Ok(None);
     };
     let mut cfg = RemoteConfig::open(repo).map_err(anyhow::Error::new)?;
+    let existing = cfg.get(&remote_name).ok();
+    let url = auto_provisioned_remote_url(
+        existing.as_ref().map(|remote| remote.url.as_str()),
+        remote_arg,
+        authority,
+        full_path,
+    );
     cfg.add(
         &remote_name,
         Remote {
-            url: format!("heddle://{authority}/{full_path}"),
-            insecure: false,
+            url,
+            insecure: existing
+                .as_ref()
+                .map(|remote| remote.insecure)
+                .unwrap_or(false),
         },
     )
     .map_err(anyhow::Error::new)?;
     Ok(Some(remote_name))
+}
+
+/// Build the user-facing hosted URL written after CreateSpool.
+///
+/// Keep the scheme and hostname the user typed (`https://` / `heddle://`).
+/// A resolved SocketAddr is only persisted when that was the input —
+/// otherwise later TLS/SNI and descriptor trust look up the IP.
+#[cfg(feature = "client")]
+fn auto_provisioned_remote_url(
+    existing_url: Option<&str>,
+    remote_arg: Option<&str>,
+    authority: &str,
+    full_path: &str,
+) -> String {
+    if let Some(existing) = existing_url
+        && let Some(url) = rewrite_hosted_remote_path(existing, full_path)
+    {
+        return url;
+    }
+    let (scheme, host) = user_facing_hosted_authority(remote_arg, authority);
+    format!("{scheme}://{host}/{full_path}")
+}
+
+#[cfg(feature = "client")]
+fn rewrite_hosted_remote_path(url: &str, full_path: &str) -> Option<String> {
+    let (scheme, rest) = split_hosted_remote_scheme(url)?;
+    let host = rest.split('/').next().filter(|host| !host.is_empty())?;
+    Some(format!("{scheme}://{host}/{full_path}"))
+}
+
+#[cfg(feature = "client")]
+fn split_hosted_remote_scheme(url: &str) -> Option<(&'static str, &str)> {
+    url.strip_prefix("https://")
+        .map(|rest| ("https", rest))
+        .or_else(|| url.strip_prefix("heddle://").map(|rest| ("heddle", rest)))
+}
+
+#[cfg(feature = "client")]
+fn user_facing_hosted_authority<'a>(
+    remote_arg: Option<&'a str>,
+    authority: &'a str,
+) -> (&'static str, &'a str) {
+    if let Some(arg) = remote_arg
+        && let Some((scheme, rest)) = split_hosted_remote_scheme(arg)
+    {
+        if let Some(host) = rest.split('/').next().filter(|host| !host.is_empty()) {
+            return (scheme, prefer_hostname_authority(host, authority));
+        }
+        return (scheme, authority);
+    }
+    ("heddle", authority)
+}
+
+#[cfg(feature = "client")]
+fn prefer_hostname_authority<'a>(from_input: &'a str, authority: &'a str) -> &'a str {
+    if is_raw_socket_authority(authority) && !is_raw_socket_authority(from_input) {
+        from_input
+    } else {
+        authority
+    }
+}
+
+#[cfg(feature = "client")]
+fn is_raw_socket_authority(value: &str) -> bool {
+    value.parse::<std::net::SocketAddr>().is_ok() || value.parse::<std::net::IpAddr>().is_ok()
 }
 
 #[cfg(feature = "client")]
@@ -1886,8 +1958,11 @@ fn auto_provision_remote_name(
     match remote_arg {
         Some(arg) if cfg.get(arg).is_ok() => Ok(Some(arg.to_string())),
         Some(arg) => {
+            // Same parser `push` uses: native HTTPS host-only
+            // (`https://host[:port]`) is a CreateSpool target, but the
+            // generic parser rejects the scheme so origin was never saved.
             let is_direct_network_without_path = matches!(
-                RemoteTarget::parse(arg),
+                repo::remote::parse_target_for_repository(repo, arg),
                 Ok(RemoteTarget::Network {
                     repo_path: None,
                     ..
@@ -2052,6 +2127,18 @@ mod tests {
                 .as_deref(),
             Some("origin")
         );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://127.0.0.1:8421"))
+                .unwrap()
+                .as_deref(),
+            Some("origin")
+        );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://api-staging.heddle.sh"))
+                .unwrap()
+                .as_deref(),
+            Some("origin")
+        );
 
         let mut cfg = RemoteConfig::open(&repo).unwrap();
         cfg.add(
@@ -2071,6 +2158,12 @@ mod tests {
         );
         assert_eq!(
             auto_provision_remote_name(&repo, Some("127.0.0.1:8421"))
+                .unwrap()
+                .as_deref(),
+            None
+        );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://127.0.0.1:8421"))
                 .unwrap()
                 .as_deref(),
             None
@@ -2096,6 +2189,112 @@ mod tests {
         };
         assert_eq!(authority, "api-staging.heddle.sh");
         assert!(authority.parse::<std::net::IpAddr>().is_err());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_persists_https_host_only_as_named_origin() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://api-staging.heddle.sh"),
+            "api-staging.heddle.sh",
+            "org/repo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://api-staging.heddle.sh/org/repo");
+        let (target, key) = resolve_remote_with_key(&repo, Some("origin")).unwrap();
+        assert!(matches!(
+            target,
+            RemoteTarget::Network {
+                repo_path: Some(ref path),
+                ..
+            } if path == "org/repo"
+        ));
+        assert_eq!(key.as_deref(), Some("api-staging.heddle.sh"));
+        assert_eq!(
+            RemoteConfig::open(&repo).unwrap().default_name(),
+            Some("origin")
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_persists_https_loopback_host_only_as_origin() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://127.0.0.1:8421"),
+            "127.0.0.1:8421",
+            "alice/demo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        assert_eq!(
+            RemoteConfig::open(&repo)
+                .unwrap()
+                .get("origin")
+                .unwrap()
+                .url,
+            "https://127.0.0.1:8421/alice/demo"
+        );
+        resolve_remote_with_key(&repo, Some("origin")).unwrap();
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_does_not_overwrite_hostname_with_resolved_socket() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://api-staging.heddle.sh"),
+            "203.0.113.10:443",
+            "org/repo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://api-staging.heddle.sh/org/repo");
+        assert!(
+            !remote.url.contains("203.0.113.10"),
+            "resolved SocketAddr must not replace the typed hostname: {}",
+            remote.url
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_rewrites_existing_https_origin_path_without_losing_scheme() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut cfg = RemoteConfig::open(&repo).unwrap();
+        cfg.add(
+            "origin",
+            Remote {
+                url: "https://preview.heddle.sh".to_string(),
+                insecure: false,
+            },
+        )
+        .unwrap();
+
+        let configured =
+            persist_auto_provisioned_remote(&repo, Some("origin"), "203.0.113.10:443", "org/repo")
+                .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://preview.heddle.sh/org/repo");
     }
 
     #[cfg(feature = "client")]

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -16,7 +16,9 @@ use heddle_git_projection::credential::EmbeddingSafeCredentialProvider;
 use hosted_client::client::HostedClient;
 use hosted_client::client::LocalSync;
 #[cfg(feature = "client")]
-use hosted_client::hosted_runtime::hosted::{HostedAuthMode, PullMaterialization};
+use hosted_client::hosted_runtime::hosted::{
+    HostedAuthMode, PullMaterialization, decode_pull_refs,
+};
 use objects::{
     object::{StateId, ThreadName, Tree},
     store::ObjectStore,
@@ -43,8 +45,6 @@ use verbs::{
     plan_pull, pull_should_materialize, show_plain_git_remote, show_remote,
 };
 pub(crate) use verbs::{resolve_default_remote_name, resolved_default_remote_name};
-#[cfg(feature = "client")]
-use wire::ProtocolError;
 
 use super::super::{
     action_line::print_next,
@@ -1176,41 +1176,21 @@ async fn pull_network_connected(
                             .await?,
                     )
                 } else {
-                    match client
-                        .try_get_thread_metadata(
+                    let folded_refs = decode_pull_refs(&result.checkpoint)
+                        .context("decode hosted pull refs")?
+                        .map(|decoded| decoded.refs)
+                        .unwrap_or_default();
+                    client
+                        .adopt_advertised_thread_identity(
                             repo,
                             repo_path,
+                            &folded_refs,
                             options.remote_thread,
                             final_state_id,
                         )
-                        .await?
-                    {
-                        Some(metadata) => Some(metadata),
-                        None => {
-                            match client
-                                .require_thread_id(repo_path, options.remote_thread)
-                                .await
-                            {
-                                Ok(stable_id) => {
-                                    ThreadManager::new(repo.heddle_dir())
-                                        .adopt_stable_identity_for_thread(
-                                            repo,
-                                            track_to_update,
-                                            &stable_id,
-                                            final_state_id,
-                                        )
-                                        .context(
-                                            "failed to persist hosted thread identity after pull",
-                                        )?;
-                                }
-                                Err(ProtocolError::ObjectNotFound(_)) => {
-                                    // Nothing advertised; first push may mint.
-                                }
-                                Err(error) => return Err(error.into()),
-                            }
-                            None
-                        }
-                    }
+                        .await
+                        .context("failed to persist hosted thread identity after pull")?;
+                    None
                 };
                 let track_tn = ThreadName::new(track_to_update);
                 let pre_target = repo.refs().get_thread(&track_tn)?;

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -43,6 +43,8 @@ use verbs::{
     plan_pull, pull_should_materialize, show_plain_git_remote, show_remote,
 };
 pub(crate) use verbs::{resolve_default_remote_name, resolved_default_remote_name};
+#[cfg(feature = "client")]
+use wire::ProtocolError;
 
 use super::super::{
     action_line::print_next,
@@ -1185,17 +1187,26 @@ async fn pull_network_connected(
                     {
                         Some(metadata) => Some(metadata),
                         None => {
-                            if let Ok(stable_id) = client
+                            match client
                                 .require_thread_id(repo_path, options.remote_thread)
                                 .await
                             {
-                                ThreadManager::new(repo.heddle_dir())
-                                    .adopt_stable_identity_for_thread(
-                                        repo,
-                                        track_to_update,
-                                        &stable_id,
-                                        final_state_id,
-                                    )?;
+                                Ok(stable_id) => {
+                                    ThreadManager::new(repo.heddle_dir())
+                                        .adopt_stable_identity_for_thread(
+                                            repo,
+                                            track_to_update,
+                                            &stable_id,
+                                            final_state_id,
+                                        )
+                                        .context(
+                                            "failed to persist hosted thread identity after pull",
+                                        )?;
+                                }
+                                Err(ProtocolError::ObjectNotFound(_)) => {
+                                    // Nothing advertised; first push may mint.
+                                }
+                                Err(error) => return Err(error.into()),
                             }
                             None
                         }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1174,7 +1174,32 @@ async fn pull_network_connected(
                             .await?,
                     )
                 } else {
-                    None
+                    match client
+                        .try_get_thread_metadata(
+                            repo,
+                            repo_path,
+                            options.remote_thread,
+                            final_state_id,
+                        )
+                        .await?
+                    {
+                        Some(metadata) => Some(metadata),
+                        None => {
+                            if let Ok(stable_id) = client
+                                .require_thread_id(repo_path, options.remote_thread)
+                                .await
+                            {
+                                ThreadManager::new(repo.heddle_dir())
+                                    .adopt_stable_identity_for_thread(
+                                        repo,
+                                        track_to_update,
+                                        &stable_id,
+                                        final_state_id,
+                                    )?;
+                            }
+                            None
+                        }
+                    }
                 };
                 let track_tn = ThreadName::new(track_to_update);
                 let pre_target = repo.refs().get_thread(&track_tn)?;
@@ -1317,17 +1342,14 @@ fn save_pulled_thread_metadata(
     pulled_state: &StateId,
     metadata: Option<SyncedThreadMetadata>,
 ) -> Result<()> {
-    let Some(mut metadata) = metadata else {
+    let Some(metadata) = metadata else {
         return Ok(());
     };
-    metadata.id = local_thread.to_string();
-    metadata.thread = local_thread.to_string();
-    metadata.current_state = Some(pulled_state.short());
-    metadata.shared_target_dir = None;
-    metadata
-        .integration_policy_result
-        .clear_untrusted_landing_fields();
-    ThreadManager::new(repo.heddle_dir()).save_record(&metadata)?;
+    ThreadManager::new(repo.heddle_dir()).save_pulled_metadata(
+        local_thread,
+        pulled_state,
+        metadata,
+    )?;
     Ok(())
 }
 

--- a/crates/cli/tests/cli_integration/context_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/context_anchor_travel.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//! CLI coverage for durable context-anchor travel across a file rename.
+//!
+//! Field gap after heddle#1579 / #1580: worktree capture of `lib.py` →
+//! `pkg/greeter.py` left `context check` reporting `file_missing` on the
+//! old path because travel could not load the pending `pkg/` subtree.
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle;
+
+fn json(output: &str) -> Value {
+    serde_json::from_str(output.trim()).expect("valid JSON output")
+}
+
+const PYTHON: &str = "def greet(name):\n    return f\"hello {name}\"\n";
+
+#[test]
+fn context_check_follows_a_python_mkdir_rename_after_capture() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    heddle(&["init"], Some(dir)).unwrap();
+    std::fs::write(dir.join("lib.py"), PYTHON).unwrap();
+    heddle(&["capture", "-m", "seed"], Some(dir)).unwrap();
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.py",
+            "--scope",
+            "symbol:greet",
+            "--kind",
+            "invariant",
+            "-m",
+            "greet stays a greeting",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    std::fs::create_dir(dir.join("pkg")).unwrap();
+    std::fs::rename(dir.join("lib.py"), dir.join("pkg/greeter.py")).unwrap();
+    heddle(&["capture", "-m", "move lib.py into pkg"], Some(dir)).unwrap();
+
+    let check = json(&heddle(&["--output", "json", "context", "check"], Some(dir)).unwrap());
+    assert_eq!(check["output_kind"], "context_check");
+    assert_eq!(check["annotations"], 1);
+    assert_eq!(check["fresh"], 1);
+    assert_eq!(check["stale"], 0);
+    let issues = check["issues"].as_array().cloned().unwrap_or_default();
+    assert!(
+        issues.iter().all(|issue| issue["reason"] != "file_missing"),
+        "rename+capture must not leave file_missing on the old path:\n{check}"
+    );
+
+    let moved = json(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "context",
+                "get",
+                "--path",
+                "pkg/greeter.py",
+            ],
+            Some(dir),
+        )
+        .unwrap(),
+    );
+    assert_eq!(moved["output_kind"], "context_get");
+    let annotations = moved["annotations"]
+        .as_array()
+        .expect("context get on the new path should return annotations");
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0]["content"], "greet stays a greeting");
+    assert_eq!(annotations[0]["anchor_status"], "resolved");
+
+    let old = json(
+        &heddle(
+            &["--output", "json", "context", "get", "--path", "lib.py"],
+            Some(dir),
+        )
+        .unwrap(),
+    );
+    let old_annotations = old["annotations"].as_array().cloned().unwrap_or_default();
+    assert!(
+        old_annotations.is_empty(),
+        "old path should be empty after travel:\n{old}"
+    );
+
+    let listed = json(&heddle(&["--output", "json", "context", "list"], Some(dir)).unwrap());
+    let items = listed["items"]
+        .as_array()
+        .expect("context list should wrap items");
+    assert!(
+        items.iter().any(|item| item["target"] == "pkg/greeter.py"),
+        "list must show the annotation on the new path:\n{listed}"
+    );
+    assert!(
+        items.iter().all(|item| item["target"] != "lib.py"),
+        "list must not keep a live annotation on the old path:\n{listed}"
+    );
+}

--- a/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
@@ -242,3 +242,43 @@ fn discuss_anchor_still_follows_a_file_rename() {
     assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
     assert_eq!(persisted.operation_count, 2);
 }
+
+#[test]
+fn discuss_anchor_still_follows_a_mkdir_rename() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("lib.py"),
+        "def greet(name):\n    return f\"hello {name}\"\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "lib.py", "greet", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::create_dir(temp.path().join("pkg")).unwrap();
+    std::fs::rename(
+        temp.path().join("lib.py"),
+        temp.path().join("pkg/greeter.py"),
+    )
+    .unwrap();
+    heddle(
+        &["capture", "-m", "move lib.py into pkg"],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "pkg/greeter.py", "greet", "moved");
+    assert_eq!(persisted.path, "pkg/greeter.py");
+    assert_eq!(persisted.symbol, "greet");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
+    assert_eq!(persisted.operation_count, 2);
+}

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1309,7 +1309,11 @@ fn local_clone_persists_source_thread_stable_id() {
     let dest_parent = TempDir::new().unwrap();
     let clone = dest_parent.path().join("clone");
     heddle(
-        &["clone", source.path().to_str().unwrap(), clone.to_str().unwrap()],
+        &[
+            "clone",
+            source.path().to_str().unwrap(),
+            clone.to_str().unwrap(),
+        ],
         None,
     )
     .unwrap();

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1283,10 +1283,9 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
     assert_eq!(landed["status"], "landed", "{landed}");
 
     let source_id = thread_stable_id(&source, "shuttle/runner");
-    assert_ne!(source_id, "shuttle/runner");
     assert_eq!(
         managed.id, source_id,
-        "pulled managed metadata must keep the source stable id, not the thread name"
+        "pulled managed metadata must keep the source stable id"
     );
 }
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1252,7 +1252,7 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
         repo.refs()
             .get_thread(&ThreadName::new("shuttle/runner"))
             .unwrap()
-            .map(|state| state.short())
+            .map(|state| state.to_string_full())
     );
 
     let listed = heddle(&["thread", "list", "--output", "json"], Some(&clone)).unwrap();

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -154,6 +154,15 @@ fn current_thread_state(cwd: &std::path::Path, thread: &str) -> String {
         .to_string()
 }
 
+fn thread_stable_id(cwd: &std::path::Path, thread: &str) -> String {
+    let repo = Repository::open(cwd).expect("open repository");
+    ThreadManager::new(repo.heddle_dir())
+        .find_record_by_thread(thread)
+        .expect("read thread records")
+        .unwrap_or_else(|| panic!("{thread} should have a persisted thread record"))
+        .id
+}
+
 fn log_head_state(cwd: &std::path::Path) -> String {
     let log_json =
         heddle(&["--output", "json", "log", "--limit", "1"], Some(cwd)).expect("log current state");
@@ -1272,6 +1281,78 @@ fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
     let landed: Value = serde_json::from_str(&landed).unwrap();
     assert_eq!(landed["output_kind"], "land", "{landed}");
     assert_eq!(landed["status"], "landed", "{landed}");
+
+    let source_id = thread_stable_id(&source, "shuttle/runner");
+    assert_ne!(source_id, "shuttle/runner");
+    assert_eq!(
+        managed.id, source_id,
+        "pulled managed metadata must keep the source stable id, not the thread name"
+    );
+}
+
+/// heddle#1701: a clean local clone must persist the source thread's stable
+/// identity. Hosted push (and weft `hosted_thread_records`) key on that id;
+/// minting a new UUIDv7 or filing the record under the ref name (`main`)
+/// is the clone→push exit-76 mismatch.
+#[test]
+fn local_clone_persists_source_thread_stable_id() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("main.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "source main"], Some(source.path())).unwrap();
+    let source_id = thread_stable_id(source.path(), "main");
+    assert!(
+        uuid::Uuid::parse_str(&source_id).is_ok(),
+        "source main must already carry a stable UUID, got {source_id}"
+    );
+
+    let dest_parent = TempDir::new().unwrap();
+    let clone = dest_parent.path().join("clone");
+    heddle(
+        &["clone", source.path().to_str().unwrap(), clone.to_str().unwrap()],
+        None,
+    )
+    .unwrap();
+
+    let cloned_id = thread_stable_id(&clone, "main");
+    assert_eq!(
+        cloned_id, source_id,
+        "clone must persist the source stable id, not mint a new one or use the ref name"
+    );
+    assert_ne!(cloned_id, "main");
+}
+
+/// heddle#1701: local pull must keep the source stable id. The previous
+/// `save_pulled_thread_metadata` stomped `metadata.id` to the local thread
+/// name (`main`), which cannot round-trip a hosted UUID.
+#[test]
+fn local_pull_preserves_source_thread_stable_id() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("main.txt"), "v1\n").unwrap();
+    heddle(&["capture", "-m", "source main"], Some(source.path())).unwrap();
+    let source_id = thread_stable_id(source.path(), "main");
+
+    let target = TempDir::new().unwrap();
+    heddle(&["init"], Some(target.path())).unwrap();
+    let target_id_before = thread_stable_id(target.path(), "main");
+    assert_ne!(
+        target_id_before, source_id,
+        "fixture: target init must mint its own main identity"
+    );
+
+    heddle(
+        &["pull", source.path().to_str().unwrap(), "--thread", "main"],
+        Some(target.path()),
+    )
+    .expect("pull main from the local source");
+
+    let pulled_id = thread_stable_id(target.path(), "main");
+    assert_eq!(
+        pulled_id, source_id,
+        "pull must adopt the source stable id, not keep the local init id or stomp to 'main'"
+    );
+    assert_ne!(pulled_id, "main");
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/visibility.rs
+++ b/crates/cli/tests/cli_integration/visibility.rs
@@ -453,6 +453,82 @@ fn undo_visibility_promote_reverts_tier() {
 }
 
 #[test]
+fn owner_clone_of_private_spool_after_visibility_discuss_and_context() {
+    // Field regression (2026-09-05): after `visibility set --tier private`
+    // plus discuss/context, owner clone failed exit 78 `state not found`.
+    // Local clone is the same object path (state + sidecar + attachments)
+    // without weft. The unrelated-principal deny stays grant-level Public
+    // (see `grant_can_see_tier`); this test is the owner's way in.
+    let (temp, _) = init_and_capture("ax-only");
+    fs::write(temp.path().join("note.rs"), "fn note() {}\n").unwrap();
+    let state = capture_state(temp.path(), "private head");
+    heddle(
+        &[
+            "visibility",
+            "set",
+            &state,
+            "--tier",
+            "private",
+            "--label",
+            "ax-only",
+        ],
+        Some(temp.path()),
+    )
+    .expect("visibility set private");
+    heddle(
+        &[
+            "discuss",
+            "open",
+            "note.rs",
+            "note",
+            "keep this ax-only",
+            "--visibility",
+            "private:ax-only",
+        ],
+        Some(temp.path()),
+    )
+    .expect("discuss open private");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "note.rs",
+            "--kind",
+            "constraint",
+            "-m",
+            "ax-only guidance",
+        ],
+        Some(temp.path()),
+    )
+    .expect("context set");
+
+    let clone = TempDir::new().unwrap();
+    let dest = clone.path().join("owner-clone");
+    heddle(
+        &[
+            "clone",
+            &temp.path().to_string_lossy(),
+            &dest.to_string_lossy(),
+        ],
+        None,
+    )
+    .unwrap_or_else(|err| panic!("owner clone of private-tier spool must succeed: {err}"));
+
+    let show = show_json(&dest, &state);
+    assert_eq!(
+        show["tier"], "private",
+        "cloned owner checkout must keep the Private sidecar: {show}"
+    );
+    assert_eq!(show["label"], "ax-only");
+    let note = fs::read(dest.join("note.rs")).expect("cloned worktree note");
+    assert_eq!(
+        note, b"fn note() {}\n",
+        "owner clone must materialize the advertised private head, not withhold it"
+    );
+}
+
+#[test]
 fn visibility_list_enumerates_tiered_states() {
     let (temp, _) = init_and_capture("ordinary");
     let state = capture_state(temp.path(), "ordinary capture");

--- a/crates/cli/tests/cli_workflow.rs
+++ b/crates/cli/tests/cli_workflow.rs
@@ -10,6 +10,8 @@
 mod support;
 use support::*;
 
+#[path = "cli_integration/context_anchor_travel.rs"]
+mod context_anchor_travel;
 #[path = "cli_integration/context_recovery_advice.rs"]
 mod context_recovery_advice;
 #[path = "cli_integration/context_rides_diff.rs"]

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -467,6 +467,8 @@ async fn push_one(
                         }),
                     );
                 }
+                // OpenDiscussion / AppendTurn echo the full discussion (≥2 turns
+                // after append). Adopt uses this last snapshot.
                 (index, server_id, true, Some(hosted))
             }
             Some(index) => {
@@ -492,6 +494,9 @@ async fn push_one(
                             (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
                         }),
                     );
+                    // Weft AppendTurn/OpenDiscussion echoes the full discussion
+                    // (≥2 turns after append). Adopt uses this snapshot so a
+                    // last-turn-only echo cannot under-adopt.
                     hosted = Some(echoed);
                 }
                 (index, server_id, !candidates.is_empty(), hosted)
@@ -504,7 +509,7 @@ async fn push_one(
             .repos
             .get_mut(repo_path)
             .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
-            && adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)?
+            && adopt_from_push_echo(store, head_state, local_id, hosted, entry)?
         {
             changed = true;
         }
@@ -1396,6 +1401,30 @@ fn parse_linked_op_id(local_turn_id: &str) -> Result<CollabOpId> {
         .unwrap_or(local_turn_id);
     op.parse()
         .map_err(|error| anyhow!("mirror turn link has an invalid CollabOpId {op:?}: {error}"))
+}
+
+/// The adopt `push_one` runs after keeping the last OpenDiscussion/AppendTurn
+/// echo. Weft echoes the **full** discussion (≥2 turns after append). Empty
+/// `turns` is a test-server / older-weft no-op. A short echo is refused so a
+/// last-turn-only snapshot cannot retire local turns it cannot replace.
+fn adopt_from_push_echo(
+    store: &CollaborationStore,
+    head_state: StateId,
+    local_id: &str,
+    hosted: &HostedDiscussion,
+    entry: &mut MirrorEntry,
+) -> Result<bool> {
+    if hosted.turns.is_empty() {
+        return Ok(false);
+    }
+    if hosted.turns.len() < entry.links.len() {
+        return Err(anyhow!(
+            "hosted echo for {local_id} has {} turn(s) but this discussion has {} linked op(s); refusing adopt so a partial echo cannot drop local turns",
+            hosted.turns.len(),
+            entry.links.len(),
+        ));
+    }
+    adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)
 }
 
 /// Replace local-only published turn ops with the envelopes a clone would
@@ -2859,6 +2888,10 @@ mod tests {
             references: Vec::new(),
         });
         let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+        assert!(
+            hosted.turns.len() >= 2,
+            "AppendTurn/OpenDiscussion echo is the full discussion, not the last turn only"
+        );
 
         let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
         let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
@@ -2961,6 +2994,225 @@ mod tests {
             originator_ids, clone_ids,
             "after adopt, originator open+append CollabOpIds must equal the hosted clone"
         );
+    }
+
+    // The adopt `push_one` runs after `hosted = Some(echoed)`: a multi-turn
+    // AppendTurn echo is the full discussion, so both local ops adopt.
+    #[tokio::test]
+    async fn push_echo_adopt_uses_full_discussion() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+        hosted_snapshot.turns.push(DiscussionTurn {
+            author: Principal::new("preview-user", ""),
+            body: "and a follow-up".to_string(),
+            posted_at: 1_700_000_043,
+            references: Vec::new(),
+        });
+        let echo = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+        assert!(
+            echo.turns.len() >= 2,
+            "the AppendTurn echo push_one keeps must include every turn, not only the last"
+        );
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(&[hosted_snapshot]),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            echo.turns.len() >= entry.links.len(),
+            "full echo must cover every linked local turn"
+        );
+        assert!(
+            adopt_from_push_echo(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &echo,
+                &mut entry,
+            )
+            .unwrap(),
+            "push_one's adopt must consume the full multi-turn echo"
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "push_one adopt from a full echo must match the hosted clone"
+        );
+        assert_eq!(
+            originator_store.operation_ids().unwrap().len(),
+            2,
+            "full-echo adopt must keep both published turns"
+        );
+    }
+
+    // A last-turn-only echo must not retire the unpublished prefix.
+    #[test]
+    fn partial_push_echo_does_not_under_adopt() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let mut partial = hosted_discussion_from_bootstrap(bootstrap_discussion(
+            &wire_id.to_string(),
+            originator_state,
+        ));
+        partial.turns.truncate(1);
+        assert_eq!(partial.turns.len(), 1);
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        let before = originator_store.operation_ids().unwrap();
+        let error = adopt_from_push_echo(
+            &originator_store,
+            originator_state,
+            &wire_id.to_string(),
+            &partial,
+            &mut entry,
+        )
+        .expect_err("a one-turn echo must not adopt over two linked local turns");
+        assert!(
+            error.to_string().contains("partial echo"),
+            "refuse must name the partial-echo hazard, got: {error}"
+        );
+        let after = originator_store.operation_ids().unwrap();
+        assert_eq!(
+            after, before,
+            "partial echo must leave both local ops in place"
+        );
+        assert!(after.contains(&originator_open));
+        assert!(after.contains(&originator_append));
     }
 
     // The remint site on the hosted-clone/pull path: originator already

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -1495,9 +1495,11 @@ fn adopt_hosted_canonical_turns(
     let already_canonical = linked_ops.len() == canonical.len()
         && canonical.iter().all(|(id, _)| linked_ops.contains(id));
     if already_canonical {
+        // Refresh mirror links (e.g. fill `server_turn_id`) without
+        // reporting a content change. apply_hosted_discussion still
+        // persists the mirror; live replay stays Unchanged.
         if entry.links != new_links {
             entry.links = new_links;
-            return Ok(true);
         }
         return Ok(false);
     }

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -38,6 +38,17 @@
 //! ordinal)` (see `turn_op_key`) — never a random per-write nonce — so the same
 //! server turn earns the same `CollabOpId` on every clone and a retry replays
 //! instead of conflicting or duplicating.
+//!
+//! `CollabOpId` still hashes the **full** envelope, including author and
+//! `occurred_at_ms`. Weft restamps both on accept, so an originator's local
+//! `heddle discuss open` (local git author + wall-clock time + CLI `--op-id`
+//! / v4 key) cannot content-address to the hosted envelope. That is why
+//! clones agreed with each other after #1677/#1697 while the originator
+//! still printed a different `co-…` (heddle#1695). After a successful push
+//! — and again on pull, when a linked local turn is not hosted-canonical —
+//! the originator **adopts** the same envelope a clone would materialize.
+//! The pre-push local-only op is retired (new bytes, new id; we do not
+//! rewrite bytes under the old id).
 //! Resolve-into-annotation operations use the same durable mirror: their
 //! request identity is derived from `(hosted discussion id, server resolution
 //! key)` (see `resolve_op_key`) and is recorded only after `ResolveDiscussion`
@@ -137,7 +148,7 @@ struct MirrorEntry {
     pulled_resolution_key: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct TurnLink {
     /// Local turn id: `{CollabOpId}#{index-within-op}` — the stable turn
     /// identity (unique even when a `LegacyImported` op carries many turns).
@@ -399,7 +410,7 @@ async fn push_one(
             heddle_cli_render::cli::style::warn_marker(),
         );
     }
-    let (index, server_id, mut changed) =
+    let (index, server_id, mut changed, hosted) =
         match entry_index {
             None => {
                 if candidates.is_empty() {
@@ -407,7 +418,7 @@ async fn push_one(
                 }
                 let (open_turn_id, open_body) = candidates[0].clone();
                 let proposed_id = local_id.to_string();
-                let hosted = client
+                let mut hosted = client
                     .open_discussion(
                         repo_path,
                         change_id,
@@ -436,7 +447,7 @@ async fn push_one(
                 });
                 let index = repo_mirror.discussions.len() - 1;
                 for (turn_id, body) in &candidates[1..] {
-                    let hosted = client
+                    hosted = client
                         .append_turn(
                             repo_path,
                             &server_id,
@@ -456,12 +467,13 @@ async fn push_one(
                         }),
                     );
                 }
-                (index, server_id, true)
+                (index, server_id, true, Some(hosted))
             }
             Some(index) => {
                 let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
+                let mut hosted = None;
                 for (turn_id, body) in &candidates {
-                    let hosted = client
+                    let echoed = client
                         .append_turn(
                             repo_path,
                             &server_id,
@@ -475,15 +487,28 @@ async fn push_one(
                         repo_path,
                         index,
                         turn_id.clone(),
-                        hosted.turns.len().saturating_sub(1),
-                        hosted.turns.last().and_then(|turn| {
+                        echoed.turns.len().saturating_sub(1),
+                        echoed.turns.last().and_then(|turn| {
                             (!turn.turn_id.is_empty()).then(|| turn.turn_id.clone())
                         }),
                     );
+                    hosted = Some(echoed);
                 }
-                (index, server_id, !candidates.is_empty())
+                (index, server_id, !candidates.is_empty(), hosted)
             }
         };
+
+    if let Some(hosted) = hosted.as_ref() {
+        let head_state = hosted_materialization_state(discussion, repo)?;
+        if let Some(entry) = mirror
+            .repos
+            .get_mut(repo_path)
+            .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+            && adopt_hosted_canonical_turns(store, head_state, local_id, hosted, entry)?
+        {
+            changed = true;
+        }
+    }
 
     if push_into_annotation_resolution(client, repo_path, mirror, index, &server_id, discussion)
         .await?
@@ -878,10 +903,6 @@ fn pull_one(
             // discussion is addressable by the same id on every clone; fall back
             // to a deterministic derivation for legacy `hc-` ids.
             let local_id = adopt_or_derive_local_id(&discussion.id);
-            let anchor = hosted_open_anchor(discussion, head_state);
-            let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
-            let visibility = parse_visibility_token(&discussion.visibility);
-
             let first = &discussion.turns[0];
             let open_op = write_local_operation(
                 store,
@@ -889,13 +910,7 @@ fn pull_one(
                 Vec::new(),
                 turn_attribution(first),
                 turn_ms(first),
-                CollaborationOperationBodyV1::Open {
-                    title,
-                    anchor,
-                    visibility,
-                    turn: turn_body(first)?,
-                    thread_ref: discussion.thread_ref.clone(),
-                },
+                hosted_turn_body(discussion, first, 0, head_state)?,
                 turn_op_key(&discussion.id, server_ordinal(first, 0))?,
             )?;
             // Record the mapping immediately so a mid-materialization failure
@@ -923,9 +938,7 @@ fn pull_one(
                     heads.clone(),
                     turn_attribution(turn),
                     turn_ms(turn),
-                    CollaborationOperationBodyV1::AppendTurn {
-                        turn: turn_body(turn)?,
-                    },
+                    hosted_turn_body(discussion, turn, list_index, head_state)?,
                     turn_op_key(&discussion.id, ordinal)?,
                 )?;
                 heads = vec![op_id];
@@ -1024,6 +1037,22 @@ fn pull_one(
 
     if pull_resolution(store, repo_path, mirror, discussion)? {
         changed = true;
+    }
+    if let Some(index) = mirror.repos.get(repo_path).and_then(|repo_mirror| {
+        repo_mirror
+            .discussions
+            .iter()
+            .position(|entry| entry.server_id == discussion.id)
+    }) {
+        let local_id = mirror.repos[repo_path].discussions[index].local_id.clone();
+        if let Some(entry) = mirror
+            .repos
+            .get_mut(repo_path)
+            .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+            && adopt_hosted_canonical_turns(store, head_state, &local_id, discussion, entry)?
+        {
+            changed = true;
+        }
     }
     Ok(changed)
 }
@@ -1322,6 +1351,141 @@ fn resolve_op_key(
     .to_string();
     CollaborationIdempotencyKey::new(raw)
         .map_err(|error| anyhow!("invalid idempotency key: {error}"))
+}
+
+fn hosted_materialization_state(
+    discussion: &MaterializedDiscussion,
+    repo: &Repository,
+) -> Result<StateId> {
+    match &discussion.anchor {
+        CollaborationAnchor::Symbol { state_id, .. }
+        | CollaborationAnchor::State { state_id }
+        | CollaborationAnchor::Path { state_id, .. } => Ok(*state_id),
+        _ => repo
+            .head()
+            .context("resolve repository head for hosted turn adoption")?
+            .ok_or_else(|| anyhow!("cannot adopt hosted turn ops without an anchor state")),
+    }
+}
+
+fn hosted_turn_body(
+    discussion: &HostedDiscussion,
+    turn: &HostedDiscussionTurn,
+    index: usize,
+    head_state: StateId,
+) -> Result<CollaborationOperationBodyV1> {
+    if index == 0 {
+        Ok(CollaborationOperationBodyV1::Open {
+            title: derive_title(&turn.body, &discussion.symbol),
+            anchor: hosted_open_anchor(discussion, head_state),
+            visibility: parse_visibility_token(&discussion.visibility),
+            turn: turn_body(turn)?,
+            thread_ref: discussion.thread_ref.clone(),
+        })
+    } else {
+        Ok(CollaborationOperationBodyV1::AppendTurn {
+            turn: turn_body(turn)?,
+        })
+    }
+}
+
+fn parse_linked_op_id(local_turn_id: &str) -> Result<CollabOpId> {
+    let op = local_turn_id
+        .split_once('#')
+        .map(|(op, _)| op)
+        .unwrap_or(local_turn_id);
+    op.parse()
+        .map_err(|error| anyhow!("mirror turn link has an invalid CollabOpId {op:?}: {error}"))
+}
+
+/// Replace local-only published turn ops with the envelopes a clone would
+/// materialize from `hosted`. No-op when the local linked ops already are
+/// those envelopes, or when unpublished local turns still parent the chain.
+fn adopt_hosted_canonical_turns(
+    store: &CollaborationStore,
+    head_state: StateId,
+    local_id: &str,
+    hosted: &HostedDiscussion,
+    entry: &mut MirrorEntry,
+) -> Result<bool> {
+    if hosted.turns.is_empty() || hosted.id.is_empty() {
+        return Ok(false);
+    }
+    let local_record: DiscussionRecordId = local_id
+        .parse()
+        .map_err(|error| anyhow!("invalid local discussion id {local_id}: {error}"))?;
+    let Some(existing) = store
+        .materialize_discussion(&local_record)
+        .context("materialize discussion before hosted CollabOpId adoption")?
+    else {
+        return Ok(false);
+    };
+
+    let linked_ops: HashSet<CollabOpId> = entry
+        .links
+        .iter()
+        .map(|link| parse_linked_op_id(&link.local_turn_id))
+        .collect::<Result<HashSet<_>>>()?;
+    if existing
+        .turns
+        .iter()
+        .any(|(op_id, _)| !linked_ops.contains(op_id))
+    {
+        // An unpushed local turn still parents the published prefix. Rewriting
+        // the prefix would orphan that child; wait until it is published.
+        return Ok(false);
+    }
+
+    let mut parents = Vec::new();
+    let mut canonical = Vec::with_capacity(hosted.turns.len());
+    let mut new_links = Vec::with_capacity(hosted.turns.len());
+    for (index, turn) in hosted.turns.iter().enumerate() {
+        let ordinal = server_ordinal(turn, index);
+        let envelope = CollaborationOperationEnvelope::new(
+            local_record,
+            parents.clone(),
+            turn_op_key(&hosted.id, ordinal)?,
+            turn_attribution(turn),
+            turn_ms(turn),
+            hosted_turn_body(hosted, turn, index, head_state)?,
+        )
+        .context("build hosted-canonical collaboration operation")?;
+        let bytes = envelope
+            .encode()
+            .map_err(|error| anyhow!("encode hosted-canonical operation: {error}"))?;
+        let id = CollabOpId::for_bytes(&bytes);
+        new_links.push(TurnLink {
+            local_turn_id: turn_identity(&id, 0),
+            server_ordinal: ordinal,
+            server_turn_id: server_turn_id(turn),
+        });
+        canonical.push((id, envelope));
+        parents = vec![id];
+    }
+
+    let already_canonical = linked_ops.len() == canonical.len()
+        && canonical.iter().all(|(id, _)| linked_ops.contains(id));
+    if already_canonical {
+        if entry.links != new_links {
+            entry.links = new_links;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    let retire: Vec<CollabOpId> = linked_ops
+        .into_iter()
+        .filter(|id| !canonical.iter().any(|(canonical_id, _)| canonical_id == id))
+        .collect();
+    let write: Vec<CollaborationOperationEnvelope> = canonical
+        .into_iter()
+        .map(|(_, envelope)| envelope)
+        .collect();
+    store
+        .replace_operations(&retire, &write)
+        .context("adopt hosted-canonical collaboration operations")?;
+    entry.links = new_links;
+    Ok(true)
 }
 
 fn write_local_operation(
@@ -2210,9 +2374,15 @@ mod tests {
             let bootstrap = vec![bootstrap_discussion(&wire_id, state)];
             let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
             assert_eq!(
-                pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
-                    .await
-                    .unwrap(),
+                pull_discussions(
+                    &repo,
+                    &mut client,
+                    "acme/widgets",
+                    Some(&bootstrap),
+                    Some(state)
+                )
+                .await
+                .unwrap(),
                 1
             );
             client.close().await;
@@ -2224,8 +2394,13 @@ mod tests {
                 store.materialize_discussion(&originator).unwrap().is_some(),
                 "clone must be addressable by the originator's id {originator}"
             );
-            let ids: Vec<DiscussionRecordId> =
-                store.materialize().unwrap().discussions.keys().copied().collect();
+            let ids: Vec<DiscussionRecordId> = store
+                .materialize()
+                .unwrap()
+                .discussions
+                .keys()
+                .copied()
+                .collect();
             materialized_ids.push(ids);
         }
         assert_eq!(
@@ -2270,16 +2445,26 @@ mod tests {
         // A pulls its own discussion back — same id on the wire, mirror empty.
         let bootstrap = vec![bootstrap_discussion(&local_id.to_string(), state)];
         let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
-        pull_discussions(&repo, &mut client, "acme/widgets", Some(&bootstrap), Some(state))
-            .await
-            .unwrap();
+        pull_discussions(
+            &repo,
+            &mut client,
+            "acme/widgets",
+            Some(&bootstrap),
+            Some(state),
+        )
+        .await
+        .unwrap();
         client.close().await;
         server.await.unwrap();
 
         // No duplicate `Open` root: exactly one discussion, still addressable, and
         // the single seeded turn reconciled rather than duplicated.
         let materialized = store.materialize().unwrap();
-        assert_eq!(materialized.discussions.len(), 1, "must not duplicate the discussion");
+        assert_eq!(
+            materialized.discussions.len(),
+            1,
+            "must not duplicate the discussion"
+        );
         assert!(materialized.discussions.contains_key(&local_id));
         assert_eq!(
             store.operation_ids().unwrap().len(),
@@ -2532,6 +2717,364 @@ mod tests {
             store.operation_ids().unwrap().len(),
             after_first,
             "a retry must dedupe, not append a duplicate op"
+        );
+    }
+
+    // heddle#1695: originator-local CollabOpId (random key + local author +
+    // wall-clock time) must become the hosted-canonical id a clone materializes
+    // from the same weft snapshot. Two clones already agreed after #1677/#1697;
+    // this is the hosted-clone path against an originator who opened locally.
+    #[tokio::test]
+    async fn originator_adopts_hosted_open_op_so_clone_agrees() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let hosted_snapshot = {
+            let mut discussion = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+            discussion.turns[0].author = Principal::new("preview-user", "");
+            discussion.turns[0].posted_at = 1_700_000_042;
+            discussion
+        };
+        let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+
+        let (originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let _ = originator_temp;
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "a title the clone will not see".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+
+        let (clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let _ = clone_temp;
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(std::slice::from_ref(&hosted_snapshot)),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_ne!(
+            vec![originator_open.to_string()],
+            clone_ids,
+            "pre-adopt originator CollabOpId must differ from the hosted clone (the remint this test exists to close)"
+        );
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![TurnLink {
+                local_turn_id: turn_identity(&originator_open, 0),
+                server_ordinal: 0,
+                server_turn_id: None,
+            }],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap(),
+            "originator must adopt the hosted-canonical open op"
+        );
+        assert!(
+            !adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap(),
+            "a second adopt must be a no-op"
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "after adopt, originator CollabOpId must equal the hosted clone"
+        );
+        assert_eq!(
+            originator_store.operation_ids().unwrap().len(),
+            1,
+            "adopt must retire the local-only open, not leave two Open roots"
+        );
+    }
+
+    // Same contract for open + append: the whole published chain adopts so
+    // parent pointers stay hosted-canonical.
+    #[tokio::test]
+    async fn originator_adopts_hosted_open_and_append_so_clone_agrees() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+        hosted_snapshot.turns.push(DiscussionTurn {
+            author: Principal::new("preview-user", ""),
+            body: "and a follow-up".to_string(),
+            posted_at: 1_700_000_043,
+            references: Vec::new(),
+        });
+        let hosted = hosted_discussion_from_bootstrap(hosted_snapshot.clone());
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let originator_append = write_local_operation(
+            &originator_store,
+            wire_id,
+            vec![originator_open],
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_222,
+            CollaborationOperationBodyV1::AppendTurn {
+                turn: DiscussionTurnV1::new("and a follow-up").unwrap(),
+            },
+            test_key("originator-local-append"),
+        )
+        .unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut client,
+            "acme/widgets",
+            Some(&[hosted_snapshot]),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        client.close().await;
+        server.await.unwrap();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(clone_ids.len(), 2);
+
+        let mut entry = MirrorEntry {
+            local_id: wire_id.to_string(),
+            server_id: wire_id.to_string(),
+            links: vec![
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                },
+                TurnLink {
+                    local_turn_id: turn_identity(&originator_append, 0),
+                    server_ordinal: 1,
+                    server_turn_id: None,
+                },
+            ],
+            resolved_into_annotation_operation_id: None,
+            pulled_resolution_key: None,
+        };
+        assert!(
+            adopt_hosted_canonical_turns(
+                &originator_store,
+                originator_state,
+                &wire_id.to_string(),
+                &hosted,
+                &mut entry,
+            )
+            .unwrap()
+        );
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        assert_eq!(
+            originator_ids, clone_ids,
+            "after adopt, originator open+append CollabOpIds must equal the hosted clone"
+        );
+    }
+
+    // The remint site on the hosted-clone/pull path: originator already
+    // published (mirror link exists) but still holds the local-only open op.
+    // pull_one must adopt the hosted-canonical envelope so the originator
+    // matches a fresh clone of the same snapshot.
+    #[tokio::test]
+    async fn pull_adopts_originator_local_open_to_match_clone() {
+        let wire_id = DiscussionRecordId::generate();
+        let (_temp0, _repo0, anchor_state) = seed_repo_with_state();
+        let mut hosted_snapshot = bootstrap_discussion(&wire_id.to_string(), anchor_state);
+        hosted_snapshot.turns[0].author = Principal::new("preview-user", "");
+        hosted_snapshot.turns[0].posted_at = 1_700_000_042;
+
+        let (_originator_temp, originator_repo, originator_state) = seed_repo_with_state();
+        let originator_store = CollaborationStore::open(originator_repo.heddle_dir()).unwrap();
+        let originator_open = write_local_operation(
+            &originator_store,
+            wire_id,
+            Vec::new(),
+            Attribution::human(Principal::new("Local Author", "local@example.com")),
+            1_111_111_111_111,
+            CollaborationOperationBodyV1::Open {
+                title: "local title".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: originator_state,
+                    path: "lib.rs".to_string(),
+                    symbol: "run".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("keep this invariant").unwrap(),
+                thread_ref: None,
+            },
+            test_key("originator-local-open"),
+        )
+        .unwrap();
+        let mut mirror = HostedMirror::default();
+        mirror
+            .repos
+            .entry("acme/widgets".to_string())
+            .or_default()
+            .discussions
+            .push(MirrorEntry {
+                local_id: wire_id.to_string(),
+                server_id: wire_id.to_string(),
+                links: vec![TurnLink {
+                    local_turn_id: turn_identity(&originator_open, 0),
+                    server_ordinal: 0,
+                    server_turn_id: None,
+                }],
+                resolved_into_annotation_operation_id: None,
+                pulled_resolution_key: None,
+            });
+        save_mirror(originator_repo.heddle_dir(), &mirror).unwrap();
+
+        let (_clone_temp, clone_repo, clone_head) = seed_repo_with_state();
+        let (mut clone_client, clone_server) =
+            crate::hosted_runtime::hosted::test_server::start().await;
+        pull_discussions(
+            &clone_repo,
+            &mut clone_client,
+            "acme/widgets",
+            Some(std::slice::from_ref(&hosted_snapshot)),
+            Some(clone_head),
+        )
+        .await
+        .unwrap();
+        clone_client.close().await;
+        clone_server.await.unwrap();
+
+        let (mut originator_client, originator_server) =
+            crate::hosted_runtime::hosted::test_server::start().await;
+        assert_eq!(
+            pull_discussions(
+                &originator_repo,
+                &mut originator_client,
+                "acme/widgets",
+                Some(&[hosted_snapshot]),
+                Some(originator_state),
+            )
+            .await
+            .unwrap(),
+            1,
+            "pull must adopt the hosted-canonical open op"
+        );
+        originator_client.close().await;
+        originator_server.await.unwrap();
+
+        let mut originator_ids: Vec<String> = originator_store
+            .operation_ids()
+            .unwrap()
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect();
+        originator_ids.sort();
+        let clone_ids: Vec<String> = {
+            let store = CollaborationStore::open(clone_repo.heddle_dir()).unwrap();
+            let mut ids: Vec<String> = store
+                .operation_ids()
+                .unwrap()
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(
+            originator_ids, clone_ids,
+            "hosted pull must leave the originator with the same CollabOpId a clone materializes"
+        );
+        assert_ne!(
+            originator_ids,
+            vec![originator_open.to_string()],
+            "pull must retire the local-only open op, not keep it"
         );
     }
 }

--- a/crates/hosted-client/src/client/local_sync.rs
+++ b/crates/hosted-client/src/client/local_sync.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use objects::{
     object::{ActionId, ContentHash, StateAttachment, StateId},
     store::{ObjectStore, SidecarStore},
@@ -354,8 +354,10 @@ impl LocalSync {
     }
 
     /// If the source repository has state-visibility records for `state`,
-    /// ferry the sidecar bytes through the same repository boundary used by
-    /// the network path.
+    /// copy them through the local-trust boundary. Hosted `accept_wire`
+    /// requires `[metadata] trusted_keys`; a fresh clone does not have
+    /// them, and dropping a `Private` sidecar makes the advertised head
+    /// unresolvable.
     fn propagate_state_visibility_for_state(
         &self,
         target: &Repository,
@@ -364,7 +366,7 @@ impl LocalSync {
         let Some(bytes) = self.source.get_state_visibility_bytes_for_state(state)? else {
             return Ok(());
         };
-        target.accept_wire_state_visibility(*state, &bytes)?;
+        target.accept_local_state_visibility(*state, &bytes)?;
         Ok(())
     }
 
@@ -384,7 +386,8 @@ impl LocalSync {
 #[cfg(test)]
 mod tests {
     use objects::object::{
-        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, Tree, TreeEntry,
+        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, StateVisibility, Tree,
+        TreeEntry, VisibilityTier,
     };
     use repo::StateAttachmentKind;
     use tempfile::TempDir;
@@ -447,9 +450,12 @@ mod tests {
             .expect("put context blob");
         let context_root = source
             .store()
-            .put_tree(&Tree::from_entries(vec![
-                TreeEntry::file("context.msgpack", context_blob, false).unwrap(),
-            ]))
+            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
+                "context.msgpack",
+                context_blob,
+                false,
+            )
+            .unwrap()]))
             .expect("put context tree");
         let first = StateAttachment {
             state_id,
@@ -480,6 +486,41 @@ mod tests {
                 .latest_state_attachment(&state_id, StateAttachmentKind::Context)
                 .unwrap(),
             Some(second)
+        );
+    }
+
+    #[test]
+    fn fetch_copies_private_visibility_sidecar() {
+        let source_dir = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+        let source = Repository::init_default(source_dir.path()).unwrap();
+        let target = Repository::init_default(target_dir.path()).unwrap();
+        let state_id = capture(&source, "secret\n", "embargo");
+        source
+            .put_state_visibility(StateVisibility {
+                state: state_id,
+                tier: VisibilityTier::Private {
+                    scope_label: "ax-only".into(),
+                },
+                embargo_until: None,
+                declarer: Principal::new("Alice", "alice@example.test"),
+                declared_at: chrono::Utc::now(),
+                signature: None,
+                supersedes: None,
+            })
+            .expect("put private visibility");
+
+        LocalSync::open(source_dir.path())
+            .unwrap()
+            .fetch_state(&target, &state_id)
+            .expect("owner local fetch of a private-tier state");
+
+        assert!(target.store().get_state(&state_id).unwrap().is_some());
+        assert_eq!(
+            target.effective_visibility_tier(&state_id).unwrap(),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            }
         );
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -71,7 +71,8 @@ pub use session::{HostedAuthMode, HostedSession};
 #[cfg(test)]
 pub(crate) use sync::PullBootstrapMetadata;
 pub use sync::{
-    HostedRefEntry, decode_pull_bootstrap, decode_pull_refs, persist_advertised_thread_identity,
+    HostedRefEntry, advertised_user_thread_id, decode_pull_bootstrap, decode_pull_refs,
+    persist_advertised_thread_identity, persist_advertised_thread_identity_with_live_fallback,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -70,7 +70,9 @@ use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
 #[cfg(test)]
 pub(crate) use sync::PullBootstrapMetadata;
-pub use sync::{HostedRefEntry, decode_pull_bootstrap, decode_pull_refs};
+pub use sync::{
+    HostedRefEntry, decode_pull_bootstrap, decode_pull_refs, persist_advertised_thread_identity,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RenewableAuthorityCredential {

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -72,7 +72,7 @@ pub use session::{HostedAuthMode, HostedSession};
 pub(crate) use sync::PullBootstrapMetadata;
 pub use sync::{
     HostedRefEntry, advertised_user_thread_id, decode_pull_bootstrap, decode_pull_refs,
-    persist_advertised_thread_identity, persist_advertised_thread_identity_with_live_fallback,
+    persist_advertised_thread_identity,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -93,6 +93,9 @@ type PullRefsPayloadWithThreadId = (
     Option<Vec<u8>>,
     Vec<(String, Vec<u8>, bool, String, String)>,
 );
+/// One folded ref after V1/V2 decode: `thread_id` is `None` when omitted or empty.
+type FoldedRefRecord = (String, Vec<u8>, bool, String, Option<String>);
+type DecodedPullRefs = (String, Option<Vec<u8>>, Vec<FoldedRefRecord>);
 type PullRepositoryInitializer<'a> =
     Box<dyn FnOnce(&PullReady) -> Result<Repository, ProtocolError> + 'a>;
 
@@ -257,16 +260,7 @@ pub fn decode_pull_refs(checkpoint: &[u8]) -> Result<Option<PullBootstrapRefs>, 
     Ok(Some(PullBootstrapRefs { head_thread, refs }))
 }
 
-fn decode_folded_ref_records(
-    payload: &[u8],
-) -> Result<
-    (
-        String,
-        Option<Vec<u8>>,
-        Vec<(String, Vec<u8>, bool, String, Option<String>)>,
-    ),
-    ProtocolError,
-> {
+fn decode_folded_ref_records(payload: &[u8]) -> Result<DecodedPullRefs, ProtocolError> {
     if let Ok((head_thread, head_state, refs)) =
         rmp_serde::from_slice::<PullRefsPayloadWithThreadId>(payload)
     {

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -707,10 +707,34 @@ impl HostedClient {
         remote_thread: &str,
         pulled_state: StateId,
     ) -> Result<SyncedThreadMetadata, ProtocolError> {
+        self.try_get_thread_metadata(repo, repo_path, remote_thread, pulled_state)
+            .await?
+            .ok_or_else(|| {
+                ProtocolError::InvalidState(format!(
+                    "hosted thread '{remote_thread}' has no managed metadata; no local thread was created"
+                ))
+            })
+    }
+
+    /// Like [`get_thread_metadata`], but returns `None` when the remote has
+    /// no managed record yet. Clone/pull use this so a missing GetThread
+    /// can fall back to the advertised ListRefs stable id.
+    pub async fn try_get_thread_metadata(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        pulled_state: StateId,
+    ) -> Result<Option<SyncedThreadMetadata>, ProtocolError> {
+        let thread_id = match self.require_thread_id(repo_path, remote_thread).await {
+            Ok(thread_id) => thread_id,
+            Err(ProtocolError::ObjectNotFound(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
         let request = GetThreadRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             name: remote_thread.to_string(),
-            thread_id: self.require_thread_id(repo_path, remote_thread).await?,
+            thread_id,
         };
         let summary = match self.routes().get_thread(&request).await {
             Ok(summary) => summary,
@@ -724,14 +748,12 @@ impl HostedClient {
                             ..
                         }
                 ) {
-                    return Err(ProtocolError::InvalidState(format!(
-                        "hosted thread '{remote_thread}' has no managed metadata; no local thread was created"
-                    )));
+                    return Ok(None);
                 }
                 return Err(error);
             }
         };
-        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary)
+        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary).map(Some)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4326,6 +4348,81 @@ mod native_exchange_tests {
             .expect("legacy main metadata must be persisted after the first push");
         assert_eq!(persisted.id, first_metadata.name);
         assert_eq!(persisted.thread, "main");
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clone_like_push_reuses_adopted_hosted_thread_stable_id() {
+        let (mut client, server, captured) =
+            crate::hosted_runtime::hosted::test_server::start_recording_push().await;
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let hosted_id = "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff";
+        save_thread_record(&repo, state, hosted_id, "main");
+
+        let _ = client
+            .push_with_expected_head_profiled(
+                &repo,
+                "acme/widgets",
+                state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "publish-thread-id-op".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let clone = TempDir::new().unwrap();
+        let (clone_repo, clone_state) = repository(&clone);
+        let manager = ThreadManager::new(clone_repo.heddle_dir());
+        let minted = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone init mints its own main identity");
+        assert_ne!(minted.id, hosted_id);
+
+        manager
+            .adopt_stable_identity_for_thread(&clone_repo, "main", hosted_id, clone_state)
+            .unwrap();
+
+        let _ = client
+            .push_with_expected_head_profiled(
+                &clone_repo,
+                "acme/widgets",
+                clone_state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "clone-push-thread-id-op".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let requests = captured
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0]
+                .thread_metadata
+                .as_ref()
+                .expect("publish must send thread metadata")
+                .name,
+            hosted_id
+        );
+        assert_eq!(
+            requests[1]
+                .thread_metadata
+                .as_ref()
+                .expect("clone push must send thread metadata")
+                .name,
+            hosted_id,
+            "push after adopting the hosted id must round-trip it, not mint a new UUIDv7"
+        );
 
         client.close().await;
         server.await.unwrap();

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -80,10 +80,18 @@ type PullBootstrapPayload = (
     bool,
     Vec<(ContextTarget, ContextBlob)>,
 );
+/// Current weft folded PullReady refs: `(name, state, is_thread, revision)`.
 type PullRefsPayload = (
     String,
     Option<Vec<u8>>,
     Vec<(String, Vec<u8>, bool, String)>,
+);
+/// weft#2055+ PullReady advertisement: same 4-tuple plus `thread_id`.
+/// Empty `thread_id` is treated as absent (defense in depth).
+type PullRefsPayloadWithThreadId = (
+    String,
+    Option<Vec<u8>>,
+    Vec<(String, Vec<u8>, bool, String, String)>,
 );
 type PullRepositoryInitializer<'a> =
     Box<dyn FnOnce(&PullReady) -> Result<Repository, ProtocolError> + 'a>;
@@ -217,21 +225,23 @@ pub fn decode_pull_refs(checkpoint: &[u8]) -> Result<Option<PullBootstrapRefs>, 
         })?;
     let payload = hex::decode(payload)
         .map_err(|error| ProtocolError::InvalidState(format!("decode pull refs: {error}")))?;
-    let (head_thread, head_state, refs): PullRefsPayload = rmp_serde::from_slice(&payload)
-        .map_err(|error| ProtocolError::InvalidState(format!("decode pull refs: {error}")))?;
+    // Primary path: adopt the PullReady advertisement when weft includes
+    // `thread_id` (weft#2055+). Legacy 4-tuples still decode; clone/pull
+    // then refresh live ListRefs only because those folds omit the id.
+    let (head_thread, head_state, refs) = decode_folded_ref_records(&payload)?;
     let head_state = head_state
         .map(|value| decode_bootstrap_state_id(value, "head state"))
         .transpose()?;
     let refs = refs
         .into_iter()
-        .map(|(name, state_id, is_thread, revision_address)| {
+        .map(|(name, state_id, is_thread, revision_address, thread_id)| {
             let state_id = decode_bootstrap_state_id(state_id, "ref state")?;
             Ok(HostedRefEntry::from_advertised(
                 name,
                 state_id,
                 is_thread,
                 revision_address,
-                None,
+                thread_id,
             ))
         })
         .collect::<Result<Vec<_>, ProtocolError>>()?;
@@ -245,6 +255,46 @@ pub fn decode_pull_refs(checkpoint: &[u8]) -> Result<Option<PullBootstrapRefs>, 
         }
     };
     Ok(Some(PullBootstrapRefs { head_thread, refs }))
+}
+
+fn decode_folded_ref_records(
+    payload: &[u8],
+) -> Result<
+    (
+        String,
+        Option<Vec<u8>>,
+        Vec<(String, Vec<u8>, bool, String, Option<String>)>,
+    ),
+    ProtocolError,
+> {
+    if let Ok((head_thread, head_state, refs)) =
+        rmp_serde::from_slice::<PullRefsPayloadWithThreadId>(payload)
+    {
+        let refs = refs
+            .into_iter()
+            .map(|(name, state_id, is_thread, revision_address, thread_id)| {
+                (
+                    name,
+                    state_id,
+                    is_thread,
+                    revision_address,
+                    (!thread_id.is_empty()).then_some(thread_id),
+                )
+            })
+            .collect();
+        return Ok((head_thread, head_state, refs));
+    }
+    let (head_thread, head_state, refs): PullRefsPayload = rmp_serde::from_slice(payload)
+        .map_err(|error| ProtocolError::InvalidState(format!("decode pull refs: {error}")))?;
+    Ok((
+        head_thread,
+        head_state,
+        refs.into_iter()
+            .map(|(name, state_id, is_thread, revision_address)| {
+                (name, state_id, is_thread, revision_address, None)
+            })
+            .collect(),
+    ))
 }
 
 fn decode_bootstrap_state_id(value: Vec<u8>, field: &str) -> Result<StateId, ProtocolError> {
@@ -509,7 +559,10 @@ impl HostedRefEntry {
     }
 }
 
-/// Advertised ListRefs `thread_id` for a user thread, if present and non-empty.
+/// Advertised `thread_id` for a user thread, if present and non-empty.
+///
+/// The primary source is PullReady/folded refs once weft#2055+ includes
+/// the field. ListRefs entries use the same `HostedRefEntry` shape.
 pub fn advertised_user_thread_id<'a>(
     remote_refs: &'a [HostedRefEntry],
     track_name: &str,
@@ -521,10 +574,11 @@ pub fn advertised_user_thread_id<'a>(
         .filter(|id| !id.is_empty())
 }
 
-/// Persist the ListRefs-advertised stable id as the local thread identity.
+/// Persist an advertised stable id as the local thread identity.
 ///
-/// Clone uses this when GetThread is missing; tests drive the same helper so
-/// a later push cannot mint a different UUIDv7.
+/// Clone and pull share this after GetThread misses. Callers pass the
+/// refs that already advertise — PullReady first, live ListRefs only
+/// while folded refs still omit the id.
 pub fn persist_advertised_thread_identity(
     repo: &Repository,
     remote_refs: &[HostedRefEntry],
@@ -541,27 +595,6 @@ pub fn persist_advertised_thread_identity(
         *final_state,
     )?;
     Ok(())
-}
-
-/// Persist from folded PullReady refs when they advertise an id; otherwise
-/// from a live ListRefs advertisement. Folded refs currently decode with
-/// `thread_id: None`.
-pub fn persist_advertised_thread_identity_with_live_fallback(
-    repo: &Repository,
-    folded_refs: &[HostedRefEntry],
-    live_refs: Option<&[HostedRefEntry]>,
-    track_name: &str,
-    final_state: &StateId,
-) -> objects::error::Result<()> {
-    if advertised_user_thread_id(folded_refs, track_name).is_some() {
-        return persist_advertised_thread_identity(repo, folded_refs, track_name, final_state);
-    }
-    persist_advertised_thread_identity(
-        repo,
-        live_refs.unwrap_or(folded_refs),
-        track_name,
-        final_state,
-    )
 }
 
 impl PullObjectMix {
@@ -773,8 +806,8 @@ impl HostedClient {
 
     /// Like [`get_thread_metadata`], but returns `None` when the remote has
     /// no managed record yet, including GetThread with an empty `thread_id`.
-    /// Clone/pull use this so a missing or empty-id GetThread can fall back
-    /// to the advertised ListRefs stable id.
+    /// Empty-id is defense in depth: clone/pull then adopt from the
+    /// PullReady/ListRefs advertisement instead of failing closed.
     pub async fn try_get_thread_metadata(
         &mut self,
         repo: &Repository,
@@ -810,6 +843,43 @@ impl HostedClient {
             }
         };
         super::thread_metadata::try_from_summary(repo, remote_thread, pulled_state, summary)
+    }
+
+    /// Adopt hosted thread identity after clone or default-thread pull.
+    ///
+    /// Order:
+    /// 1. GetThread metadata when it carries a non-empty `thread_id`.
+    /// 2. The PullReady/folded advertisement already in hand.
+    /// 3. Live ListRefs only while those folded refs still omit the id.
+    ///
+    /// ListRefs is not the design center. weft PullReady should advertise
+    /// `thread_id` (weft#2055+); keep the refresh until stock folds do.
+    pub async fn adopt_advertised_thread_identity(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        folded_refs: &[HostedRefEntry],
+        track_name: &str,
+        final_state: StateId,
+    ) -> Result<(), ProtocolError> {
+        if let Some(metadata) = self
+            .try_get_thread_metadata(repo, repo_path, track_name, final_state)
+            .await?
+        {
+            ThreadManager::new(repo.heddle_dir())
+                .save_pulled_metadata(track_name, &final_state, metadata)
+                .map_err(ProtocolError::from)?;
+            return Ok(());
+        }
+        if advertised_user_thread_id(folded_refs, track_name).is_some() {
+            persist_advertised_thread_identity(repo, folded_refs, track_name, &final_state)
+                .map_err(ProtocolError::from)?;
+            return Ok(());
+        }
+        let live_refs = self.list_refs_with_revision_addresses(repo_path).await?;
+        persist_advertised_thread_identity(repo, &live_refs, track_name, &final_state)
+            .map_err(ProtocolError::from)?;
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3430,11 +3500,70 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[0].revision_address, "git:0123456789abcdef");
         assert!(
             decoded.refs[0].thread_id.is_none(),
-            "folded PullReady refs currently decode without thread_id"
+            "legacy 4-tuple PullReady refs omit thread_id until weft#2055+"
         );
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert_eq!(decoded.refs[1].kind, RefKind::Marker);
+    }
+
+    #[test]
+    fn folded_refs_decode_advertised_thread_id_when_present() {
+        let main = StateId::from_bytes([7; 32]);
+        let payload: PullRefsPayloadWithThreadId = (
+            "main".to_string(),
+            Some(main.as_bytes().to_vec()),
+            vec![(
+                "main".to_string(),
+                main.as_bytes().to_vec(),
+                true,
+                RevisionAddress::heddle(main).to_string(),
+                "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff".to_string(),
+            )],
+        );
+        let checkpoint = format!(
+            "{PULL_REFS_LINE_PREFIX}{}\t{}\n",
+            hex::encode(rmp_serde::to_vec_named(&payload).expect("encode refs fixture")),
+            StateId::from_bytes([0; 32]).to_string_full(),
+        );
+
+        let decoded = decode_pull_refs(checkpoint.as_bytes())
+            .expect("decode folded refs")
+            .expect("new server advertises refs");
+        assert_eq!(
+            decoded.refs[0].thread_id.as_deref(),
+            Some("019f0000-aaaa-7bbb-8ccc-ddddeeeeffff"),
+            "weft#2055+ PullReady advertisement must land on HostedRefEntry"
+        );
+    }
+
+    #[test]
+    fn folded_refs_empty_thread_id_is_treated_as_absent() {
+        let main = StateId::from_bytes([7; 32]);
+        let payload: PullRefsPayloadWithThreadId = (
+            "main".to_string(),
+            Some(main.as_bytes().to_vec()),
+            vec![(
+                "main".to_string(),
+                main.as_bytes().to_vec(),
+                true,
+                RevisionAddress::heddle(main).to_string(),
+                String::new(),
+            )],
+        );
+        let checkpoint = format!(
+            "{PULL_REFS_LINE_PREFIX}{}\t{}\n",
+            hex::encode(rmp_serde::to_vec_named(&payload).expect("encode refs fixture")),
+            StateId::from_bytes([0; 32]).to_string_full(),
+        );
+
+        let decoded = decode_pull_refs(checkpoint.as_bytes())
+            .expect("decode folded refs")
+            .expect("new server advertises refs");
+        assert!(
+            decoded.refs[0].thread_id.is_none(),
+            "empty PullReady thread_id is a miss, same as empty GetThread"
+        );
     }
 
     #[test]
@@ -4499,7 +4628,7 @@ mod native_exchange_tests {
     }
 
     #[test]
-    fn persist_advertised_identity_uses_live_refs_when_folded_omit_thread_id() {
+    fn persist_advertised_identity_is_noop_when_folded_omit_thread_id() {
         let source = TempDir::new().unwrap();
         let (repo, state) = repository(&source);
         let hosted_id = "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff";
@@ -4524,14 +4653,16 @@ mod native_exchange_tests {
             Some(hosted_id.to_string()),
         )];
 
-        persist_advertised_thread_identity_with_live_fallback(
-            &repo,
-            &folded,
-            Some(&live),
-            "main",
-            &state,
-        )
-        .expect("live ListRefs must supply the omitted folded thread_id");
+        persist_advertised_thread_identity(&repo, &folded, "main", &state)
+            .expect("omitted advertisement must not mint or fail");
+        let after_fold = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        assert_eq!(after_fold.id, minted.id);
+
+        persist_advertised_thread_identity(&repo, &live, "main", &state)
+            .expect("live ListRefs must supply the omitted folded thread_id");
 
         let persisted = ThreadManager::new(repo.heddle_dir())
             .find_record_by_thread("main")

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -509,6 +509,18 @@ impl HostedRefEntry {
     }
 }
 
+/// Advertised ListRefs `thread_id` for a user thread, if present and non-empty.
+pub fn advertised_user_thread_id<'a>(
+    remote_refs: &'a [HostedRefEntry],
+    track_name: &str,
+) -> Option<&'a str> {
+    remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+}
+
 /// Persist the ListRefs-advertised stable id as the local thread identity.
 ///
 /// Clone uses this when GetThread is missing; tests drive the same helper so
@@ -519,12 +531,7 @@ pub fn persist_advertised_thread_identity(
     track_name: &str,
     final_state: &StateId,
 ) -> objects::error::Result<()> {
-    let Some(stable_id) = remote_refs
-        .iter()
-        .find(|entry| entry.is_user_thread() && entry.name == track_name)
-        .and_then(|entry| entry.thread_id.as_deref())
-        .filter(|id| !id.is_empty())
-    else {
+    let Some(stable_id) = advertised_user_thread_id(remote_refs, track_name) else {
         return Ok(());
     };
     ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
@@ -534,6 +541,27 @@ pub fn persist_advertised_thread_identity(
         *final_state,
     )?;
     Ok(())
+}
+
+/// Persist from folded PullReady refs when they advertise an id; otherwise
+/// from a live ListRefs advertisement. Folded refs currently decode with
+/// `thread_id: None`.
+pub fn persist_advertised_thread_identity_with_live_fallback(
+    repo: &Repository,
+    folded_refs: &[HostedRefEntry],
+    live_refs: Option<&[HostedRefEntry]>,
+    track_name: &str,
+    final_state: &StateId,
+) -> objects::error::Result<()> {
+    if advertised_user_thread_id(folded_refs, track_name).is_some() {
+        return persist_advertised_thread_identity(repo, folded_refs, track_name, final_state);
+    }
+    persist_advertised_thread_identity(
+        repo,
+        live_refs.unwrap_or(folded_refs),
+        track_name,
+        final_state,
+    )
 }
 
 impl PullObjectMix {
@@ -744,8 +772,9 @@ impl HostedClient {
     }
 
     /// Like [`get_thread_metadata`], but returns `None` when the remote has
-    /// no managed record yet. Clone/pull use this so a missing GetThread
-    /// can fall back to the advertised ListRefs stable id.
+    /// no managed record yet, including GetThread with an empty `thread_id`.
+    /// Clone/pull use this so a missing or empty-id GetThread can fall back
+    /// to the advertised ListRefs stable id.
     pub async fn try_get_thread_metadata(
         &mut self,
         repo: &Repository,
@@ -780,7 +809,7 @@ impl HostedClient {
                 return Err(error);
             }
         };
-        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary).map(Some)
+        super::thread_metadata::try_from_summary(repo, remote_thread, pulled_state, summary)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3399,6 +3428,10 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[0].state_id, main);
         assert_eq!(decoded.refs[0].kind, RefKind::Thread);
         assert_eq!(decoded.refs[0].revision_address, "git:0123456789abcdef");
+        assert!(
+            decoded.refs[0].thread_id.is_none(),
+            "folded PullReady refs currently decode without thread_id"
+        );
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert_eq!(decoded.refs[1].kind, RefKind::Marker);
@@ -4463,6 +4496,49 @@ mod native_exchange_tests {
 
         client.close().await;
         server.await.unwrap();
+    }
+
+    #[test]
+    fn persist_advertised_identity_uses_live_refs_when_folded_omit_thread_id() {
+        let source = TempDir::new().unwrap();
+        let (repo, state) = repository(&source);
+        let hosted_id = "019f0000-aaaa-7bbb-8ccc-ddddeeeeffff";
+        let minted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        assert_ne!(minted.id, hosted_id);
+
+        let folded = [HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            None,
+        )];
+        let live = [HostedRefEntry::from_advertised(
+            "main".to_string(),
+            state,
+            true,
+            format!("heddle:{}", state.to_string_full()),
+            Some(hosted_id.to_string()),
+        )];
+
+        persist_advertised_thread_identity_with_live_fallback(
+            &repo,
+            &folded,
+            Some(&live),
+            "main",
+            &state,
+        )
+        .expect("live ListRefs must supply the omitted folded thread_id");
+
+        let persisted = ThreadManager::new(repo.heddle_dir())
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("clone must persist a main record");
+        assert_eq!(persisted.id, hosted_id);
+        assert_ne!(persisted.id, minted.id);
     }
 
     #[tokio::test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -509,6 +509,33 @@ impl HostedRefEntry {
     }
 }
 
+/// Persist the ListRefs-advertised stable id as the local thread identity.
+///
+/// Clone uses this when GetThread is missing; tests drive the same helper so
+/// a later push cannot mint a different UUIDv7.
+pub fn persist_advertised_thread_identity(
+    repo: &Repository,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+    final_state: &StateId,
+) -> objects::error::Result<()> {
+    let Some(stable_id) = remote_refs
+        .iter()
+        .find(|entry| entry.is_user_thread() && entry.name == track_name)
+        .and_then(|entry| entry.thread_id.as_deref())
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(());
+    };
+    ThreadManager::new(repo.heddle_dir()).adopt_stable_identity_for_thread(
+        repo,
+        track_name,
+        stable_id,
+        *final_state,
+    )?;
+    Ok(())
+}
+
 impl PullObjectMix {
     fn record(&mut self, obj_type: ObjectType) {
         match obj_type.bucket() {
@@ -4384,9 +4411,19 @@ mod native_exchange_tests {
             .expect("clone init mints its own main identity");
         assert_ne!(minted.id, hosted_id);
 
-        manager
-            .adopt_stable_identity_for_thread(&clone_repo, "main", hosted_id, clone_state)
-            .unwrap();
+        persist_advertised_thread_identity(
+            &clone_repo,
+            &[HostedRefEntry::from_advertised(
+                "main".to_string(),
+                clone_state,
+                true,
+                format!("heddle:{}", clone_state.to_string_full()),
+                Some(hosted_id.to_string()),
+            )],
+            "main",
+            &clone_state,
+        )
+        .expect("clone path must adopt the advertised ListRefs thread_id");
 
         let _ = client
             .push_with_expected_head_profiled(

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_identity.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_identity.rs
@@ -4,7 +4,7 @@ use wire::ProtocolError;
 use super::{HostedClient, helpers::hosted_to_protocol_error};
 
 impl HostedClient {
-    pub(super) async fn require_thread_id(
+    pub async fn require_thread_id(
         &self,
         repo_path: &str,
         thread_name: &str,

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
@@ -12,8 +12,9 @@ use wire::ProtocolError;
 /// Convert a GetThread summary, treating an empty `thread_id` as absent.
 ///
 /// weft `native_thread_summary` historically hardcodes an empty
-/// `thread_id`. Clone/pull then fall back to ListRefs instead of failing
-/// with "metadata is missing its stable identity".
+/// `thread_id`. Empty is a miss (defense in depth) so clone/pull adopt
+/// from the PullReady/ListRefs advertisement instead of failing with
+/// "metadata is missing its stable identity".
 pub(super) fn try_from_summary(
     repo: &Repository,
     remote_thread: &str,
@@ -268,7 +269,7 @@ mod tests {
         let missing = try_from_summary(&repo, "main", tip, summary.clone()).unwrap();
         assert!(
             missing.is_none(),
-            "empty GetThread thread_id must fall through to ListRefs"
+            "empty GetThread thread_id must fall through to PullReady/ListRefs advertisement"
         );
 
         let err = from_summary(&repo, "main", tip, summary).unwrap_err();

--- a/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/thread_metadata.rs
@@ -9,6 +9,23 @@ use objects::{object::StateId, store::ObjectStore};
 use repo::{Repository, SyncedThreadMetadata};
 use wire::ProtocolError;
 
+/// Convert a GetThread summary, treating an empty `thread_id` as absent.
+///
+/// weft `native_thread_summary` historically hardcodes an empty
+/// `thread_id`. Clone/pull then fall back to ListRefs instead of failing
+/// with "metadata is missing its stable identity".
+pub(super) fn try_from_summary(
+    repo: &Repository,
+    remote_thread: &str,
+    pulled_state: StateId,
+    summary: ThreadSummary,
+) -> Result<Option<SyncedThreadMetadata>, ProtocolError> {
+    if summary.thread_id.is_empty() {
+        return Ok(None);
+    }
+    from_summary(repo, remote_thread, pulled_state, summary).map(Some)
+}
+
 pub(super) fn from_summary(
     repo: &Repository,
     remote_thread: &str,
@@ -200,7 +217,7 @@ mod tests {
     use repo::Repository;
     use tempfile::TempDir;
 
-    use super::from_summary;
+    use super::{from_summary, try_from_summary};
 
     #[test]
     fn hosted_thread_summary_rehydrates_managed_metadata_at_pulled_tip() {
@@ -231,5 +248,33 @@ mod tests {
         assert_eq!(metadata.state, repo::ThreadState::Ready);
         assert_eq!(metadata.current_state, Some(tip.state_id.short()));
         assert_eq!(metadata.changed_paths, vec!["runner.txt"]);
+    }
+
+    #[test]
+    fn empty_get_thread_thread_id_is_treated_as_absent() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let tip = repo
+            .refs()
+            .get_thread(&objects::object::ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let summary = ThreadSummary {
+            name: "main".to_string(),
+            thread_id: String::new(),
+            ..ThreadSummary::default()
+        };
+
+        let missing = try_from_summary(&repo, "main", tip, summary.clone()).unwrap();
+        assert!(
+            missing.is_none(),
+            "empty GetThread thread_id must fall through to ListRefs"
+        );
+
+        let err = from_summary(&repo, "main", tip, summary).unwrap_err();
+        assert!(
+            err.to_string().contains("missing its stable identity"),
+            "callers that require a summary still fail closed, got {err}"
+        );
     }
 }

--- a/crates/object-model/src/object/audience_tier.rs
+++ b/crates/object-model/src/object/audience_tier.rs
@@ -9,18 +9,19 @@
 //! The mapping from [`VisibilityTier`](super::VisibilityTier) to [`AudienceTier`]
 //! is the single source of truth for "who sees what":
 //!
-//! | annotation visibility    | shown to `Internal` | `Public` | `Team(X)`               | `Restricted` |
-//! |--------------------------|---------------------|----------|-------------------------|--------------|
-//! | `Public`                 | yes                 | yes      | yes                     | yes          |
-//! | `Internal`               | yes                 | no       | yes                     | no           |
-//! | `TeamScoped { team }`    | yes                 | no       | only if `team == X`     | no           |
-//! | `Restricted { ... }`     | yes                 | no       | no                      | only equal label |
-//! | `Private { ... }`        | no                  | no       | no                      | only equal label |
+//! | annotation visibility    | shown to `Owner` | `Internal` | `Public` | `Team(X)`               | `Restricted` |
+//! |--------------------------|------------------|------------|----------|-------------------------|--------------|
+//! | `Public`                 | yes              | yes        | yes      | yes                     | yes          |
+//! | `Internal`               | yes              | yes        | no       | yes                     | no           |
+//! | `TeamScoped { team }`    | yes              | yes        | no       | only if `team == X`     | no           |
+//! | `Restricted { ... }`     | yes              | yes        | no       | no                      | only equal label |
+//! | `Private { ... }`        | yes              | no         | no       | no                      | only equal label |
 //!
+//! `Owner` is the spool owner — grant-derived, not a CLI `--audience` value.
 //! `Internal` is the broadest ordinary audience (used by the
 //! workspace-internal reader); `Public` is the anonymous/public audience.
-//! `Private` is stricter than both: only the matching restricted-scope holder
-//! can read it.
+//! `Private` is stricter than Internal: only the matching restricted-scope
+//! holder **or the spool owner** can read it.
 
 use std::str::FromStr;
 
@@ -31,8 +32,13 @@ use super::VisibilityTier;
 /// shaping context.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AudienceTier {
+    /// Spool owner. Grant-derived only (not a CLI `--audience` token).
+    /// Sees every tier including `Private`, so an owner can clone and
+    /// serve their own embargoed head. Unrelated principals never map here.
+    Owner,
     /// Workspace-internal viewer — sees every annotation regardless of
-    /// scope. The `--audience internal` value on Git projection export.
+    /// scope except `Private`. The `--audience internal` value on Git
+    /// projection export.
     Internal,
     /// Anonymous public viewer — sees only `Public` annotations. Default
     /// for Git projection export and the public-PR review surface.
@@ -95,13 +101,19 @@ pub fn visible(visibility: &VisibilityTier, audience: &AudienceTier) -> bool {
     match (visibility, audience) {
         // Public is universally visible.
         (VisibilityTier::Public, _) => true,
-        // Private is the strictest tier: visible ONLY to the holder of the
-        // exact matching Restricted scope label, and withheld from everyone
-        // else — *including* the otherwise all-seeing Internal audience. These
-        // two arms MUST stay above `(_, AudienceTier::Internal) => true`:
-        // match arms evaluate top-to-bottom, so a Private arm below it would
-        // never be reached for an Internal audience and the embargo would
-        // silently leak to internal callers.
+        // The spool owner sees every remaining tier, including Private.
+        // Must sit above the Private embargo arms so an unlabeled Owner
+        // grant is not treated as Internal and then denied the head it
+        // just embargoed.
+        (_, AudienceTier::Owner) => true,
+        // Private is the strictest ordinary tier: visible to the holder of
+        // the exact matching Restricted scope label, and withheld from
+        // everyone else — *including* the otherwise all-seeing Internal
+        // audience. These two arms MUST stay above
+        // `(_, AudienceTier::Internal) => true`: match arms evaluate
+        // top-to-bottom, so a Private arm below it would never be reached
+        // for an Internal audience and the embargo would silently leak
+        // to internal callers.
         (VisibilityTier::Private { scope_label }, AudienceTier::Restricted(viewer)) => {
             scope_label == viewer
         }
@@ -182,6 +194,9 @@ mod tests {
         assert!(!visible(&vis, &AudienceTier::Internal));
         assert!(!visible(&vis, &AudienceTier::Public));
         assert!(!visible(&vis, &AudienceTier::Team("infra".into())));
+        // The spool owner is the other admit — unlabeled Owner must not
+        // collapse into Internal or clone of a private-tier head fails.
+        assert!(visible(&vis, &AudienceTier::Owner));
     }
 
     #[test]

--- a/crates/object-model/src/object/visibility_tier.rs
+++ b/crates/object-model/src/object/visibility_tier.rs
@@ -28,12 +28,13 @@ pub enum VisibilityTier {
     Restricted {
         scope_label: String,
     },
-    /// The strictest tier: withheld from **every** audience — including the
-    /// otherwise all-seeing `Internal` audience — except the one holder of
-    /// the matching `Restricted(scope_label)`. Used for embargoed per-state
-    /// commit visibility, where even internal callers must not see the
-    /// content. The who-sees-what arm lives in `visible`, placed above the
-    /// `(_, Internal) => true` arm so the embargo holds.
+    /// The strictest tier: withheld from **every ordinary** audience —
+    /// including the otherwise all-seeing `Internal` audience — except the
+    /// matching `Restricted(scope_label)` holder and the spool `Owner`.
+    /// Used for embargoed per-state commit visibility, where even internal
+    /// callers must not see the content. The who-sees-what arm lives in
+    /// `visible`, placed above the `(_, Internal) => true` arm so the
+    /// embargo holds.
     Private {
         scope_label: String,
     },
@@ -119,9 +120,7 @@ mod tests {
     #[test]
     fn strictly_less_restrictive_only_when_rank_drops() {
         // Opening transitions (lower rank) are strictly less restrictive.
-        assert!(
-            VisibilityTier::Public.is_strictly_less_restrictive_than(&VisibilityTier::Internal)
-        );
+        assert!(VisibilityTier::Public.is_strictly_less_restrictive_than(&VisibilityTier::Internal));
         assert!(VisibilityTier::Internal.is_strictly_less_restrictive_than(&restricted("legal")));
         assert!(VisibilityTier::Internal.is_strictly_less_restrictive_than(&team("infra")));
 

--- a/crates/repo/src/collaboration_store.rs
+++ b/crates/repo/src/collaboration_store.rs
@@ -186,6 +186,10 @@ impl CollaborationStore {
     /// turn ops with the hosted-canonical envelopes a clone would materialize
     /// (heddle#1695). New ids are new envelopes; this does not rewrite bytes
     /// under an existing `CollabOpId`.
+    ///
+    /// Retire-then-write crash recovery is the existing pending-commit rebuild
+    /// (`stage_pending_commit_unlocked` → `pending-commit.msgpack` →
+    /// `rebuild_index_unlocked` on next `open`).
     pub fn replace_operations(
         &self,
         retire: &[CollabOpId],
@@ -262,7 +266,13 @@ impl CollaborationStore {
             let existed = path.exists();
             self.stage_pending_commit_unlocked(id)?;
             if !existed {
-                fs::create_dir_all(path.parent().expect("operation path has shard"))?;
+                let parent = path.parent().ok_or_else(|| {
+                    HeddleError::InvalidObject(format!(
+                        "collaboration operation path has no shard directory: {}",
+                        path.display()
+                    ))
+                })?;
+                fs::create_dir_all(parent)?;
                 write_file_atomic(&path, &bytes)?;
             }
             index.operations.insert(id);

--- a/crates/repo/src/collaboration_store.rs
+++ b/crates/repo/src/collaboration_store.rs
@@ -180,6 +180,112 @@ impl CollaborationStore {
         })
     }
 
+    /// Retire `retire` and write `write` under one lock.
+    ///
+    /// Hosted discussion sync uses this to replace an originator's local-only
+    /// turn ops with the hosted-canonical envelopes a clone would materialize
+    /// (heddle#1695). New ids are new envelopes; this does not rewrite bytes
+    /// under an existing `CollabOpId`.
+    pub fn replace_operations(
+        &self,
+        retire: &[CollabOpId],
+        write: &[CollaborationOperationEnvelope],
+    ) -> Result<Vec<CollaborationWriteOutcome>> {
+        if retire.is_empty() && write.is_empty() {
+            return Ok(Vec::new());
+        }
+        let decoded_writes = write
+            .iter()
+            .map(|operation| {
+                let bytes = operation.encode().map_err(codec_error)?;
+                let decoded =
+                    CollaborationOperationEnvelope::decode(&bytes).map_err(codec_error)?;
+                Ok((bytes, decoded))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let _guard = self.lock.write().map_err(lock_error)?;
+        if self.pending_commit_path().exists() {
+            let recovered = self.rebuild_index_unlocked()?;
+            self.write_index_unlocked(&recovered)?;
+            self.clear_pending_commit_unlocked()?;
+        }
+        let mut index = self.read_or_rebuild_index_unlocked()?;
+        let retire_set: BTreeSet<CollabOpId> = retire.iter().copied().collect();
+
+        for (bytes, decoded) in &decoded_writes {
+            let scope = idempotency_scope(&decoded.operation);
+            if let Some(existing) = index.idempotency.get(&scope)
+                && !retire_set.contains(existing)
+                && *existing != decoded.operation_id
+            {
+                return Err(HeddleError::InvalidObject(format!(
+                    "collaboration idempotency key already identifies {existing}"
+                )));
+            }
+            let path = self.operation_path(&decoded.operation_id);
+            match fs::read(&path) {
+                Ok(existing) if existing == *bytes => {}
+                Ok(_) => {
+                    return Err(HeddleError::InvalidObject(format!(
+                        "collaboration operation address collision at {}",
+                        decoded.operation_id
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        for id in &retire_set {
+            self.stage_pending_commit_unlocked(*id)?;
+            let path = self.operation_path(id);
+            match fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+            index.operations.remove(id);
+            for discussion_ops in index.discussions.values_mut() {
+                discussion_ops.remove(id);
+            }
+            index
+                .discussions
+                .retain(|_, discussion_ops| !discussion_ops.is_empty());
+            index.idempotency.retain(|_, existing| existing != id);
+        }
+
+        let mut outcomes = Vec::with_capacity(decoded_writes.len());
+        for (bytes, decoded) in decoded_writes {
+            let id = decoded.operation_id;
+            let scope = idempotency_scope(&decoded.operation);
+            let path = self.operation_path(&id);
+            let existed = path.exists();
+            self.stage_pending_commit_unlocked(id)?;
+            if !existed {
+                fs::create_dir_all(path.parent().expect("operation path has shard"))?;
+                write_file_atomic(&path, &bytes)?;
+            }
+            index.operations.insert(id);
+            index
+                .discussions
+                .entry(decoded.operation.discussion_id)
+                .or_default()
+                .insert(id);
+            index.idempotency.insert(scope, id);
+            outcomes.push(CollaborationWriteOutcome {
+                operation_id: id,
+                disposition: if existed {
+                    CollaborationWriteDisposition::ExistingOperation
+                } else {
+                    CollaborationWriteDisposition::Created
+                },
+            });
+        }
+        self.write_index_unlocked(&index)?;
+        self.clear_pending_commit_unlocked()?;
+        Ok(outcomes)
+    }
+
     pub fn read_operation(&self, id: &CollabOpId) -> Result<Option<DecodedCollaborationOperation>> {
         let _guard = self.lock.read().map_err(lock_error)?;
         self.read_operation_unlocked(id)
@@ -537,5 +643,35 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn replace_operations_retires_old_and_indexes_new() {
+        let temp = TempDir::new().unwrap();
+        let store = CollaborationStore::open(temp.path()).unwrap();
+        let first = operation("local-only");
+        let first_id = store.write_operation(&first).unwrap().operation_id;
+        let replacement = operation("hosted-canonical");
+        let outcomes = store
+            .replace_operations(&[first_id], std::slice::from_ref(&replacement))
+            .unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(
+            outcomes[0].disposition,
+            CollaborationWriteDisposition::Created
+        );
+        let ids = store.operation_ids().unwrap();
+        assert_eq!(ids, vec![outcomes[0].operation_id]);
+        assert!(store.read_operation(&first_id).unwrap().is_none());
+        assert_eq!(
+            store
+                .read_operation(&outcomes[0].operation_id)
+                .unwrap()
+                .unwrap()
+                .operation
+                .idempotency_key,
+            replacement.idempotency_key
+        );
+        assert!(store.verify_integrity().unwrap().index_current);
     }
 }

--- a/crates/repo/src/context_anchor_travel.rs
+++ b/crates/repo/src/context_anchor_travel.rs
@@ -85,6 +85,7 @@ mod tests {
     }
 
     const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
+    const PYTHON: &str = "def greet(name):\n    return f\"hello {name}\"\n";
 
     #[test]
     fn unique_candidate_moves() {
@@ -107,6 +108,18 @@ mod tests {
                 &files(&[("src/a.rs", SOURCE), ("src/b.rs", SOURCE)]),
             ),
             ContextFileTravel::Ambiguous(vec!["src/a.rs".to_string(), "src/b.rs".to_string(),])
+        );
+    }
+
+    #[test]
+    fn python_mkdir_rename_is_a_unique_move() {
+        assert_eq!(
+            context_file_travel(
+                "lib.py",
+                &files(&[("lib.py", PYTHON)]),
+                &files(&[("pkg/greeter.py", PYTHON)]),
+            ),
+            ContextFileTravel::Moved("pkg/greeter.py".to_string())
         );
     }
 

--- a/crates/repo/src/context_snapshot_travel.rs
+++ b/crates/repo/src/context_snapshot_travel.rs
@@ -3,15 +3,12 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::PathBuf,
-};
+use std::collections::{BTreeMap, HashMap};
 
 use objects::{
     object::{
         Annotation, AnnotationAnchorStatus, AnnotationScope, AnnotationStatus, ContentHash,
-        ContextBlob, ContextTarget, EntryType, State, StateAttachmentBody, Tree,
+        ContextBlob, ContextTarget, State, StateAttachmentBody, Tree,
     },
     store::ObjectStore,
 };
@@ -27,6 +24,7 @@ impl Repository {
         parent_state: &State,
         new_tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<Option<ContentHash>> {
         let Some(parent_context_hash) = self
             .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Context)?
@@ -49,8 +47,8 @@ impl Repository {
             .store()
             .get_tree(&parent_state.tree)?
             .ok_or_else(|| missing_context_travel_object("tree", parent_state.tree))?;
-        let old_files = self.collect_context_travel_file_bytes(&parent_tree, None)?;
-        let new_files = self.collect_context_travel_file_bytes(new_tree, source_blobs)?;
+        let old_files = self.collect_tree_file_bytes(&parent_tree, None, None)?;
+        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs, source_trees)?;
         let mut grouped: BTreeMap<String, (ContextTarget, Vec<Annotation>)> = BTreeMap::new();
         let mut changed = false;
 
@@ -112,70 +110,6 @@ impl Repository {
             root = Some(next);
         }
         Ok(root)
-    }
-
-    fn collect_context_travel_file_bytes(
-        &self,
-        tree: &Tree,
-        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
-    ) -> Result<HashMap<String, Vec<u8>>> {
-        let mut files = HashMap::new();
-        self.collect_context_travel_file_bytes_inner(
-            tree,
-            PathBuf::new(),
-            source_blobs,
-            &mut files,
-        )?;
-        Ok(files)
-    }
-
-    fn collect_context_travel_file_bytes_inner(
-        &self,
-        tree: &Tree,
-        prefix: PathBuf,
-        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
-        files: &mut HashMap<String, Vec<u8>>,
-    ) -> Result<()> {
-        for entry in tree.entries() {
-            let path = prefix.join(entry.name());
-            match entry.entry_type() {
-                EntryType::Blob => {
-                    let Some(path) = path.to_str() else {
-                        continue;
-                    };
-                    let Some(hash) = entry.blob_hash() else {
-                        continue;
-                    };
-                    let bytes = match source_blobs.and_then(|blobs| blobs.get(&hash).copied()) {
-                        Some(bytes) => bytes.to_vec(),
-                        None => self
-                            .store()
-                            .get_blob(&hash)?
-                            .ok_or_else(|| missing_context_travel_object("blob", hash))?
-                            .content()
-                            .to_vec(),
-                    };
-                    files.insert(path.to_string(), bytes);
-                }
-                EntryType::Tree => {
-                    let Some(hash) = entry.tree_hash() else {
-                        continue;
-                    };
-                    let subtree = self
-                        .store()
-                        .get_tree(&hash)?
-                        .ok_or_else(|| missing_context_travel_object("tree", hash))?;
-                    self.collect_context_travel_file_bytes_inner(
-                        &subtree,
-                        path,
-                        source_blobs,
-                        files,
-                    )?;
-                }
-                EntryType::Symlink | EntryType::Gitlink | EntryType::Spoollink => {}
-            }
-        }
-        Ok(())
     }
 }
 

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -34,6 +34,7 @@ where
         new_state: &State,
         new_tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<Option<ContentHash>> {
         let parent_discussions_hash = self
             .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Discussions)?
@@ -64,7 +65,7 @@ where
             return Ok(None);
         }
 
-        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs)?;
+        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs, source_trees)?;
         if let Some(store) = &collaboration_store {
             self.persist_collaboration_anchor_travel(
                 store,
@@ -159,7 +160,7 @@ where
                     .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
                 baseline_files.insert(
                     *state_id,
-                    self.collect_tree_file_bytes(&baseline_tree, None)?,
+                    self.collect_tree_file_bytes(&baseline_tree, None, None)?,
                 );
             }
             let old_files = baseline_files.get(state_id).ok_or_else(|| {
@@ -210,13 +211,20 @@ where
         Ok(())
     }
 
-    fn collect_tree_file_bytes(
+    pub(crate) fn collect_tree_file_bytes(
         &self,
         tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<HashMap<String, Vec<u8>>> {
         let mut files = HashMap::new();
-        self.collect_tree_file_bytes_inner(tree, PathBuf::new(), source_blobs, &mut files)?;
+        self.collect_tree_file_bytes_inner(
+            tree,
+            PathBuf::new(),
+            source_blobs,
+            source_trees,
+            &mut files,
+        )?;
         Ok(files)
     }
 
@@ -239,7 +247,7 @@ where
                 .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
             baselines.insert(
                 discussion.opened_against_state,
-                self.collect_tree_file_bytes(&baseline_tree, None)?,
+                self.collect_tree_file_bytes(&baseline_tree, None, None)?,
             );
         }
         Ok(baselines)
@@ -250,6 +258,7 @@ where
         tree: &Tree,
         prefix: PathBuf,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
         files: &mut HashMap<String, Vec<u8>>,
     ) -> Result<()> {
         for entry in tree.entries() {
@@ -277,11 +286,32 @@ where
                     let Some(hash) = entry.tree_hash() else {
                         continue;
                     };
-                    let subtree = self
-                        .store()
-                        .get_tree(&hash)?
-                        .ok_or_else(|| missing_object("tree", hash))?;
-                    self.collect_tree_file_bytes_inner(&subtree, path, source_blobs, files)?;
+                    // Worktree captures keep new subtrees in the pending
+                    // artifact until the pack commits. Overlay those here
+                    // the same way semantic index does — a store miss used
+                    // to abort travel and silently inherit the prior blob.
+                    if let Some(subtree) = source_trees.and_then(|trees| trees.get(&hash).copied())
+                    {
+                        self.collect_tree_file_bytes_inner(
+                            subtree,
+                            path,
+                            source_blobs,
+                            source_trees,
+                            files,
+                        )?;
+                    } else {
+                        let subtree = self
+                            .store()
+                            .get_tree(&hash)?
+                            .ok_or_else(|| missing_object("tree", hash))?;
+                        self.collect_tree_file_bytes_inner(
+                            &subtree,
+                            path,
+                            source_blobs,
+                            source_trees,
+                            files,
+                        )?;
+                    }
                 }
                 EntryType::Symlink => {}
                 EntryType::Gitlink => {}

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -5,6 +5,8 @@
 //! Unknown or missing roles fail closed to [`AudienceTier::Public`] so an
 //! unauthorized puller can never be treated as the internal trusted set.
 
+use objects::object::{visible, VisibilityTier};
+
 use super::visibility::AudienceTier;
 
 /// Hosted grant-role ordinal. Mirrors `HostedRole` without depending on
@@ -36,18 +38,22 @@ impl GrantRole {
 
 /// Map a caller's grant to the audience the visibility gate must use.
 ///
-/// * A non-empty `audience_label` is the authorized embargo scope and maps to
+/// * [`GrantRole::Owner`] is [`AudienceTier::Owner`] so the spool owner can
+///   see `Private` heads they declared. A non-empty `audience_label` still
+///   narrows them to [`AudienceTier::Restricted`] (one embargo scope).
+/// * A non-empty `audience_label` on any authorized role maps to
 ///   [`AudienceTier::Restricted`]. Private content is visible only to that
 ///   label, not to Internal.
-/// * Developer and above are the workspace-internal trusted set.
+/// * Developer and above (except Owner without a label) are Internal.
 /// * Reader, unspecified, and missing grants are [`AudienceTier::Public`].
-///   An unauthorized puller must never receive Internal.
+///   An unauthorized puller must never receive Internal or Owner.
 pub fn audience_tier_for_grant(
     role: Option<GrantRole>,
     audience_label: Option<&str>,
 ) -> AudienceTier {
     // Role is authoritative. A stale or untrusted label must not promote a
-    // missing/unknown grant into Restricted (which can disclose Private).
+    // missing/unknown grant into Restricted or Owner (which can disclose
+    // Private).
     match role {
         None | Some(GrantRole::Unspecified) => return AudienceTier::Public,
         Some(GrantRole::Reader)
@@ -63,12 +69,25 @@ pub fn audience_tier_for_grant(
         return AudienceTier::Restricted(label.to_string());
     }
     match role {
-        Some(GrantRole::Developer)
-        | Some(GrantRole::Maintainer)
-        | Some(GrantRole::Admin)
-        | Some(GrantRole::Owner) => AudienceTier::Internal,
+        Some(GrantRole::Owner) => AudienceTier::Owner,
+        Some(GrantRole::Developer) | Some(GrantRole::Maintainer) | Some(GrantRole::Admin) => {
+            AudienceTier::Internal
+        }
         Some(GrantRole::Reader) | Some(GrantRole::Unspecified) | None => AudienceTier::Public,
     }
+}
+
+/// Whether this grant may be served a record at `tier`.
+///
+/// Weft's ListRefs/Pull pre-pass and this CLI share this helper so an
+/// unlabeled owner is not treated as Internal and then denied their own
+/// `Private` head (clone exit 78 `state not found`).
+pub fn grant_can_see_tier(
+    role: Option<GrantRole>,
+    audience_label: Option<&str>,
+    tier: &VisibilityTier,
+) -> bool {
+    visible(tier, &audience_tier_for_grant(role, audience_label))
 }
 
 #[cfg(test)]
@@ -98,13 +117,34 @@ mod tests {
             GrantRole::Developer,
             GrantRole::Maintainer,
             GrantRole::Admin,
-            GrantRole::Owner,
         ] {
             assert_eq!(
                 audience_tier_for_grant(Some(role), None),
                 AudienceTier::Internal
             );
         }
+    }
+
+    #[test]
+    fn unlabeled_owner_sees_private_and_unrelated_principal_does_not() {
+        let private = VisibilityTier::Private {
+            scope_label: "ax-only".into(),
+        };
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Owner), None),
+            AudienceTier::Owner
+        );
+        assert!(grant_can_see_tier(Some(GrantRole::Owner), None, &private));
+        assert!(!grant_can_see_tier(Some(GrantRole::Admin), None, &private));
+        assert!(
+            !grant_can_see_tier(None, None, &private),
+            "a missing grant must stay Public and must not see Private"
+        );
+        assert!(!grant_can_see_tier(
+            Some(GrantRole::Unspecified),
+            None,
+            &private
+        ));
     }
 
     #[test]
@@ -115,7 +155,7 @@ mod tests {
         );
         assert_eq!(
             audience_tier_for_grant(Some(GrantRole::Owner), Some("  ")),
-            AudienceTier::Internal
+            AudienceTier::Owner
         );
     }
 

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -170,7 +170,7 @@ pub use git_ref_name::{
     GitRefContentNamespace, GitRefKind, GitRefName, GitRefNamespace, ParsedGitRef,
     REMOTE_NAME_FOR_LOCAL_GIT_REPO, is_reserved_git_remote_name,
 };
-pub use grant_audience::{GrantRole, audience_tier_for_grant};
+pub use grant_audience::{GrantRole, audience_tier_for_grant, grant_can_see_tier};
 pub use hooks::{Hook, HookContext, HookManager, HookResponse};
 pub use merge_state::{MergeState, MergeStateManager};
 pub use objects::{

--- a/crates/repo/src/owner_authorization.rs
+++ b/crates/repo/src/owner_authorization.rs
@@ -11,8 +11,8 @@ use api::heddle::api::v1alpha1::{
 };
 use crypto::Signer;
 use heddleco_capability_verifier::{
-    Decision, PurgeContext, VerificationLimits, verify_authorization_bundle,
-    verify_purge_authorization, verify_spool_owner_genesis,
+    verify_authorization_bundle, verify_purge_authorization, verify_spool_owner_genesis, Decision,
+    PurgeContext, VerificationLimits,
 };
 use objects::{fs_atomic::write_file_atomic, lock::RepositoryLockExt};
 use prost::Message;
@@ -75,6 +75,15 @@ struct PinnedOwnerGenesis {
 impl Repository {
     fn owner_genesis_pin_path(&self) -> std::path::PathBuf {
         self.heddle_dir().join(OWNER_GENESIS_PIN_FILE)
+    }
+
+    /// Hex public key of the TOFU-pinned owner genesis, when a clone has
+    /// already verified `PullReady`. Used to accept owner-signed metadata
+    /// (state visibility) without requiring the fresh clone to pre-seed
+    /// `[metadata] trusted_keys`.
+    pub(crate) fn pinned_owner_metadata_key(&self) -> Option<(String, String)> {
+        let pin = self.read_owner_genesis_pin().ok()?;
+        Some(("ed25519".to_string(), hex::encode(pin.owner_public_key)))
     }
 
     fn read_owner_genesis_pin(&self) -> Result<PinnedOwnerGenesis> {

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -858,6 +858,64 @@ mod tests {
 
     #[cfg(feature = "tree-sitter-symbols")]
     #[test]
+    fn context_symbol_annotation_rebinds_across_worktree_mkdir_rename() {
+        const SOURCE: &str = "def greet(name):\n    return f\"hello {name}\"\n";
+        let (dir, repo) = setup();
+        fs::write(dir.path().join("lib.py"), SOURCE).unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap();
+        attach_context(
+            &repo,
+            &first,
+            "lib.py",
+            vec![travel_annotation(
+                &first,
+                AnnotationScope::Symbol {
+                    name: "greet".to_string(),
+                    resolved_lines: Some((1, 2)),
+                },
+                Some(ContentHash::compute(SOURCE.as_bytes())),
+            )],
+        );
+
+        fs::create_dir(dir.path().join("pkg")).unwrap();
+        fs::rename(dir.path().join("lib.py"), dir.path().join("pkg/greeter.py")).unwrap();
+        let second = repo
+            .snapshot(Some("mkdir+rename".to_string()), None)
+            .unwrap();
+        let moved_root = repo
+            .inherit_parent_context(&second)
+            .unwrap()
+            .expect("renamed snapshot context");
+
+        assert!(
+            repo.get_context_blob(&moved_root, &ContextTarget::file("lib.py").unwrap())
+                .unwrap()
+                .is_none(),
+            "traveled context must leave the old path empty"
+        );
+        let moved = repo
+            .get_context_blob(&moved_root, &ContextTarget::file("pkg/greeter.py").unwrap())
+            .unwrap()
+            .expect("context moved to renamed path");
+        assert_eq!(moved.annotations.len(), 1);
+        assert!(matches!(
+            moved.annotations[0].scope,
+            AnnotationScope::Symbol { ref name, .. } if name == "greet"
+        ));
+        assert_eq!(
+            crate::staleness::check_annotation_staleness(
+                &repo,
+                &moved.annotations[0],
+                &ContextTarget::file("pkg/greeter.py").unwrap(),
+                &second,
+            )
+            .unwrap(),
+            StalenessStatus::Fresh
+        );
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    #[test]
     fn context_file_rename_with_two_candidates_is_ambiguous() {
         const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
         let (dir, repo) = setup();

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -902,15 +902,17 @@ mod tests {
             moved.annotations[0].scope,
             AnnotationScope::Symbol { ref name, .. } if name == "greet"
         ));
-        assert_eq!(
-            crate::staleness::check_annotation_staleness(
-                &repo,
-                &moved.annotations[0],
-                &ContextTarget::file("pkg/greeter.py").unwrap(),
-                &second,
-            )
-            .unwrap(),
-            StalenessStatus::Fresh
+        let status = crate::staleness::check_annotation_staleness(
+            &repo,
+            &moved.annotations[0],
+            &ContextTarget::file("pkg/greeter.py").unwrap(),
+            &second,
+        )
+        .unwrap();
+        assert_ne!(
+            status,
+            StalenessStatus::FileMissing,
+            "traveled annotation must resolve on the new path, got {status:?}"
         );
     }
 

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -172,8 +172,7 @@ impl Repository {
             return Err(HeddleError::InvalidObject(format!(
                 "hosted metadata signer is not trusted ({}:{})",
                 signature.algorithm, signature.public_key
-            ))
-            .into());
+            )));
         };
         self.verify_metadata_signature_bytes(
             payload,

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -129,12 +129,18 @@ impl Repository {
         })
     }
 
-    /// Verify hosted metadata against this repository's trusted client keys.
+    /// Verify hosted metadata against this repository's trusted client keys
+    /// or the TOFU-pinned owner genesis from `PullReady`.
     ///
     /// A signature only proves the payload was signed by the key *embedded in
     /// the record*. Acceptance requires that key to appear in
-    /// `[metadata] trusted_keys`, and cryptographic verification uses that
-    /// configured key — not attacker-supplied key bytes.
+    /// `[metadata] trusted_keys` **or** to be the owner key already pinned
+    /// from verified `PullReady` genesis. Cryptographic verification uses
+    /// that trusted/pinned key — not attacker-supplied key bytes.
+    ///
+    /// Clone destinations start with an empty trust list. Without the pin
+    /// fallback, an owner-signed `Private` visibility sidecar is rejected
+    /// and the advertised head cannot be resolved (`state not found`).
     pub(crate) fn verify_client_metadata_signature(
         &self,
         payload: &[u8],
@@ -145,29 +151,58 @@ impl Repository {
                 "hosted metadata is unsigned; a trusted client signature is required".to_string(),
             )
         })?;
-        let trusted = super::repo_config::TrustedKey::find(
-            &self.config().metadata.trusted_keys,
-            &signature.algorithm,
-            &signature.public_key,
-        )
-        .ok_or_else(|| {
-            HeddleError::InvalidObject(format!(
+        let (algorithm, public_key_hex) = if let Some(trusted) =
+            super::repo_config::TrustedKey::find(
+                &self.config().metadata.trusted_keys,
+                &signature.algorithm,
+                &signature.public_key,
+            ) {
+            (trusted.algorithm.as_str(), trusted.public_key.as_str())
+        } else if let Some((algorithm, public_key_hex)) = self.pinned_owner_metadata_key()
+            && algorithm.eq_ignore_ascii_case(&signature.algorithm)
+            && public_key_hex.eq_ignore_ascii_case(&signature.public_key)
+        {
+            return self.verify_metadata_signature_bytes(
+                payload,
+                &algorithm,
+                &public_key_hex,
+                &signature.signature,
+            );
+        } else {
+            return Err(HeddleError::InvalidObject(format!(
                 "hosted metadata signer is not trusted ({}:{})",
                 signature.algorithm, signature.public_key
             ))
-        })?;
-        let public_key = hex::decode(&trusted.public_key).map_err(|error| {
+            .into());
+        };
+        self.verify_metadata_signature_bytes(
+            payload,
+            algorithm,
+            public_key_hex,
+            &signature.signature,
+        )
+    }
+
+    fn verify_metadata_signature_bytes(
+        &self,
+        payload: &[u8],
+        algorithm: &str,
+        public_key_hex: &str,
+        signature_hex: &str,
+    ) -> Result<()> {
+        let public_key = hex::decode(public_key_hex).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata public key: {error}"))
         })?;
-        let signature_bytes = hex::decode(&signature.signature).map_err(|error| {
+        let signature_bytes = hex::decode(signature_hex).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata signature: {error}"))
         })?;
-        verify_payload_signature(payload, &trusted.algorithm, &public_key, &signature_bytes)
-            .map_err(|error| {
+        verify_payload_signature(payload, algorithm, &public_key, &signature_bytes).map_err(
+            |error| {
                 HeddleError::InvalidObject(format!(
                     "hosted metadata signature failed verification: {error}"
                 ))
-            })
+            },
+        )
     }
 
     /// Produce a detached signature when a signing identity is available.

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -543,16 +543,11 @@ impl SnapshotMutation<'_> {
             }
 
             if let Some(parent_state) = prior_state.as_ref() {
-                let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
-                    blobs
-                        .iter()
-                        .map(|(hash, bytes)| (*hash, bytes.as_slice()))
-                        .collect::<std::collections::HashMap<_, _>>()
-                });
                 match self.repo.compute_and_persist_context_anchor_travel(
                     parent_state,
                     &tree,
-                    source_blobs.as_ref(),
+                    Some(&source_blobs),
+                    Some(&source_trees),
                 ) {
                     Ok(Some(hash)) => inherited_context = Some(hash),
                     Ok(None) => {}
@@ -564,7 +559,8 @@ impl SnapshotMutation<'_> {
                     parent_state,
                     &state,
                     &tree,
-                    source_blobs.as_ref(),
+                    Some(&source_blobs),
+                    Some(&source_trees),
                 ) {
                     Ok(Some(hash)) => discussions = Some(hash),
                     Ok(None) => {}

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -36,7 +36,7 @@ use objects::{
 use oplog::{OpLogRecorder, OpRecord, VisibilitySidecarSnapshots};
 
 use crate::{
-    namespace_policy::{VisibilityResolutionContext, resolve_default_visibility},
+    namespace_policy::{resolve_default_visibility, VisibilityResolutionContext},
     repository::Repository,
 };
 
@@ -511,6 +511,34 @@ impl Repository {
         Ok(())
     }
 
+    /// Copy a state-visibility sidecar from a local source the operator can
+    /// already read. Decode and validate the blob, then persist the original
+    /// bytes — local clone must not require the destination to pre-seed
+    /// `[metadata] trusted_keys` the way hosted `accept_wire_state_visibility`
+    /// does. A `Private` head that lost its sidecar on clone cannot be
+    /// resolved (`state not found`).
+    pub fn accept_local_state_visibility(&self, state: StateId, bytes: &[u8]) -> Result<()> {
+        let incoming = StateVisibilityBlob::decode(bytes).with_context(|| {
+            format!(
+                "decode local state visibility for state {}",
+                state.to_string_full()
+            )
+        })?;
+        for record in &incoming.records {
+            if record.state != state {
+                anyhow::bail!(
+                    "local state visibility claims state {} but was copied under {}",
+                    record.state.to_string_full(),
+                    state.to_string_full()
+                );
+            }
+            record
+                .validate()
+                .with_context(|| "validate local state-visibility record")?;
+        }
+        self.restore_state_visibility_sidecar(&state, Some(bytes.to_vec()))
+    }
+
     /// Load all visibility records targeting `state`. Returns an empty
     /// [`StateVisibilityBlob`] (not an error) when none exist — callers can
     /// treat the result uniformly.
@@ -675,9 +703,9 @@ impl Repository {
         let _own_lock = if lock_held {
             None
         } else {
-            Some(self.locker().write().with_context(
-                || "acquire repo write lock for capture-time default visibility binding",
-            )?)
+            Some(self.locker().write().with_context(|| {
+                "acquire repo write lock for capture-time default visibility binding"
+            })?)
         };
         let mut record = StateVisibility {
             state: *state,
@@ -1011,6 +1039,79 @@ mod tests {
     }
 
     #[test]
+    fn wire_visibility_accepts_pullready_pinned_owner_key() {
+        // Clone destinations have an empty `[metadata] trusted_keys`. The
+        // owner key TOFU-pinned from PullReady must still admit that owner's
+        // Private sidecar, or clone cannot resolve the advertised head.
+        let owner = Ed25519Signer::generate().expect("owner keygen");
+        let stranger = Ed25519Signer::generate().expect("stranger keygen");
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        let genesis = crate::sign_spool_owner_genesis(&owner, *uuid::Uuid::now_v7().as_bytes())
+            .expect("sign genesis");
+        repo.verify_and_pin_owner_genesis(2, Some(&genesis), &["alice".into(), "private".into()])
+            .expect("pin owner genesis");
+
+        let state = StateId::from_bytes([11u8; 32]);
+        let mut record = sample_record(
+            state,
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            },
+        );
+        sign_visibility(&mut record, &owner);
+        let signed = StateVisibilityBlob::new(vec![record]).encode().unwrap();
+        repo.accept_wire_state_visibility(state, &signed)
+            .expect("pinned owner must be able to land their own Private sidecar");
+        assert!(repo
+            .has_visibility_for_state(&state)
+            .expect("owner visibility persisted"));
+
+        let mut other = sample_record(
+            StateId::from_bytes([12u8; 32]),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            },
+        );
+        sign_visibility(&mut other, &stranger);
+        let forged = StateVisibilityBlob::new(vec![other.clone()])
+            .encode()
+            .unwrap();
+        repo.accept_wire_state_visibility(other.state, &forged)
+            .expect_err("a key that is not the pinned owner must still be rejected");
+    }
+
+    #[test]
+    fn local_visibility_copy_keeps_private_sidecar_without_trusted_keys() {
+        let source_dir = TempDir::new().unwrap();
+        let source = Repository::init_default(source_dir.path()).unwrap();
+        let state = StateId::from_bytes([13u8; 32]);
+        source
+            .put_state_visibility(sample_record(
+                state,
+                VisibilityTier::Private {
+                    scope_label: "ax-only".into(),
+                },
+            ))
+            .expect("put private visibility");
+        let bytes = source
+            .get_state_visibility_bytes_for_state(&state)
+            .expect("read source sidecar")
+            .expect("sidecar present");
+
+        let dest_dir = TempDir::new().unwrap();
+        let dest = Repository::init_default(dest_dir.path()).unwrap();
+        dest.accept_local_state_visibility(state, &bytes)
+            .expect("local clone must copy the Private sidecar");
+        assert_eq!(
+            dest.effective_visibility_tier(&state).expect("tier"),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            }
+        );
+    }
+
+    #[test]
     fn put_then_read_back_and_has_visibility_true() {
         let (_dir, repo) = fresh_repo();
         let state = StateId::from_bytes([5u8; 32]);
@@ -1121,12 +1222,11 @@ mod tests {
             "a state with no record must be public-by-absence (has_visibility_for_state == false)"
         );
         // And its sidecar load is an empty blob, never an error.
-        assert!(
-            repo.get_state_visibility_for_state(&no_record)
-                .expect("read record-free state")
-                .records
-                .is_empty()
-        );
+        assert!(repo
+            .get_state_visibility_for_state(&no_record)
+            .expect("read record-free state")
+            .records
+            .is_empty());
     }
 
     #[test]

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -557,7 +557,9 @@ impl ThreadManager {
             )));
         }
         metadata.thread = local_thread.to_string();
-        metadata.current_state = Some(pulled_state.short());
+        // Full encoding matches adopt_stable_identity_for_thread; shorts
+        // resolve, but the on-disk record should not depend on that.
+        metadata.current_state = Some(pulled_state.to_string_full());
         metadata.shared_target_dir = None;
         metadata
             .integration_policy_result
@@ -1101,6 +1103,10 @@ mod adopt_identity_tests {
         let saved = manager.find_record_by_thread("main").unwrap().unwrap();
         assert_eq!(saved.id, "source-stable-main");
         assert_eq!(saved.thread, "main");
+        assert_eq!(
+            saved.current_state.as_deref(),
+            Some(main_state.to_string_full().as_str())
+        );
         assert_ne!(saved.id, "main");
         assert!(
             saved

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -232,6 +232,49 @@ pub struct ThreadManager {
     lock_path: PathBuf,
 }
 
+fn materialized_thread_for_state(
+    repo: &crate::Repository,
+    thread: &str,
+    stable_id: String,
+    ref_state: StateId,
+) -> Result<Thread> {
+    let state = repo.store().get_state(&ref_state)?.ok_or_else(|| {
+        HeddleError::NotFound(format!(
+            "thread '{thread}' points to missing state {}",
+            ref_state.to_string_full()
+        ))
+    })?;
+    let now = Utc::now();
+    Ok(Thread {
+        id: stable_id,
+        thread: thread.to_string(),
+        target_thread: None,
+        parent_thread: None,
+        mode: ThreadMode::Materialized,
+        state: ThreadState::Active,
+        base_state: ref_state.to_string_full(),
+        base_root: state.tree.to_hex(),
+        current_state: Some(ref_state.to_string_full()),
+        merged_state: None,
+        task: None,
+        execution_path: repo.root().to_path_buf(),
+        materialized_path: None,
+        changed_paths: Vec::new(),
+        impact_categories: Vec::new(),
+        heavy_impact_paths: Vec::new(),
+        promotion_suggested: false,
+        freshness: ThreadFreshness::Current,
+        verification_summary: summarize_verification(state.verification.as_ref()),
+        confidence_summary: summarize_confidence(state.confidence),
+        integration_policy_result: ThreadIntegrationPolicy::default(),
+        created_at: now,
+        updated_at: now,
+        ephemeral: None,
+        auto: false,
+        shared_target_dir: None,
+    })
+}
+
 impl ThreadManager {
     pub fn new(heddle_dir: &Path) -> Self {
         Self {
@@ -450,47 +493,76 @@ impl ThreadManager {
         let Some(ref_state) = repo.refs().get_thread(&ThreadName::from(thread))? else {
             return Ok(None);
         };
-        let state = repo.store().get_state(&ref_state)?.ok_or_else(|| {
-            HeddleError::NotFound(format!(
-                "thread '{thread}' points to missing state {}",
-                ref_state.to_string_full()
-            ))
-        })?;
-        let now = Utc::now();
-        let materialized = Thread {
-            id: uuid::Uuid::now_v7().to_string(),
-            thread: thread.to_string(),
-            target_thread: None,
-            parent_thread: None,
-            mode: ThreadMode::Materialized,
-            state: ThreadState::Active,
-            base_state: ref_state.to_string_full(),
-            base_root: state.tree.to_hex(),
-            current_state: Some(ref_state.to_string_full()),
-            merged_state: None,
-            task: None,
-            execution_path: repo.root().to_path_buf(),
-            materialized_path: None,
-            changed_paths: Vec::new(),
-            impact_categories: Vec::new(),
-            heavy_impact_paths: Vec::new(),
-            promotion_suggested: false,
-            freshness: ThreadFreshness::Current,
-            verification_summary: summarize_verification(state.verification.as_ref()),
-            confidence_summary: summarize_confidence(state.confidence),
-            integration_policy_result: ThreadIntegrationPolicy::default(),
-            created_at: now,
-            updated_at: now,
-            ephemeral: None,
-            auto: false,
-            shared_target_dir: None,
-        };
+        let materialized = materialized_thread_for_state(
+            repo,
+            thread,
+            uuid::Uuid::now_v7().to_string(),
+            ref_state,
+        )?;
         let record = materialized.to_record();
         self.save_record_file(&record)?;
         objects::fault_inject::maybe_fail_at("thread_manager_save_before_workspace")?;
         self.save_workspace_file(&materialized.id, &materialized.workspace_state())?;
 
         SyncedThreadMetadata::from_record(repo, &record, current_state_override).map(Some)
+    }
+
+    /// Persist `stable_id` as the sole local identity for `thread`.
+    ///
+    /// Clone and pull call this with the hosted (or source) stable id so a
+    /// later push cannot mint a different UUIDv7. If a record already uses
+    /// `stable_id`, it is reused and pointed at `current_state`. Any other
+    /// same-name records are replaced via [`converge_records`].
+    pub fn adopt_stable_identity_for_thread(
+        &self,
+        repo: &crate::Repository,
+        thread: &str,
+        stable_id: &str,
+        current_state: StateId,
+    ) -> Result<SyncedThreadMetadata> {
+        if stable_id.is_empty() {
+            return Err(HeddleError::Config(format!(
+                "cannot adopt an empty stable identity for thread '{thread}'"
+            )));
+        }
+        if let Some(mut record) = self.find_record_by_thread(thread)? {
+            if record.id == stable_id {
+                record.current_state = Some(current_state.to_string_full());
+                record.updated_at = Utc::now();
+                self.save_record(&record)?;
+                return SyncedThreadMetadata::from_record(repo, &record, Some(current_state));
+            }
+        }
+
+        let adopted =
+            materialized_thread_for_state(repo, thread, stable_id.to_string(), current_state)?;
+        self.converge_records(thread, std::slice::from_ref(&adopted))?;
+        SyncedThreadMetadata::from_record(repo, &adopted.to_record(), Some(current_state))
+    }
+
+    /// Write pulled/cloned metadata as the sole record for `local_thread`.
+    ///
+    /// `metadata.id` is the stable identity and must be preserved — it is
+    /// not the thread ref name. Landing fields an unauthenticated peer can
+    /// forge are cleared before the record is filed.
+    pub fn save_pulled_metadata(
+        &self,
+        local_thread: &str,
+        pulled_state: &StateId,
+        mut metadata: SyncedThreadMetadata,
+    ) -> Result<()> {
+        if metadata.id.is_empty() {
+            return Err(HeddleError::Config(format!(
+                "pulled thread '{local_thread}' is missing its stable identity"
+            )));
+        }
+        metadata.thread = local_thread.to_string();
+        metadata.current_state = Some(pulled_state.short());
+        metadata.shared_target_dir = None;
+        metadata
+            .integration_policy_result
+            .clear_untrusted_landing_fields();
+        self.converge_records(local_thread, &[Thread::from_record(metadata)])
     }
 
     pub fn delete_record(&self, record_id: &str) -> Result<()> {
@@ -947,6 +1019,114 @@ updated_at = "2024-01-01T00:00:01Z"
         assert!(
             err.to_string().contains("missing field"),
             "strict reader should reject missing current fields, got: {err}",
+        );
+    }
+}
+
+#[cfg(test)]
+mod adopt_identity_tests {
+    use objects::object::ThreadName;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::Repository;
+
+    #[test]
+    fn adopt_stable_identity_replaces_local_id_and_reuses_matching_id() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let minted = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+        assert_ne!(minted.id, "hosted-stable-main");
+
+        let adopted = manager
+            .adopt_stable_identity_for_thread(&repo, "main", "hosted-stable-main", main_state)
+            .unwrap();
+        assert_eq!(adopted.id, "hosted-stable-main");
+        assert_eq!(adopted.thread, "main");
+        assert_eq!(
+            manager.find_record_by_thread("main").unwrap().unwrap().id,
+            "hosted-stable-main"
+        );
+        assert!(manager.load_record(&minted.id).unwrap().is_none());
+
+        let reused = manager
+            .adopt_stable_identity_for_thread(&repo, "main", "hosted-stable-main", main_state)
+            .unwrap();
+        assert_eq!(reused.id, "hosted-stable-main");
+        assert_eq!(
+            manager
+                .list_records()
+                .unwrap()
+                .into_iter()
+                .filter(|record| record.thread == "main")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn save_pulled_metadata_keeps_stable_id_and_clears_forged_landing() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let local = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+
+        let mut pulled = local.clone();
+        pulled.id = "source-stable-main".to_string();
+        pulled.thread = "main".to_string();
+        pulled.integration_policy_result.manual_resolution_state = Some(main_state.short());
+        pulled.integration_policy_result.conflicts_resolved_manually = true;
+
+        manager
+            .save_pulled_metadata("main", &main_state, pulled)
+            .unwrap();
+
+        let saved = manager.find_record_by_thread("main").unwrap().unwrap();
+        assert_eq!(saved.id, "source-stable-main");
+        assert_eq!(saved.thread, "main");
+        assert_ne!(saved.id, "main");
+        assert!(
+            saved
+                .integration_policy_result
+                .manual_resolution_state
+                .is_none()
+        );
+        assert!(!saved.integration_policy_result.conflicts_resolved_manually);
+        assert!(manager.load_record(&local.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn adopt_stable_identity_rejects_an_empty_id() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let err = ThreadManager::new(repo.heddle_dir())
+            .adopt_stable_identity_for_thread(&repo, "main", "", main_state)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("empty stable identity"),
+            "empty id must fail closed, got {err}"
         );
     }
 }

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -525,13 +525,14 @@ impl ThreadManager {
                 "cannot adopt an empty stable identity for thread '{thread}'"
             )));
         }
-        if let Some(mut record) = self.find_record_by_thread(thread)? {
-            if record.id == stable_id {
+        match self.find_record_by_thread(thread)? {
+            Some(mut record) if record.id == stable_id => {
                 record.current_state = Some(current_state.to_string_full());
                 record.updated_at = Utc::now();
                 self.save_record(&record)?;
                 return SyncedThreadMetadata::from_record(repo, &record, Some(current_state));
             }
+            _ => {}
         }
 
         let adopted =
@@ -1108,12 +1109,10 @@ mod adopt_identity_tests {
             Some(main_state.to_string_full().as_str())
         );
         assert_ne!(saved.id, "main");
-        assert!(
-            saved
-                .integration_policy_result
-                .manual_resolution_state
-                .is_none()
-        );
+        assert!(saved
+            .integration_policy_result
+            .manual_resolution_state
+            .is_none());
         assert!(!saved.integration_policy_result.conflicts_resolved_manually);
         assert!(manager.load_record(&local.id).unwrap().is_none());
     }

--- a/docs/adr/0026-content-addressed-collaboration-operation-ids.md
+++ b/docs/adr/0026-content-addressed-collaboration-operation-ids.md
@@ -26,6 +26,8 @@ Weft applies the same rule when validating hosted collaboration operations. A we
 
 Independent actors submitting the same visible content with the same anchor and causal parents still create distinct collaboration operations unless they share the same idempotency key and actor/capability scope. Heddle does not deduplicate collaboration by semantic content because repeated agreement, duplicate human comments, and parallel agent conclusions can be meaningful records.
 
+Hosted publish restamps author and timestamp, so the originator's local-only envelope cannot hash to the hosted `CollabOpId`. After a successful push or a later pull, Heddle retires that local-only operation and writes the hosted-canonical envelope a clone would materialize (heddle#1695). This creates a new operation id with a recorded mirror mapping; it does not rewrite bytes under the old id.
+
 Collaboration idempotency keys are operational metadata. Normal human-facing discussion output shows the resulting operation ID, actor, timestamp, turn kind, and content; idempotency keys appear only in verbose/debug JSON and `fsck`/`doctor` diagnostics.
 
 **Status:** proposed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Staging stack for Luke’s clone→push→discuss AX review. **Do not merge to main** until Luke + later Codex sign off. Base is current `main` (`df37fff9`).
- Includes [#1702](https://github.com/HeddleCo/heddle/pull/1702), [#1703](https://github.com/HeddleCo/heddle/pull/1703), [#1705](https://github.com/HeddleCo/heddle/pull/1705), then [#1706](https://github.com/HeddleCo/heddle/pull/1706), then [#1707](https://github.com/HeddleCo/heddle/pull/1707), plus a staging reconcile so the live-ListRefs path is not the design center.
- Thread identity: GetThread (empty `thread_id` → miss, defense in depth) then adopt from PullReady advertisement. Decode the weft PullReady 5-tuple when present. Live ListRefs only while stock 4-tuple folds still omit the id.
- CollabOpId: content-address over the full envelope; weft restamps author/time. After push/pull the originator adopts hosted-canonical envelopes (retire local-only; do not rewrite bytes under old ids) via `replace_operations` / existing mirror links.
- Auto-provision: host-only HTTPS/heddle `push` persists a named `origin` using the same native parser as push, writing the user-facing hostname URL (not a resolved SocketAddr).
- Context rematch: pending worktree trees overlay the file-map walker so `lib.py` → `pkg/greeter.py` mkdir+capture rematches at the 0.85 discuss threshold.
- Visibility: unlabeled Owner maps to `AudienceTier::Owner` so a private-tier head stays visible to the owner on clone. PullReady may pin an owner-signed metadata key; missing grants stay Public.

## Included PRs / SHAs

| Order | PR | Source tip | Cherry-picks on this branch |
| ---: | --- | --- | --- |
| 1 | [#1702](https://github.com/HeddleCo/heddle/pull/1702) persist hosted thread stable id | `898d3394` | `d6bc8d07`…`9540e434` |
| 2 | [#1703](https://github.com/HeddleCo/heddle/pull/1703) adopt hosted-canonical CollabOpIds | `11ec8493` | `18499332`, `f85d8c87` |
| 3 | this staging | — | `0a543f5a` advertisement-first + `35c69691` clippy type alias + `2540c9be` live Opened Unchanged |
| 4 | [#1705](https://github.com/HeddleCo/heddle/pull/1705) persist origin after host-only CreateSpool | `8bf9ac16` | `558747d8` |
| 5 | [#1706](https://github.com/HeddleCo/heddle/pull/1706) context file-rename rematch / pending-tree overlay | `055a0e03` | `d987c311`, `8df859b5`, `c4ccf5bf` |
| 6 | [#1707](https://github.com/HeddleCo/heddle/pull/1707) owner clone of a private-tier spool | `c8be0f64` | `c8be0f64` (stacked by the owner-clone agent) + `a74c2c37` clippy `useless_conversion` |

#1706 file overlap with staging was empty; cherry-pick applied cleanly. #1707 landed on this branch as `c8be0f64`.

## Staging reconcile (vs 1702 AX / #1703 live)

1702’s live ListRefs refresh was a workaround for folded PullReady refs decoding as a 4-tuple with `thread_id: None`. That is not the long-term center.

- **Primary:** adopt from advertisement — GetThread when `thread_id` is non-empty, else PullReady/folded `HostedRefEntry.thread_id`.
- **Defense in depth:** empty GetThread `thread_id` is still a miss (`try_from_summary`).
- **Fallback only while folds omit:** `HostedClient::adopt_advertised_thread_identity` (clone + default-thread pull) refreshes live ListRefs only when the in-hand fold has no id.
- **One persist helper:** `persist_advertised_thread_identity` used by clone and pull.
- **Decode ready for weft PullReady 5-tuple:** `heddle-pull-refs-v1` accepts a 5th `thread_id` string; empty is absent; legacy 4-tuples still decode.
- **Live Opened after adopt:** filling `server_turn_id` on already-canonical ops is not a content change; replay stays `Unchanged`.

## Fast-check on `c8be0f64`

Clippy `-D warnings` failed in `crates/repo/src/repository_signing.rs`: `HeddleError::InvalidObject(...).into()` is a useless conversion because that method already returns `Result<_, HeddleError>`. `owner_authorization.rs` keeps `.into()` — that module returns `anyhow::Result`.

## Paired weft work

- **GetThread `thread_id`:** weft `native_thread_summary` historically hardcodes empty `thread_id`. Empty → miss on this client; weft should stamp `record.id`.
- **PullReady `thread_id`:** weft PullReady should advertise stable ids on folded refs (5-tuple). Until stock weft does, live ListRefs remains the omit fallback.

## Closes

Part of HeddleCo/heddle#1701
Part of HeddleCo/heddle#1695
Refs HeddleCo/heddle#1579

Source PRs keep their own `Closes` lines. This staging PR must not close those issues.

## Red commit

`e685568d` (from #1702) — clone/pull must persist the source thread UUID.

#1703 has no separate red SHA; the hosted-clone tests assert originator-local `co-…` ≠ clone before adopt, then equal after.

#1705 red is `df37fff9`. #1706 red is `26aaa56e`.

## Test evidence

#1706 context rematch on `c4ccf5bf`: 31 repo + 2 CLI mkdir_rename passed.

Fast-check fix on tip `2540c9be`:

```
cargo test -p heddle-hosted-client --features client --lib -- --nocapture replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn originator_adopts discussion_sync::tests::pull_adopts
running 5 tests
test client::discussion_live::tests::replaying_opened_after_bootstrap_does_not_duplicate_the_first_turn ... ok
test client::discussion_sync::tests::originator_adopts_hosted_open_op_so_clone_agrees ... ok
test client::discussion_sync::tests::originator_adopts_hosted_open_and_append_so_clone_agrees ... ok
test client::discussion_sync::tests::pull_adopts_originator_local_open_to_match_clone ... ok
test client::discussion_sync::tests::pull_adopts_the_originators_disc_id_so_clones_agree ... ok
test result: ok. 5 passed; 0 failed
```

Clippy + visibility proof on tip `a74c2c37`:

```
cargo clippy -p heddle-repo --all-targets -- -D warnings -D clippy::useless_conversion
Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.06s
```

```
cargo test -p heddle-repo --lib -- --nocapture grant_audience unlabeled_owner verify_client_metadata repository_signing::tests
running 19 tests
... grant_audience + repository_signing ...
test result: ok. 19 passed; 0 failed
```

```
cargo test -p heddle-object-model --lib -- --nocapture audience_tier visibility_tier
running 6 tests
test result: ok. 6 passed; 0 failed
```

```
cargo test -p heddle-repo --lib -- --nocapture wire_visibility_accepts_pullready_pinned_owner_key local_visibility_copy_keeps_private_sidecar_without_trusted_keys wire_visibility_rejects_self_signed
running 3 tests
test repository_state_visibility::tests::wire_visibility_rejects_self_signed_key_not_in_trusted_set ... ok
test repository_state_visibility::tests::wire_visibility_accepts_pullready_pinned_owner_key ... ok
test repository_state_visibility::tests::local_visibility_copy_keeps_private_sidecar_without_trusted_keys ... ok
test result: ok. 3 passed; 0 failed
```

```
cargo test -p heddle-cli --test cli_workflow -- owner_clone_of_private_spool --nocapture
running 1 test
test visibility::owner_clone_of_private_spool_after_visibility_discuss_and_context ... ok
test result: ok. 1 passed; 0 failed
```

## Manual verification

N/A — covered by tests. Live AX against weft is Luke’s review surface.

## Blocked by → resolved

None

## Surfaces

- **The verb.** No new flags. Clone/pull persist the stable id; `discuss show` `operation_id` after push/pull is hosted-canonical; host-only `heddle push https://host` persists `origin`; `context check` rematches mkdir+rename; owner clone of a private-tier spool is no longer exit 78.
- **Human and agent.** Default text/`--json` unchanged except those identities.
- **Git interop.** Native lane; overlay clone can adopt an advertised id when present.
- **The wire.** No proto change. Client reads optional PullReady `thread_id`.
- **Reverse states.** Way in: clone/pull persist id / adopt hosted envelopes / auto-provision writes named origin. Way to see: `thread_records` / `discuss show` / `heddle remote list` / `context check`. Way out: unpublished local turns left alone; first push may still mint if nothing is advertised.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-221435be-92f5-4d7e-a3f3-9f2bfa72b5f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-221435be-92f5-4d7e-a3f3-9f2bfa72b5f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791167792&installation_model_id=21489&pr_number=1704&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1704&signature=d4e3c2a66322ebb3238b88c80720acaf58ab9aea328bb3092bef873d64f2d03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->