### PR TITLE
fix(visibility): owner clone of a private-tier spool

### DIFF
--- a/crates/cli/tests/cli_integration/visibility.rs
+++ b/crates/cli/tests/cli_integration/visibility.rs
@@ -453,6 +453,91 @@ fn undo_visibility_promote_reverts_tier() {
 }
 
 #[test]
+fn owner_clone_of_private_spool_after_visibility_discuss_and_context() {
+    // Field regression (2026-09-05): after `visibility set --tier private`
+    // plus discuss/context, owner clone failed exit 78 `state not found`.
+    // Owners stay label-scoped: `visibility set --label ax-only` stamps
+    // Restricted(ax-only) membership (not an all-Private Owner audience).
+    // Local clone copies the sidecar without `[metadata] trusted_keys`.
+    // Unlabeled Owner / missing grant cannot see Private — see
+    // `grant_can_see_tier`.
+    let (temp, _) = init_and_capture("ax-only");
+    fs::write(temp.path().join("note.rs"), "fn note() {}\n").unwrap();
+    let state = capture_state(temp.path(), "private head");
+    heddle(
+        &[
+            "visibility",
+            "set",
+            &state,
+            "--tier",
+            "private",
+            "--label",
+            "ax-only",
+        ],
+        Some(temp.path()),
+    )
+    .expect("visibility set private");
+    let membership = fs::read_to_string(temp.path().join(".heddle/visibility/audience_label"))
+        .expect("visibility set must stamp Restricted(L) embargo membership");
+    assert_eq!(
+        membership.trim(),
+        "ax-only",
+        "declaring Private{{ax-only}} must carry Restricted(ax-only), not unlabeled Owner"
+    );
+    heddle(
+        &[
+            "discuss",
+            "open",
+            "note.rs",
+            "note",
+            "keep this ax-only",
+            "--visibility",
+            "private:ax-only",
+        ],
+        Some(temp.path()),
+    )
+    .expect("discuss open private");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "note.rs",
+            "--kind",
+            "constraint",
+            "-m",
+            "ax-only guidance",
+        ],
+        Some(temp.path()),
+    )
+    .expect("context set");
+
+    let clone = TempDir::new().unwrap();
+    let dest = clone.path().join("owner-clone");
+    heddle(
+        &[
+            "clone",
+            &temp.path().to_string_lossy(),
+            &dest.to_string_lossy(),
+        ],
+        None,
+    )
+    .unwrap_or_else(|err| panic!("owner clone of private-tier spool must succeed: {err}"));
+
+    let show = show_json(&dest, &state);
+    assert_eq!(
+        show["tier"], "private",
+        "cloned owner checkout must keep the Private sidecar: {show}"
+    );
+    assert_eq!(show["label"], "ax-only");
+    let note = fs::read(dest.join("note.rs")).expect("cloned worktree note");
+    assert_eq!(
+        note, b"fn note() {}\n",
+        "owner clone must materialize the advertised private head, not withhold it"
+    );
+}
+
+#[test]
 fn visibility_list_enumerates_tiered_states() {
     let (temp, _) = init_and_capture("ordinary");
     let state = capture_state(temp.path(), "ordinary capture");

--- a/crates/hosted-client/src/client/local_sync.rs
+++ b/crates/hosted-client/src/client/local_sync.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use objects::{
     object::{ActionId, ContentHash, StateAttachment, StateId},
     store::{ObjectStore, SidecarStore},
@@ -354,8 +354,10 @@ impl LocalSync {
     }
 
     /// If the source repository has state-visibility records for `state`,
-    /// ferry the sidecar bytes through the same repository boundary used by
-    /// the network path.
+    /// copy them through the local-trust boundary. Hosted `accept_wire`
+    /// requires `[metadata] trusted_keys`; a fresh clone does not have
+    /// them, and dropping a `Private` sidecar makes the advertised head
+    /// unresolvable.
     fn propagate_state_visibility_for_state(
         &self,
         target: &Repository,
@@ -364,7 +366,7 @@ impl LocalSync {
         let Some(bytes) = self.source.get_state_visibility_bytes_for_state(state)? else {
             return Ok(());
         };
-        target.accept_wire_state_visibility(*state, &bytes)?;
+        target.accept_local_state_visibility(*state, &bytes)?;
         Ok(())
     }
 
@@ -384,7 +386,8 @@ impl LocalSync {
 #[cfg(test)]
 mod tests {
     use objects::object::{
-        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, Tree, TreeEntry,
+        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, StateVisibility, Tree,
+        TreeEntry, VisibilityTier,
     };
     use repo::StateAttachmentKind;
     use tempfile::TempDir;
@@ -447,9 +450,12 @@ mod tests {
             .expect("put context blob");
         let context_root = source
             .store()
-            .put_tree(&Tree::from_entries(vec![
-                TreeEntry::file("context.msgpack", context_blob, false).unwrap(),
-            ]))
+            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
+                "context.msgpack",
+                context_blob,
+                false,
+            )
+            .unwrap()]))
             .expect("put context tree");
         let first = StateAttachment {
             state_id,
@@ -480,6 +486,46 @@ mod tests {
                 .latest_state_attachment(&state_id, StateAttachmentKind::Context)
                 .unwrap(),
             Some(second)
+        );
+    }
+
+    #[test]
+    fn fetch_copies_private_visibility_sidecar() {
+        let source_dir = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+        let source = Repository::init_default(source_dir.path()).unwrap();
+        let target = Repository::init_default(target_dir.path()).unwrap();
+        let state_id = capture(&source, "secret\n", "embargo");
+        source
+            .put_state_visibility(StateVisibility {
+                state: state_id,
+                tier: VisibilityTier::Private {
+                    scope_label: "ax-only".into(),
+                },
+                embargo_until: None,
+                declarer: Principal::new("Alice", "alice@example.test"),
+                declared_at: chrono::Utc::now(),
+                signature: None,
+                supersedes: None,
+            })
+            .expect("put private visibility");
+
+        LocalSync::open(source_dir.path())
+            .unwrap()
+            .fetch_state(&target, &state_id)
+            .expect("owner local fetch of a private-tier state");
+
+        assert!(target.store().get_state(&state_id).unwrap().is_some());
+        assert_eq!(
+            target.effective_visibility_tier(&state_id).unwrap(),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            }
+        );
+        assert_eq!(
+            target.embargo_membership_label().unwrap().as_deref(),
+            Some("ax-only"),
+            "local fetch of Private{{ax-only}} must stamp Restricted(ax-only) membership"
         );
     }
 }

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -4,6 +4,10 @@
 //! This is the heddle-side typed contract Weft gates `ListRefs`/`Pull` against.
 //! Unknown or missing roles fail closed to [`AudienceTier::Public`] so an
 //! unauthorized puller can never be treated as the internal trusted set.
+//! Owners stay label-scoped: unlabeled Owner is Internal; Private is visible
+//! only with a matching `audience_label` (`Restricted`).
+
+use objects::object::{VisibilityTier, visible};
 
 use super::visibility::AudienceTier;
 
@@ -71,6 +75,20 @@ pub fn audience_tier_for_grant(
     }
 }
 
+/// Whether this grant may be served a record at `tier`.
+///
+/// Owners stay label-scoped: unlabeled Owner is Internal and cannot see
+/// `Private`. A matching `audience_label` is `Restricted(L)` and is the
+/// only Owner admit for that embargo. Missing/unspecified grants stay
+/// Public (Bob without a grant remains PermissionDenied).
+pub fn grant_can_see_tier(
+    role: Option<GrantRole>,
+    audience_label: Option<&str>,
+    tier: &VisibilityTier,
+) -> bool {
+    visible(tier, &audience_tier_for_grant(role, audience_label))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,6 +135,49 @@ mod tests {
             audience_tier_for_grant(Some(GrantRole::Owner), Some("  ")),
             AudienceTier::Internal
         );
+    }
+
+    #[test]
+    fn owner_sees_private_only_with_matching_embargo_label() {
+        let private = VisibilityTier::Private {
+            scope_label: "ax-only".into(),
+        };
+        let other = VisibilityTier::Private {
+            scope_label: "other".into(),
+        };
+        assert_eq!(
+            audience_tier_for_grant(Some(GrantRole::Owner), None),
+            AudienceTier::Internal
+        );
+        assert!(
+            !grant_can_see_tier(Some(GrantRole::Owner), None, &private),
+            "unlabeled Owner must not see every Private label"
+        );
+        assert!(grant_can_see_tier(
+            Some(GrantRole::Owner),
+            Some("ax-only"),
+            &private
+        ));
+        assert!(!grant_can_see_tier(
+            Some(GrantRole::Owner),
+            Some("other"),
+            &private
+        ));
+        assert!(!grant_can_see_tier(
+            Some(GrantRole::Owner),
+            Some("ax-only"),
+            &other
+        ));
+        assert!(!grant_can_see_tier(Some(GrantRole::Admin), None, &private));
+        assert!(
+            !grant_can_see_tier(None, None, &private),
+            "a missing grant must stay Public and must not see Private"
+        );
+        assert!(!grant_can_see_tier(
+            Some(GrantRole::Unspecified),
+            None,
+            &private
+        ));
     }
 
     #[test]

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -170,7 +170,7 @@ pub use git_ref_name::{
     GitRefContentNamespace, GitRefKind, GitRefName, GitRefNamespace, ParsedGitRef,
     REMOTE_NAME_FOR_LOCAL_GIT_REPO, is_reserved_git_remote_name,
 };
-pub use grant_audience::{GrantRole, audience_tier_for_grant};
+pub use grant_audience::{GrantRole, audience_tier_for_grant, grant_can_see_tier};
 pub use hooks::{Hook, HookContext, HookManager, HookResponse};
 pub use merge_state::{MergeState, MergeStateManager};
 pub use objects::{

--- a/crates/repo/src/owner_authorization.rs
+++ b/crates/repo/src/owner_authorization.rs
@@ -11,8 +11,8 @@ use api::heddle::api::v1alpha1::{
 };
 use crypto::Signer;
 use heddleco_capability_verifier::{
-    Decision, PurgeContext, VerificationLimits, verify_authorization_bundle,
-    verify_purge_authorization, verify_spool_owner_genesis,
+    verify_authorization_bundle, verify_purge_authorization, verify_spool_owner_genesis, Decision,
+    PurgeContext, VerificationLimits,
 };
 use objects::{fs_atomic::write_file_atomic, lock::RepositoryLockExt};
 use prost::Message;
@@ -75,6 +75,15 @@ struct PinnedOwnerGenesis {
 impl Repository {
     fn owner_genesis_pin_path(&self) -> std::path::PathBuf {
         self.heddle_dir().join(OWNER_GENESIS_PIN_FILE)
+    }
+
+    /// Hex public key of the TOFU-pinned owner genesis, when a clone has
+    /// already verified `PullReady`. Used to accept owner-signed metadata
+    /// (state visibility) without requiring the fresh clone to pre-seed
+    /// `[metadata] trusted_keys`.
+    pub(crate) fn pinned_owner_metadata_key(&self) -> Option<(String, String)> {
+        let pin = self.read_owner_genesis_pin().ok()?;
+        Some(("ed25519".to_string(), hex::encode(pin.owner_public_key)))
     }
 
     fn read_owner_genesis_pin(&self) -> Result<PinnedOwnerGenesis> {

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -172,8 +172,7 @@ impl Repository {
             return Err(HeddleError::InvalidObject(format!(
                 "hosted metadata signer is not trusted ({}:{})",
                 signature.algorithm, signature.public_key
-            ))
-            .into());
+            )));
         };
         self.verify_metadata_signature_bytes(
             payload,

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -129,12 +129,18 @@ impl Repository {
         })
     }
 
-    /// Verify hosted metadata against this repository's trusted client keys.
+    /// Verify hosted metadata against this repository's trusted client keys
+    /// or the TOFU-pinned owner genesis from `PullReady`.
     ///
     /// A signature only proves the payload was signed by the key *embedded in
     /// the record*. Acceptance requires that key to appear in
-    /// `[metadata] trusted_keys`, and cryptographic verification uses that
-    /// configured key — not attacker-supplied key bytes.
+    /// `[metadata] trusted_keys` **or** to be the owner key already pinned
+    /// from verified `PullReady` genesis. Cryptographic verification uses
+    /// that trusted/pinned key — not attacker-supplied key bytes.
+    ///
+    /// Clone destinations start with an empty trust list. Without the pin
+    /// fallback, an owner-signed `Private` visibility sidecar is rejected
+    /// and the advertised head cannot be resolved (`state not found`).
     pub(crate) fn verify_client_metadata_signature(
         &self,
         payload: &[u8],
@@ -145,29 +151,58 @@ impl Repository {
                 "hosted metadata is unsigned; a trusted client signature is required".to_string(),
             )
         })?;
-        let trusted = super::repo_config::TrustedKey::find(
-            &self.config().metadata.trusted_keys,
-            &signature.algorithm,
-            &signature.public_key,
-        )
-        .ok_or_else(|| {
-            HeddleError::InvalidObject(format!(
+        let (algorithm, public_key_hex) = if let Some(trusted) =
+            super::repo_config::TrustedKey::find(
+                &self.config().metadata.trusted_keys,
+                &signature.algorithm,
+                &signature.public_key,
+            ) {
+            (trusted.algorithm.as_str(), trusted.public_key.as_str())
+        } else if let Some((algorithm, public_key_hex)) = self.pinned_owner_metadata_key()
+            && algorithm.eq_ignore_ascii_case(&signature.algorithm)
+            && public_key_hex.eq_ignore_ascii_case(&signature.public_key)
+        {
+            return self.verify_metadata_signature_bytes(
+                payload,
+                &algorithm,
+                &public_key_hex,
+                &signature.signature,
+            );
+        } else {
+            return Err(HeddleError::InvalidObject(format!(
                 "hosted metadata signer is not trusted ({}:{})",
                 signature.algorithm, signature.public_key
             ))
-        })?;
-        let public_key = hex::decode(&trusted.public_key).map_err(|error| {
+            .into());
+        };
+        self.verify_metadata_signature_bytes(
+            payload,
+            algorithm,
+            public_key_hex,
+            &signature.signature,
+        )
+    }
+
+    fn verify_metadata_signature_bytes(
+        &self,
+        payload: &[u8],
+        algorithm: &str,
+        public_key_hex: &str,
+        signature_hex: &str,
+    ) -> Result<()> {
+        let public_key = hex::decode(public_key_hex).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata public key: {error}"))
         })?;
-        let signature_bytes = hex::decode(&signature.signature).map_err(|error| {
+        let signature_bytes = hex::decode(signature_hex).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata signature: {error}"))
         })?;
-        verify_payload_signature(payload, &trusted.algorithm, &public_key, &signature_bytes)
-            .map_err(|error| {
+        verify_payload_signature(payload, algorithm, &public_key, &signature_bytes).map_err(
+            |error| {
                 HeddleError::InvalidObject(format!(
                     "hosted metadata signature failed verification: {error}"
                 ))
-            })
+            },
+        )
     }
 
     /// Produce a detached signature when a signing identity is available.

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -36,7 +36,7 @@ use objects::{
 use oplog::{OpLogRecorder, OpRecord, VisibilitySidecarSnapshots};
 
 use crate::{
-    namespace_policy::{VisibilityResolutionContext, resolve_default_visibility},
+    namespace_policy::{resolve_default_visibility, VisibilityResolutionContext},
     repository::Repository,
 };
 
@@ -257,6 +257,9 @@ impl Repository {
             fs::create_dir_all(parent).with_context(|| format!("create '{}'", parent.display()))?;
         }
         write_file_atomic(&path, &bytes).with_context(|| format!("write '{}'", path.display()))?;
+        if let Some(latest) = existing.latest()? {
+            self.record_embargo_membership_from_tier(&latest.tier)?;
+        }
         Ok(PutVisibilityOutcome {
             id,
             prior_sidecar,
@@ -511,6 +514,38 @@ impl Repository {
         Ok(())
     }
 
+    /// Copy a state-visibility sidecar from a local source the operator can
+    /// already read. Decode and validate the blob, then persist the original
+    /// bytes — local clone must not require the destination to pre-seed
+    /// `[metadata] trusted_keys` the way hosted `accept_wire_state_visibility`
+    /// does. A `Private` head that lost its sidecar on clone cannot be
+    /// resolved (`state not found`).
+    pub fn accept_local_state_visibility(&self, state: StateId, bytes: &[u8]) -> Result<()> {
+        let incoming = StateVisibilityBlob::decode(bytes).with_context(|| {
+            format!(
+                "decode local state visibility for state {}",
+                state.to_string_full()
+            )
+        })?;
+        for record in &incoming.records {
+            if record.state != state {
+                anyhow::bail!(
+                    "local state visibility claims state {} but was copied under {}",
+                    record.state.to_string_full(),
+                    state.to_string_full()
+                );
+            }
+            record
+                .validate()
+                .with_context(|| "validate local state-visibility record")?;
+        }
+        self.restore_state_visibility_sidecar(&state, Some(bytes.to_vec()))?;
+        if let Some(latest) = incoming.latest()? {
+            self.record_embargo_membership_from_tier(&latest.tier)?;
+        }
+        Ok(())
+    }
+
     /// Load all visibility records targeting `state`. Returns an empty
     /// [`StateVisibilityBlob`] (not an error) when none exist — callers can
     /// treat the result uniformly.
@@ -675,9 +710,9 @@ impl Repository {
         let _own_lock = if lock_held {
             None
         } else {
-            Some(self.locker().write().with_context(
-                || "acquire repo write lock for capture-time default visibility binding",
-            )?)
+            Some(self.locker().write().with_context(|| {
+                "acquire repo write lock for capture-time default visibility binding"
+            })?)
         };
         let mut record = StateVisibility {
             state: *state,
@@ -798,6 +833,52 @@ impl Repository {
     /// `<heddle_dir>/visibility/` — root of the per-state visibility store.
     pub(crate) fn state_visibility_dir(&self) -> PathBuf {
         self.heddle_dir().join("visibility")
+    }
+
+    /// Local embargo membership for this checkout — the `audience_label`
+    /// `audience_tier_for_grant` maps to Restricted.
+    ///
+    /// Stamped when this principal declares or accepts a `Private` /
+    /// `Restricted` sidecar so they carry that one label, not every Private
+    /// scope. Unlabeled Owner stays Internal.
+    pub fn embargo_membership_label(&self) -> Result<Option<String>> {
+        let path = self.embargo_membership_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("read embargo membership '{}'", path.display()))?;
+        let label = raw.trim();
+        if label.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(label.to_string()))
+        }
+    }
+
+    fn embargo_membership_path(&self) -> PathBuf {
+        self.state_visibility_dir().join("audience_label")
+    }
+
+    fn record_embargo_membership_from_tier(&self, tier: &VisibilityTier) -> Result<()> {
+        let label = match tier {
+            VisibilityTier::Private { scope_label } | VisibilityTier::Restricted { scope_label } => {
+                scope_label.trim()
+            }
+            VisibilityTier::Public
+            | VisibilityTier::Internal
+            | VisibilityTier::TeamScoped { .. } => return Ok(()),
+        };
+        if label.is_empty() {
+            return Ok(());
+        }
+        let path = self.embargo_membership_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create '{}'", parent.display()))?;
+        }
+        write_file_atomic(&path, label.as_bytes())
+            .with_context(|| format!("write embargo membership '{}'", path.display()))
     }
 
     /// `<heddle_dir>/visibility/<change-id>.bin` — the visibility sidecar
@@ -1011,6 +1092,122 @@ mod tests {
     }
 
     #[test]
+    fn wire_visibility_accepts_pullready_pinned_owner_key() {
+        // Clone destinations have an empty `[metadata] trusted_keys`. The
+        // owner key TOFU-pinned from PullReady must still admit that owner's
+        // Private sidecar, or clone cannot resolve the advertised head.
+        let owner = Ed25519Signer::generate().expect("owner keygen");
+        let stranger = Ed25519Signer::generate().expect("stranger keygen");
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        let genesis = crate::sign_spool_owner_genesis(&owner, *uuid::Uuid::now_v7().as_bytes())
+            .expect("sign genesis");
+        repo.verify_and_pin_owner_genesis(2, Some(&genesis), &["alice".into(), "private".into()])
+            .expect("pin owner genesis");
+
+        let state = StateId::from_bytes([11u8; 32]);
+        let mut record = sample_record(
+            state,
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            },
+        );
+        sign_visibility(&mut record, &owner);
+        let signed = StateVisibilityBlob::new(vec![record]).encode().unwrap();
+        repo.accept_wire_state_visibility(state, &signed)
+            .expect("pinned owner must be able to land their own Private sidecar");
+        assert!(
+            repo.has_visibility_for_state(&state)
+                .expect("owner visibility persisted")
+        );
+        assert_eq!(
+            repo.embargo_membership_label()
+                .expect("membership")
+                .as_deref(),
+            Some("ax-only"),
+            "accepting Private{ax-only} must stamp Restricted(ax-only), not all-Private Owner"
+        );
+
+        let mut other = sample_record(
+            StateId::from_bytes([12u8; 32]),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            },
+        );
+        sign_visibility(&mut other, &stranger);
+        let forged = StateVisibilityBlob::new(vec![other.clone()])
+            .encode()
+            .unwrap();
+        repo.accept_wire_state_visibility(other.state, &forged)
+            .expect_err("a key that is not the pinned owner must still be rejected");
+    }
+
+    #[test]
+    fn local_visibility_copy_keeps_private_sidecar_without_trusted_keys() {
+        let source_dir = TempDir::new().unwrap();
+        let source = Repository::init_default(source_dir.path()).unwrap();
+        let state = StateId::from_bytes([13u8; 32]);
+        source
+            .put_state_visibility(sample_record(
+                state,
+                VisibilityTier::Private {
+                    scope_label: "ax-only".into(),
+                },
+            ))
+            .expect("put private visibility");
+        let bytes = source
+            .get_state_visibility_bytes_for_state(&state)
+            .expect("read source sidecar")
+            .expect("sidecar present");
+
+        let dest_dir = TempDir::new().unwrap();
+        let dest = Repository::init_default(dest_dir.path()).unwrap();
+        dest.accept_local_state_visibility(state, &bytes)
+            .expect("local clone must copy the Private sidecar");
+        assert_eq!(
+            dest.effective_visibility_tier(&state).expect("tier"),
+            VisibilityTier::Private {
+                scope_label: "ax-only".into(),
+            }
+        );
+        assert_eq!(
+            source
+                .embargo_membership_label()
+                .expect("source membership")
+                .as_deref(),
+            Some("ax-only")
+        );
+        assert_eq!(
+            dest.embargo_membership_label()
+                .expect("dest membership")
+                .as_deref(),
+            Some("ax-only")
+        );
+        let private = VisibilityTier::Private {
+            scope_label: "ax-only".into(),
+        };
+        let other = VisibilityTier::Private {
+            scope_label: "other".into(),
+        };
+        let label = dest.embargo_membership_label().expect("label");
+        assert!(crate::grant_can_see_tier(
+            Some(crate::GrantRole::Owner),
+            label.as_deref(),
+            &private
+        ));
+        assert!(!crate::grant_can_see_tier(
+            Some(crate::GrantRole::Owner),
+            None,
+            &private
+        ));
+        assert!(!crate::grant_can_see_tier(
+            Some(crate::GrantRole::Owner),
+            label.as_deref(),
+            &other
+        ));
+    }
+
+    #[test]
     fn put_then_read_back_and_has_visibility_true() {
         let (_dir, repo) = fresh_repo();
         let state = StateId::from_bytes([5u8; 32]);
@@ -1121,12 +1318,11 @@ mod tests {
             "a state with no record must be public-by-absence (has_visibility_for_state == false)"
         );
         // And its sidecar load is an empty blob, never an error.
-        assert!(
-            repo.get_state_visibility_for_state(&no_record)
-                .expect("read record-free state")
-                .records
-                .is_empty()
-        );
+        assert!(repo
+            .get_state_visibility_for_state(&no_record)
+            .expect("read record-free state")
+            .records
+            .is_empty());
     }
 
     #[test]

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -1125,7 +1125,7 @@ mod tests {
                 .expect("membership")
                 .as_deref(),
             Some("ax-only"),
-            "accepting Private{ax-only} must stamp Restricted(ax-only), not all-Private Owner"
+            "accepting Private{{ax-only}} must stamp Restricted(ax-only), not all-Private Owner"
         );
 
         let mut other = sample_record(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Owner clone after `visibility set --tier private --label L` plus discuss/context failed exit 78 `state not found`. Bob without a grant was correctly PermissionDenied (exit 77) — that stay.
- Fresh clones rejected the owner-signed visibility sidecar (`[metadata] trusted_keys` empty). Local clone used the hosted accept path, so the Private sidecar never landed.
- **Owners stay label-scoped.** Unlabeled Owner remains Internal and cannot see `Private`. Declaring `Private{L}` stamps Restricted(L) embargo membership (`audience_label`) on the acting principal — not an `AudienceTier::Owner` that sees every Private label.

Fix:

1. Hosted `accept_wire_state_visibility` admits the TOFU-pinned PullReady owner genesis key when `trusted_keys` is empty.
2. Local clone copies sidecars via `accept_local_state_visibility`.
3. `visibility set --tier private --label L` (and accept/copy of that sidecar) records Restricted(L) membership. `grant_can_see_tier(Owner, Some(L), Private{L})` is the admit; unlabeled Owner and missing grants are not.

Rebased onto `origin/main` only. The #1704 staging stack is not in this branch.

## Closes

Refs field report 2026-09-05 (`/tmp/ax-vis-2p/`, Alice owner clone exit 78 after private visibility + discuss/context; Bob remain exit 77)

## Red commit

N/A — field evidence is the red (Alice owner clone of `local-alice/repo-ax-vis-2p`).

## Test evidence

Executed on HEAD `96f88a2372ac9a7f7fbc7b21f666582d067d11d8` (onto `origin/main` `df37fff9`). Not `--no-run`.

```
$ cargo test -p heddle-object-model --lib audience_tier -- --nocapture
running 4 tests
test object::audience_tier::tests::private_visible_only_to_matching_restricted_audience ... ok
test object::audience_tier::tests::private_is_hidden_even_from_the_all_seeing_internal_audience ... ok
test object::audience_tier::tests::parse_audience_strings ... ok
test object::audience_tier::tests::public_is_universally_visible_and_team_matches_exact_id ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 259 filtered out

$ cargo test -p heddle-repo --lib grant_audience -- --nocapture
running 5 tests
test grant_audience::tests::owner_sees_private_only_with_matching_embargo_label ... ok
test grant_audience::tests::embargo_label_is_restricted_even_for_owners ... ok
test grant_audience::tests::unauthorized_and_unknown_roles_are_public ... ok
test grant_audience::tests::trusted_writers_are_internal ... ok
test grant_audience::tests::missing_or_unknown_role_with_label_is_public ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 740 filtered out

$ cargo test -p heddle-repo --lib -- wire_visibility_accepts_pullready_pinned_owner_key local_visibility_copy_keeps_private_sidecar wire_visibility_requires_trusted_signature_and_covers_tier wire_visibility_rejects_self_signed_key_not_in_trusted_set --nocapture
running 4 tests
test repository_state_visibility::tests::wire_visibility_rejects_self_signed_key_not_in_trusted_set ... ok
test repository_state_visibility::tests::wire_visibility_requires_trusted_signature_and_covers_tier ... ok
test repository_state_visibility::tests::wire_visibility_accepts_pullready_pinned_owner_key ... ok
test repository_state_visibility::tests::local_visibility_copy_keeps_private_sidecar_without_trusted_keys ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 741 filtered out

$ cargo test -p heddle-hosted-client --lib fetch_copies_private_visibility_sidecar -- --nocapture
running 1 test
test client::local_sync::tests::fetch_copies_private_visibility_sidecar ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out

$ cargo test -p heddle-cli --test cli_workflow -- visibility --nocapture
running 13 tests
...
test visibility::owner_clone_of_private_spool_after_visibility_discuss_and_context ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 368 filtered out

$ cargo clippy -p heddle-repo --all-targets -- -D warnings
Finished `dev` profile (clean)

$ cargo clippy -p heddle-hosted-client --all-targets -- -D warnings
Finished `dev` profile (clean)
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Surfaces

- **Verb:** no new flags. `visibility set` now also stamps local Restricted(L) membership.
- **Human and agent:** clone success path; no JSON contract change.
- **Git interop:** export frontier still Public/Internal; Private remains withheld from Internal.
- **Wire:** no proto change. `audience_tier_for_grant` / `grant_can_see_tier` stays the weft ListRefs/Pull contract (Owner + label → Restricted; unlabeled Owner → Internal).
- **Reverse states:** way out remains `visibility promote` / public-by-absence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8da62b44-0e1e-49fe-a8ce-0d275387ac96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8da62b44-0e1e-49fe-a8ce-0d275387ac96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791172259&installation_model_id=21489&pr_number=1707&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1707&signature=a1a92314632ee15fb0620b31d68813ec6d3b73f680def8d41b4a63e425bd5184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->