### PR TITLE
perf(repo): keep default main identity off the warm status/capture path

### DIFF
--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::{
     ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
     RepositorySourceAuthority, ThreadFreshness, ThreadManager, WorktreeIndex,
+    refresh_active_thread_metadata,
 };
 
 fn create_test_repo() -> (TempDir, Repository) {
@@ -63,6 +64,73 @@ fn init_default_persists_and_reuses_stable_main_thread_record() {
         second.id, first.id,
         "main's stable id must not be regenerated"
     );
+
+    let hydrated = ThreadManager::new(reopened.heddle_dir())
+        .find_by_thread("main")
+        .unwrap()
+        .expect("reopening must still hydrate the persisted main record");
+    assert!(
+        hydrated.execution_path.as_os_str().is_empty(),
+        "default main is identity-only, not an isolated checkout"
+    );
+    assert!(hydrated.materialized_path.is_none());
+    assert!(
+        ThreadManager::new(reopened.heddle_dir())
+            .find_by_execution_root(reopened.root())
+            .unwrap()
+            .is_none(),
+        "warm status/capture must not treat default main as the execution-root thread"
+    );
+}
+
+#[test]
+fn capture_refresh_does_not_rewrite_identity_only_default_main() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let mut main = manager
+        .find_by_thread("main")
+        .unwrap()
+        .expect("init_default persists main");
+    let original_id = main.id.clone();
+    // Legacy #1639 records claimed the repo root as execution_path.
+    // Refresh must still refuse to rewrite them on the warm path.
+    main.execution_path = repo.root().to_path_buf();
+    manager.save(&main).unwrap();
+    assert!(
+        manager
+            .find_by_execution_root(repo.root())
+            .unwrap()
+            .is_some(),
+        "fixture must reproduce the execution-root match that bloated the record"
+    );
+
+    for index in 0..32 {
+        fs::write(
+            temp_dir.path().join(format!("warm-{index:02}.txt")),
+            format!("warm-{index}\n"),
+        )
+        .unwrap();
+    }
+    let state = repo.snapshot(Some("warm".to_string()), None).unwrap();
+    let tree = repo
+        .store()
+        .get_tree(&state.tree)
+        .unwrap()
+        .expect("snapshot tree");
+    let refresh = refresh_active_thread_metadata(&repo, &state, &tree).unwrap();
+    assert!(
+        refresh.changed_paths.is_empty(),
+        "identity-only main must not grow changed_paths on capture"
+    );
+
+    let after = manager
+        .find_by_thread("main")
+        .unwrap()
+        .expect("identity record must survive capture");
+    assert_eq!(after.id, original_id);
+    assert!(after.changed_paths.is_empty());
+    assert!(after.heavy_impact_paths.is_empty());
 }
 
 #[test]

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -59,6 +59,13 @@ pub fn refresh_active_thread_metadata(
     let Some(mut thread) = manager.find_by_execution_root(repo.root())? else {
         return Ok(ThreadMetadataRefresh::default());
     };
+    // Isolated checkouts only. Identity-only records (default `main`,
+    // in-repo `thread create`) have no materialized_path. Refreshing
+    // those diffs against genesis and persists every changed path on
+    // the warm capture path.
+    if thread.materialized_path.is_none() {
+        return Ok(ThreadMetadataRefresh::default());
+    }
     let base_state = repo
         .resolve_state(&thread.base_state)?
         .and_then(|id| repo.store().get_state(&id).ok().flatten());

--- a/crates/repo/src/thread_storage.rs
+++ b/crates/repo/src/thread_storage.rs
@@ -257,7 +257,13 @@ fn materialized_thread_for_state(
         current_state: Some(ref_state.to_string_full()),
         merged_state: None,
         task: None,
-        execution_path: repo.root().to_path_buf(),
+        // Identity-only. `heddle thread create` leaves execution_path
+        // empty for in-repo threads; `heddle start --path` sets both
+        // execution_path and materialized_path to the isolated checkout.
+        // Claiming `repo.root()` here makes `find_by_execution_root`
+        // treat default `main` as a managed checkout, so every capture
+        // diffs against genesis and rewrites the record on the warm path.
+        execution_path: PathBuf::new(),
         materialized_path: None,
         changed_paths: Vec::new(),
         impact_categories: Vec::new(),
@@ -1109,10 +1115,12 @@ mod adopt_identity_tests {
             Some(main_state.to_string_full().as_str())
         );
         assert_ne!(saved.id, "main");
-        assert!(saved
-            .integration_policy_result
-            .manual_resolution_state
-            .is_none());
+        assert!(
+            saved
+                .integration_policy_result
+                .manual_resolution_state
+                .is_none()
+        );
         assert!(!saved.integration_policy_result.conflicts_resolved_manually);
         assert!(manager.load_record(&local.id).unwrap().is_none());
     }


### PR DESCRIPTION
## Summary

- `#1639` (53f26a7f) persists a stable UUID for default `main`, which we keep.
- Materialization also claimed `repo.root()` as `execution_path`, so warm `capture` treated default `main` as a managed checkout: it diffed against the empty genesis tree (~1000 object decodes at 100k paths), wrote every changed path into the thread-record TOML, and `status` re-read that record on every invocation.
- This PR leaves `execution_path` empty (same as `heddle thread create`) and skips `refresh_active_thread_metadata` unless the thread has a `materialized_path`. Identity persist, clone/push/pull reuse, and isolated `heddle start --path` refresh are unchanged.

## Closes

Refs HeddleCo/heddle#1639

Core Loop Performance gate regression on `main` after #1639.

## Red commit
`53f26a7f` — Persist stable identity for default main thread (#1639)

A/B on this host (Ryzen 7 7700, 16 cores, `HEDDLE_PERF_SAMPLES=8`, `HEDDLE_PERF_BASELINE=ci-blacksmith-4vcpu-ubuntu-2404`), parent `1566fd2a` vs regress `53f26a7f`, 100k paths:

| Case | Parent p95 | #1639 p95 | Budget |
|---|---:|---:|---:|
| `status_clean` | 10.5 ms | 134.1 ms | 50 |
| `status_one_dirty` | 12.6 ms | 119.4 ms | 75 |
| `capture_one` | 80.0 ms | 284.2 ms | 100 |

Phases that grew: `thread_summary_ms` 0→41 ms; `snapshot_thread_metadata_ms` 0→130 ms; capture `object_decodes` 9→1009. `files_hashed` stayed 0/1.

## Test evidence
```
# Identity / #1639 correctness
cargo test -p heddle-repo --lib init_default_persists -- --nocapture
  test repository::repository_tests::init_default_persists_and_reuses_stable_main_thread_record ... ok

cargo test -p heddle-repo --lib capture_refresh_does_not_rewrite -- --nocapture
  test repository::repository_tests::capture_refresh_does_not_rewrite_identity_only_default_main ... ok

cargo test -p heddle-repo --lib adopt_stable_identity -- --nocapture
  test thread_storage::adopt_identity_tests::adopt_stable_identity_rejects_an_empty_id ... ok
  test thread_storage::adopt_identity_tests::adopt_stable_identity_replaces_local_id_and_reuses_matching_id ... ok

cargo test -p heddle-repo --lib save_pulled_metadata -- --nocapture
  test thread_storage::adopt_identity_tests::save_pulled_metadata_keeps_stable_id_and_clears_forged_landing ... ok

cargo test -p heddle-hosted-client --features client --lib native_first_push_sends_complete_stable -- --nocapture
  test hosted_runtime::hosted::sync::native_exchange_tests::native_first_push_sends_complete_stable_local_thread_metadata ... ok

cargo test -p heddle-hosted-client --features client --lib legacy_ref_only_main_push_materializes -- --nocapture
  test hosted_runtime::hosted::sync::native_exchange_tests::legacy_ref_only_main_push_materializes_once_and_reuses_stable_identity ... ok

cargo test -p heddle-cli --lib hosted_clone_persists_advertised_thread_stable_id -- --nocapture
  test cli::commands::clone::tests::hosted_clone_persists_advertised_thread_stable_id ... ok

cargo test -p heddle-cli --lib hosted_clone_refreshes_list_refs_when_folded_refs_omit_thread_id -- --nocapture
  test cli::commands::clone::tests::hosted_clone_refreshes_list_refs_when_folded_refs_omit_thread_id ... ok

# Core loop gate after the fix (20 samples, same baseline)
TMPDIR=/home/scratch HEDDLE_PERF_BASELINE=ci-blacksmith-4vcpu-ubuntu-2404 HEDDLE_PERF_SAMPLES=20 \
  cargo test --release -p heddle-cli --test cli_basics -- --ignored --nocapture core_loop_release_contract

TARGET case=status_clean paths=100000 budget_p95_ms=50.000 observed_p95_ms=10.490
TARGET case=status_one_dirty paths=100000 budget_p95_ms=75.000 observed_p95_ms=10.662
TARGET case=capture_one paths=100000 budget_p95_ms=100.000 observed_p95_ms=81.166
TARGET case=diff_one paths=100000 budget_p95_ms=100.000 observed_p95_ms=16.591
TARGET case=log_bounded paths=100000 budget_p95_ms=100.000 observed_p95_ms=10.105
TARGET case=thread_list_bounded paths=100000 budget_p95_ms=100.000 observed_p95_ms=31.403
GATES green: absolute p95 targets, scale invariance, structural bounds, repository opens, zero network
test perf_core_loop::core_loop_release_contract ... ok
```

#1640's live weft client-flow test remains `#[ignore]` (needs `HEDDLE_E2E_WEFT_URL`); the local clone/push identity tests it sits on are green above.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791240027&installation_model_id=21489&pr_number=1714&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1714&signature=11eca8bcd1604e15cf44ccecddbe5506b939cba152b5258703515f031bc9c706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->