### PR TITLE
feat(cli): heddle promote + personal-first hosted reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **`heddle promote` and personal-first hosted reads.** `heddle promote`
+  calls `RegistryService/PromoteSpool` to lift `spool/<handle>/<name>` to
+  `spool/<name>`. Clone and pull resolve a bare first path segment to the
+  caller's personal child first, then the shared root. Promotion denials
+  (taken slug, unverified account, missing owner grant) print recovery
+  instead of a generic remote error (heddle#1728, weft#2107).
+
 - **Harness identity cursor on each capture.** `integration install` writes
   per-harness hooks that stamp a workspace `.heddle/identity` sidecar
   (`provider`, `model`, `thought_level`, `session`, `parent`). Each

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -24520,6 +24520,101 @@
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
+    "promote": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "JSON payload for `heddle promote`.",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "full_path": {
+          "type": "string"
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_repo": {
+          "type": "boolean"
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "promote"
+          ],
+          "type": "string"
+        },
+        "recommended_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "server": {
+          "type": "string"
+        },
+        "spool_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "status",
+        "from",
+        "full_path",
+        "spool_id",
+        "is_repo",
+        "server"
+      ],
+      "title": "PromoteSchema",
+      "type": "object"
+    },
     "pull": {
       "$defs": {
         "ActionTemplate": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1814,6 +1814,22 @@ export interface PrincipalReport {
   name: string;
 }
 
+/** JSON payload for `heddle promote`. */
+export interface PromoteSchema {
+  from: string;
+  full_path: string;
+  idempotency_status?: string | null;
+  is_repo: boolean;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "promote";
+  recommended_action?: string | null;
+  replayed?: boolean | null;
+  server: string;
+  spool_id: string;
+  status: string;
+}
+
 export interface ProvenanceReport {
   clean: boolean;
   registry_hash?: string | null;
@@ -3593,6 +3609,7 @@ export interface HeddleVerbOutputs {
   "netd serve": NetdServeSchema;
   "netd status": NetdStatusSchema;
   "netd stop": NetdStopSchema;
+  promote: PromoteSchema;
   pull: PullOutput;
   push: PushOutput;
   query: QueryReport;
@@ -3762,6 +3779,7 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "netd serve",
   "netd status",
   "netd stop",
+  "promote",
   "pull",
   "push",
   "query",

--- a/crates/cli-args/CHANGELOG.md
+++ b/crates/cli-args/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `heddle promote` clap surface (heddle#1728).
+
 ## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-cli-args-v0.15.2...heddle-cli-args-v0.15.3) - 2026-08-28
 
 ### Other

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -6,6 +6,31 @@ use clap::{Args, Subcommand, ValueEnum};
 const DEFAULT_CLAIM_TIMEOUT: &str = "15m";
 pub const DEFAULT_CLAIM_WEB_ORIGIN: &str = "https://app.heddle.sh";
 
+/// Arguments for `heddle promote`.
+#[derive(Args, Clone, Debug)]
+#[command(after_help = "\
+Promote moves a personal hosted spool to the shared root namespace:
+
+  spool/<your-handle>/<name>  →  spool/<name>
+
+The server requires the root slug to be free, a claimed/verified account, and
+an owner grant on the personal spool. Denials print the recovery step.
+
+Examples:
+  heddle promote spool/willow-ibis-8e7264/notes
+  heddle promote willow-ibis-8e7264/notes --server api.preview.heddle.sh
+  heddle promote https://api.preview.heddle.sh/willow-ibis-8e7264/notes
+")]
+pub struct PromoteArgs {
+    /// Personal spool to lift to root (`spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL).
+    #[arg(value_name = "PATH")]
+    pub path: String,
+
+    /// Hosted Heddle server. Omit when `PATH` is a URL, or to use the configured default.
+    #[arg(long)]
+    pub server: Option<String>,
+}
+
 /// Offer the current agent-rooted account for a human to claim.
 #[derive(Args, Clone, Debug)]
 pub struct ClaimArgs {
@@ -160,7 +185,7 @@ pub enum AuthCommands {
         #[arg(long = "ttl", default_value_t = 3600)]
         ttl_secs: u64,
 
-        /// Resource scope (`repo:org/name`, `namespace:org`, `spool:org/name`, or a bare repo path).
+        /// Resource scope (`spool:name`, `spool:handle/name`, or a bare spool path).
         #[arg(long = "scope")]
         scopes: Vec<String>,
 
@@ -366,6 +391,24 @@ mod tests {
         assert_eq!(args.web_origin.as_deref(), Some("https://heddle.example"));
         assert_eq!(args.timeout, std::time::Duration::from_secs(30 * 60));
         assert!(Cli::try_parse_from(["heddle", "claim", "--timeout", "0s"]).is_err());
+    }
+
+    #[test]
+    fn promote_parses_path_and_optional_server() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "promote",
+            "spool/willow-ibis-8e7264/notes",
+            "--server",
+            "api.preview.heddle.sh",
+        ])
+        .expect("promote flags parse");
+        let Commands::Promote(args) = cli.command else {
+            panic!("expected top-level promote");
+        };
+        assert_eq!(args.path, "spool/willow-ibis-8e7264/notes");
+        assert_eq!(args.server.as_deref(), Some("api.preview.heddle.sh"));
+        assert!(Cli::try_parse_from(["heddle", "promote"]).is_err());
     }
 
     #[test]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -18,7 +18,7 @@ use super::{
     },
 };
 #[cfg(feature = "client")]
-use super::{AuthCommands, ClaimArgs};
+use super::{AuthCommands, ClaimArgs, PromoteArgs};
 
 #[derive(Clone, Debug, Args)]
 pub struct FsckArgs {
@@ -372,6 +372,15 @@ Examples:
         #[command(subcommand)]
         command: AuthCommands,
     },
+
+    /// Promote a personal hosted spool to a root-level spool.
+    ///
+    /// Moves `spool/<your-handle>/<name>` to `spool/<name>` after the server
+    /// confirms the root slug is free, the account is claimed/verified, and
+    /// you hold an owner grant. Clone a bare name still prefers your personal
+    /// copy first.
+    #[cfg(feature = "client")]
+    Promote(PromoteArgs),
 
     /// Offer this agent account for a human to claim.
     ///

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -57,7 +57,7 @@ pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
 pub use commands_client::{
     AgentTemplateArg, AuthCommands, AuthInviteCommands, AuthTrustCommands, AuthTrustReplaceArgs,
-    AuthTrustShowArgs, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN,
+    AuthTrustShowArgs, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN, PromoteArgs,
 };
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]

--- a/crates/cli-contract/CHANGELOG.md
+++ b/crates/cli-contract/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `promote` command catalog, JSON schema, and recovery advice (heddle#1728).
+
 ## [0.15.2](https://github.com/HeddleCo/heddle/compare/heddle-cli-contract-v0.15.1...heddle-cli-contract-v0.15.2) - 2026-08-28
 
 ### Other

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1171,6 +1171,80 @@ impl RecoveryAdvice {
     }
 
     #[cfg(feature = "client")]
+    pub fn promote_slug_taken(full_path: &str, slug: &str) -> Self {
+        Self::safety_refusal(
+            "promote_slug_taken",
+            format!("Cannot promote '{full_path}': root slug '{slug}' is already taken"),
+            "Pick a free root name, or rename the personal spool first. Inspect with `heddle whoami`."
+                .to_string(),
+            format!("a root-level spool named '{slug}' already exists or is reserved"),
+            "the personal spool stays under your handle until the root slug is free",
+            "hosted spool path, grants, and local checkouts were left unchanged",
+            "heddle whoami".to_string(),
+            vec!["heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn promote_account_standing(full_path: &str) -> Self {
+        Self::safety_refusal(
+            "promote_account_standing",
+            format!("Cannot promote '{full_path}': the account is not claimed and verified"),
+            "Promotion requires a claimed, verified account. Run `heddle claim`, then retry.",
+            "the server refused promotion because this account is anonymous or unverified",
+            "the personal spool stays under your handle until the account is claimed",
+            "hosted spool path, grants, and local checkouts were left unchanged",
+            "heddle claim".to_string(),
+            vec!["heddle claim".to_string(), "heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn promote_not_owner(full_path: &str) -> Self {
+        Self::safety_refusal(
+            "promote_not_owner",
+            format!("Cannot promote '{full_path}': only an owner of this spool can promote it"),
+            "Ask an owner to promote it, or check the roles on `heddle whoami`.",
+            "the caller does not hold an owner grant on the personal spool",
+            "the personal spool was not moved",
+            "hosted spool path, grants, and local checkouts were left unchanged",
+            "heddle whoami".to_string(),
+            vec!["heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn promote_already_root(full_path: &str) -> Self {
+        Self::safety_refusal(
+            "promote_already_root",
+            format!("'{full_path}' is already a root-level spool"),
+            format!("Clone it with `heddle clone https://<host>/{full_path} <dir>`."),
+            "promotion only moves a personal child spool to the shared root",
+            "no hosted path would change",
+            "hosted spool path, grants, and local checkouts were left unchanged",
+            format!("heddle clone https://<host>/{full_path} <dir>"),
+            vec![format!("heddle clone https://<host>/{full_path} <dir>")],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn promote_failed(full_path: &str, error: &str) -> Self {
+        Self::safety_refusal(
+            "promote_failed",
+            format!("Cannot promote '{full_path}': {error}"),
+            "Fix the reported condition, then retry `heddle promote` with the same path.",
+            format!("the server refused PromoteSpool for '{full_path}': {error}"),
+            "the personal spool was not moved",
+            "hosted spool path, grants, and local checkouts were left unchanged",
+            format!("heddle promote {full_path}"),
+            vec![
+                format!("heddle promote {full_path}"),
+                "heddle whoami".to_string(),
+            ],
+        )
+    }
+
+    #[cfg(feature = "client")]
     pub fn network_clone_failed(error: &str, local_path: &std::path::Path) -> Self {
         Self::safety_refusal(
             "network_clone_failed",

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1569,6 +1569,38 @@ const CONTRACTS: &[CommandContractEntry] = &[
             191,
         ),
     ),
+    entry(
+        &["promote"],
+        feature_gated(
+            exits(
+                json_discriminators(
+                    documented_schemas(
+                        CommandContract {
+                            help_rank: 192,
+                            ..user_scoped(NETWORK_METADATA_MUTATION)
+                        },
+                        &["promote"],
+                    ),
+                    &[json_discriminator(
+                        Some("promote"),
+                        "output_kind",
+                        "promote",
+                    )],
+                ),
+                &[
+                    (0, "ok"),
+                    (75, "server unreachable; safe to retry"),
+                    (
+                        76,
+                        "target slug taken or request rejected; do not retry without changing inputs",
+                    ),
+                    (77, "not the owner, or account is not claimed/verified"),
+                    (78, "not authenticated or spool path missing"),
+                ],
+            ),
+            "client",
+        ),
+    ),
     entry(&["bridge"], surface(GROUP, "git_projection")),
     entry(&["bridge", "git"], surface(GROUP, "git_projection")),
     entry(
@@ -4615,6 +4647,8 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         Commands::Whoami { .. } => vec!["whoami"],
         #[cfg(feature = "client")]
         Commands::Claim(_) => vec!["claim"],
+        #[cfg(feature = "client")]
+        Commands::Promote(_) => vec!["promote"],
         Commands::Context { command } => match command {
             ContextCommands::Set(_) => vec!["context", "set"],
             ContextCommands::Get(_) => vec!["context", "get"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -183,6 +183,8 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["whoami"], &["whoami"]),
     #[cfg(feature = "client")]
     sample(&["claim"], &["claim"]),
+    #[cfg(feature = "client")]
+    sample(&["promote"], &["promote", "spool/willow-ibis-8e7264/notes"]),
     #[cfg(feature = "git-overlay")]
     sample(&["bridge", "git", "import"], &["bridge", "git", "import"]),
     #[cfg(feature = "git-overlay")]
@@ -1782,6 +1784,7 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             // advertises its discriminator here alongside the other
             // client-gated hosted verbs.
             "whoami",
+            "promote",
             "bridge git import",
             "bridge git export",
             "sync git",
@@ -2487,6 +2490,6 @@ fn feature_gated_command_roots_are_catalog_owned() {
     // listed here.
     assert_eq!(
         feature_gated_command_roots(),
-        &["auth", "ci", "claim", "whoami"]
+        &["auth", "ci", "claim", "promote", "whoami"]
     );
 }

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -46,7 +46,8 @@ use super::{
         },
         auth::{
             AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput,
-            ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput, WhoamiOutput,
+            PromoteOutput, ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput,
+            WhoamiOutput,
         },
         thread::{
             ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, ThreadAbsorbOutput,
@@ -176,6 +177,7 @@ schema_registry! {
     (&["auth status"], AuthStatusOutput),
     (&["auth trust show", "auth trust replace"], AuthTrustOutput),
     (&["whoami"], WhoamiOutput),
+    (&["promote"], PromoteOutput),
     (&["auth create-service-token"], ServiceTokenOutput),
     (&["auth invite"], SignupInviteCreatedOutput),
     (&["auth invite list"], SignupInviteListOutput),

--- a/crates/cli-contract/src/cli/commands/surface_conformance.rs
+++ b/crates/cli-contract/src/cli/commands/surface_conformance.rs
@@ -69,6 +69,7 @@ pub const APPROVED_NON_EVERYDAY_ROOT_COMMANDS: &[&str] = &[
     "env",
     "hook",
     "netd",
+    "promote",
     "revert",
     "semantic",
     "visibility",

--- a/crates/cli-contract/src/cli/commands/wire/auth.rs
+++ b/crates/cli-contract/src/cli/commands/wire/auth.rs
@@ -8,6 +8,20 @@
 use schemars::JsonSchema;
 use serde::Serialize;
 
+/// JSON payload for `heddle promote`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "PromoteSchema")]
+pub struct PromoteOutput {
+    pub output_kind: &'static str,
+    pub status: &'static str,
+    pub from: String,
+    pub full_path: String,
+    pub spool_id: String,
+    pub is_repo: bool,
+    pub server: String,
+    pub recommended_action: Option<String>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 #[schemars(rename = "AgentAccountCreatedSchema")]
 pub struct AgentAccountCreatedOutput {

--- a/crates/cli-contract/src/cli/commands/wire/mod.rs
+++ b/crates/cli-contract/src/cli/commands/wire/mod.rs
@@ -36,8 +36,8 @@ pub use agent::{
 };
 pub use auth::{
     AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, CaptureActor,
-    HumanPromotionDirective, ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput,
-    SignupInviteOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
+    HumanPromotionDirective, PromoteOutput, ServiceTokenOutput, SignupInviteCreatedOutput,
+    SignupInviteListOutput, SignupInviteOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
 };
 pub use bridge::{
     ExportGitOutput, ExportedRefOutput, ImportGitOutput, IntegrationStatusOutput,

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -583,6 +583,10 @@ options. Advanced/planned flags `--lazy` and `--filter blob:none`
 skip blob content and hydrate it on demand for hosted/network Heddle
 remotes; local clone paths reject them today.
 
+A bare hosted name (`https://host/notes`) clones your personal copy
+`spool/<handle>/notes` when it exists, otherwise the root `spool/notes`.
+`heddle promote` moves a personal spool to that root.
+
 See `heddle help threads` for the thread model and `heddle help remotes`
 for remote management.
 "#;
@@ -840,7 +844,9 @@ Common loop:
     heddle verify
 
 Remote values may be Git URLs, hosted endpoints, or local paths. `push` and
-`pull` use the default remote unless a positional remote is supplied. In Git
+`pull` use the default remote unless a positional remote is supplied. A bare
+hosted name on clone/pull resolves to your personal spool first, then the
+shared root; `heddle promote` lifts a personal spool to that root. In Git
 Overlay, Sley reads and edits the repository's Git configuration and streams
 objects directly between the remote and `.git`. In Native Heddle, the same
 verbs use Heddle transport and storage. The Git executable is not involved.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `heddle promote` lifts a personal hosted spool to the shared root.
+  Clone and pull resolve a bare hosted name to the caller's personal
+  copy first (heddle#1728).
+
 ## [0.15.3](https://github.com/HeddleCo/heddle/compare/heddle-cli-v0.15.2...heddle-cli-v0.15.3) - 2026-08-28
 
 ### Other

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1574,10 +1574,14 @@ async fn clone_network(
         .with_warning_sink(std::sync::Arc::new(
             crate::cli::warning_render::StderrWarningSink,
         ));
+    let repo_path =
+        hosted_client::hosted_runtime::hosted::resolve_personal_first_read(&mut client, repo_path)
+            .await
+            .map_err(anyhow::Error::new)?;
     let result = clone_network_connected(
         cli,
         authority,
-        repo_path,
+        &repo_path,
         local_path,
         options,
         endpoint_spec,
@@ -2189,10 +2193,14 @@ async fn clone_monorepo(
         .with_warning_sink(std::sync::Arc::new(
             crate::cli::warning_render::StderrWarningSink,
         ));
+    let root_path =
+        hosted_client::hosted_runtime::hosted::resolve_personal_first_read(&mut client, root_path)
+            .await
+            .map_err(anyhow::Error::new)?;
     let result = clone_monorepo_connected(
         cli,
         authority,
-        root_path,
+        &root_path,
         local_path,
         endpoint_spec,
         &mut client,
@@ -2508,7 +2516,7 @@ fn monorepo_requires_hosted_remote_advice(remote: &str) -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "monorepo_requires_hosted_remote",
         format!("--recursive monorepo clone requires a hosted spool remote; '{remote}' is not one"),
-        "Point `--recursive` at a hosted spool (e.g. `https://host/org/root`), or clone this remote without `--recursive`.",
+        "Point `--recursive` at a hosted spool (e.g. `https://host/spool/root`), or clone this remote without `--recursive`.",
         format!("remote '{remote}' does not resolve to a hosted spool that can carry a child tree"),
         "a monorepo clone must call ResolveMonorepo on a hosted spool to discover its children",
         "no destination directory, repository metadata, or worktree files were written",
@@ -3315,11 +3323,11 @@ mod tests {
     #[test]
     fn hosted_endpoint_spec_strips_repo_path_suffix() {
         assert_eq!(
-            hosted_endpoint_spec("example.heddle.cloud:443/org/acme/repo"),
+            hosted_endpoint_spec("example.heddle.cloud:443/spool/acme/repo"),
             "example.heddle.cloud:443",
         );
         assert_eq!(
-            hosted_endpoint_spec("https://example.heddle.cloud:443/org/acme/repo"),
+            hosted_endpoint_spec("https://example.heddle.cloud:443/spool/acme/repo"),
             "example.heddle.cloud:443",
         );
     }

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -52,6 +52,8 @@ mod next_action;
 mod operator_core;
 mod operator_loop;
 mod oplog;
+#[cfg(feature = "client")]
+mod promote;
 mod purge;
 mod query;
 mod ready_cmd;
@@ -154,6 +156,8 @@ pub use netdaemon::{cmd_netd_serve, cmd_netd_status, cmd_netd_stop};
 pub use operator_core::operator_emission_output_kinds;
 pub use operator_loop::{cmd_abort, cmd_continue, cmd_sync_smart};
 pub use oplog::cmd_oplog;
+#[cfg(feature = "client")]
+pub use promote::cmd_promote;
 pub use purge::cmd_purge;
 pub use query::run as cmd_query;
 pub use ready_cmd::cmd_ready;

--- a/crates/cli/src/cli/commands/promote.rs
+++ b/crates/cli/src/cli/commands/promote.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `heddle promote` — lift a personal hosted spool to the shared root.
+
+use anyhow::{Context, Result, anyhow};
+use heddle_cli_contract::cli::commands::wire::auth::PromoteOutput;
+use hosted_client::hosted_runtime::{
+    auth::resolve_server,
+    hosted::{
+        HostedAuthMode, HostedClient, HostedSession, canonicalize_spool_path,
+        is_root_level_spool_path,
+    },
+};
+use wire::ProtocolError;
+
+use super::{
+    advice::RecoveryAdvice,
+    next_action::{NextActionValidationContext, write_full_command_json},
+};
+use crate::{
+    cli::{Cli, CliContext, PromoteArgs, should_output_json, style},
+    config::UserConfig,
+    remote::RemoteTarget,
+};
+
+pub async fn cmd_promote(cli: &Cli, args: PromoteArgs) -> Result<()> {
+    let (server, typed_path) = split_promote_target(&args.path, args.server.as_deref())?;
+    let full_path = canonicalize_spool_path(&typed_path).map_err(anyhow::Error::new)?;
+    if is_root_level_spool_path(&full_path) {
+        return Err(anyhow!(RecoveryAdvice::promote_already_root(&full_path)));
+    }
+
+    let user_config = UserConfig::load_default()?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.clone()),
+        HostedAuthMode::CredentialFallback,
+    )?;
+    let mut client = session.connect(&server).await?;
+    let result = promote_connected(cli, &mut client, &server, &full_path).await;
+    client.close().await;
+    result
+}
+
+async fn promote_connected(
+    cli: &Cli,
+    client: &mut HostedClient,
+    server: &str,
+    full_path: &str,
+) -> Result<()> {
+    let promoted = client
+        .promote_spool(full_path, &cli.operation_id_wire())
+        .await
+        .map_err(|err| map_promote_error(full_path, &err))?;
+    if should_output_json(cli, None) {
+        write_full_command_json(
+            &PromoteOutput {
+                output_kind: "promote",
+                status: "promoted",
+                from: full_path.to_string(),
+                full_path: promoted.full_path.clone(),
+                spool_id: promoted.spool_id,
+                is_repo: promoted.is_repo,
+                server: server.to_string(),
+                recommended_action: None,
+            },
+            NextActionValidationContext::without_repo(&["promote"]),
+        )?;
+    } else {
+        println!(
+            "{} promoted {} → {}",
+            style::ok_marker(),
+            style::bold(full_path),
+            style::bold(&promoted.full_path)
+        );
+        super::action_line::print_next(&format!(
+            "heddle clone https://{server}/{} <dir>",
+            promoted.full_path
+        ));
+    }
+    Ok(())
+}
+
+fn split_promote_target(path: &str, server: Option<&str>) -> Result<(String, String)> {
+    // Only `https://host/...` is a remote URL. A canonical spool path such as
+    // `spool/<handle>/<name>` must not be parsed as host `spool`.
+    if path.starts_with("https://") {
+        match RemoteTarget::parse(path) {
+            Ok(RemoteTarget::Network {
+                authority,
+                repo_path: Some(repo_path),
+            }) => return Ok((authority, repo_path)),
+            Ok(_) | Err(_) => {
+                return Err(anyhow!(
+                    "hosted promote URL must include a spool path, e.g. https://api.heddle.sh/spool/<handle>/<name>"
+                ));
+            }
+        }
+    }
+    let server = resolve_server(server).context("resolve hosted server for promote")?;
+    Ok((server, path.to_string()))
+}
+
+fn map_promote_error(full_path: &str, err: &ProtocolError) -> anyhow::Error {
+    let slug = full_path.rsplit('/').next().unwrap_or(full_path);
+    let message = match err {
+        ProtocolError::RemoteFailure { message, .. } => message.as_str(),
+        ProtocolError::AlreadyExists(message)
+        | ProtocolError::AuthorizationFailed(message)
+        | ProtocolError::AuthenticationFailed(message)
+        | ProtocolError::InvalidState(message)
+        | ProtocolError::ObjectNotFound(message)
+        | ProtocolError::Remote(message) => message.as_str(),
+        _ => "",
+    };
+    let lower = message.to_ascii_lowercase();
+    let advice = if matches!(err, ProtocolError::AlreadyExists(_))
+        || lower.contains("already exists")
+        || lower.contains("taken")
+        || lower.contains("reserved")
+    {
+        RecoveryAdvice::promote_slug_taken(full_path, slug)
+    } else if lower.contains("claim")
+        || lower.contains("verif")
+        || lower.contains("standing")
+        || lower.contains("anonymous")
+        || lower.contains("unverified")
+    {
+        RecoveryAdvice::promote_account_standing(full_path)
+    } else if matches!(
+        err,
+        ProtocolError::AuthorizationFailed(_) | ProtocolError::AuthenticationFailed(_)
+    ) || lower.contains("owner")
+        || lower.contains("permission")
+    {
+        RecoveryAdvice::promote_not_owner(full_path)
+    } else {
+        let display = if message.is_empty() {
+            err.to_string()
+        } else {
+            message.to_string()
+        };
+        RecoveryAdvice::promote_failed(full_path, &display)
+    };
+    anyhow!(advice)
+}
+
+#[cfg(test)]
+mod tests {
+    use hosted_client::hosted_runtime::hosted::{
+        canonicalize_spool_path, is_root_level_spool_path,
+    };
+    use wire::ProtocolError;
+
+    use super::{map_promote_error, split_promote_target};
+
+    #[test]
+    fn url_target_takes_host_and_path() {
+        let (server, path) = split_promote_target(
+            "https://api.preview.heddle.sh/willow-ibis-8e7264/notes",
+            None,
+        )
+        .expect("parse url");
+        assert_eq!(server, "api.preview.heddle.sh");
+        assert_eq!(path, "willow-ibis-8e7264/notes");
+    }
+
+    #[test]
+    fn canonical_spool_path_is_not_a_hostname() {
+        let (server, path) =
+            split_promote_target("spool/pine-yak-87fa33/repo", Some("api.preview.heddle.sh"))
+                .expect("canonical path");
+        assert_eq!(server, "api.preview.heddle.sh");
+        assert_eq!(path, "spool/pine-yak-87fa33/repo");
+    }
+
+    #[test]
+    fn canonical_personal_path_is_not_root() {
+        let path = canonicalize_spool_path("willow-ibis-8e7264/notes").expect("path");
+        assert_eq!(path, "spool/willow-ibis-8e7264/notes");
+        assert!(!is_root_level_spool_path(&path));
+    }
+
+    #[test]
+    fn slug_taken_denial_is_not_swallowed() {
+        let err = ProtocolError::AlreadyExists("root slug notes is taken".into());
+        let mapped = map_promote_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "promote_slug_taken");
+        assert!(advice.error.contains("notes"));
+    }
+
+    #[test]
+    fn standing_denial_is_not_swallowed() {
+        let err = ProtocolError::InvalidState("account is not claimed/verified".into());
+        let mapped = map_promote_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "promote_account_standing");
+        assert!(advice.hint.contains("heddle claim"));
+    }
+
+    #[test]
+    fn owner_denial_is_not_swallowed() {
+        let err = ProtocolError::AuthorizationFailed("missing owner grant".into());
+        let mapped = map_promote_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "promote_not_owner");
+    }
+}

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1105,7 +1105,11 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     .with_warning_sink(std::sync::Arc::new(
         crate::cli::warning_render::StderrWarningSink,
     ));
-    let result = pull_network_connected(repo, &mut client, repo_path, options).await;
+    let repo_path =
+        hosted_client::hosted_runtime::hosted::resolve_personal_first_read(&mut client, repo_path)
+            .await
+            .map_err(anyhow::Error::new)?;
+    let result = pull_network_connected(repo, &mut client, &repo_path, options).await;
     client.close().await;
     result
 }

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -138,6 +138,9 @@ impl HeddleExitCode {
             | "env_store_not_found"
             | "env_store_slot_not_found" => Some(Self::DataErr),
             "env_store_denied" | "env_store_expired" => Some(Self::NoPerm),
+            "promote_not_owner" | "promote_account_standing" => Some(Self::NoPerm),
+            "promote_slug_taken" | "promote_failed" => Some(Self::Protocol),
+            "promote_already_root" => Some(Self::DataErr),
             // Capture aborted on ENOSPC; working tree is intact. Classifies
             // as IO rather than a distinct raw-28 OS code so agents stay on
             // the documented sysexits taxonomy.
@@ -537,6 +540,11 @@ mod tests {
             ("env_store_denied", HeddleExitCode::NoPerm),
             ("env_store_expired", HeddleExitCode::NoPerm),
             ("capture_out_of_space", HeddleExitCode::IoErr),
+            ("promote_not_owner", HeddleExitCode::NoPerm),
+            ("promote_account_standing", HeddleExitCode::NoPerm),
+            ("promote_slug_taken", HeddleExitCode::Protocol),
+            ("promote_failed", HeddleExitCode::Protocol),
+            ("promote_already_root", HeddleExitCode::DataErr),
         ] {
             assert_eq!(
                 HeddleExitCode::from_error(&advice_with_kind(kind)),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,8 @@ use clap::{Arg, ArgAction, CommandFactory, Parser, error::ErrorKind};
 use cli::cli::commands::cmd_context_reason_git;
 #[cfg(feature = "semantic")]
 use cli::cli::commands::cmd_semantic;
+#[cfg(feature = "client")]
+use cli::cli::commands::{cmd_hosted_auth, cmd_hosted_claim, cmd_hosted_whoami, cmd_promote};
 #[cfg(feature = "git-overlay")]
 use cli::cli::{
     BridgeCommands, BridgeGitCommands,
@@ -53,9 +55,6 @@ use cli::{
     perf::{ProfileField, emit_command_profile, profile_enabled},
 };
 use tracing::debug;
-
-#[cfg(feature = "client")]
-use cli::cli::commands::{cmd_hosted_auth, cmd_hosted_claim, cmd_hosted_whoami};
 
 // `current_thread` flavor avoids spinning up a CPU-count-sized worker
 // pool on every CLI invocation. The foreground `heddle` binary is a
@@ -639,6 +638,9 @@ async fn async_main() -> Result<()> {
 
         #[cfg(feature = "client")]
         Commands::Claim(args) => cmd_hosted_claim(args.clone()).await,
+
+        #[cfg(feature = "client")]
+        Commands::Promote(args) => cmd_promote(&cli, args.clone()).await,
 
         #[cfg(feature = "client")]
         Commands::Whoami { server } => cmd_hosted_whoami(&cli, server.clone()).await,

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -65,6 +65,7 @@ const SWEPT: &[&str] = &[
     // heddle#1057 — whoami emits `output_kind: "whoami"` (matches its verb path,
     // no override needed).
     "whoami",
+    "promote",
     // heddle#272 — output_kind sweep on the named-by-persona verbs.
     "agent presence list",
     "agent presence show",

--- a/crates/hosted-client/CHANGELOG.md
+++ b/crates/hosted-client/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `GetSpool` / `PromoteSpool` client routes and personal-first read
+  resolution for a bare hosted path (heddle#1728).
+
 ### Fixed
 
 - Side-channel `heddle-pull-refs-v1` removed. Clone bootstrap refs are

--- a/crates/hosted-client/src/hosted_runtime/auth.rs
+++ b/crates/hosted-client/src/hosted_runtime/auth.rs
@@ -1342,7 +1342,7 @@ fn current_unix_timestamp_i64() -> Result<i64> {
 // ---------------------------------------------------------------------------
 
 /// Resolve server from explicit arg, default credential, or fallback.
-pub(crate) fn resolve_server(explicit: Option<&str>) -> Result<String> {
+pub fn resolve_server(explicit: Option<&str>) -> Result<String> {
     if let Some(s) = explicit {
         return Ok(s.to_string());
     }

--- a/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/methods.rs
@@ -163,6 +163,20 @@ impl HostedRoutes<'_> {
         HostedSpool
     );
     unary_method!(
+        get_spool,
+        "RegistryService",
+        "GetSpool",
+        GetSpoolRequest,
+        HostedSpool
+    );
+    unary_method!(
+        promote_spool,
+        "RegistryService",
+        "PromoteSpool",
+        PromoteSpoolRequest,
+        PromoteSpoolResponse
+    );
+    unary_method!(
         grant_support_access,
         "RegistryService",
         "GrantSupportAccess",
@@ -454,7 +468,7 @@ mod tests {
     };
 
     #[test]
-    fn shipped_native_inventory_is_36_unary_seven_server_streams_and_two_bidi() {
+    fn shipped_native_inventory_is_38_unary_seven_server_streams_and_two_bidi() {
         const ROUTES: &[MethodRoute] = &[
             MethodRoute::CollaborationServiceAppendTurn,
             MethodRoute::CollaborationServiceListByState,
@@ -472,6 +486,8 @@ mod tests {
             MethodRoute::RegistryServiceDeleteGrant,
             MethodRoute::RegistryServiceDeleteSpool,
             MethodRoute::RegistryServiceGetCurrentUserSpool,
+            MethodRoute::RegistryServiceGetSpool,
+            MethodRoute::RegistryServicePromoteSpool,
             MethodRoute::RegistryServiceGrantSupportAccess,
             MethodRoute::RegistryServiceListGrants,
             MethodRoute::RegistryServiceListSpools,
@@ -511,13 +527,13 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(shipped.len(), 45);
+        assert_eq!(shipped.len(), 47);
         assert_eq!(
             shipped
                 .iter()
                 .filter(|method| method.streaming == StreamingShape::Unary)
                 .count(),
-            36
+            38
         );
         assert_eq!(
             shipped

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -26,6 +26,7 @@ mod resolver;
 mod session;
 #[cfg(test)]
 mod session_tests;
+mod spool_path;
 mod state_review;
 mod sync;
 #[cfg(test)]
@@ -69,6 +70,10 @@ pub use methods::HostedRoutes;
 use objects::{NoopWarnings, Warning, WarningSink};
 use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
+pub use spool_path::{
+    HostedReadPath, canonicalize_spool_path, is_root_level_spool_path, plan_personal_first_read,
+    resolve_personal_first_read, strip_spool_prefix,
+};
 #[cfg(test)]
 pub(crate) use sync::PullBootstrapMetadata;
 pub use sync::{

--- a/crates/hosted-client/src/hosted_runtime/hosted/spool_path.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/spool_path.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Personal-first hosted spool path resolution for reads.
+//!
+//! A bare first path segment on clone/pull resolves against the caller's
+//! personal root (`spool/<personal-slug>/<seg>`) first, then falls back to
+//! the top-level spool (`spool/<seg>`). Writes are not resolved here.
+//! Authorization is always the caller's identity via GetCurrentUserSpool;
+//! this module never constructs another account's personal path.
+
+use wire::ProtocolError;
+
+use super::HostedClient;
+
+const SPOOL_PREFIX: &str = "spool/";
+
+/// How a typed hosted path should be read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostedReadPath {
+    /// Use this canonical path as-is (explicit `spool/…` or multi-segment).
+    Explicit(String),
+    /// Probe `personal` first; only if it is absent for this caller, use `root`.
+    PersonalFirst { personal: String, root: String },
+}
+
+/// Strip a leading `spool/` if present.
+pub fn strip_spool_prefix(path: &str) -> &str {
+    path.strip_prefix(SPOOL_PREFIX).unwrap_or(path)
+}
+
+/// Canonicalize a typed hosted path to `spool/…`.
+///
+/// Rejects empty components, `.`, and `..`. Does not apply personal-first
+/// resolution — callers that need that use [`plan_personal_first_read`].
+pub fn canonicalize_spool_path(typed: &str) -> Result<String, ProtocolError> {
+    let normalized = normalize_typed_path(typed)?;
+    Ok(ensure_spool_prefix(&normalized))
+}
+
+/// True when `path` is a root-level spool (`spool/<one-segment>`).
+pub fn is_root_level_spool_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix(SPOOL_PREFIX) else {
+        return false;
+    };
+    !rest.is_empty() && !rest.contains('/')
+}
+
+/// Plan personal-first read resolution for a typed hosted path.
+///
+/// `personal_root` is the caller's GetCurrentUserSpool `full_path` (for
+/// example `spool/willow-ibis-8e7264`). An empty root means the caller has
+/// no personal spool (anonymous or unprovisioned): a bare name then
+/// resolves only to the top-level path.
+pub fn plan_personal_first_read(
+    personal_root: &str,
+    typed_path: &str,
+) -> Result<HostedReadPath, ProtocolError> {
+    let typed = normalize_typed_path(typed_path)?;
+    if typed.contains('/') {
+        return Ok(HostedReadPath::Explicit(ensure_spool_prefix(&typed)));
+    }
+    let root = format!("{SPOOL_PREFIX}{typed}");
+    let personal_root = personal_root.trim().trim_matches('/');
+    if personal_root.is_empty() {
+        return Ok(HostedReadPath::Explicit(root));
+    }
+    let personal = join_child(personal_root, &typed);
+    if personal == root {
+        return Ok(HostedReadPath::Explicit(root));
+    }
+    Ok(HostedReadPath::PersonalFirst { personal, root })
+}
+
+/// Resolve a typed hosted path for a read (clone/pull).
+///
+/// Identity comes from GetCurrentUserSpool. A miss or existence-hiding
+/// denial on the personal child falls back to the root path. Any other
+/// error fails closed so a lookup blip cannot clone a different spool.
+pub async fn resolve_personal_first_read(
+    client: &mut HostedClient,
+    typed_path: &str,
+) -> Result<String, ProtocolError> {
+    let typed = normalize_typed_path(typed_path)?;
+    if typed.contains('/') {
+        return Ok(ensure_spool_prefix(&typed));
+    }
+    let personal_root = match client.get_current_user_spool().await {
+        Ok(spool) => spool.full_path,
+        Err(
+            ProtocolError::AuthorizationFailed(_)
+            | ProtocolError::AuthenticationFailed(_)
+            | ProtocolError::ObjectNotFound(_),
+        ) => String::new(),
+        Err(ProtocolError::RemoteFailure {
+            code:
+                wire::RemoteFailureCode::PermissionDenied
+                | wire::RemoteFailureCode::Unauthenticated
+                | wire::RemoteFailureCode::NotFound,
+            ..
+        }) => String::new(),
+        Err(err) => return Err(err),
+    };
+    match plan_personal_first_read(&personal_root, &typed)? {
+        HostedReadPath::Explicit(path) => Ok(path),
+        HostedReadPath::PersonalFirst { personal, root } => {
+            if personal_child_exists(client, &personal).await? {
+                Ok(personal)
+            } else {
+                Ok(root)
+            }
+        }
+    }
+}
+
+async fn personal_child_exists(
+    client: &mut HostedClient,
+    personal_path: &str,
+) -> Result<bool, ProtocolError> {
+    match client.get_spool(personal_path).await {
+        Ok(spool) if spool.full_path == personal_path => Ok(true),
+        Ok(spool) => Err(ProtocolError::InvalidState(format!(
+            "GetSpool({personal_path}) returned a different spool ({})",
+            spool.full_path
+        ))),
+        Err(ProtocolError::ObjectNotFound(_) | ProtocolError::AuthorizationFailed(_)) => Ok(false),
+        Err(ProtocolError::RemoteFailure {
+            code: wire::RemoteFailureCode::NotFound | wire::RemoteFailureCode::PermissionDenied,
+            ..
+        }) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn normalize_typed_path(typed: &str) -> Result<String, ProtocolError> {
+    let trimmed = typed.trim().trim_matches('/');
+    if trimmed.is_empty() {
+        return Err(ProtocolError::InvalidState(
+            "hosted spool path must not be empty".to_string(),
+        ));
+    }
+    if trimmed
+        .split('/')
+        .any(|component| matches!(component, "" | "." | ".."))
+    {
+        return Err(ProtocolError::InvalidState(
+            "hosted spool path must contain nonempty names, without '.' or '..'".to_string(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn ensure_spool_prefix(path: &str) -> String {
+    if path == "spool" || path.starts_with(SPOOL_PREFIX) {
+        path.to_string()
+    } else {
+        format!("{SPOOL_PREFIX}{path}")
+    }
+}
+
+fn join_child(parent: &str, slug: &str) -> String {
+    let parent = ensure_spool_prefix(parent.trim().trim_matches('/'));
+    format!("{parent}/{slug}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HostedReadPath, is_root_level_spool_path, plan_personal_first_read};
+
+    #[test]
+    fn bare_name_prefers_the_caller_personal_child_over_the_root() {
+        let plan = plan_personal_first_read("spool/alice", "foo").expect("plan");
+        assert_eq!(
+            plan,
+            HostedReadPath::PersonalFirst {
+                personal: "spool/alice/foo".into(),
+                root: "spool/foo".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn caller_with_no_personal_root_gets_the_root_spool() {
+        let plan = plan_personal_first_read("", "foo").expect("plan");
+        assert_eq!(plan, HostedReadPath::Explicit("spool/foo".into()));
+    }
+
+    #[test]
+    fn never_constructs_another_owners_personal_path() {
+        let plan = plan_personal_first_read("spool/alice", "foo").expect("plan");
+        match plan {
+            HostedReadPath::PersonalFirst { personal, root } => {
+                assert_eq!(personal, "spool/alice/foo");
+                assert_eq!(root, "spool/foo");
+                assert!(
+                    !personal.contains("spool/bob/"),
+                    "must not shadow a root spool with a different owner's child"
+                );
+            }
+            other => panic!("expected personal-first, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_spool_root_is_not_rewritten_to_personal() {
+        let plan = plan_personal_first_read("spool/alice", "spool/foo").expect("plan");
+        assert_eq!(plan, HostedReadPath::Explicit("spool/foo".into()));
+    }
+
+    #[test]
+    fn explicit_personal_path_stays_explicit() {
+        let plan = plan_personal_first_read("spool/alice", "spool/alice/foo").expect("plan");
+        assert_eq!(plan, HostedReadPath::Explicit("spool/alice/foo".into()));
+    }
+
+    #[test]
+    fn multi_segment_without_prefix_is_prefixed_not_personal_first() {
+        let plan = plan_personal_first_read("spool/alice", "alice/foo").expect("plan");
+        assert_eq!(plan, HostedReadPath::Explicit("spool/alice/foo".into()));
+    }
+
+    #[test]
+    fn personal_root_without_spool_prefix_still_scopes_to_the_caller() {
+        let plan = plan_personal_first_read("alice", "foo").expect("plan");
+        assert_eq!(
+            plan,
+            HostedReadPath::PersonalFirst {
+                personal: "spool/alice/foo".into(),
+                root: "spool/foo".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_dot_and_empty_components() {
+        for path in ["", ".", "..", "foo/../bar", "foo//bar", "foo/."] {
+            assert!(
+                plan_personal_first_read("spool/alice", path).is_err(),
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    fn root_level_detection() {
+        assert!(is_root_level_spool_path("spool/foo"));
+        assert!(!is_root_level_spool_path("spool/alice/foo"));
+        assert!(!is_root_level_spool_path("foo"));
+        assert!(!is_root_level_spool_path("spool/"));
+    }
+
+    #[test]
+    fn picking_the_root_when_a_personal_child_exists_is_the_wrong_spool() {
+        // This is the security assertion the issue requires: given both
+        // spool/<me>/foo and spool/foo, a bare `foo` must select personal.
+        match plan_personal_first_read("spool/me", "foo").expect("plan") {
+            HostedReadPath::PersonalFirst { personal, root } => {
+                assert_eq!(personal, "spool/me/foo");
+                assert_eq!(root, "spool/foo");
+                assert_ne!(
+                    personal, root,
+                    "personal and root must be distinct so the probe can pick the caller's copy"
+                );
+            }
+            HostedReadPath::Explicit(path) => {
+                panic!("bare foo must not skip personal-first; would clone {path}")
+            }
+        }
+    }
+}

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -17,15 +17,16 @@ use api::{
         AnnotatedFile, BlobResponse, CallFailure, CallFailureCode, ContextRevision,
         CreateSpoolRequest, DeleteSpoolRequest, Discussion, GetBlobRequest,
         GetContextHistoryPageEnd, GetContextHistoryRequest, GetContextHistoryResponse,
-        GetDiscussionRequest, HostedSpool, ListContextPageEnd, ListContextRequest,
-        ListContextResponse, ListDiscussionsByStateRequest, ListDiscussionsPageEnd,
-        ListDiscussionsResponse, ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd,
-        ListThreadsResponse, PackChunk, PackStreamKind, PullComplete, PullReady, PullServerFrame,
-        PushClientFrame, PushComplete, PushReady, PushRequest, PushServerFrame, RepoEvent,
-        SignedSpoolOwnerGenesis, StateContextEntry, StateId, SubscribeRepoEventsRequest,
-        TransferCheckpoint, TransportMode, UpdateSpoolRequest, get_context_history_response,
-        list_context_response, list_discussions_response, list_refs_response,
-        list_threads_response, pull_server_frame, push_client_frame, push_server_frame,
+        GetCurrentUserSpoolRequest, GetDiscussionRequest, GetSpoolRequest, HostedSpool,
+        ListContextPageEnd, ListContextRequest, ListContextResponse, ListDiscussionsByStateRequest,
+        ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd, ListRefsResponse,
+        ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind, PromoteSpoolRequest,
+        PromoteSpoolResponse, PullComplete, PullReady, PullServerFrame, PushClientFrame,
+        PushComplete, PushReady, PushRequest, PushServerFrame, RepoEvent, SignedSpoolOwnerGenesis,
+        StateContextEntry, StateId, SubscribeRepoEventsRequest, TransferCheckpoint, TransportMode,
+        UpdateSpoolRequest, get_context_history_response, list_context_response,
+        list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
+        push_client_frame, push_server_frame,
     },
     method_descriptor,
 };
@@ -43,6 +44,10 @@ const GET_BLOB_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/GetBlob";
 const CREATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/CreateSpool";
 const DELETE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/DeleteSpool";
 const UPDATE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/UpdateSpool";
+const GET_CURRENT_USER_SPOOL_METHOD: &str =
+    "/heddle.api.v1alpha1.RegistryService/GetCurrentUserSpool";
+const GET_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/GetSpool";
+const PROMOTE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/PromoteSpool";
 const GET_DISCUSSION_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/GetDiscussion";
 const LIST_BY_STATE_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/ListByState";
 const LIST_CONTEXT_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/ListContext";
@@ -54,6 +59,15 @@ const SUBSCRIBE_REPO_EVENTS_METHOD: &str =
 pub(crate) struct SpoolMutationCapture {
     pub updates: Vec<UpdateSpoolRequest>,
     pub deletes: Vec<DeleteSpoolRequest>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct RegistryFixture {
+    pub personal_root: Option<HostedSpool>,
+    pub spools: HashMap<String, HostedSpool>,
+    pub get_spool_requests: Arc<Mutex<Vec<String>>>,
+    pub promote_requests: Arc<Mutex<Vec<PromoteSpoolRequest>>>,
+    pub promote_denial: Option<(CallFailureCode, String)>,
 }
 
 fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
@@ -87,7 +101,35 @@ pub(crate) struct ContextFixture {
 }
 
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None, BlobFixture::default(), None, None, None, None, None).await
+    start_inner(
+        None,
+        BlobFixture::default(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn start_with_registry(
+    fixture: RegistryFixture,
+) -> (HostedClient, JoinHandle<()>, RegistryFixture) {
+    let fixture_clone = fixture.clone();
+    let (client, server) = start_inner(
+        None,
+        BlobFixture::default(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(fixture),
+    )
+    .await;
+    (client, server, fixture_clone)
 }
 
 pub(crate) async fn start_with_collaboration(
@@ -102,6 +144,7 @@ pub(crate) async fn start_with_collaboration(
         None,
         None,
         Some(fixture),
+        None,
     )
     .await;
     (client, server, fixture_clone)
@@ -119,6 +162,7 @@ pub(crate) async fn start_with_context(
         None,
         Some(fixture),
         None,
+        None,
     )
     .await;
     (client, server, fixture_clone)
@@ -133,6 +177,7 @@ pub(crate) async fn start_recording_push()
         None,
         None,
         Some(Arc::clone(&captured)),
+        None,
         None,
         None,
     )
@@ -150,6 +195,7 @@ pub(crate) async fn start_recording_create_spool() -> (
         None,
         BlobFixture::default(),
         Some(Arc::clone(&captured)),
+        None,
         None,
         None,
         None,
@@ -173,6 +219,7 @@ pub(crate) async fn start_recording_spool_mutations() -> (
         None,
         None,
         None,
+        None,
     )
     .await;
     (client, server, captured)
@@ -187,6 +234,7 @@ pub(crate) async fn start_with_remote_state(
             pack: None,
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -207,6 +255,7 @@ pub(crate) async fn start_with_pull_pack(
             pack: Some((pack_data, index_data)),
         }),
         BlobFixture::default(),
+        None,
         None,
         None,
         None,
@@ -247,7 +296,7 @@ async fn start_with_get_blob_contents_and_pull(
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(pull, fixture, None, None, None, None, None).await;
+    let (client, server) = start_inner(pull, fixture, None, None, None, None, None, None).await;
     (client, server, requested)
 }
 
@@ -263,6 +312,7 @@ struct BlobFixture {
     requested: Arc<Mutex<Vec<String>>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_inner(
     pull: Option<PullFixture>,
     blobs: BlobFixture,
@@ -271,6 +321,7 @@ async fn start_inner(
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
     context: Option<ContextFixture>,
     collaboration: Option<CollaborationFixture>,
+    registry: Option<RegistryFixture>,
 ) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
@@ -299,6 +350,7 @@ async fn start_inner(
                 push_requests.clone(),
                 context.clone(),
                 collaboration.clone(),
+                registry.clone(),
             ));
         }
         server.close().await;
@@ -331,6 +383,7 @@ async fn serve_call(
     push_requests: Option<Arc<Mutex<Vec<PushRequest>>>>,
     context: Option<ContextFixture>,
     collaboration: Option<CollaborationFixture>,
+    registry: Option<RegistryFixture>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -353,6 +406,12 @@ async fn serve_call(
                 serve_update_spool(&mut send, &mut recv, &mut request, spool_mutations).await;
             } else if method == DELETE_SPOOL_METHOD {
                 serve_delete_spool(&mut send, &mut recv, &mut request, spool_mutations).await;
+            } else if method == GET_CURRENT_USER_SPOOL_METHOD {
+                serve_get_current_user_spool(&mut send, &mut recv, &mut request, registry).await;
+            } else if method == GET_SPOOL_METHOD {
+                serve_get_spool(&mut send, &mut recv, &mut request, registry).await;
+            } else if method == PROMOTE_SPOOL_METHOD {
+                serve_promote_spool(&mut send, &mut recv, &mut request, registry).await;
             } else if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
                 serve_get_blob(&mut send, &mut recv, &mut request, blobs).await;
             } else if method == GET_DISCUSSION_METHOD {
@@ -599,6 +658,121 @@ fn bidi_responses(method: &str, pull: Option<PullFixture>) -> Vec<Vec<u8>> {
         }
         _ => Vec::new(),
     }
+}
+
+async fn serve_get_current_user_spool(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    registry: Option<RegistryFixture>,
+) {
+    read_request_body(recv, request).await;
+    let _ = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| GetCurrentUserSpoolRequest::decode(frame.body).ok());
+    let response = registry
+        .and_then(|fixture| fixture.personal_root)
+        .unwrap_or_default();
+    send.write_chunk(Bytes::from(
+        encode_success_response(&response.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_get_spool(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    registry: Option<RegistryFixture>,
+) {
+    read_request_body(recv, request).await;
+    let full_path = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| GetSpoolRequest::decode(frame.body).ok())
+        .map(|body| body.full_path)
+        .unwrap_or_default();
+    let Some(fixture) = registry else {
+        send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+            .await
+            .unwrap();
+        return;
+    };
+    fixture
+        .get_spool_requests
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(full_path.clone());
+    let Some(spool) = fixture.spools.get(&full_path) else {
+        let failure = CallFailure {
+            code: CallFailureCode::NotFound as i32,
+            message: format!("{full_path} not found"),
+            error: None,
+        };
+        send.write_chunk(Bytes::from(encode_failure_response(&failure).unwrap()))
+            .await
+            .unwrap();
+        return;
+    };
+    send.write_chunk(Bytes::from(
+        encode_success_response(&spool.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_promote_spool(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    registry: Option<RegistryFixture>,
+) {
+    read_request_body(recv, request).await;
+    let body = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| PromoteSpoolRequest::decode(frame.body).ok());
+    if let (Some(fixture), Some(body)) = (registry.as_ref(), body.as_ref()) {
+        fixture
+            .promote_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .push(body.clone());
+        if let Some((code, message)) = fixture.promote_denial.clone() {
+            let failure = CallFailure {
+                code: code as i32,
+                message,
+                error: None,
+            };
+            send.write_chunk(Bytes::from(encode_failure_response(&failure).unwrap()))
+                .await
+                .unwrap();
+            return;
+        }
+        let slug = body
+            .full_path
+            .rsplit('/')
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        let promoted = HostedSpool {
+            full_path: format!("spool/{slug}"),
+            kind: "spool".to_string(),
+            is_repo: true,
+            ..HostedSpool::default()
+        };
+        let response = PromoteSpoolResponse {
+            spool: Some(promoted),
+        };
+        send.write_chunk(Bytes::from(
+            encode_success_response(&response.encode_to_vec()).unwrap(),
+        ))
+        .await
+        .unwrap();
+        return;
+    }
+    send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+        .await
+        .unwrap();
 }
 
 async fn serve_create_spool(

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -5,10 +5,10 @@ use api::heddle::api::v1alpha1::{
     CreateInvitationRequest, CreateServiceAccountRequest, CreateSignupInviteRequest,
     CreateSignupInviteResponse, CreateSpoolRequest, DeleteGrantRequest, DeleteSpoolRequest,
     GetCurrentOwnerKeyringRequest, GetCurrentOwnerKeyringResponse, GetCurrentUserSpoolRequest,
-    GrantSupportAccessRequest, GrantTargetRef, Invitation as ProtoInvitation,
+    GetSpoolRequest, GrantSupportAccessRequest, GrantTargetRef, Invitation as ProtoInvitation,
     IssueServiceAccountCredentialRequest, IssuedCredentialResponse, ListGrantsRequest,
     ListSignupInvitesRequest, ListSignupInvitesResponse, ListSpoolsRequest,
-    ListSupportAccessGrantsRequest, ListThreadApprovalsRequest, MonorepoNode,
+    ListSupportAccessGrantsRequest, ListThreadApprovalsRequest, MonorepoNode, PromoteSpoolRequest,
     ResolveMonorepoRequest, RevokeApprovalRequest, RevokeSupportAccessRequest,
     ServiceAccountResponse, SpoolSummary, SupportAccessGrant, ThreadApproval, UpdateGrantRequest,
     UpdateSpoolRequest, Visibility, grant_target_ref::Target as GrantTargetKind,
@@ -161,6 +161,47 @@ impl HostedClient {
             "GetCurrentUserSpool",
             GetCurrentUserSpoolRequest {}
         );
+        Ok(to_protocol_spool(spool))
+    }
+
+    pub async fn get_spool(
+        &mut self,
+        full_path: &str,
+    ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
+        let spool = authed_call!(
+            self,
+            get_spool,
+            "GetSpool",
+            GetSpoolRequest {
+                full_path: full_path.to_string(),
+            }
+        );
+        Ok(to_protocol_spool(spool))
+    }
+
+    pub async fn promote_spool(
+        &mut self,
+        full_path: &str,
+        client_operation_id: &str,
+    ) -> Result<wire::HostedSpoolInfo, ProtocolError> {
+        let method = "heddle.api.v1alpha1.RegistryService/PromoteSpool";
+        let operation_id = if client_operation_id.is_empty() {
+            ClientOperationId::fresh(method)
+        } else {
+            ClientOperationId::for_required_method(method, client_operation_id.to_string())?
+        };
+        let response = authed_call!(
+            self,
+            promote_spool,
+            "PromoteSpool",
+            PromoteSpoolRequest {
+                full_path: full_path.to_string(),
+                client_operation_id: operation_id.to_wire(),
+            }
+        );
+        let spool = response.spool.ok_or_else(|| {
+            ProtocolError::InvalidState("PromoteSpool returned no spool".to_string())
+        })?;
         Ok(to_protocol_spool(spool))
     }
 
@@ -672,7 +713,7 @@ fn parse_hosted_role_arg(
 mod tests {
     use std::{ffi::OsString, sync::MutexGuard};
 
-    use api::heddle::api::v1alpha1::{HostedRole, grant_target_ref::Target};
+    use api::heddle::api::v1alpha1::{HostedRole, HostedSpool, grant_target_ref::Target};
 
     use super::*;
 
@@ -995,5 +1036,152 @@ mod tests {
             ["/heddle.api.v1alpha1.RegistryService/CreateSpool"],
             "auto-provision must issue CreateSpool without BootstrapOwnerRoot"
         );
+    }
+
+    fn test_spool(full_path: &str) -> HostedSpool {
+        HostedSpool {
+            spool_id: full_path.to_string(),
+            full_path: full_path.to_string(),
+            kind: "spool".to_string(),
+            is_repo: true,
+            ..HostedSpool::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn promote_spool_moves_personal_child_to_root() {
+        let _home = IsolatedHeddleHome::new();
+        let fixture = crate::hosted_runtime::hosted::test_server::RegistryFixture {
+            personal_root: Some(test_spool("spool/alice")),
+            ..Default::default()
+        };
+        let (mut client, server, fixture) =
+            crate::hosted_runtime::hosted::test_server::start_with_registry(fixture).await;
+
+        let promoted = client
+            .promote_spool("spool/alice/foo", "promote-op-1")
+            .await
+            .expect("promote");
+        assert_eq!(promoted.full_path, "spool/foo");
+        assert!(promoted.is_repo);
+
+        client.close().await;
+        server.await.unwrap();
+        let requests = fixture
+            .promote_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].full_path, "spool/alice/foo");
+        assert_eq!(requests[0].client_operation_id, "promote-op-1");
+    }
+
+    #[tokio::test]
+    async fn promote_spool_surfaces_slug_taken() {
+        use api::heddle::api::v1alpha1::CallFailureCode;
+
+        let _home = IsolatedHeddleHome::new();
+        let fixture = crate::hosted_runtime::hosted::test_server::RegistryFixture {
+            promote_denial: Some((
+                CallFailureCode::AlreadyExists,
+                "root slug foo is taken".to_string(),
+            )),
+            ..Default::default()
+        };
+        let (mut client, server, _) =
+            crate::hosted_runtime::hosted::test_server::start_with_registry(fixture).await;
+        let err = client
+            .promote_spool("spool/alice/foo", "promote-op-2")
+            .await
+            .expect_err("slug taken");
+        assert!(matches!(err, ProtocolError::AlreadyExists(_)), "{err:?}");
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn personal_first_read_selects_the_caller_child_when_both_exist() {
+        let _home = IsolatedHeddleHome::new();
+        let mut spools = std::collections::HashMap::new();
+        spools.insert("spool/me/foo".to_string(), test_spool("spool/me/foo"));
+        spools.insert("spool/foo".to_string(), test_spool("spool/foo"));
+        spools.insert("spool/other/foo".to_string(), test_spool("spool/other/foo"));
+        let fixture = crate::hosted_runtime::hosted::test_server::RegistryFixture {
+            personal_root: Some(test_spool("spool/me")),
+            spools,
+            ..Default::default()
+        };
+        let (mut client, server, fixture) =
+            crate::hosted_runtime::hosted::test_server::start_with_registry(fixture).await;
+
+        let resolved = super::super::resolve_personal_first_read(&mut client, "foo")
+            .await
+            .expect("resolve");
+        assert_eq!(
+            resolved, "spool/me/foo",
+            "bare foo must clone the caller's copy, not the root or another owner"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+        let probed = fixture
+            .get_spool_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone();
+        assert_eq!(probed, vec!["spool/me/foo".to_string()]);
+        assert!(
+            !probed.iter().any(|path| path.starts_with("spool/other/")),
+            "must never probe another owner's personal child: {probed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn personal_first_read_falls_back_to_root_when_caller_has_no_child() {
+        let _home = IsolatedHeddleHome::new();
+        let mut spools = std::collections::HashMap::new();
+        spools.insert("spool/foo".to_string(), test_spool("spool/foo"));
+        let fixture = crate::hosted_runtime::hosted::test_server::RegistryFixture {
+            personal_root: Some(test_spool("spool/bob")),
+            spools,
+            ..Default::default()
+        };
+        let (mut client, server, fixture) =
+            crate::hosted_runtime::hosted::test_server::start_with_registry(fixture).await;
+
+        let resolved = super::super::resolve_personal_first_read(&mut client, "foo")
+            .await
+            .expect("resolve");
+        assert_eq!(resolved, "spool/foo");
+
+        client.close().await;
+        server.await.unwrap();
+        let probed = fixture
+            .get_spool_requests
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone();
+        assert_eq!(probed, vec!["spool/bob/foo".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn get_spool_mismatch_fails_closed_instead_of_cloning_the_wrong_spool() {
+        let _home = IsolatedHeddleHome::new();
+        let mut spools = std::collections::HashMap::new();
+        // Server returns the root spool when asked for the personal child.
+        spools.insert("spool/me/foo".to_string(), test_spool("spool/foo"));
+        let fixture = crate::hosted_runtime::hosted::test_server::RegistryFixture {
+            personal_root: Some(test_spool("spool/me")),
+            spools,
+            ..Default::default()
+        };
+        let (mut client, server, _) =
+            crate::hosted_runtime::hosted::test_server::start_with_registry(fixture).await;
+        let err = super::super::resolve_personal_first_read(&mut client, "foo")
+            .await
+            .expect_err("mismatched GetSpool must not resolve");
+        assert!(matches!(err, ProtocolError::InvalidState(_)), "{err:?}");
+        client.close().await;
+        server.await.unwrap();
     }
 }

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2054,6 +2054,30 @@ reported.
 
 ---
 
+## `heddle promote --output json`
+
+Lift a personal hosted spool to the shared root (`spool/<handle>/<name>` →
+`spool/<name>`).
+
+```json
+{
+  "output_kind": "promote",
+  "status": "promoted",
+  "from": "spool/willow-ibis-8e7264/notes",
+  "full_path": "spool/notes",
+  "spool_id": "spool-123",
+  "is_repo": true,
+  "server": "api.preview.heddle.sh",
+  "recommended_action": null
+}
+```
+
+`from` is the personal path that was promoted. `full_path` is the new
+root-level path. Clone a bare name still prefers a remaining personal copy
+before this root.
+
+---
+
 ## `heddle auth create-service-token --output json`
 
 ```json
@@ -3248,26 +3272,26 @@ as one; no `help advanced`).
       "visibility set",
       "visibility promote"
     ],
-    "advanced_scope_json_commands_total": 107,
+    "advanced_scope_json_commands_total": 108,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 44,
-    "advanced_scope_mutating_commands_total": 61,
+    "advanced_scope_mutating_commands_total": 62,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 24,
-    "catalog_commands_total": 194,
-    "catalog_mutating_commands_total": 94,
-    "json_commands_total": 154,
+    "catalog_commands_total": 195,
+    "catalog_mutating_commands_total": 95,
+    "json_commands_total": 155,
     "json_commands_with_accepted_opaque_schema": 44,
-    "json_commands_with_schema": 110,
+    "json_commands_with_schema": 111,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 90,
+    "json_mutating_commands_total": 91,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 90,
+    "mutating_commands_total": 91,
     "mutating_commands_with_accepted_opaque_schema": 24,
-    "mutating_commands_with_schema": 66,
+    "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 44,
     "status": "available",
-    "summary": "196 command(s), 154 JSON command(s), 94 mutating command(s), 90 mutating JSON command(s); verified everyday/agent machine surface has 47 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
+    "summary": "197 command(s), 155 JSON command(s), 95 mutating command(s), 91 mutating JSON command(s); verified everyday/agent machine surface has 47 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3305,7 +3329,7 @@ as one; no `help advanced`).
     "try"
   ],
   "status": "available",
-  "summary": "196 command(s), 154 JSON command(s), 94 mutating command(s), 90 mutating JSON command(s); verified everyday/agent machine surface has 47 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
+  "summary": "197 command(s), 155 JSON command(s), 95 mutating command(s), 91 mutating JSON command(s); verified everyday/agent machine surface has 47 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
Closes #1728.

Part of weft#2107.

## What

Phase 2 (CLI) of the flat spool-namespace unification. The wire and server already ship `RegistryService/PromoteSpool` and `HostedSpoolKind::Spool`.

- **`heddle promote`** — user-initiated promotion of a personal spool to a root-level spool (`spool/<handle>/<name>` → `spool/<name>`). Calls `RegistryService/PromoteSpool` with `{ full_path, client_operation_id }`. Slug-taken, unverified/unclaimed account, and missing-owner denials print recovery (`heddle claim` / `heddle whoami`) instead of a generic remote error.
- **Personal-first read resolution** — a bare first path segment on clone/pull resolves to the caller's `spool/<personal-slug>/<seg>` first, then falls back to `spool/<seg>`. Identity comes from `GetCurrentUserSpool`; a mismatched `GetSpool` response fails closed so a lookup cannot clone a different owner's content. Explicit multi-segment paths are not rewritten.
- Tests fail if a bare name would pick the root while the caller has a personal copy, if resolution constructs another owner's path, or if `GetSpool` returns a different spool than requested.

## Verify

- `cargo build --release -p heddle-cli`
- `cargo test -p heddle-cli` (plus `heddle-hosted-client --features client`, `heddle-cli-args`, `heddle-cli-contract`)
- `cargo clippy -p heddle-cli --all-targets -- -D warnings`
- `rustfmt +nightly --edition 2024` on touched files

## Live staging (`api.preview.heddle.sh`)

Invite signup created agent account `pine-yak-87fa33`. Push auto-provisioned `spool/pine-yak-87fa33/repo`. Bare clone `https://api.preview.heddle.sh/repo` resolved to that personal copy.

`heddle promote spool/pine-yak-87fa33/repo` reached PromoteSpool and was denied for account standing (fresh invite agent is unclaimed/unverified), with `Next: heddle claim` and exit 77. Completing the move to `spool/repo` needs a claimed/verified account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791507654&installation_model_id=21489&pr_number=1729&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1729&signature=8b68e0b80e9c6f047fee7656ba48b65dc23e7c80d8cd633f8344e858317d7b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->