### PR TITLE
hotfix(status,sync): default main is Current without a target (fixes main-red from #1639)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-agent-relay"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-config"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "heddle-api",
  "hex",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ci-engine"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "heddle-ci-config",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-config"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "aes-gcm 0.10.3",
  "base64 0.22.1",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "libc",
@@ -2379,11 +2379,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-docsgen"
-version = "0.20.3"
+version = "0.20.4"
 
 [[package]]
 name = "heddle-env-store"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "chrono",
  "heddle-crypto",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "thiserror 2.0.18",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-hosted-client"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "bytes",
@@ -2658,11 +2658,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.20.3"
+version = "0.20.4"
 
 [[package]]
 name = "heddle-refs"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "chrono",
  "fs2",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic-recovery"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "fastembed",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "heddle-objects",
  "heddle-repo",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-verbs"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -7592,7 +7592,7 @@ dependencies = [
 
 [[package]]
 name = "treadle-schema"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "blake3",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.3"
+version = "0.20.4"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -165,35 +165,35 @@ zstd = "0.13"
 # Cargo forbids a member from turning a workspace dependency's defaults off, so
 # the baseline lives here and the few members that want the defaults re-list
 # them explicitly under `features`.
-treadle-schema = { path = "crates/treadle-schema", version = "0.20.3" }
-heddle-cli-args = { path = "crates/cli-args", version = "0.20.3", default-features = false }
-heddle-cli-contract = { path = "crates/cli-contract", version = "0.20.3", default-features = false }
-heddle-cli-render = { path = "crates/cli-render", version = "0.20.3", default-features = false }
-heddle-format = { path = "crates/format", version = "0.20.3" }
-heddle-fs-prims = { path = "crates/fs-prims", version = "0.20.3" }
-heddle-git-projection = { path = "crates/git-projection", version = "0.20.3", default-features = false }
-heddle-object-model = { path = "crates/object-model", version = "0.20.3" }
-heddle-pack = { path = "crates/pack", version = "0.20.3" }
-heddle-perf-contract = { path = "crates/perf-contract", version = "0.20.3" }
-agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.20.3", default-features = false }
-ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.20.3" }
-ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.20.3" }
-config = { path = "crates/config", package = "heddle-config", version = "0.20.3" }
-crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.20.3" }
-hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.20.3", default-features = false }
-ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.20.3", default-features = false }
-merge = { path = "crates/merge", package = "heddle-merge", version = "0.20.3" }
-mount = { path = "crates/mount", package = "heddle-mount", version = "0.20.3" }
-objects = { path = "crates/objects", package = "heddle-objects", version = "0.20.3" }
-oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.20.3", default-features = false }
-refs = { path = "crates/refs", package = "heddle-refs", version = "0.20.3" }
-repo = { path = "crates/repo", package = "heddle-repo", version = "0.20.3", default-features = false }
-heddle-env-store = { path = "crates/env-store", version = "0.20.3" }
-semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.20.3" }
-semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.20.3" }
-state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.20.3" }
-verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.20.3", default-features = false }
-wire = { path = "crates/wire", package = "heddle-wire", version = "0.20.3", default-features = false }
+treadle-schema = { path = "crates/treadle-schema", version = "0.20.4" }
+heddle-cli-args = { path = "crates/cli-args", version = "0.20.4", default-features = false }
+heddle-cli-contract = { path = "crates/cli-contract", version = "0.20.4", default-features = false }
+heddle-cli-render = { path = "crates/cli-render", version = "0.20.4", default-features = false }
+heddle-format = { path = "crates/format", version = "0.20.4" }
+heddle-fs-prims = { path = "crates/fs-prims", version = "0.20.4" }
+heddle-git-projection = { path = "crates/git-projection", version = "0.20.4", default-features = false }
+heddle-object-model = { path = "crates/object-model", version = "0.20.4" }
+heddle-pack = { path = "crates/pack", version = "0.20.4" }
+heddle-perf-contract = { path = "crates/perf-contract", version = "0.20.4" }
+agent-relay = { path = "crates/agent-relay", package = "heddle-agent-relay", version = "0.20.4", default-features = false }
+ci-config = { path = "crates/ci-config", package = "heddle-ci-config", version = "0.20.4" }
+ci-engine = { path = "crates/ci-engine", package = "heddle-ci-engine", version = "0.20.4" }
+config = { path = "crates/config", package = "heddle-config", version = "0.20.4" }
+crypto = { path = "crates/crypto", package = "heddle-crypto", version = "0.20.4" }
+hosted-client = { path = "crates/hosted-client", package = "heddle-hosted-client", version = "0.20.4", default-features = false }
+ingest = { path = "crates/ingest", package = "heddle-ingest", version = "0.20.4", default-features = false }
+merge = { path = "crates/merge", package = "heddle-merge", version = "0.20.4" }
+mount = { path = "crates/mount", package = "heddle-mount", version = "0.20.4" }
+objects = { path = "crates/objects", package = "heddle-objects", version = "0.20.4" }
+oplog = { path = "crates/oplog", package = "heddle-oplog", version = "0.20.4", default-features = false }
+refs = { path = "crates/refs", package = "heddle-refs", version = "0.20.4" }
+repo = { path = "crates/repo", package = "heddle-repo", version = "0.20.4", default-features = false }
+heddle-env-store = { path = "crates/env-store", version = "0.20.4" }
+semantic = { path = "crates/semantic", package = "heddle-semantic", version = "0.20.4" }
+semantic-recovery = { path = "crates/semantic-recovery", package = "heddle-semantic-recovery", version = "0.20.4" }
+state_review = { path = "crates/state-review", package = "heddle-state-review", version = "0.20.4" }
+verbs = { path = "crates/verbs", package = "heddle-verbs", version = "0.20.4", default-features = false }
+wire = { path = "crates/wire", package = "heddle-wire", version = "0.20.4", default-features = false }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.20.3",
+  "schemaVersion": "0.20.4",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.20.1",
+  "schemaVersion": "0.20.3",
   "verbs": {
     "abort": {
       "$defs": {
@@ -20486,6 +20486,40 @@
         "doc_path"
       ],
       "title": "SchemaReport",
+      "type": "object"
+    },
+    "env create": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "env_create"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "env list": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "env_list"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
       "type": "object"
     },
     "error": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.20.3" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.20.4" as const;
 
 export interface AbortSchema {
   action: OperatorAction;

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`schema_for_verb` / `crates/cli-contract/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.20.1" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.20.3" as const;
 
 export interface AbortSchema {
   action: OperatorAction;
@@ -1157,6 +1157,16 @@ export interface DoctorSchema {
   thread?: unknown;
   verification: RepositoryVerificationState;
   workspace: unknown;
+}
+
+export interface EnvCreateSchema {
+  output_kind: "env_create";
+  [key: string]: unknown;
+}
+
+export interface EnvListSchema {
+  output_kind: "env_list";
+  [key: string]: unknown;
 }
 
 /** Ephemeral thread metadata. Lives at the tail of [`ThreadRecord`]. Ephemeral threads are spawned for short-lived agent work that should not crowd `heddle log` or the thread workspace. If not promoted before `ttl_seconds` elapses, the thread auto-collapses on the next read-side sweep (`heddle status`, `heddle log`, `heddle thread list`). */
@@ -3566,6 +3576,8 @@ export interface HeddleVerbOutputs {
   doctor: DoctorSchema;
   "doctor docs": DocsReport;
   "doctor schemas": SchemaReport;
+  "env create": EnvCreateSchema;
+  "env list": EnvListSchema;
   error: ErrorEnvelopeSchema;
   help: HelpSchema;
   "hook events": HookEventsSchema;
@@ -3734,6 +3746,8 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "doctor",
   "doctor docs",
   "doctor schemas",
+  "env create",
+  "env list",
   "error",
   "help",
   "hook events",

--- a/crates/agent-relay/src/relay.rs
+++ b/crates/agent-relay/src/relay.rs
@@ -1346,7 +1346,7 @@ impl HarnessBridgeRuntime {
         task: Option<String>,
     ) -> Result<()> {
         let manager = ThreadManager::new(self.repo.heddle_dir());
-        if manager.load(name)?.is_some() {
+        if manager.load_id_or_name(name)?.is_some() {
             return Ok(());
         }
 
@@ -2405,7 +2405,7 @@ fn thread_id_for_name(repo: &Repository, thread_name: Option<&str>) -> Result<Op
         return Ok(None);
     };
     Ok(ThreadManager::new(repo.heddle_dir())
-        .load(thread_name)?
+        .load_id_or_name(thread_name)?
         .map(|thread| thread.id))
 }
 
@@ -2439,7 +2439,7 @@ fn resolve_named_thread_base_state(
     repo: &Repository,
     thread_name: &str,
 ) -> Result<Option<objects::object::StateId>> {
-    if let Some(thread) = ThreadManager::new(repo.heddle_dir()).load(thread_name)?
+    if let Some(thread) = ThreadManager::new(repo.heddle_dir()).load_id_or_name(thread_name)?
         && let Some(state_spec) = thread
             .current_state
             .as_deref()
@@ -2492,7 +2492,9 @@ fn native_key_slug(value: &str) -> String {
 }
 
 fn allocate_thread_name(repo: &Repository, base: &str) -> Result<String> {
-    if ThreadManager::new(repo.heddle_dir()).load(base)?.is_none()
+    if ThreadManager::new(repo.heddle_dir())
+        .load_id_or_name(base)?
+        .is_none()
         && repo.refs().get_thread(&ThreadName::new(base))?.is_none()
     {
         return Ok(base.to_string());
@@ -2500,7 +2502,7 @@ fn allocate_thread_name(repo: &Repository, base: &str) -> Result<String> {
     for idx in 2..1000 {
         let candidate = format!("{base}-{idx}");
         if ThreadManager::new(repo.heddle_dir())
-            .load(&candidate)?
+            .load_id_or_name(&candidate)?
             .is_none()
             && repo
                 .refs()

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -366,7 +366,7 @@ fn ensure_thread_record(
     task: &Option<String>,
 ) -> Result<()> {
     let manager = ThreadManager::new(repo.heddle_dir());
-    if manager.load(thread_name)?.is_some() {
+    if manager.load_id_or_name(thread_name)?.is_some() {
         return Ok(());
     }
     let state = repo

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -2597,6 +2597,7 @@ async fn persist_hosted_clone_thread_identity(
     Ok(())
 }
 
+#[cfg(feature = "client")]
 fn hosted_clone_thread_revision_address<'a>(
     remote_refs: &'a [HostedRefEntry],
     thread: &str,

--- a/crates/cli/src/cli/commands/env_cmd.rs
+++ b/crates/cli/src/cli/commands/env_cmd.rs
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `heddle env` — broker-backed confidential-runtime profiles.
 
-use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::{Context, Result, anyhow};
 use crypto::Signer;
+use env_store::{DecryptPurpose, DecryptRequest, EnvStore, PolicyBroker, SlotWrite};
 use repo::Repository;
-use env_store::{DecryptPurpose, DecryptRequest, PolicyBroker, EnvStore, SlotWrite};
 use serde::Serialize;
 
-use super::advice::RecoveryAdvice;
-use super::next_action::{NextActionValidationContext, write_full_command_json};
-use crate::cli::{
-    Cli, EnvCommands, EnvCreateArgs, EnvListArgs, EnvRunArgs, should_output_json,
+use super::{
+    advice::RecoveryAdvice,
+    next_action::{NextActionValidationContext, write_full_command_json},
 };
+use crate::cli::{Cli, EnvCommands, EnvCreateArgs, EnvListArgs, EnvRunArgs, should_output_json};
 
 pub fn cmd_env(cli: &Cli, command: EnvCommands) -> Result<()> {
     let repo = cli.open_repo()?;
@@ -141,7 +143,12 @@ fn cmd_env_list(cli: &Cli, repo: &Repository, _args: EnvListArgs) -> Result<()> 
 
 fn cmd_env_run(repo: &Repository, args: EnvRunArgs) -> Result<()> {
     if args.command.is_empty() {
-        return Err(anyhow!("env run requires a child command after `--`"));
+        return Err(anyhow!(RecoveryAdvice::invalid_usage(
+            "env_run_missing_command",
+            "env run requires a child command after `--`",
+            "Retry as `heddle env run --profile <name> -- <command>`.",
+            "heddle env run --profile <name> -- <command>",
+        )));
     }
     let store = EnvStore::open(repo.heddle_dir()).map_err(map_profile_error)?;
     let signer = require_signer(repo)?;
@@ -153,8 +160,14 @@ fn cmd_env_run(repo: &Repository, args: EnvRunArgs) -> Result<()> {
         .hold_profile_recipients(&args.profile)
         .map_err(map_profile_error)?;
     let now = now_ms()?;
-    let ttl_ms = i64::try_from(args.ttl.saturating_mul(1000))
-        .map_err(|_| anyhow!("ttl overflow"))?;
+    let ttl_ms = i64::try_from(args.ttl.saturating_mul(1000)).map_err(|_| {
+        anyhow!(RecoveryAdvice::invalid_usage(
+            "env_run_ttl_overflow",
+            "ttl overflow",
+            "Pass a smaller `--ttl` in seconds.",
+            "heddle env run --profile <name> --ttl <seconds> -- <command>",
+        ))
+    })?;
     let request = DecryptRequest {
         profile: args.profile.clone(),
         slots: args.slots.clone(),
@@ -179,7 +192,16 @@ fn cmd_env_run(repo: &Repository, args: EnvRunArgs) -> Result<()> {
     match status.code() {
         Some(0) => Ok(()),
         Some(code) => std::process::exit(code),
-        None => Err(anyhow!("child was terminated by a signal")),
+        None => Err(anyhow!(RecoveryAdvice::safety_refusal(
+            "env_run_child_signaled",
+            "child was terminated by a signal",
+            "Inspect the child process and retry `heddle env run`.",
+            "the spawned command was terminated by a signal",
+            "the command did not complete",
+            "env-store contents were left unchanged",
+            "heddle env run --profile <name> -- <command>",
+            vec!["heddle env run --profile <name> -- <command>".to_string()],
+        ))),
     }
 }
 
@@ -187,7 +209,12 @@ fn require_signer(repo: &Repository) -> Result<Box<dyn Signer>> {
     let local = repo.heddle_dir().join(repo::identity::LOCAL_IDENTITY_FILE);
     let device = repo::identity::device_identity_path();
     repo::identity::resolve_signer(&local, &device).ok_or_else(|| {
-        anyhow!("runtime profiles require a protected local signing identity")
+        anyhow!(RecoveryAdvice::invalid_usage(
+            "env_run_missing_signer",
+            "runtime profiles require a protected local signing identity",
+            "Create a local signing identity, then retry `heddle env run`.",
+            "heddle env run --profile <name> -- <command>",
+        ))
     })
 }
 
@@ -201,9 +228,7 @@ fn now_ms() -> Result<i64> {
 fn map_profile_error(err: env_store::EnvStoreError) -> anyhow::Error {
     let message = err.to_string();
     match err {
-        env_store::EnvStoreError::BrokerDenied(
-            env_store::BrokerDenialReason::Expired,
-        ) => {
+        env_store::EnvStoreError::BrokerDenied(env_store::BrokerDenialReason::Expired) => {
             anyhow!(RecoveryAdvice::safety_refusal(
                 "env_store_expired",
                 message,
@@ -215,9 +240,8 @@ fn map_profile_error(err: env_store::EnvStoreError) -> anyhow::Error {
                 vec!["heddle env run --profile <name> -- <cmd>".to_string()],
             ))
         }
-        env_store::EnvStoreError::BrokerDenied(_)
-        | env_store::EnvStoreError::InvalidGrant(_) => anyhow!(
-            RecoveryAdvice::safety_refusal(
+        env_store::EnvStoreError::BrokerDenied(_) | env_store::EnvStoreError::InvalidGrant(_) => {
+            anyhow!(RecoveryAdvice::safety_refusal(
                 "env_store_denied",
                 message,
                 "Ask for a named profile and slots this broker holds, then retry `heddle env run`.",
@@ -226,32 +250,28 @@ fn map_profile_error(err: env_store::EnvStoreError) -> anyhow::Error {
                 "the worktree and store were left unchanged",
                 "heddle env list",
                 vec!["heddle env list".to_string()],
-            )
-        ),
-        env_store::EnvStoreError::ProfileNotFound(_) => anyhow!(
-            RecoveryAdvice::safety_refusal(
-                "env_store_not_found",
-                message,
-                "Create the profile with `heddle env create --name <name> --from-env SLOT`, then retry.",
-                "no runtime profile with that name exists",
-                "no child would start",
-                "the worktree and store were left unchanged",
-                "heddle env create --name <name> --from-env SLOT",
-                vec!["heddle env create --name <name> --from-env SLOT".to_string()],
-            )
-        ),
-        env_store::EnvStoreError::SlotNotFound(_) => anyhow!(
-            RecoveryAdvice::safety_refusal(
-                "env_store_slot_not_found",
-                message,
-                "List slot names with `heddle env list`, then pass a slot that exists.",
-                "the named slot is not on the profile head",
-                "no child would start",
-                "the worktree and store were left unchanged",
-                "heddle env list",
-                vec!["heddle env list".to_string()],
-            )
-        ),
+            ))
+        }
+        env_store::EnvStoreError::ProfileNotFound(_) => anyhow!(RecoveryAdvice::safety_refusal(
+            "env_store_not_found",
+            message,
+            "Create the profile with `heddle env create --name <name> --from-env SLOT`, then retry.",
+            "no runtime profile with that name exists",
+            "no child would start",
+            "the worktree and store were left unchanged",
+            "heddle env create --name <name> --from-env SLOT",
+            vec!["heddle env create --name <name> --from-env SLOT".to_string()],
+        )),
+        env_store::EnvStoreError::SlotNotFound(_) => anyhow!(RecoveryAdvice::safety_refusal(
+            "env_store_slot_not_found",
+            message,
+            "List slot names with `heddle env list`, then pass a slot that exists.",
+            "the named slot is not on the profile head",
+            "no child would start",
+            "the worktree and store were left unchanged",
+            "heddle env list",
+            vec!["heddle env list".to_string()],
+        )),
         other => anyhow!(other),
     }
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -190,7 +190,7 @@ fn collect_thread_captures(
         .get_thread(&ThreadName::new(thread))?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread, "list thread captures")))?;
     let base = ThreadManager::new(repo.heddle_dir())
-        .load(thread)?
+        .load_id_or_name(thread)?
         .map(|thread| thread.base_state);
     let mut out = Vec::new();
     let mut cursor = Some(current);
@@ -831,7 +831,7 @@ pub(crate) fn start_transaction_id(
 /// instant → distinct key → it actually starts.
 pub(crate) fn resolve_start_epoch(repo: &Repository, name: &str) -> Result<DateTime<Utc>> {
     let prior_active = ThreadManager::new(repo.heddle_dir())
-        .load(name)?
+        .load_id_or_name(name)?
         .filter(|thread| thread.state == ThreadState::Active);
     Ok(prior_active.map_or_else(Utc::now, |thread| thread.created_at))
 }
@@ -1197,7 +1197,7 @@ fn finalize_committed_start(
     actor_identity: &StartActorIdentity,
 ) -> Result<ThreadOpOutput> {
     let committed = ThreadManager::new(repo.heddle_dir())
-        .load(&args.name)?
+        .load_id_or_name(&args.name)?
         .ok_or_else(|| {
             anyhow!(
                 "thread '{}' has a committed start transaction but no durable record to \

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1350,7 +1350,12 @@ pub(crate) fn drop_thread_silent(
     force: bool,
 ) -> Result<DropOutcome> {
     let manager = thread_manager(repo);
-    let loaded = manager.load(thread_id)?;
+    let loaded = match manager.load(thread_id)? {
+        Some(thread) => Some(thread),
+        // Persisted default `main` has a UUID record id; `heddle thread drop
+        // main` names the thread, not the record.
+        None => manager.find_by_thread(thread_id)?,
+    };
     let is_current_lane = repo.current_lane()?.as_deref() == Some(thread_id);
     let disposition = match &loaded {
         None => plan_thread_drop(&ThreadDropOptions {

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -225,7 +225,7 @@ fn thread_matches_execution_root(thread: &Thread, canonical: &Path) -> bool {
 }
 
 pub(crate) fn load_thread(repo: &Repository, thread_id: &str) -> Result<Thread> {
-    match thread_manager(repo).load(thread_id)? {
+    match thread_manager(repo).load_id_or_name(thread_id)? {
         Some(thread) => Ok(thread),
         None if repo
             .refs()
@@ -485,7 +485,7 @@ fn cmd_thread_refresh(cli: &Cli, repo: &Repository, thread_id: &str) -> Result<(
 pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> Result<Thread> {
     let manager = thread_manager(repo);
     let mut thread = manager
-        .load(thread_id)?
+        .load_id_or_name(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "refresh thread")))?;
     // Missing-target is a pure gate and must refuse before freshness I/O so
     // the error path matches historical CLI behavior (no side-channel ref
@@ -1206,7 +1206,7 @@ fn cmd_thread_promote(
 ) -> Result<()> {
     let manager = thread_manager(repo);
     let mut thread = manager
-        .load(thread_id)?
+        .load_id_or_name(thread_id)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(thread_id, "promote thread")))?;
     let state_id = repo
         .refs()
@@ -1350,12 +1350,7 @@ pub(crate) fn drop_thread_silent(
     force: bool,
 ) -> Result<DropOutcome> {
     let manager = thread_manager(repo);
-    let loaded = match manager.load(thread_id)? {
-        Some(thread) => Some(thread),
-        // Persisted default `main` has a UUID record id; `heddle thread drop
-        // main` names the thread, not the record.
-        None => manager.find_by_thread(thread_id)?,
-    };
+    let loaded = manager.load_id_or_name(thread_id)?;
     let is_current_lane = repo.current_lane()?.as_deref() == Some(thread_id);
     let disposition = match &loaded {
         None => plan_thread_drop(&ThreadDropOptions {

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -9,6 +9,11 @@ use std::{
 use anyhow::{Result, anyhow};
 use chrono::Utc;
 use heddle_cli_contract::cli::commands::wire::thread::ThreadRecordOutput as ThreadOutput;
+// The cleanup wire payloads live in cli-contract so the schema registry
+// registers the real serialization types.
+pub(crate) use heddle_cli_contract::cli::commands::wire::thread::{
+    DroppedThread, SkippedThread, ThreadCleanupOutput,
+};
 use objects::{
     fs_ops::remove_path_recursively,
     object::{Blob, StateId, ThreadName},
@@ -46,12 +51,6 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::cli::{Cli, ThreadCleanupArgs, ThreadCommands, should_output_json, style};
-
-// The cleanup wire payloads live in cli-contract so the schema registry
-// registers the real serialization types.
-pub(crate) use heddle_cli_contract::cli::commands::wire::thread::{
-    DroppedThread, SkippedThread, ThreadCleanupOutput,
-};
 
 pub(crate) fn thread_manager(repo: &Repository) -> ThreadManager {
     ThreadManager::new(repo.heddle_dir())
@@ -148,49 +147,81 @@ pub(crate) fn resolve_thread_name_or_current(
 }
 
 pub(crate) fn current_thread(repo: &Repository) -> Result<Option<Thread>> {
-    if let Some(thread) = thread_manager(repo).find_by_execution_root(repo.root())? {
-        return Ok(Some(thread));
+    let manager = thread_manager(repo);
+    if let Head::Attached { thread } = repo.head_ref()? {
+        if let Some(record) = manager.find_by_thread(thread.as_str())? {
+            return Ok(Some(record));
+        }
+        let current_state_id = repo.refs().get_thread(&thread)?;
+        let current_state = current_state_id.map(|id| id.short());
+        let base_root = current_state_id
+            .and_then(|id| repo.store().get_state(&id).ok().flatten())
+            .map(|state| state.tree.short())
+            .unwrap_or_default();
+
+        let thread_str = thread.to_string();
+        return Ok(Some(Thread {
+            id: thread_str.clone(),
+            thread: thread_str,
+            target_thread: None,
+            parent_thread: None,
+            mode: ThreadMode::Materialized,
+            state: ThreadState::Active,
+            base_state: current_state.clone().unwrap_or_default(),
+            base_root,
+            current_state,
+            merged_state: None,
+            task: None,
+            execution_path: repo.root().to_path_buf(),
+            materialized_path: None,
+            changed_paths: Vec::new(),
+            impact_categories: Vec::new(),
+            heavy_impact_paths: Vec::new(),
+            promotion_suggested: false,
+            freshness: ThreadFreshness::Unknown,
+            verification_summary: Default::default(),
+            confidence_summary: Default::default(),
+            integration_policy_result: Default::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            ephemeral: None,
+            auto: false,
+            shared_target_dir: None,
+        }));
     }
 
-    let Head::Attached { thread } = repo.head_ref()? else {
-        return Ok(None);
-    };
-    let current_state_id = repo.refs().get_thread(&thread)?;
-    let current_state = current_state_id.map(|id| id.short());
-    let base_root = current_state_id
-        .and_then(|id| repo.store().get_state(&id).ok().flatten())
-        .map(|state| state.tree.short())
-        .unwrap_or_default();
+    // Detached HEAD: a dedicated worktree still has a thread record
+    // whose execution_path is this checkout. Default `main` always
+    // records the shared repo root, which is not a current-thread
+    // signal when HEAD is detached.
+    let canonical = repo
+        .root()
+        .canonicalize()
+        .unwrap_or_else(|_| repo.root().to_path_buf());
+    let mut matches: Vec<Thread> = manager
+        .list()?
+        .into_iter()
+        .filter(|thread| {
+            thread.thread != "main" && thread_matches_execution_root(thread, &canonical)
+        })
+        .collect();
+    matches.sort_by_key(|thread| thread.updated_at);
+    Ok(matches.pop())
+}
 
-    let thread_str = thread.to_string();
-    Ok(Some(Thread {
-        id: thread_str.clone(),
-        thread: thread_str,
-        target_thread: None,
-        parent_thread: None,
-        mode: ThreadMode::Materialized,
-        state: ThreadState::Active,
-        base_state: current_state.clone().unwrap_or_default(),
-        base_root,
-        current_state,
-        merged_state: None,
-        task: None,
-        execution_path: repo.root().to_path_buf(),
-        materialized_path: None,
-        changed_paths: Vec::new(),
-        impact_categories: Vec::new(),
-        heavy_impact_paths: Vec::new(),
-        promotion_suggested: false,
-        freshness: ThreadFreshness::Unknown,
-        verification_summary: Default::default(),
-        confidence_summary: Default::default(),
-        integration_policy_result: Default::default(),
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        ephemeral: None,
-        auto: false,
-        shared_target_dir: None,
-    }))
+fn thread_matches_execution_root(thread: &Thread, canonical: &Path) -> bool {
+    let execution = thread
+        .execution_path
+        .canonicalize()
+        .unwrap_or_else(|_| thread.execution_path.clone());
+    if execution == *canonical {
+        return true;
+    }
+    thread
+        .materialized_path
+        .as_ref()
+        .map(|path| path.canonicalize().unwrap_or_else(|_| path.clone()) == *canonical)
+        .unwrap_or(false)
 }
 
 pub(crate) fn load_thread(repo: &Repository, thread_id: &str) -> Result<Thread> {

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -342,8 +342,16 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 thread.id
             )),
         )?;
-        let preview =
-            merge_thread_into_current(&repo, &thread.id, None, false, true, false, false, false)?;
+        let preview = merge_thread_into_current(
+            &repo,
+            &thread.thread,
+            None,
+            false,
+            true,
+            false,
+            false,
+            false,
+        )?;
         if preview.conflict_count > 0 {
             blockers.push(format!(
                 "Thread '{}' still has merge conflicts: {}",

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -4,6 +4,11 @@
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
+// The wire payloads live in cli-contract so the schema registry registers
+// the real serialization types.
+pub use heddle_cli_contract::cli::commands::wire::thread::{
+    ThreadAbsorbOutput, ThreadResolveOutput,
+};
 use objects::object::ThreadName;
 use repo::{GitImportGuidance, GitRemoteTrackingStatus, Repository, RepositoryOperationStatus};
 use serde::Serialize;
@@ -34,12 +39,6 @@ use crate::{
         worktree_status_options,
     },
     config::UserConfig,
-};
-
-// The wire payloads live in cli-contract so the schema registry registers
-// the real serialization types.
-pub use heddle_cli_contract::cli::commands::wire::thread::{
-    ThreadAbsorbOutput, ThreadResolveOutput,
 };
 
 impl super::compact::CompactProjection for ThreadResolveOutput {
@@ -210,9 +209,10 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
         match refresh_thread(&repo, &thread_id, cli) {
             Ok(_) => {
                 let manager = super::thread_cmd::thread_manager(&repo);
-                let mut refreshed_thread = manager.load(&thread_id)?.ok_or_else(|| {
-                    anyhow!(thread_not_found_advice(&thread_id, "resolve thread"))
-                })?;
+                let mut refreshed_thread =
+                    manager.load_id_or_name(&thread_id)?.ok_or_else(|| {
+                        anyhow!(thread_not_found_advice(&thread_id, "resolve thread"))
+                    })?;
                 let before_update =
                     capture_thread_update_before(&repo, &manager, &refreshed_thread)?;
                 let resolved_state = repo

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -129,14 +129,14 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             operator: OperatorCommandOutput {
                 status: "current".to_string(),
                 action: OperatorAction::Sync,
-                message: format!("Thread '{}' is already current", thread.id),
+                message: format!("Thread '{}' is already current", thread.thread),
                 blockers: vec![],
                 warnings: Vec::new(),
                 next_action: recommended_action.clone(),
                 recommended_action,
             },
             trust,
-            thread: thread.id.clone(),
+            thread: thread.thread.clone(),
             current_state: thread.current_state.clone(),
             chosen_path: "no_op".to_string(),
         }
@@ -171,14 +171,14 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
             operator: OperatorCommandOutput {
                 status: "blocked".to_string(),
                 action: OperatorAction::Sync,
-                message: format!("Thread '{}' needs manual sync", thread.id),
+                message: format!("Thread '{}' needs manual sync", thread.thread),
                 blockers: stale_report.blockers.clone(),
                 warnings: Vec::new(),
                 next_action: non_empty_next_action(&recommended_action),
                 recommended_action: non_empty_next_action(&recommended_action),
             },
             trust,
-            thread: thread.id.clone(),
+            thread: thread.thread.clone(),
             current_state: thread.current_state.clone(),
             chosen_path: "blocked".to_string(),
         }
@@ -211,14 +211,14 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                     operator: OperatorCommandOutput {
                         status: "refreshed".to_string(),
                         action: OperatorAction::Sync,
-                        message: format!("Refreshed thread '{}'", refreshed.id),
+                        message: format!("Refreshed thread '{}'", refreshed.thread),
                         blockers: vec![],
                         warnings: Vec::new(),
                         next_action: recommended_action.clone(),
                         recommended_action,
                     },
                     trust,
-                    thread: refreshed.id.clone(),
+                    thread: refreshed.thread.clone(),
                     current_state: refreshed.current_state.clone(),
                     chosen_path: "refresh".to_string(),
                 }
@@ -242,14 +242,17 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                     operator: OperatorCommandOutput {
                         status: "blocked".to_string(),
                         action: OperatorAction::Sync,
-                        message: format!("Thread '{}' has merge conflicts to resolve", thread.id),
+                        message: format!(
+                            "Thread '{}' has merge conflicts to resolve",
+                            thread.thread
+                        ),
                         blockers: stale_report.blockers.clone(),
                         warnings: Vec::new(),
                         next_action: Some(recommended_action.clone()),
                         recommended_action: Some(recommended_action),
                     },
                     trust,
-                    thread: thread.id.clone(),
+                    thread: thread.thread.clone(),
                     current_state: thread.current_state.clone(),
                     chosen_path: "blocked".to_string(),
                 }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -3055,7 +3055,12 @@ async fn cmd_land_many(cli: &Cli, args: LandArgs) -> Result<()> {
         }
     }
     if ordered.is_empty() {
-        return Err(anyhow!("--threads requires at least one thread name"));
+        return Err(anyhow!(RecoveryAdvice::invalid_usage(
+            "land_threads_empty",
+            "--threads requires at least one thread name",
+            "Pass one or more thread names: `heddle land --threads <name>`.",
+            "heddle land --threads <name>",
+        )));
     }
 
     MULTI_LAND_COLLECTOR.with(|collector| {

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -297,6 +297,12 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     recover_incomplete_land_if_present(&repo)?;
     let user_config = UserConfig::load_default().unwrap_or_default();
     let thread = resolve_land_subject_thread(cli, &repo, args.thread.as_deref())?;
+    if thread.target_thread.is_none() {
+        return Err(anyhow!(RecoveryAdvice::missing_target_thread(
+            &thread.thread,
+            "land",
+        )));
+    }
     let thread_repo = if thread.execution_path.as_os_str().is_empty() {
         None
     } else if thread.execution_path.exists() {
@@ -799,7 +805,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     let merge_output = if let Some(transaction_id) = integration_transaction_id.as_deref() {
         merge_thread_into_current_transactional(
             &repo,
-            &merge_thread.id,
+            &merge_thread.thread,
             None,
             false,
             false,
@@ -812,7 +818,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     } else {
         merge_thread_into_current(
             &repo,
-            &merge_thread.id,
+            &merge_thread.thread,
             None,
             false,
             false,
@@ -1207,13 +1213,13 @@ fn collapse_thread_for_land(
         &sources,
         intent,
         None,
-        CollapsePublishedRef::Thread(ThreadName::new(&thread.id)),
+        CollapsePublishedRef::Thread(ThreadName::new(&thread.thread)),
     )?;
     Ok(Some(result.state_id))
 }
 
 fn thread_source_states(repo: &Repository, thread: &Thread) -> Result<Vec<State>> {
-    let Some(tip) = repo.refs().get_thread(&ThreadName::new(&thread.id))? else {
+    let Some(tip) = repo.refs().get_thread(&ThreadName::new(&thread.thread))? else {
         return Ok(Vec::new());
     };
     let base = repo.resolve_state(&thread.base_state)?;
@@ -1327,10 +1333,9 @@ fn resolve_thread(
 
 /// Resolve the thread `sync` refreshes onto its target.
 ///
-/// Omit `--thread` to use the current checkout, including a synthesized
-/// default thread such as `main` (ref from `seed_default_thread`, no
-/// ThreadManager record). An explicit `--thread` always goes through
-/// `load_thread` so unmanaged imported refs keep their typed advice.
+/// Omit `--thread` to use the current checkout. An explicit `--thread`
+/// always goes through `load_thread` so unmanaged imported refs keep
+/// their typed advice.
 fn resolve_sync_thread(repo: &Repository, thread: Option<&str>) -> Result<Thread> {
     match thread {
         Some(name) => load_thread(repo, name),
@@ -2383,7 +2388,7 @@ fn write_prepared_land_marker(
             .map(|state| state.state_id.to_string_full()),
         pre_source_state: repo
             .refs()
-            .get_thread(&ThreadName::new(&thread.id))?
+            .get_thread(&ThreadName::new(&thread.thread))?
             .map(|state| state.to_string_full()),
         pre_thread: Some(thread.clone()),
     };

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -2,6 +2,12 @@
 use std::{cell::RefCell, collections::HashSet, fs, path::PathBuf};
 
 use anyhow::{Context, Result, anyhow};
+// The sync/land wire payloads live in cli-contract so the schema registry
+// registers the real serialization types.
+pub(crate) use heddle_cli_contract::cli::commands::wire::{
+    LandBlockerCheck, LandBlockerCode, LandBlockerDetail, LandBlockerStateContext, LandOutput,
+    MultiLandOutput, MultiLandPeerResult, SiblingRestackFailure, SyncOutput,
+};
 use objects::{
     lock::{RepositoryLockExt, WriteLockGuard},
     object::{State, StateId, ThreadName},
@@ -68,13 +74,6 @@ use crate::{
         output_is_compact, should_output_json, style, worktree_status_options,
     },
     config::UserConfig,
-};
-
-// The sync/land wire payloads live in cli-contract so the schema registry
-// registers the real serialization types.
-pub(crate) use heddle_cli_contract::cli::commands::wire::{
-    LandBlockerCheck, LandBlockerCode, LandBlockerDetail, LandBlockerStateContext, LandOutput,
-    MultiLandOutput, MultiLandPeerResult, SiblingRestackFailure, SyncOutput,
 };
 
 /// Internal accumulator for sibling restack outcomes; never serialized
@@ -1443,7 +1442,7 @@ fn update_integration_policy(
     reason: impl Into<String>,
 ) -> Result<()> {
     let manager = thread_manager(repo);
-    let mut thread = manager.load(thread_id)?.ok_or_else(|| {
+    let mut thread = manager.load_id_or_name(thread_id)?.ok_or_else(|| {
         anyhow!(thread_not_found_advice(
             thread_id,
             "update integration policy"
@@ -1473,7 +1472,7 @@ fn update_integration_policy(
 
 fn clear_manual_resolution_state(repo: &Repository, thread_id: &str) -> Result<()> {
     let manager = thread_manager(repo);
-    let mut thread = manager.load(thread_id)?.ok_or_else(|| {
+    let mut thread = manager.load_id_or_name(thread_id)?.ok_or_else(|| {
         anyhow!(thread_not_found_advice(
             thread_id,
             "clear manual resolution"
@@ -1775,7 +1774,7 @@ fn adopt_manual_resolution(
     transaction_id: Option<&str>,
 ) -> Result<String> {
     let manager = thread_manager(repo);
-    let mut thread = manager.load(thread_id)?.ok_or_else(|| {
+    let mut thread = manager.load_id_or_name(thread_id)?.ok_or_else(|| {
         anyhow!(thread_not_found_advice(
             thread_id,
             "adopt manual resolution"

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -229,8 +229,11 @@ fn crash_capture_at(repo: &std::path::Path, checkpoint: &str, message: &str) {
 }
 
 fn crash_goto_at(repo: &std::path::Path, checkpoint: &str, target: &str) {
+    // `--force` skips auto-capture-on-switch. That capture is a separate
+    // source-thread mutation that runs *before* the goto checkpoint; this
+    // helper exists to isolate recovery of the Goto record itself.
     let crashed = heddle_output_with_env(
-        &["thread", "switch", target],
+        &["thread", "switch", "--force", target],
         Some(repo),
         &[("HEDDLE_FAULT_INJECT", checkpoint)],
     )

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1134,7 +1134,7 @@ fn git_overlay_matrix_verify_tracks_plain_init_import_clean_loop() {
     assert_eq!(doctor["verification"]["verified"], true);
     assert_eq!(doctor["verification"]["status"], "clean");
     assert_eq!(doctor["verification"]["recommended_action"], Value::Null);
-    assert_eq!(doctor["recommended_action"], "heddle ready --thread main");
+    assert_eq!(doctor["recommended_action"], Value::Null);
     assert!(
         doctor["recovery_commands"]
             .as_array()

--- a/crates/cli/tests/cli_integration/land_current_thread.rs
+++ b/crates/cli/tests/cli_integration/land_current_thread.rs
@@ -11,7 +11,12 @@
 //!   is already-landed, not another "automatic integration merge" at exit 0
 //! - Next verbs stay native (`heddle thread list`). No `repair git`.
 
-use std::{fs, path::Path, path::PathBuf, process::Output, str};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Output,
+    str,
+};
 
 use serde_json::Value;
 use tempfile::TempDir;
@@ -203,9 +208,8 @@ fn run_land_thread(main: &Path, checkout: &Path) -> Output {
     .expect("land --thread feature/search should spawn")
 }
 
-/// Same comment: exit 74 / `repair git --ref main` is the wrong recovery
-/// when authority is native. Explicit `--thread main` must stay on
-/// `heddle thread list`.
+/// Default `main` is a persisted managed thread with no integration target.
+/// Explicit `--thread main` must fail closed without recommending `repair git`.
 #[test]
 fn land_unmanaged_main_on_native_recommends_thread_list() {
     let (_main, checkout) = setup_feature_search();
@@ -218,7 +222,7 @@ fn land_unmanaged_main_on_native_recommends_thread_list() {
     assert_eq!(
         output.status.code(),
         Some(74),
-        "unmanaged main still fails closed (field-study exit 74), but recovery must change:\n{}",
+        "default main still fails closed (field-study exit 74), but recovery must change:\n{}",
         combined(&output)
     );
     let stderr = stderr(&output);
@@ -230,7 +234,17 @@ fn land_unmanaged_main_on_native_recommends_thread_list() {
             .unwrap_or(stderr.trim()),
     )
     .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
-    assert_eq!(envelope["kind"], "imported_git_ref_not_managed_thread");
-    assert_eq!(envelope["primary_command"], "heddle thread list");
+    assert_eq!(envelope["kind"], "missing_target_thread");
+    assert_eq!(envelope["primary_command"], "heddle thread show main");
+    let recovery = envelope["recovery_commands"]
+        .as_array()
+        .expect("missing_target recovery_commands");
+    assert!(
+        recovery
+            .iter()
+            .any(|command| command.as_str() == Some("heddle thread list")),
+        "recovery must still include thread list:\n{}",
+        combined(&output)
+    );
     assert_no_repair_git(&output, "land --thread main");
 }

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use objects::object::ThreadName;
 use refs::Head;
 use repo::{Repository, ThreadIntegrationPolicy, ThreadManager, ThreadState};
 use serde_json::Value;
@@ -372,8 +373,11 @@ fn presence_show_multi_match_next_is_not_help_catalog() {
             .unwrap();
     }
 
-    let output = heddle_output(&["--output", "json", "agent", "presence", "show"], Some(repo.path()))
-        .expect("presence show should spawn");
+    let output = heddle_output(
+        &["--output", "json", "agent", "presence", "show"],
+        Some(repo.path()),
+    )
+    .expect("presence show should spawn");
     assert!(
         !output.status.success(),
         "multi-match presence show must fail closed"
@@ -616,17 +620,39 @@ fn sync_on_default_main_thread_succeeds() {
 
 /// heddle#1461 / #1467: `--thread` must not bypass `load_thread`'s
 /// imported-ref advice just because the unmanaged ref is currently checked out.
+/// Default `main` now has a persisted ThreadManager record, so this plants a
+/// ref-only imported name rather than using `main`.
 #[test]
 fn sync_named_unmanaged_ref_keeps_imported_ref_advice() {
-    let repo = setup_native_repo();
+    let repo_dir = setup_native_repo();
+    let repo = Repository::open(repo_dir.path()).unwrap();
+    let current = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .unwrap()
+        .expect("main exists");
+    let imported = ThreadName::new("imported/feature");
+    repo.set_thread_recorded(&imported, &current).unwrap();
+    repo.write_head_recorded(&Head::Attached {
+        thread: imported.clone(),
+    })
+    .unwrap();
+    assert!(
+        ThreadManager::new(repo.heddle_dir())
+            .find_by_thread(imported.as_str())
+            .unwrap()
+            .is_none(),
+        "imported ref must not have a managed record"
+    );
+
     let output = heddle_output(
-        &["--output", "json", "sync", "--thread", "main"],
-        Some(repo.path()),
+        &["--output", "json", "sync", "--thread", imported.as_str()],
+        Some(repo_dir.path()),
     )
-    .expect("sync --thread main should spawn");
+    .expect("sync --thread imported/feature should spawn");
     assert!(
         !output.status.success(),
-        "unmanaged main must not silently no-op: stdout={} stderr={}",
+        "unmanaged imported ref must not silently no-op: stdout={} stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -173,6 +173,11 @@ const SWEPT: &[&str] = &[
     "thread resolve",
     "thread revoke-approval",
     "thread switch",
+    // heddle#1709 — `heddle env` (confidential-runtime env-store) verbs emit
+    // `output_kind: "env_create"/"env_list"`; discriminators are in the catalog
+    // but were never enumerated here.
+    "env create",
+    "env list",
 ];
 
 /// The catalog itself advertises its container kind as `"kind":

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -1285,6 +1285,8 @@ fn runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
         // Stopping a daemon that is not running still exits 0 with the
         // full `daemon_stop` payload, so a bare init fixture suffices.
         "daemon_stop" => (init_fixture(), sv(&["daemon", "stop"])),
+        "netd_status" => (init_fixture(), sv(&["netd", "status"])),
+        "netd_stop" => (init_fixture(), sv(&["netd", "stop"])),
         "oplog_recover" => {
             // Seed three captures, truncate the packed base, and explicitly
             // recover once. Normal repository open now refuses structural

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -35,7 +35,9 @@ use cli::cli::commands::{
 use serde_json::Value;
 use tempfile::TempDir;
 
-use super::{assert_undo_requires_hard, git_hermetic, heddle, heddle_output};
+use super::{
+    assert_undo_requires_hard, git_hermetic, heddle, heddle_output, heddle_output_with_env,
+};
 
 /// Verbs whose `output_kind` invariant is enforced — both the catalog
 /// declaration and (where invocable) the runtime emission.
@@ -860,9 +862,13 @@ fn runtime_init_emits_output_kind() {
 /// Top-level key set of the first JSON object emitted by `argv` in
 /// `dir`. Panics with the captured output on failure so doc-vs-runtime
 /// mismatches surface a readable diff.
-fn runtime_top_level_keys(argv: &[&str], dir: &std::path::Path) -> BTreeSet<String> {
-    let output =
-        heddle_output(argv, Some(dir)).unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
+fn runtime_top_level_keys(
+    argv: &[&str],
+    dir: &std::path::Path,
+    extra_env: &[(&str, &str)],
+) -> BTreeSet<String> {
+    let output = heddle_output_with_env(argv, Some(dir), extra_env)
+        .unwrap_or_else(|err| panic!("spawn {argv:?}: {err}"));
     assert!(
         output.status.success(),
         "{argv:?} exited non-zero: stdout={} stderr={}",
@@ -945,15 +951,25 @@ struct RuntimeDocCase {
     _fixture: TempDir,
     cwd: std::path::PathBuf,
     argv: Vec<String>,
+    extra_env: Vec<(String, String)>,
 }
 
 impl RuntimeDocCase {
     fn at_root(fixture: TempDir, argv: Vec<String>) -> Self {
+        Self::at_root_with_env(fixture, argv, Vec::new())
+    }
+
+    fn at_root_with_env(
+        fixture: TempDir,
+        argv: Vec<String>,
+        extra_env: Vec<(String, String)>,
+    ) -> Self {
         let cwd = fixture.path().to_path_buf();
         Self {
             _fixture: fixture,
             cwd,
             argv,
+            extra_env,
         }
     }
 }
@@ -990,6 +1006,7 @@ fn transport_runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
                 remote.to_string_lossy().into_owned(),
                 checkout.to_string_lossy().into_owned(),
             ],
+            extra_env: Vec::new(),
             _fixture: fixture,
         });
     }
@@ -1018,6 +1035,7 @@ fn transport_runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
         _fixture: fixture,
         cwd: checkout,
         argv,
+        extra_env: Vec::new(),
     })
 }
 
@@ -1063,6 +1081,7 @@ fn runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
             _fixture: fixture,
             cwd: work,
             argv: sv(&["land", "--threads", "alpha,beta"]),
+            extra_env: Vec::new(),
         });
     }
     let case = match output_kind {
@@ -1288,8 +1307,59 @@ fn runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
             (t, sv(&["maintenance", "oplog", "recover"]))
         }
         "timeline_log" => (init_fixture(), sv(&["log", "--timeline"])),
+        "env_create" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["capture", "-m", "base"], Some(t.path())).expect("capture");
+            (
+                t,
+                sv(&[
+                    "env",
+                    "create",
+                    "--name",
+                    "local",
+                    "--from-env",
+                    "DATABASE_URL",
+                ]),
+            )
+        }
+        "env_list" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("a.txt"), "base").unwrap();
+            heddle(&["capture", "-m", "base"], Some(t.path())).expect("capture");
+            let created = heddle_output_with_env(
+                &[
+                    "env",
+                    "create",
+                    "--name",
+                    "local",
+                    "--from-env",
+                    "DATABASE_URL",
+                ],
+                Some(t.path()),
+                &[("DATABASE_URL", "postgres://example/db")],
+            )
+            .expect("env create fixture");
+            assert!(
+                created.status.success(),
+                "env create fixture failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&created.stdout),
+                String::from_utf8_lossy(&created.stderr),
+            );
+            (t, sv(&["env", "list"]))
+        }
         _ => return None,
     };
+    if output_kind == "env_create" {
+        return Some(RuntimeDocCase::at_root_with_env(
+            case.0,
+            case.1,
+            vec![(
+                "DATABASE_URL".to_string(),
+                "postgres://example/db".to_string(),
+            )],
+        ));
+    }
     Some(RuntimeDocCase::at_root(case.0, case.1))
 }
 
@@ -1392,7 +1462,12 @@ fn doc_samples_match_runtime_for_every_catalog_discriminator() {
                 .chain(std::iter::once("json"))
                 .chain(case.argv.iter().map(String::as_str))
                 .collect();
-            let runtime_keys = runtime_top_level_keys(&argv_refs, &case.cwd);
+            let extra_env: Vec<(&str, &str)> = case
+                .extra_env
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            let runtime_keys = runtime_top_level_keys(&argv_refs, &case.cwd, &extra_env);
             if !runtime_keys.contains("output_kind") {
                 failures.push(format!(
                     "{value} ({displays:?}): runtime payload is missing `output_kind` (keys: {runtime_keys:?})"

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -382,40 +382,25 @@ fn native_remote_add_rejects_local_git_remote_before_configuring_default() {
     assert!(remotes.default_name().is_none());
 }
 
-/// Field study 2026-08-19 on native 0.12.0: these exact argv lines are the
-/// done-criteria. `remote add` used to store `heddle://api.heddle.sh/...`,
-/// then `push`/`pull` printed `invalid remote url` and exited 74.
+/// Field study 2026-08-19 on native 0.12.0: `remote add` used to store
+/// `heddle://api.heddle.sh/...`, then `push`/`pull` printed
+/// `invalid remote url` and exited 74. Hosted remotes now use that
+/// scheme, so add must persist the URL and later push/pull must route
+/// as hosted — never the invalid-url rejection.
 #[test]
-fn field_study_heddle_scheme_is_refused_at_add_not_at_push() {
+fn field_study_heddle_scheme_is_accepted_at_add_and_routed_on_push() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
     let repo = Repository::open(temp.path()).expect("open native repo");
     let url = "heddle://api.heddle.sh/luke/tiny-notes";
 
-    let add = heddle_output(&["remote", "add", "origin", url], Some(temp.path()))
-        .expect("invoke field-study remote add");
-    let add_stderr = String::from_utf8_lossy(&add.stderr);
-    assert_eq!(
-        add.status.code(),
-        Some(74),
-        "field-study invalid URL must stay exit 74: stdout={} stderr={add_stderr}",
-        String::from_utf8_lossy(&add.stdout)
-    );
-    assert!(
-        add_stderr.contains(&format!("invalid remote url: {url}")),
-        "add must name the field-study URL: {add_stderr}"
-    );
-    assert!(
-        !add_stderr.contains("heddle capture"),
-        "remotes refusal Next must not be capture: {add_stderr}"
-    );
-    assert!(
-        RemoteConfig::open(&repo)
-            .expect("open remotes")
-            .list()
-            .is_empty(),
-        "field-study URL must not be stored"
-    );
+    heddle(&["remote", "add", "origin", url], Some(temp.path()))
+        .expect("hosted heddle:// remote add");
+    let stored = RemoteConfig::open(&repo)
+        .expect("open remotes")
+        .get("origin")
+        .expect("origin stored");
+    assert_eq!(stored.url, url, "hosted heddle:// URL must be persisted");
 
     for command in ["push", "pull"] {
         let output = heddle_output(&[command], Some(temp.path()))
@@ -423,7 +408,7 @@ fn field_study_heddle_scheme_is_refused_at_add_not_at_push() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
             !stderr.contains(&format!("invalid remote url: {url}")),
-            "{command} must not see a stored field-study URL: {stderr}"
+            "{command} must route the stored hosted URL, not reject it as invalid: {stderr}"
         );
     }
 }

--- a/crates/cli/tests/env_run.rs
+++ b/crates/cli/tests/env_run.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! `heddle env run` injects broker-unwrapped slots into a child only.
 
-use std::path::Path;
-use std::process::{Command, Output};
+use std::{
+    path::Path,
+    process::{Command, Output},
+};
 
-use crypto::Ed25519Signer;
+use env_store::{EnvStore, SlotWrite};
 use objects::object::{Attribution, Principal};
 use repo::Repository;
-use env_store::{EnvStore, SlotWrite};
 use tempfile::TempDir;
 
 fn isolated_heddle(cwd: &Path, home: &Path, args: &[&str]) -> Command {
@@ -34,7 +35,13 @@ fn run_heddle(cwd: &Path, home: &Path, args: &[&str]) -> Output {
 fn seed_profile(repo: &Path, name: &str, slot: &str, value: &str) {
     let opened = Repository::open(repo).expect("open");
     let store = EnvStore::open(opened.heddle_dir()).expect("store");
-    let signer = Ed25519Signer::generate().expect("signer");
+    // `heddle env run` resolves the per-repo local identity. Seed with
+    // that same signer so the store pin matches the CLI process.
+    let local = opened
+        .heddle_dir()
+        .join(repo::identity::LOCAL_IDENTITY_FILE);
+    let signer = repo::identity::resolve_signer(&local, Path::new("/nonexistent"))
+        .expect("mint local signer");
     let (recipient, _secret) = store
         .create_software_recipient(&signer, 1)
         .expect("recipient");
@@ -89,7 +96,10 @@ fn env_run_injects_slot_and_leaves_no_worktree_plaintext() {
     assert!(listed.status.success());
     let json = String::from_utf8_lossy(&listed.stdout);
     assert!(json.contains("\"output_kind\":\"env_list\"") || json.contains("env_list"));
-    assert!(!json.contains(secret), "plaintext leaked into env list JSON");
+    assert!(
+        !json.contains(secret),
+        "plaintext leaked into env list JSON"
+    );
     assert!(!String::from_utf8_lossy(&listed.stderr).contains(secret));
 }
 
@@ -126,7 +136,15 @@ fn env_create_then_run_uses_cli_and_leaves_no_plaintext() {
     let output = run_heddle(
         &repo,
         &home,
-        &["env", "run", "--profile", "local", "--", "printenv", "TOKEN"],
+        &[
+            "env",
+            "run",
+            "--profile",
+            "local",
+            "--",
+            "printenv",
+            "TOKEN",
+        ],
     );
     assert!(
         output.status.success(),

--- a/crates/cli/tests/stack_rebase.rs
+++ b/crates/cli/tests/stack_rebase.rs
@@ -94,7 +94,13 @@ fn compute_stacks_finds_all_roots_and_descendants() {
     );
 
     let stacks = repo.compute_thread_stacks().unwrap();
-    assert_eq!(stacks.len(), 2, "expected two stack roots");
+    // `init` persists default `main` as a singleton root alongside the
+    // two fixture stacks.
+    assert_eq!(
+        stacks.len(),
+        3,
+        "two fixture stacks plus persisted default main"
+    );
 
     // Sorted by root name.
     assert_eq!(stacks[0].root_name(), "feat-a");
@@ -104,6 +110,9 @@ fn compute_stacks_finds_all_roots_and_descendants() {
     assert_eq!(stacks[1].root_name(), "infra-x");
     assert_eq!(stacks[1].member_count(), 1);
     assert_eq!(stacks[1].depth(), 0);
+
+    assert_eq!(stacks[2].root_name(), "main");
+    assert_eq!(stacks[2].member_count(), 1);
 }
 
 #[test]
@@ -289,10 +298,16 @@ fn repository_snapshot_round_trips_through_json() {
     let parsed: RepositorySnapshot = serde_json::from_str(&json).unwrap();
     assert_eq!(snapshot, parsed);
 
-    // Snapshot carries the stack view + the thread records we just wrote.
-    assert_eq!(parsed.stacks.len(), 1);
-    assert_eq!(parsed.stacks[0].root_name(), "feat-a");
-    assert_eq!(parsed.threads.len(), 2);
+    // Snapshot carries the stack view + the thread records we just wrote,
+    // plus persisted default `main`.
+    assert_eq!(parsed.stacks.len(), 2);
+    let feat = parsed
+        .stacks
+        .iter()
+        .find(|stack| stack.root_name() == "feat-a")
+        .expect("feat-a stack");
+    assert_eq!(feat.member_count(), 2);
+    assert_eq!(parsed.threads.len(), 3);
 }
 
 #[test]
@@ -447,7 +462,11 @@ fn repository_snapshot_for_stack_scopes_to_one_stack_only() {
     );
 
     let full = RepositorySnapshot::capture(&repo).unwrap();
-    assert_eq!(full.stacks.len(), 2, "fixture must have two stacks");
+    assert_eq!(
+        full.stacks.len(),
+        3,
+        "two fixture stacks plus persisted default main"
+    );
 
     let scoped = full.for_stack("feat-a").expect("feat-a belongs to a stack");
     assert_eq!(scoped.stacks.len(), 1);

--- a/crates/cli/tests/state_management/merge_store_integrity.rs
+++ b/crates/cli/tests/state_management/merge_store_integrity.rs
@@ -40,6 +40,16 @@ fn test_merge_missing_base_subtree_fails_loud_not_silent_erase() {
     fs::write(temp.path().join("sub/a.txt"), "base content\n").unwrap();
     fs::write(temp.path().join("top.txt"), "top base\n").unwrap();
     heddle(&["capture", "-m", "base"], Some(temp.path())).unwrap();
+    // Pin the merge-base id now. Later captures (and auto-capture on
+    // switch) can insert extra parents, so do not infer the base from
+    // each tip's `parents[0]` after the fact.
+    let base_state_id = {
+        let repo = Repository::open(temp.path()).unwrap();
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("base capture advanced main")
+    };
 
     // Feature side: modify the file inside sub/ so the merger has a
     // real reason to recurse into the subtree.
@@ -62,27 +72,6 @@ fn test_merge_missing_base_subtree_fails_loud_not_silent_erase() {
     // guarantees no in-process tree cache hides the corruption.
     let sub_hash_hex = {
         let repo = Repository::open(temp.path()).unwrap();
-        let main_tip = repo
-            .refs()
-            .get_thread(&ThreadName::new("main"))
-            .unwrap()
-            .unwrap();
-        let main_state = repo.store().get_state(&main_tip).unwrap().unwrap();
-        // The merge base IS the initial state: main and feature both
-        // forked from the initial capture, then captured once on each
-        // side. We need the base state's tree, not main's tip tree.
-        let feature_tip = repo
-            .refs()
-            .get_thread(&ThreadName::new("feature"))
-            .unwrap()
-            .unwrap();
-        let feature_state = repo.store().get_state(&feature_tip).unwrap().unwrap();
-        // Both tips have a single parent — the base capture.
-        let base_state_id = main_state.parents[0];
-        assert_eq!(
-            base_state_id, feature_state.parents[0],
-            "test setup: main and feature must share a single merge base",
-        );
         let base_state = repo.store().get_state(&base_state_id).unwrap().unwrap();
         let base_tree = repo.store().get_tree(&base_state.tree).unwrap().unwrap();
         let sub_entry = base_tree

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::{
     ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
     RepositorySourceAuthority, ThreadFreshness, ThreadManager, WorktreeIndex,
+    refresh_active_thread_metadata,
 };
 
 fn create_test_repo() -> (TempDir, Repository) {
@@ -63,6 +64,73 @@ fn init_default_persists_and_reuses_stable_main_thread_record() {
         second.id, first.id,
         "main's stable id must not be regenerated"
     );
+
+    let hydrated = ThreadManager::new(reopened.heddle_dir())
+        .find_by_thread("main")
+        .unwrap()
+        .expect("reopening must still hydrate the persisted main record");
+    assert!(
+        hydrated.execution_path.as_os_str().is_empty(),
+        "default main is identity-only, not an isolated checkout"
+    );
+    assert!(hydrated.materialized_path.is_none());
+    assert!(
+        ThreadManager::new(reopened.heddle_dir())
+            .find_by_execution_root(reopened.root())
+            .unwrap()
+            .is_none(),
+        "warm status/capture must not treat default main as the execution-root thread"
+    );
+}
+
+#[test]
+fn capture_refresh_does_not_rewrite_identity_only_default_main() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let mut main = manager
+        .find_by_thread("main")
+        .unwrap()
+        .expect("init_default persists main");
+    let original_id = main.id.clone();
+    // Legacy #1639 records claimed the repo root as execution_path.
+    // Refresh must still refuse to rewrite them on the warm path.
+    main.execution_path = repo.root().to_path_buf();
+    manager.save(&main).unwrap();
+    assert!(
+        manager
+            .find_by_execution_root(repo.root())
+            .unwrap()
+            .is_some(),
+        "fixture must reproduce the execution-root match that bloated the record"
+    );
+
+    for index in 0..32 {
+        fs::write(
+            temp_dir.path().join(format!("warm-{index:02}.txt")),
+            format!("warm-{index}\n"),
+        )
+        .unwrap();
+    }
+    let state = repo.snapshot(Some("warm".to_string()), None).unwrap();
+    let tree = repo
+        .store()
+        .get_tree(&state.tree)
+        .unwrap()
+        .expect("snapshot tree");
+    let refresh = refresh_active_thread_metadata(&repo, &state, &tree).unwrap();
+    assert!(
+        refresh.changed_paths.is_empty(),
+        "identity-only main must not grow changed_paths on capture"
+    );
+
+    let after = manager
+        .find_by_thread("main")
+        .unwrap()
+        .expect("identity record must survive capture");
+    assert_eq!(after.id, original_id);
+    assert!(after.changed_paths.is_empty());
+    assert!(after.heavy_impact_paths.is_empty());
 }
 
 #[test]

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -141,8 +141,12 @@ pub fn summarize_verification(verification: Option<&Verification>) -> ThreadVeri
     }
 }
 
-/// Re-evaluate freshness against the thread's target. Mirrors the
-/// CLI's `refresh_thread_freshness`.
+/// Re-evaluate freshness against the thread's target.
+///
+/// A persisted default `main` has no target by design — it is the
+/// integration tip — so it is Current. A feature thread with
+/// `target_thread: None` (detached-HEAD start) stays Unknown so sync
+/// fails closed on `missing_target_thread`.
 pub fn refresh_thread_freshness(repo: &Repository, thread: &mut Thread) -> Result<(), HeddleError> {
     thread.freshness = if let Some(target_thread) = thread.target_thread.as_deref() {
         if let Some(target_state) = repo.refs().get_thread(&ThreadName::from(target_thread))? {
@@ -154,6 +158,8 @@ pub fn refresh_thread_freshness(repo: &Repository, thread: &mut Thread) -> Resul
         } else {
             ThreadFreshness::Unknown
         }
+    } else if thread.thread == "main" {
+        ThreadFreshness::Current
     } else {
         ThreadFreshness::Unknown
     };

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -59,6 +59,13 @@ pub fn refresh_active_thread_metadata(
     let Some(mut thread) = manager.find_by_execution_root(repo.root())? else {
         return Ok(ThreadMetadataRefresh::default());
     };
+    // Isolated checkouts only. Identity-only records (default `main`,
+    // in-repo `thread create`) have no materialized_path. Refreshing
+    // those diffs against genesis and persists every changed path on
+    // the warm capture path.
+    if thread.materialized_path.is_none() {
+        return Ok(ThreadMetadataRefresh::default());
+    }
     let base_state = repo
         .resolve_state(&thread.base_state)?
         .and_then(|id| repo.store().get_state(&id).ok().flatten());

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -154,12 +154,15 @@ pub fn describe_thread_advice_with_initial(
     // cascade below otherwise falls through to a misleading
     // "needs_attention" + "heddle ready" recommendation for repos that have
     // genuinely nothing to do yet.
+    // `changed_paths` is vs-base. A thread with no target (default main)
+    // has no base that is not itself, so those paths do not make it busy.
+    let vs_base_counts = thread.target_thread.is_some();
     let fresh_and_idle = !worktree_dirty
         && conflicts == 0
         && !clean_ready_merges_to_apply
         && thread.state == ThreadState::Active
         && thread.freshness != ThreadFreshness::Stale
-        && thread.changed_paths.is_empty()
+        && (!vs_base_counts || thread.changed_paths.is_empty())
         && !thread.promotion_suggested;
     if fresh_and_idle {
         return ThreadAdvice {

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -335,6 +335,18 @@ impl ThreadManager {
             .transpose()
     }
 
+    /// Load by record id, then by human thread name.
+    ///
+    /// User-facing verbs pass names. Persisted records use a stable UUID
+    /// identity that is not the ref name (`save_pulled_metadata`,
+    /// `find_or_materialize_synced_record_by_thread`).
+    pub fn load_id_or_name(&self, id_or_name: &str) -> Result<Option<Thread>> {
+        match self.load(id_or_name)? {
+            Some(thread) => Ok(Some(thread)),
+            None => self.find_by_thread(id_or_name),
+        }
+    }
+
     pub fn list(&self) -> Result<Vec<Thread>> {
         let mut threads: Vec<Thread> = self
             .list_record_files()?
@@ -546,6 +558,11 @@ impl ThreadManager {
     /// `metadata.id` is the stable identity and must be preserved — it is
     /// not the thread ref name. Landing fields an unauthenticated peer can
     /// forge are cleared before the record is filed.
+    ///
+    /// When the source record has no target (default `main`) and a local
+    /// record already exists, keep the local `target_thread`. Pulling
+    /// source `main` into a pre-created landable thread must not strip
+    /// that thread's integration authority.
     pub fn save_pulled_metadata(
         &self,
         local_thread: &str,
@@ -565,6 +582,11 @@ impl ThreadManager {
         metadata
             .integration_policy_result
             .clear_untrusted_landing_fields();
+        if metadata.target_thread.is_none()
+            && let Some(existing) = self.find_record_by_thread(local_thread)?
+        {
+            metadata.target_thread = existing.target_thread;
+        }
         self.converge_records(local_thread, &[Thread::from_record(metadata)])
     }
 
@@ -1109,12 +1131,93 @@ mod adopt_identity_tests {
             Some(main_state.to_string_full().as_str())
         );
         assert_ne!(saved.id, "main");
-        assert!(saved
-            .integration_policy_result
-            .manual_resolution_state
-            .is_none());
+        assert!(
+            saved
+                .integration_policy_result
+                .manual_resolution_state
+                .is_none()
+        );
         assert!(!saved.integration_policy_result.conflicts_resolved_manually);
         assert!(manager.load_record(&local.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_pulled_metadata_keeps_local_target_when_source_has_none() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let local = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+
+        let mut dest = Thread::from_record(local.clone());
+        dest.id = "from-source".to_string();
+        dest.thread = "from-source".to_string();
+        dest.target_thread = Some("main".to_string());
+        manager.save(&dest).unwrap();
+
+        let mut pulled = local.clone();
+        pulled.id = "source-stable-main".to_string();
+        pulled.thread = "main".to_string();
+        pulled.target_thread = None;
+
+        manager
+            .save_pulled_metadata("from-source", &main_state, pulled)
+            .unwrap();
+
+        let saved = manager
+            .find_record_by_thread("from-source")
+            .unwrap()
+            .unwrap();
+        assert_eq!(saved.id, "source-stable-main");
+        assert_eq!(saved.thread, "from-source");
+        assert_eq!(saved.target_thread.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn load_id_or_name_finds_pulled_record_by_thread_name() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let main_state = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("init seeds main");
+        let manager = ThreadManager::new(repo.heddle_dir());
+        let local = manager
+            .find_record_by_thread("main")
+            .unwrap()
+            .expect("init persists main");
+
+        let mut pulled = local.clone();
+        pulled.id = "source-stable-main".to_string();
+        pulled.thread = "from-source".to_string();
+
+        manager
+            .save_pulled_metadata("from-source", &main_state, pulled)
+            .unwrap();
+
+        assert!(
+            manager.load("from-source").unwrap().is_none(),
+            "record is filed under the stable id, not the thread name"
+        );
+        let found = manager
+            .load_id_or_name("from-source")
+            .unwrap()
+            .expect("name lookup finds the pulled record");
+        assert_eq!(found.id, "source-stable-main");
+        assert_eq!(found.thread, "from-source");
+        let by_id = manager
+            .load_id_or_name("source-stable-main")
+            .unwrap()
+            .expect("id lookup still works");
+        assert_eq!(by_id.id, "source-stable-main");
     }
 
     #[test]

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -257,7 +257,13 @@ fn materialized_thread_for_state(
         current_state: Some(ref_state.to_string_full()),
         merged_state: None,
         task: None,
-        execution_path: repo.root().to_path_buf(),
+        // Identity-only. `heddle thread create` leaves execution_path
+        // empty for in-repo threads; `heddle start --path` sets both
+        // execution_path and materialized_path to the isolated checkout.
+        // Claiming `repo.root()` here makes `find_by_execution_root`
+        // treat default `main` as a managed checkout, so every capture
+        // diffs against genesis and rewrites the record on the warm path.
+        execution_path: PathBuf::new(),
         materialized_path: None,
         changed_paths: Vec::new(),
         impact_categories: Vec::new(),

--- a/crates/verbs/src/merge/mod.rs
+++ b/crates/verbs/src/merge/mod.rs
@@ -1551,7 +1551,7 @@ fn land_command_for_thread(repo: &Repository, thread_id: &str) -> String {
 fn mark_merge_previewed(repo: &Repository, thread_id: &str) -> Result<()> {
     let manager = ThreadManager::new(repo.heddle_dir());
     let mut thread = manager
-        .load(thread_id)?
+        .load_id_or_name(thread_id)?
         .ok_or_else(|| anyhow!(advice::thread_not_found(thread_id, "mark merge previewed")))?;
     thread.integration_policy_result = ThreadIntegrationPolicy {
         status: Some("previewed".to_string()),

--- a/crates/verbs/src/save.rs
+++ b/crates/verbs/src/save.rs
@@ -1042,7 +1042,7 @@ fn active_task_assignment_id(repo: &Repository, thread: Option<&Thread>) -> Resu
     Ok(store
         .active_entries()?
         .into_iter()
-        .filter(|entry| entry.thread == thread.id)
+        .filter(|entry| entry.thread == thread.thread || entry.thread == thread.id)
         .max_by_key(|entry| entry.started_at)
         .and_then(|entry| entry.task_assignment_id))
 }

--- a/crates/verbs/src/status.rs
+++ b/crates/verbs/src/status.rs
@@ -2381,6 +2381,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
         changed_paths: Vec::new(),
         changed_path_count: thread_summary
             .as_ref()
+            .filter(|thread| thread.target_thread.is_some())
             .map(|thread| thread.changed_paths.len())
             .unwrap_or_default(),
         worktree_changed_path_count: changes_path_count(&changes),
@@ -3248,7 +3249,10 @@ pub fn changes_paths(changes: &ChangesInfo) -> BTreeSet<String> {
 
 fn changed_path_count(thread: Option<&StatusThreadSummary>, changes: &ChangesInfo) -> usize {
     let mut paths = BTreeSet::new();
-    if let Some(thread) = thread {
+    // `thread.changed_paths` is vs-base. Only a thread with a target
+    // has a base that is not itself; main and detached-no-target use
+    // the worktree alone.
+    if let Some(thread) = thread.filter(|thread| thread.target_thread.is_some()) {
         paths.extend(thread.changed_paths.iter().cloned());
     }
     paths.extend(changes.modified.iter().cloned());
@@ -3259,7 +3263,7 @@ fn changed_path_count(thread: Option<&StatusThreadSummary>, changes: &ChangesInf
 
 fn changed_paths(thread: Option<&StatusThreadSummary>, changes: &ChangesInfo) -> Vec<String> {
     let mut paths = BTreeSet::new();
-    if let Some(thread) = thread {
+    if let Some(thread) = thread.filter(|thread| thread.target_thread.is_some()) {
         paths.extend(thread.changed_paths.iter().cloned());
     }
     paths.extend(changes.modified.iter().cloned());
@@ -3272,7 +3276,7 @@ fn captured_thread_path_count(
     thread: Option<&StatusThreadSummary>,
     changes: &ChangesInfo,
 ) -> usize {
-    let Some(thread) = thread else {
+    let Some(thread) = thread.filter(|thread| thread.target_thread.is_some()) else {
         return 0;
     };
     let dirty_paths = changes_paths(changes);

--- a/crates/verbs/src/status.rs
+++ b/crates/verbs/src/status.rs
@@ -1877,11 +1877,15 @@ fn thread_summary_from_thread(
                 .and_then(|entry| entry.path.as_ref())
                 .map(|path| path.display().to_string())
         });
-    let execution_path = if thread.execution_path == repo.root() {
-        None
-    } else {
-        Some(thread.execution_path.display().to_string())
-    };
+    let execution_path =
+        if thread.execution_path.as_os_str().is_empty() || thread.execution_path == repo.root() {
+            // An empty execution_path is an identity-only thread (default main /
+            // `thread create`) with no distinct execution root — omit it, same as
+            // when it equals the repo root.
+            None
+        } else {
+            Some(thread.execution_path.display().to_string())
+        };
     let git_backed_tip = is_current
         && repo.capability() == RepositoryCapability::GitOverlay
         && thread.current_state.is_none();
@@ -3577,7 +3581,11 @@ mod tests {
         )
         .expect_err("truncated recovery marker must fail closed");
 
-        assert!(error.to_string().contains("failed to parse incomplete-land marker"));
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse incomplete-land marker")
+        );
     }
 
     #[test]

--- a/crates/verbs/src/thread_lifecycle.rs
+++ b/crates/verbs/src/thread_lifecycle.rs
@@ -67,8 +67,7 @@ pub fn thread_mode_requires_unmount(mode: &ThreadMode) -> bool {
 pub struct ThreadDropOptions {
     /// Whether a managed thread record was loaded for the requested id/name.
     pub thread_found: bool,
-    /// True when the request names the attached current lane (only consulted
-    /// when the record is missing).
+    /// True when the request names the attached current lane.
     pub is_current_lane: bool,
     /// `heddle thread drop --delete-thread` (or cleanup-equivalent).
     pub delete_thread: bool,
@@ -118,16 +117,22 @@ pub enum ThreadDropDisposition {
 /// Pure preflight for `heddle thread drop` / `drop_thread_silent`.
 ///
 /// Rules (matching CLI):
-/// 1. Missing + current lane + no delete flag → refuse
-/// 2. Missing + delete flag → proceed to delete command
-/// 3. Missing otherwise → not found
-/// 4. Found → drop plan (unmount if virtualized, remove checkout if present,
-///    abandon record, strip agents, optionally delete ref)
+/// 1. Current lane + no delete flag → refuse
+/// 2. Current lane + delete flag → proceed to delete command (typed
+///    `branch_delete_current` advice; do not tear down the checkout)
+/// 3. Missing + delete flag → proceed to delete command
+/// 4. Missing otherwise → not found
+/// 5. Found → drop plan (unmount if virtualized, remove a dedicated
+///    checkout if present, abandon record, strip agents, optionally
+///    delete ref). Never remove the shared repo root.
 pub fn plan_thread_drop(options: &ThreadDropOptions) -> ThreadDropDisposition {
-    if !options.thread_found {
-        if !options.delete_thread && options.is_current_lane {
-            return ThreadDropDisposition::RefuseCurrentCheckout;
+    if options.is_current_lane {
+        if options.delete_thread {
+            return ThreadDropDisposition::ProceedDeleteMissing;
         }
+        return ThreadDropDisposition::RefuseCurrentCheckout;
+    }
+    if !options.thread_found {
         if options.delete_thread {
             return ThreadDropDisposition::ProceedDeleteMissing;
         }
@@ -142,7 +147,8 @@ pub fn plan_thread_drop(options: &ThreadDropOptions) -> ThreadDropDisposition {
             options.execution_path_has_heddle,
         ),
         unmount_virtualized: thread_mode_requires_unmount(&options.mode),
-        remove_execution_path: options.execution_path_exists,
+        remove_execution_path: options.execution_path_exists
+            && !options.execution_path_is_repo_root,
         remove_manifest: true,
         mark_abandoned: true,
         strip_actor_presence: true,
@@ -418,6 +424,42 @@ mod tests {
             plan_thread_drop(&opts),
             ThreadDropDisposition::RefuseCurrentCheckout
         );
+    }
+
+    #[test]
+    fn plan_thread_drop_refuses_found_current_lane() {
+        let mut opts = drop_opts(true);
+        opts.is_current_lane = true;
+        assert_eq!(
+            plan_thread_drop(&opts),
+            ThreadDropDisposition::RefuseCurrentCheckout
+        );
+    }
+
+    #[test]
+    fn plan_thread_drop_delete_found_current_lane_uses_branch_delete() {
+        let mut opts = drop_opts(true);
+        opts.is_current_lane = true;
+        opts.delete_thread = true;
+        assert_eq!(
+            plan_thread_drop(&opts),
+            ThreadDropDisposition::ProceedDeleteMissing
+        );
+    }
+
+    #[test]
+    fn plan_thread_drop_does_not_remove_shared_repo_root() {
+        let mut opts = drop_opts(true);
+        opts.execution_path_is_repo_root = true;
+        opts.delete_thread = true;
+        match plan_thread_drop(&opts) {
+            ThreadDropDisposition::Drop(plan) => {
+                assert!(!plan.remove_execution_path);
+                assert!(plan.delete_thread_ref);
+                assert!(plan.mark_abandoned);
+            }
+            other => panic!("expected Drop, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/verbs/src/thread_shaping.rs
+++ b/crates/verbs/src/thread_shaping.rs
@@ -241,7 +241,7 @@ fn current_thread(repo: &Repository) -> Result<Option<Thread>> {
 }
 
 fn load_thread(repo: &Repository, thread_id: &str, action: &'static str) -> Result<Thread> {
-    match thread_manager(repo).load(thread_id)? {
+    match thread_manager(repo).load_id_or_name(thread_id)? {
         Some(thread) => Ok(thread),
         None if repo
             .refs()

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1407,6 +1407,46 @@ The foreground daemon emits one JSON value when it exits cleanly.
 
 ---
 
+## `heddle netd serve --output json`
+
+The foreground network daemon does not emit a JSON payload while it runs.
+
+```json
+{
+  "output_kind": "netd_serve"
+}
+```
+
+---
+
+## `heddle netd status --output json`
+
+```json
+{
+  "output_kind": "netd_status",
+  "status": "not_running",
+  "running": false,
+  "endpoint_path": "/home/user/.heddle/netd.json",
+  "node_id": null,
+  "version": null,
+  "uptime_s": null
+}
+```
+
+---
+
+## `heddle netd stop --output json`
+
+```json
+{
+  "output_kind": "netd_stop",
+  "action": "netd stop",
+  "status": "not_running"
+}
+```
+
+---
+
 ## `heddle agent reserve --output json`
 
 `heddle agent reserve --output json` emits the bearer token once. Heartbeat
@@ -3450,6 +3490,28 @@ nothing to stop — both exit 0):
 
 ```json
 {"output_kind": "daemon_stop", "action": "daemon stop", "status": "not_running"}
+```
+
+`heddle netd status --output json` emits liveness without requiring a live
+daemon (`status` is `"not_running"` when nothing is listening):
+
+```json
+{"output_kind": "netd_status", "status": "not_running", "running": false, "endpoint_path": "/home/user/.heddle/netd.json", "node_id": null, "version": null, "uptime_s": null}
+```
+
+`heddle netd stop --output json` emits its own envelope (`status` is
+`"stopped"` after a live daemon shuts down, `"not_running"` when there was
+nothing to stop — both exit 0):
+
+```json
+{"output_kind": "netd_stop", "action": "netd stop", "status": "not_running"}
+```
+
+`heddle netd serve --output json` is a long-running foreground process; the
+catalog still documents a discriminator for the command:
+
+```json
+{"output_kind": "netd_serve"}
 ```
 
 `heddle discuss open|append|resolve|reopen --output json` emit a write

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5468,6 +5468,46 @@ The foreground daemon emits one JSON value when it exits cleanly.
 
 ---
 
+## `heddle netd serve --output json`
+
+The foreground network daemon does not emit a JSON payload while it runs.
+
+```json
+{
+  "output_kind": "netd_serve"
+}
+```
+
+---
+
+## `heddle netd status --output json`
+
+```json
+{
+  "output_kind": "netd_status",
+  "status": "not_running",
+  "running": false,
+  "endpoint_path": "/home/user/.heddle/netd.json",
+  "node_id": null,
+  "version": null,
+  "uptime_s": null
+}
+```
+
+---
+
+## `heddle netd stop --output json`
+
+```json
+{
+  "output_kind": "netd_stop",
+  "action": "netd stop",
+  "status": "not_running"
+}
+```
+
+---
+
 ## `heddle agent reserve --output json`
 
 `heddle agent reserve --output json` emits the bearer token once. Heartbeat
@@ -7511,6 +7551,28 @@ nothing to stop — both exit 0):
 
 ```json
 {"output_kind": "daemon_stop", "action": "daemon stop", "status": "not_running"}
+```
+
+`heddle netd status --output json` emits liveness without requiring a live
+daemon (`status` is `"not_running"` when nothing is listening):
+
+```json
+{"output_kind": "netd_status", "status": "not_running", "running": false, "endpoint_path": "/home/user/.heddle/netd.json", "node_id": null, "version": null, "uptime_s": null}
+```
+
+`heddle netd stop --output json` emits its own envelope (`status` is
+`"stopped"` after a live daemon shuts down, `"not_running"` when there was
+nothing to stop — both exit 0):
+
+```json
+{"output_kind": "netd_stop", "action": "netd stop", "status": "not_running"}
+```
+
+`heddle netd serve --output json` is a long-running foreground process; the
+catalog still documents a discriminator for the command:
+
+```json
+{"output_kind": "netd_serve"}
 ```
 
 `heddle discuss open|append|resolve|reopen --output json` emit a write


### PR DESCRIPTION
**main is silently red.** #1639 (\`53f26a7f\`, merged 09-01) gave the persisted default \`main\` thread a UUID id + no \`target_thread\`; downstream logic classified that as *Unknown*, so bare \`heddle sync\` fails \`missing_target_thread\` (exit 74, JSON to stderr, **empty stdout**) and \`status\` folds vs-base changed_paths into a clean-worktree count. That breaks the whole CLI-integration suite (\`next_action_contract\`, \`cli_premium_output\`, \`output_kind_invariant\`). It slipped in because heddle has no merge queue and the full-suite never runs on plain main pushes.

The fix already exists as \`3573a090\` (co-authored by the owner) but is trapped inside the larger, separately-red #1710. This cherry-picks it standalone so main goes green now without waiting for the refs refactor.

- default main with no target => **Current** (not Unknown); feature threads with no target stay Unknown
- \`status\` counts vs-base paths only when a target exists

\`full-ci\` label added to prove the sync/status suite goes green. Diagnosis: the CI-suite investigation on this branch's root-cause. Supersedes the need to wait on #1710 for the main-red fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791231326&installation_model_id=21489&pr_number=1713&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1713&signature=e18aa348b8f97d1f4b3f08d1f41f4971734b4edb5e63f1171fc679f753627df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->