### PR TITLE
fix(cli): persist origin after host-only CreateSpool

### DIFF
--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1781,6 +1781,7 @@ async fn auto_provision_hosted_repo(
             provisioned_repo.status_verb(),
             style::bold(&display_full_path)
         );
+        let (scheme, host) = user_facing_hosted_authority(options.remote_arg, options.authority);
         if let Some(remote_name) = configured_remote {
             println!(
                 "{}",
@@ -1789,17 +1790,13 @@ async fn auto_provision_hosted_repo(
                     &format!(
                         "{} -> {}",
                         style::bold(&remote_name),
-                        style::dim(&format!(
-                            "heddle://{}/{}",
-                            options.authority, display_full_path
-                        ))
+                        style::dim(&format!("{scheme}://{host}/{display_full_path}"))
                     )
                 )
             );
         } else {
             print_next(&format!(
-                "heddle remote add origin heddle://{}/{}",
-                options.authority, display_full_path
+                "heddle remote add origin {scheme}://{host}/{display_full_path}"
             ));
         }
     }
@@ -1866,15 +1863,90 @@ fn persist_auto_provisioned_remote(
         return Ok(None);
     };
     let mut cfg = RemoteConfig::open(repo).map_err(anyhow::Error::new)?;
+    let existing = cfg.get(&remote_name).ok();
+    let url = auto_provisioned_remote_url(
+        existing.as_ref().map(|remote| remote.url.as_str()),
+        remote_arg,
+        authority,
+        full_path,
+    );
     cfg.add(
         &remote_name,
         Remote {
-            url: format!("heddle://{authority}/{full_path}"),
-            insecure: false,
+            url,
+            insecure: existing
+                .as_ref()
+                .map(|remote| remote.insecure)
+                .unwrap_or(false),
         },
     )
     .map_err(anyhow::Error::new)?;
     Ok(Some(remote_name))
+}
+
+/// Build the user-facing hosted URL written after CreateSpool.
+///
+/// Keep the scheme and hostname the user typed (`https://` / `heddle://`).
+/// A resolved SocketAddr is only persisted when that was the input —
+/// otherwise later TLS/SNI and descriptor trust look up the IP.
+#[cfg(feature = "client")]
+fn auto_provisioned_remote_url(
+    existing_url: Option<&str>,
+    remote_arg: Option<&str>,
+    authority: &str,
+    full_path: &str,
+) -> String {
+    if let Some(existing) = existing_url
+        && let Some(url) = rewrite_hosted_remote_path(existing, full_path)
+    {
+        return url;
+    }
+    let (scheme, host) = user_facing_hosted_authority(remote_arg, authority);
+    format!("{scheme}://{host}/{full_path}")
+}
+
+#[cfg(feature = "client")]
+fn rewrite_hosted_remote_path(url: &str, full_path: &str) -> Option<String> {
+    let (scheme, rest) = split_hosted_remote_scheme(url)?;
+    let host = rest.split('/').next().filter(|host| !host.is_empty())?;
+    Some(format!("{scheme}://{host}/{full_path}"))
+}
+
+#[cfg(feature = "client")]
+fn split_hosted_remote_scheme(url: &str) -> Option<(&'static str, &str)> {
+    url.strip_prefix("https://")
+        .map(|rest| ("https", rest))
+        .or_else(|| url.strip_prefix("heddle://").map(|rest| ("heddle", rest)))
+}
+
+#[cfg(feature = "client")]
+fn user_facing_hosted_authority<'a>(
+    remote_arg: Option<&'a str>,
+    authority: &'a str,
+) -> (&'static str, &'a str) {
+    if let Some(arg) = remote_arg
+        && let Some((scheme, rest)) = split_hosted_remote_scheme(arg)
+    {
+        if let Some(host) = rest.split('/').next().filter(|host| !host.is_empty()) {
+            return (scheme, prefer_hostname_authority(host, authority));
+        }
+        return (scheme, authority);
+    }
+    ("heddle", authority)
+}
+
+#[cfg(feature = "client")]
+fn prefer_hostname_authority<'a>(from_input: &'a str, authority: &'a str) -> &'a str {
+    if is_raw_socket_authority(authority) && !is_raw_socket_authority(from_input) {
+        from_input
+    } else {
+        authority
+    }
+}
+
+#[cfg(feature = "client")]
+fn is_raw_socket_authority(value: &str) -> bool {
+    value.parse::<std::net::SocketAddr>().is_ok() || value.parse::<std::net::IpAddr>().is_ok()
 }
 
 #[cfg(feature = "client")]
@@ -1886,8 +1958,11 @@ fn auto_provision_remote_name(
     match remote_arg {
         Some(arg) if cfg.get(arg).is_ok() => Ok(Some(arg.to_string())),
         Some(arg) => {
+            // Same parser `push` uses: native HTTPS host-only
+            // (`https://host[:port]`) is a CreateSpool target, but the
+            // generic parser rejects the scheme so origin was never saved.
             let is_direct_network_without_path = matches!(
-                RemoteTarget::parse(arg),
+                repo::remote::parse_target_for_repository(repo, arg),
                 Ok(RemoteTarget::Network {
                     repo_path: None,
                     ..
@@ -2052,6 +2127,18 @@ mod tests {
                 .as_deref(),
             Some("origin")
         );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://127.0.0.1:8421"))
+                .unwrap()
+                .as_deref(),
+            Some("origin")
+        );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://api-staging.heddle.sh"))
+                .unwrap()
+                .as_deref(),
+            Some("origin")
+        );
 
         let mut cfg = RemoteConfig::open(&repo).unwrap();
         cfg.add(
@@ -2071,6 +2158,12 @@ mod tests {
         );
         assert_eq!(
             auto_provision_remote_name(&repo, Some("127.0.0.1:8421"))
+                .unwrap()
+                .as_deref(),
+            None
+        );
+        assert_eq!(
+            auto_provision_remote_name(&repo, Some("https://127.0.0.1:8421"))
                 .unwrap()
                 .as_deref(),
             None
@@ -2096,6 +2189,112 @@ mod tests {
         };
         assert_eq!(authority, "api-staging.heddle.sh");
         assert!(authority.parse::<std::net::IpAddr>().is_err());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_persists_https_host_only_as_named_origin() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://api-staging.heddle.sh"),
+            "api-staging.heddle.sh",
+            "org/repo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://api-staging.heddle.sh/org/repo");
+        let (target, key) = resolve_remote_with_key(&repo, Some("origin")).unwrap();
+        assert!(matches!(
+            target,
+            RemoteTarget::Network {
+                repo_path: Some(ref path),
+                ..
+            } if path == "org/repo"
+        ));
+        assert_eq!(key.as_deref(), Some("api-staging.heddle.sh"));
+        assert_eq!(
+            RemoteConfig::open(&repo).unwrap().default_name(),
+            Some("origin")
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_persists_https_loopback_host_only_as_origin() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://127.0.0.1:8421"),
+            "127.0.0.1:8421",
+            "alice/demo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        assert_eq!(
+            RemoteConfig::open(&repo)
+                .unwrap()
+                .get("origin")
+                .unwrap()
+                .url,
+            "https://127.0.0.1:8421/alice/demo"
+        );
+        resolve_remote_with_key(&repo, Some("origin")).unwrap();
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_does_not_overwrite_hostname_with_resolved_socket() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+
+        let configured = persist_auto_provisioned_remote(
+            &repo,
+            Some("https://api-staging.heddle.sh"),
+            "203.0.113.10:443",
+            "org/repo",
+        )
+        .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://api-staging.heddle.sh/org/repo");
+        assert!(
+            !remote.url.contains("203.0.113.10"),
+            "resolved SocketAddr must not replace the typed hostname: {}",
+            remote.url
+        );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn auto_provision_rewrites_existing_https_origin_path_without_losing_scheme() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let mut cfg = RemoteConfig::open(&repo).unwrap();
+        cfg.add(
+            "origin",
+            Remote {
+                url: "https://preview.heddle.sh".to_string(),
+                insecure: false,
+            },
+        )
+        .unwrap();
+
+        let configured =
+            persist_auto_provisioned_remote(&repo, Some("origin"), "203.0.113.10:443", "org/repo")
+                .unwrap();
+
+        assert_eq!(configured.as_deref(), Some("origin"));
+        let remote = RemoteConfig::open(&repo).unwrap().get("origin").unwrap();
+        assert_eq!(remote.url, "https://preview.heddle.sh/org/repo");
     }
 
     #[cfg(feature = "client")]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Host-only HTTPS push (`heddle push https://host`) created the spool but never wrote a named remote, because auto-provision used the generic parser that rejects `https://`. Later `heddle push origin` failed exit 78 until a manual `heddle remote add`.
- Use the same native parser `push` already uses, so host-only HTTPS/heddle URLs persist `origin` (or the existing default).
- Write the **user-facing** hosted URL (`https://` / `heddle://` + hostname). Do not overwrite an existing origin with a resolved SocketAddr — that broke TLS/SNI on preview.

**Surfaces:** verb path (`push` auto-provision persist + human remote line); human/agent (`heddle remote list` / `heddle push origin` after host-only CreateSpool); no wire/proto change; reverse state is the persisted named remote (and the existing default if one was already set).

## Closes

Refs local AX host-only CreateSpool / auto-provision origin persist

## Red commit

`df37fff9` — main tip before this change. The new HTTPS host-only persist tests fail there because `RemoteTarget::parse` rejects `https://`, so origin was never saved.

## Test evidence

Tip `8bf9ac1675df3f14281903ce7bbb00f685acb98e`:

```
$ cargo test -p heddle-cli --lib -- --test-threads=1 https_transport_follows_repository_source_authority overlay_heddle_remote_resolves_to_hosted_mirror_transport auto_provision
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running unittests src/lib.rs (target/debug/deps/cli-1d2399a5c8c17b38)

running 10 tests
test cli::commands::remote::tests::auto_provision_does_not_overwrite_hostname_with_resolved_socket ... ok
test cli::commands::remote::tests::auto_provision_hides_internal_user_namespace_paths_in_cli_text ... ok
test cli::commands::remote::tests::auto_provision_persists_hostname_authority ... ok
test cli::commands::remote::tests::auto_provision_persists_https_host_only_as_named_origin ... ok
test cli::commands::remote::tests::auto_provision_persists_https_loopback_host_only_as_origin ... ok
test cli::commands::remote::tests::auto_provision_remote_name_uses_existing_or_origin_remote ... ok
test cli::commands::remote::tests::auto_provision_reuses_create_spool_already_exists ... ok
test cli::commands::remote::tests::auto_provision_rewrites_existing_https_origin_path_without_losing_scheme ... ok
test cli::commands::remote::tests::https_transport_follows_repository_source_authority ... ok
test cli::commands::remote::tests::overlay_heddle_remote_resolves_to_hosted_mirror_transport ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 436 filtered out; finished in 0.64s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96b5193b-e7be-4ee7-b407-6f4bbdcfdf26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b5193b-e7be-4ee7-b407-6f4bbdcfdf26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791171350&installation_model_id=21489&pr_number=1705&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1705&signature=e55213ae6de50392d4d56c8043757efe432607051cf8838cfb0de4c271b6bf11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->