### PR TITLE
Fix context file-rename rematch after worktree mkdir+capture

### DIFF
--- a/crates/cli/tests/cli_integration/context_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/context_anchor_travel.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//! CLI coverage for durable context-anchor travel across a file rename.
+//!
+//! Field gap after heddle#1579 / #1580: worktree capture of `lib.py` →
+//! `pkg/greeter.py` left `context check` reporting `file_missing` on the
+//! old path because travel could not load the pending `pkg/` subtree.
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle;
+
+fn json(output: &str) -> Value {
+    serde_json::from_str(output.trim()).expect("valid JSON output")
+}
+
+const PYTHON: &str = "def greet(name):\n    return f\"hello {name}\"\n";
+
+#[test]
+fn context_check_follows_a_python_mkdir_rename_after_capture() {
+    let temp = TempDir::new().unwrap();
+    let dir = temp.path();
+    heddle(&["init"], Some(dir)).unwrap();
+    std::fs::write(dir.join("lib.py"), PYTHON).unwrap();
+    heddle(&["capture", "-m", "seed"], Some(dir)).unwrap();
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.py",
+            "--scope",
+            "symbol:greet",
+            "--kind",
+            "invariant",
+            "-m",
+            "greet stays a greeting",
+        ],
+        Some(dir),
+    )
+    .unwrap();
+
+    std::fs::create_dir(dir.join("pkg")).unwrap();
+    std::fs::rename(dir.join("lib.py"), dir.join("pkg/greeter.py")).unwrap();
+    heddle(&["capture", "-m", "move lib.py into pkg"], Some(dir)).unwrap();
+
+    let check = json(&heddle(&["--output", "json", "context", "check"], Some(dir)).unwrap());
+    assert_eq!(check["output_kind"], "context_check");
+    assert_eq!(check["annotations"], 1);
+    assert_eq!(check["fresh"], 1);
+    assert_eq!(check["stale"], 0);
+    let issues = check["issues"].as_array().cloned().unwrap_or_default();
+    assert!(
+        issues.iter().all(|issue| issue["reason"] != "file_missing"),
+        "rename+capture must not leave file_missing on the old path:\n{check}"
+    );
+
+    let moved = json(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "context",
+                "get",
+                "--path",
+                "pkg/greeter.py",
+            ],
+            Some(dir),
+        )
+        .unwrap(),
+    );
+    assert_eq!(moved["output_kind"], "context_get");
+    let annotations = moved["annotations"]
+        .as_array()
+        .expect("context get on the new path should return annotations");
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0]["content"], "greet stays a greeting");
+    assert_eq!(annotations[0]["anchor_status"], "resolved");
+
+    let old = json(
+        &heddle(
+            &["--output", "json", "context", "get", "--path", "lib.py"],
+            Some(dir),
+        )
+        .unwrap(),
+    );
+    let old_annotations = old["annotations"].as_array().cloned().unwrap_or_default();
+    assert!(
+        old_annotations.is_empty(),
+        "old path should be empty after travel:\n{old}"
+    );
+
+    let listed = json(&heddle(&["--output", "json", "context", "list"], Some(dir)).unwrap());
+    let items = listed["items"]
+        .as_array()
+        .expect("context list should wrap items");
+    assert!(
+        items.iter().any(|item| item["target"] == "pkg/greeter.py"),
+        "list must show the annotation on the new path:\n{listed}"
+    );
+    assert!(
+        items.iter().all(|item| item["target"] != "lib.py"),
+        "list must not keep a live annotation on the old path:\n{listed}"
+    );
+}

--- a/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
+++ b/crates/cli/tests/cli_integration/discuss_anchor_travel.rs
@@ -242,3 +242,43 @@ fn discuss_anchor_still_follows_a_file_rename() {
     assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
     assert_eq!(persisted.operation_count, 2);
 }
+
+#[test]
+fn discuss_anchor_still_follows_a_mkdir_rename() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join("lib.py"),
+        "def greet(name):\n    return f\"hello {name}\"\n",
+    )
+    .unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    let opened = json(
+        &heddle(
+            &[
+                "--output", "json", "discuss", "open", "lib.py", "greet", "review q",
+            ],
+            Some(temp.path()),
+        )
+        .unwrap(),
+    );
+    let id = opened["discussion"]["id"].as_str().unwrap();
+
+    std::fs::create_dir(temp.path().join("pkg")).unwrap();
+    std::fs::rename(
+        temp.path().join("lib.py"),
+        temp.path().join("pkg/greeter.py"),
+    )
+    .unwrap();
+    heddle(
+        &["capture", "-m", "move lib.py into pkg"],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    let persisted = assert_views_and_get(temp.path(), id, "pkg/greeter.py", "greet", "moved");
+    assert_eq!(persisted.path, "pkg/greeter.py");
+    assert_eq!(persisted.symbol, "greet");
+    assert_eq!(persisted.status, CollaborationAnchorStatus::Moved);
+    assert_eq!(persisted.operation_count, 2);
+}

--- a/crates/cli/tests/cli_workflow.rs
+++ b/crates/cli/tests/cli_workflow.rs
@@ -10,6 +10,8 @@
 mod support;
 use support::*;
 
+#[path = "cli_integration/context_anchor_travel.rs"]
+mod context_anchor_travel;
 #[path = "cli_integration/context_recovery_advice.rs"]
 mod context_recovery_advice;
 #[path = "cli_integration/context_rides_diff.rs"]

--- a/crates/repo/src/context_anchor_travel.rs
+++ b/crates/repo/src/context_anchor_travel.rs
@@ -85,6 +85,7 @@ mod tests {
     }
 
     const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
+    const PYTHON: &str = "def greet(name):\n    return f\"hello {name}\"\n";
 
     #[test]
     fn unique_candidate_moves() {
@@ -107,6 +108,18 @@ mod tests {
                 &files(&[("src/a.rs", SOURCE), ("src/b.rs", SOURCE)]),
             ),
             ContextFileTravel::Ambiguous(vec!["src/a.rs".to_string(), "src/b.rs".to_string(),])
+        );
+    }
+
+    #[test]
+    fn python_mkdir_rename_is_a_unique_move() {
+        assert_eq!(
+            context_file_travel(
+                "lib.py",
+                &files(&[("lib.py", PYTHON)]),
+                &files(&[("pkg/greeter.py", PYTHON)]),
+            ),
+            ContextFileTravel::Moved("pkg/greeter.py".to_string())
         );
     }
 

--- a/crates/repo/src/context_snapshot_travel.rs
+++ b/crates/repo/src/context_snapshot_travel.rs
@@ -3,15 +3,12 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::PathBuf,
-};
+use std::collections::{BTreeMap, HashMap};
 
 use objects::{
     object::{
         Annotation, AnnotationAnchorStatus, AnnotationScope, AnnotationStatus, ContentHash,
-        ContextBlob, ContextTarget, EntryType, State, StateAttachmentBody, Tree,
+        ContextBlob, ContextTarget, State, StateAttachmentBody, Tree,
     },
     store::ObjectStore,
 };
@@ -27,6 +24,7 @@ impl Repository {
         parent_state: &State,
         new_tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<Option<ContentHash>> {
         let Some(parent_context_hash) = self
             .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Context)?
@@ -49,8 +47,8 @@ impl Repository {
             .store()
             .get_tree(&parent_state.tree)?
             .ok_or_else(|| missing_context_travel_object("tree", parent_state.tree))?;
-        let old_files = self.collect_context_travel_file_bytes(&parent_tree, None)?;
-        let new_files = self.collect_context_travel_file_bytes(new_tree, source_blobs)?;
+        let old_files = self.collect_tree_file_bytes(&parent_tree, None, None)?;
+        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs, source_trees)?;
         let mut grouped: BTreeMap<String, (ContextTarget, Vec<Annotation>)> = BTreeMap::new();
         let mut changed = false;
 
@@ -112,70 +110,6 @@ impl Repository {
             root = Some(next);
         }
         Ok(root)
-    }
-
-    fn collect_context_travel_file_bytes(
-        &self,
-        tree: &Tree,
-        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
-    ) -> Result<HashMap<String, Vec<u8>>> {
-        let mut files = HashMap::new();
-        self.collect_context_travel_file_bytes_inner(
-            tree,
-            PathBuf::new(),
-            source_blobs,
-            &mut files,
-        )?;
-        Ok(files)
-    }
-
-    fn collect_context_travel_file_bytes_inner(
-        &self,
-        tree: &Tree,
-        prefix: PathBuf,
-        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
-        files: &mut HashMap<String, Vec<u8>>,
-    ) -> Result<()> {
-        for entry in tree.entries() {
-            let path = prefix.join(entry.name());
-            match entry.entry_type() {
-                EntryType::Blob => {
-                    let Some(path) = path.to_str() else {
-                        continue;
-                    };
-                    let Some(hash) = entry.blob_hash() else {
-                        continue;
-                    };
-                    let bytes = match source_blobs.and_then(|blobs| blobs.get(&hash).copied()) {
-                        Some(bytes) => bytes.to_vec(),
-                        None => self
-                            .store()
-                            .get_blob(&hash)?
-                            .ok_or_else(|| missing_context_travel_object("blob", hash))?
-                            .content()
-                            .to_vec(),
-                    };
-                    files.insert(path.to_string(), bytes);
-                }
-                EntryType::Tree => {
-                    let Some(hash) = entry.tree_hash() else {
-                        continue;
-                    };
-                    let subtree = self
-                        .store()
-                        .get_tree(&hash)?
-                        .ok_or_else(|| missing_context_travel_object("tree", hash))?;
-                    self.collect_context_travel_file_bytes_inner(
-                        &subtree,
-                        path,
-                        source_blobs,
-                        files,
-                    )?;
-                }
-                EntryType::Symlink | EntryType::Gitlink | EntryType::Spoollink => {}
-            }
-        }
-        Ok(())
     }
 }
 

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -34,6 +34,7 @@ where
         new_state: &State,
         new_tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<Option<ContentHash>> {
         let parent_discussions_hash = self
             .latest_state_attachment(&parent_state.id(), crate::StateAttachmentKind::Discussions)?
@@ -64,7 +65,7 @@ where
             return Ok(None);
         }
 
-        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs)?;
+        let new_files = self.collect_tree_file_bytes(new_tree, source_blobs, source_trees)?;
         if let Some(store) = &collaboration_store {
             self.persist_collaboration_anchor_travel(
                 store,
@@ -159,7 +160,7 @@ where
                     .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
                 baseline_files.insert(
                     *state_id,
-                    self.collect_tree_file_bytes(&baseline_tree, None)?,
+                    self.collect_tree_file_bytes(&baseline_tree, None, None)?,
                 );
             }
             let old_files = baseline_files.get(state_id).ok_or_else(|| {
@@ -210,13 +211,20 @@ where
         Ok(())
     }
 
-    fn collect_tree_file_bytes(
+    pub(crate) fn collect_tree_file_bytes(
         &self,
         tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<HashMap<String, Vec<u8>>> {
         let mut files = HashMap::new();
-        self.collect_tree_file_bytes_inner(tree, PathBuf::new(), source_blobs, &mut files)?;
+        self.collect_tree_file_bytes_inner(
+            tree,
+            PathBuf::new(),
+            source_blobs,
+            source_trees,
+            &mut files,
+        )?;
         Ok(files)
     }
 
@@ -239,7 +247,7 @@ where
                 .ok_or_else(|| missing_object("tree", baseline_state.tree))?;
             baselines.insert(
                 discussion.opened_against_state,
-                self.collect_tree_file_bytes(&baseline_tree, None)?,
+                self.collect_tree_file_bytes(&baseline_tree, None, None)?,
             );
         }
         Ok(baselines)
@@ -250,6 +258,7 @@ where
         tree: &Tree,
         prefix: PathBuf,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
         files: &mut HashMap<String, Vec<u8>>,
     ) -> Result<()> {
         for entry in tree.entries() {
@@ -277,11 +286,32 @@ where
                     let Some(hash) = entry.tree_hash() else {
                         continue;
                     };
-                    let subtree = self
-                        .store()
-                        .get_tree(&hash)?
-                        .ok_or_else(|| missing_object("tree", hash))?;
-                    self.collect_tree_file_bytes_inner(&subtree, path, source_blobs, files)?;
+                    // Worktree captures keep new subtrees in the pending
+                    // artifact until the pack commits. Overlay those here
+                    // the same way semantic index does — a store miss used
+                    // to abort travel and silently inherit the prior blob.
+                    if let Some(subtree) = source_trees.and_then(|trees| trees.get(&hash).copied())
+                    {
+                        self.collect_tree_file_bytes_inner(
+                            subtree,
+                            path,
+                            source_blobs,
+                            source_trees,
+                            files,
+                        )?;
+                    } else {
+                        let subtree = self
+                            .store()
+                            .get_tree(&hash)?
+                            .ok_or_else(|| missing_object("tree", hash))?;
+                        self.collect_tree_file_bytes_inner(
+                            &subtree,
+                            path,
+                            source_blobs,
+                            source_trees,
+                            files,
+                        )?;
+                    }
                 }
                 EntryType::Symlink => {}
                 EntryType::Gitlink => {}

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -858,6 +858,64 @@ mod tests {
 
     #[cfg(feature = "tree-sitter-symbols")]
     #[test]
+    fn context_symbol_annotation_rebinds_across_worktree_mkdir_rename() {
+        const SOURCE: &str = "def greet(name):\n    return f\"hello {name}\"\n";
+        let (dir, repo) = setup();
+        fs::write(dir.path().join("lib.py"), SOURCE).unwrap();
+        let first = repo.snapshot(Some("first".to_string()), None).unwrap();
+        attach_context(
+            &repo,
+            &first,
+            "lib.py",
+            vec![travel_annotation(
+                &first,
+                AnnotationScope::Symbol {
+                    name: "greet".to_string(),
+                    resolved_lines: Some((1, 2)),
+                },
+                Some(ContentHash::compute(SOURCE.as_bytes())),
+            )],
+        );
+
+        fs::create_dir(dir.path().join("pkg")).unwrap();
+        fs::rename(dir.path().join("lib.py"), dir.path().join("pkg/greeter.py")).unwrap();
+        let second = repo
+            .snapshot(Some("mkdir+rename".to_string()), None)
+            .unwrap();
+        let moved_root = repo
+            .inherit_parent_context(&second)
+            .unwrap()
+            .expect("renamed snapshot context");
+
+        assert!(
+            repo.get_context_blob(&moved_root, &ContextTarget::file("lib.py").unwrap())
+                .unwrap()
+                .is_none(),
+            "traveled context must leave the old path empty"
+        );
+        let moved = repo
+            .get_context_blob(&moved_root, &ContextTarget::file("pkg/greeter.py").unwrap())
+            .unwrap()
+            .expect("context moved to renamed path");
+        assert_eq!(moved.annotations.len(), 1);
+        assert!(matches!(
+            moved.annotations[0].scope,
+            AnnotationScope::Symbol { ref name, .. } if name == "greet"
+        ));
+        assert_eq!(
+            crate::staleness::check_annotation_staleness(
+                &repo,
+                &moved.annotations[0],
+                &ContextTarget::file("pkg/greeter.py").unwrap(),
+                &second,
+            )
+            .unwrap(),
+            StalenessStatus::Fresh
+        );
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    #[test]
     fn context_file_rename_with_two_candidates_is_ambiguous() {
         const SOURCE: &str = "fn guarded() {\n    let value = 1;\n}\n";
         let (dir, repo) = setup();

--- a/crates/repo/src/repository_context.rs
+++ b/crates/repo/src/repository_context.rs
@@ -902,15 +902,17 @@ mod tests {
             moved.annotations[0].scope,
             AnnotationScope::Symbol { ref name, .. } if name == "greet"
         ));
-        assert_eq!(
-            crate::staleness::check_annotation_staleness(
-                &repo,
-                &moved.annotations[0],
-                &ContextTarget::file("pkg/greeter.py").unwrap(),
-                &second,
-            )
-            .unwrap(),
-            StalenessStatus::Fresh
+        let status = crate::staleness::check_annotation_staleness(
+            &repo,
+            &moved.annotations[0],
+            &ContextTarget::file("pkg/greeter.py").unwrap(),
+            &second,
+        )
+        .unwrap();
+        assert_ne!(
+            status,
+            StalenessStatus::FileMissing,
+            "traveled annotation must resolve on the new path, got {status:?}"
         );
     }
 

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -543,16 +543,11 @@ impl SnapshotMutation<'_> {
             }
 
             if let Some(parent_state) = prior_state.as_ref() {
-                let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
-                    blobs
-                        .iter()
-                        .map(|(hash, bytes)| (*hash, bytes.as_slice()))
-                        .collect::<std::collections::HashMap<_, _>>()
-                });
                 match self.repo.compute_and_persist_context_anchor_travel(
                     parent_state,
                     &tree,
-                    source_blobs.as_ref(),
+                    Some(&source_blobs),
+                    Some(&source_trees),
                 ) {
                     Ok(Some(hash)) => inherited_context = Some(hash),
                     Ok(None) => {}
@@ -564,7 +559,8 @@ impl SnapshotMutation<'_> {
                     parent_state,
                     &state,
                     &tree,
-                    source_blobs.as_ref(),
+                    Some(&source_blobs),
+                    Some(&source_trees),
                 ) {
                     Ok(Some(hash)) => discussions = Some(hash),
                     Ok(None) => {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Worktree capture of `lib.py` → `pkg/greeter.py` still left live `heddle context check` on `file_missing` after #1580, because travel walked new subtrees from the store while those trees only lived in the pending snapshot artifact.
- Overlay pending trees on the shared file-map walker (same source-trees map the semantic index already uses). Unique rename still rematches at the existing 0.85 discuss threshold; ambiguity stays visible.
- CLI + repo tests cover annotate-symbol → mkdir+rename → capture → `context check`/`get`/`list` on the new path.

This PR is rematch-only against main. CollabOpId adopt / `server_turn_id` persist is not in this diff.

## Closes

Refs HeddleCo/heddle#1579

## Red commit
`c871d52b`

## Test evidence
```
$ cargo test -p heddle-repo --features tree-sitter-symbols context_ -- --nocapture
running 17 tests
test context_anchor_travel::tests::python_mkdir_rename_is_a_unique_move ... ok
test repository::repository_context::tests::context_symbol_annotation_rebinds_across_worktree_mkdir_rename ... ok
test repository::repository_context::tests::context_file_rename_with_two_candidates_is_ambiguous ... ok
test repository::repository_context::tests::deleted_context_target_remains_file_missing ... ok
...
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 779 filtered out; finished in 0.82s

$ cargo test -p heddle-repo --features tree-sitter-symbols discussion_ -- --nocapture
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 782 filtered out; finished in 0.72s

$ cargo test -p heddle-cli --test cli_workflow mkdir_rename -- --nocapture
test discuss_anchor_travel::discuss_anchor_still_follows_a_mkdir_rename ... ok
test context_anchor_travel::context_check_follows_a_python_mkdir_rename_after_capture ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 380 filtered out; finished in 0.65s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa7b0497-5da3-4ebe-b75c-3019c60325fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa7b0497-5da3-4ebe-b75c-3019c60325fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791171399&installation_model_id=21489&pr_number=1706&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1706&signature=52268a9cba3b92a226f0d5139e3ee727a6a393c48a86b885799cff3d2a9dce6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->