### PR TITLE
fix(discuss): resolve --into-annotation writes a real context annotation

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_discuss.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_discuss.rs
@@ -106,7 +106,7 @@ pub struct DiscussResolveArgs {
     /// Resolution kind: `by-edit` or `dismiss`.
     #[arg(long, value_enum)]
     pub mode: Option<ResolveModeArg>,
-    /// Resolve by creating a context annotation from this discussion.
+    /// Resolve by creating a real context annotation (`context set`) and linking it.
     #[arg(long, requires = "body")]
     pub into_annotation: bool,
     /// For `by-edit`: state containing the edit (defaults to HEAD).

--- a/crates/cli/src/cli/commands/context/context_mutate.rs
+++ b/crates/cli/src/cli/commands/context/context_mutate.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, anyhow};
 use chrono::Utc;
 use objects::{
     lock::RepositoryLockExt,
-    object::{Annotation, ContextBlob},
+    object::{Annotation, AnnotationKind, AnnotationScope, ContextBlob, ContextTarget},
 };
 use repo::compute_rewrite_pct;
 use serde::Serialize;
@@ -65,6 +65,89 @@ impl CompactProjection for ContextSetOutput {
     }
 }
 
+/// Result of writing one annotation through the same path as `context set`.
+pub(crate) struct WrittenContextAnnotation {
+    pub(crate) annotation: Annotation,
+    pub(crate) target: ContextTarget,
+    pub(crate) annotation_count: usize,
+    pub(crate) active_count: usize,
+    pub(crate) state_short: String,
+}
+
+/// Append one context annotation to the current HEAD context tree.
+///
+/// Caller holds the repository write lock. This is the single write path
+/// `context set` and `discuss resolve --into-annotation` share.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn append_context_annotation(
+    repo: &repo::Repository,
+    target: ContextTarget,
+    scope: AnnotationScope,
+    kind: AnnotationKind,
+    content: String,
+    tags: Vec<String>,
+    resolved_from_discussion: Option<String>,
+) -> Result<WrittenContextAnnotation> {
+    target.validate_scope(&scope)?;
+    let head_state = resolve_state(repo, None)?;
+    // Eagerly resolve symbol scopes against the worktree so the annotation
+    // carries `resolved_lines` from the moment of creation. Without this, the
+    // staleness check returns SymbolMissing on the very first read and the
+    // chip never renders.
+    let scope = resolve_scope_at_target(repo, &target, scope)?;
+    let source_hash = compute_source_hash(repo, &target, &scope);
+    let user_config = UserConfig::load_default()?;
+    let attribution = resolve_attribution(repo, &user_config)?;
+    let mut annotation = Annotation::new(
+        scope,
+        kind,
+        content,
+        tags,
+        attribution.to_string(),
+        Utc::now().timestamp(),
+        source_hash,
+        Some(head_state.state_id),
+    );
+    annotation.resolved_from_discussion = resolved_from_discussion;
+
+    let prior_root = context_root_for_state(repo, &head_state)?;
+    let mut blob = match &prior_root {
+        Some(root) => repo
+            .get_context_blob(root, &target)?
+            .unwrap_or_else(|| ContextBlob::new(vec![])),
+        None => ContextBlob::new(vec![]),
+    };
+    blob.annotations.push(annotation.clone());
+    let new_context_root = repo.set_context_blob(prior_root.as_ref(), &target, &blob)?;
+    put_context_attachment(repo, &head_state, Some(new_context_root))?;
+    Ok(WrittenContextAnnotation {
+        annotation,
+        target,
+        annotation_count: blob.annotations.len(),
+        active_count: count_active_annotations(&blob.annotations),
+        state_short: head_state.state_id.short(),
+    })
+}
+
+/// Return the annotation previously produced by resolving `discussion_id`, if any.
+pub(crate) fn find_annotation_resolved_from_discussion(
+    repo: &repo::Repository,
+    discussion_id: &str,
+) -> Result<Option<Annotation>> {
+    let head_state = resolve_state(repo, None)?;
+    let Some(root) = context_root_for_state(repo, &head_state)? else {
+        return Ok(None);
+    };
+    for entry in repo.list_context_entries(&root, None)? {
+        if let Some(annotation) = entry.blob.annotations.into_iter().find(|annotation| {
+            annotation.resolved_from_discussion.as_deref() == Some(discussion_id)
+        }) {
+            return Ok(Some(annotation));
+        }
+    }
+    Ok(None)
+}
+
 /// Set a context annotation on a file path or state target.
 #[allow(clippy::too_many_arguments)]
 pub async fn cmd_context_set(
@@ -87,37 +170,8 @@ pub async fn cmd_context_set(
     let content = read_annotation_content(message, file)?;
 
     let _lock = repo.locker().write().map_err(|e| anyhow::anyhow!("{e}"))?;
-    let head_state = resolve_state(&repo, None)?;
-    // Eagerly resolve symbol scopes against the worktree so the annotation
-    // carries `resolved_lines` from the moment of creation. Without this, the
-    // staleness check returns SymbolMissing on the very first read and the
-    // chip never renders.
-    let scope = resolve_scope_at_target(&repo, &target, scope)?;
-    let source_hash = compute_source_hash(&repo, &target, &scope);
-    let user_config = UserConfig::load_default()?;
-    let attribution = resolve_attribution(&repo, &user_config)?;
-    let annotation = Annotation::new(
-        scope,
-        kind,
-        content,
-        tags,
-        attribution.to_string(),
-        Utc::now().timestamp(),
-        source_hash,
-        Some(head_state.state_id),
-    );
-
-    let prior_root = context_root_for_state(&repo, &head_state)?;
-    let mut blob = match &prior_root {
-        Some(root) => repo
-            .get_context_blob(root, &target)?
-            .unwrap_or_else(|| ContextBlob::new(vec![])),
-        None => ContextBlob::new(vec![]),
-    };
-    blob.annotations.push(annotation);
-    let new_context_root = repo.set_context_blob(prior_root.as_ref(), &target, &blob)?;
-    let (_, label) = target_label(&target);
-    put_context_attachment(&repo, &head_state, Some(new_context_root))?;
+    let written = append_context_annotation(&repo, target, scope, kind, content, tags, None)?;
+    let (_, label) = target_label(&written.target);
 
     if should_output_json(cli, None) {
         write_projected_command_json(
@@ -125,18 +179,21 @@ pub async fn cmd_context_set(
             &ContextSetOutput {
                 output_kind: "context_set",
                 target: label,
-                annotations: blob.annotations.len(),
-                state: head_state.state_id.short(),
+                annotations: written.annotation_count,
+                state: written.state_short,
             },
             &["context", "set"],
         )?;
     } else {
-        let active = count_active_annotations(&blob.annotations);
         println!(
             "Annotated {} ({} active annotation{})",
             label,
-            active,
-            if blob.annotations.len() == 1 { "" } else { "s" }
+            written.active_count,
+            if written.annotation_count == 1 {
+                ""
+            } else {
+                "s"
+            }
         );
     }
 

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -10,11 +10,14 @@ pub(crate) use heddle_cli_contract::cli::commands::wire::collab::{
     AnchorOutput, DiscussWaitLineOutput, DiscussionListOutput, DiscussionOutput,
     DiscussionShowOutput, DiscussionWriteOutput, ResolutionOutput, TurnOutput,
 };
-use objects::object::{
-    AnnotationKind, CollabOpId, CollaborationAnchor, CollaborationAnchorStatus,
-    CollaborationIdempotencyKey, CollaborationOperationBodyV1, CollaborationOperationEnvelope,
-    CollaborationResolution, DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, StateId,
-    VisibilityTier,
+use objects::{
+    lock::RepositoryLockExt,
+    object::{
+        AnnotationKind, AnnotationScope, CollabOpId, CollaborationAnchor,
+        CollaborationAnchorStatus, CollaborationIdempotencyKey, CollaborationOperationBodyV1,
+        CollaborationOperationEnvelope, CollaborationResolution, ContextTarget, DiscussionRecordId,
+        DiscussionTurnV1, MaterializedDiscussion, StateId, VisibilityTier,
+    },
 };
 use repo::{
     CollaborationStore, CollaborationWriteDisposition, CollaborationWriteOutcome,
@@ -202,22 +205,7 @@ fn run_resolve(
                 .ok_or_else(|| anyhow!(RecoveryAdvice::discuss_resolve_missing_dismiss_reason()))?
                 .to_string(),
         },
-        (None, true) => CollaborationResolution::IntoAnnotation {
-            annotation_kind: args
-                .kind
-                .as_deref()
-                .unwrap_or("rationale")
-                .parse::<AnnotationKind>()
-                .map_err(|error| anyhow!(error))?,
-            content: args
-                .body
-                .as_deref()
-                .map(str::trim)
-                .filter(|body| !body.is_empty())
-                .ok_or_else(|| anyhow!("--body must not be empty for --into-annotation"))?
-                .to_string(),
-            tags: args.tag.clone(),
-        },
+        (None, true) => resolve_into_context_annotation(repo, store, args)?,
         _ => {
             return Err(anyhow!(
                 "discuss resolve requires exactly one of --mode or --into-annotation"
@@ -232,6 +220,83 @@ fn run_resolve(
         "discuss_resolve",
         CollaborationOperationBodyV1::Resolve { resolution },
     )
+}
+
+/// Create (or reuse) a real context annotation, then bind the discussion to it.
+fn resolve_into_context_annotation(
+    repo: &repo::Repository,
+    store: &CollaborationStore,
+    args: &DiscussResolveArgs,
+) -> Result<CollaborationResolution> {
+    let discussion_id = parse_discussion_id(&args.discussion_id)?;
+    let discussion = store
+        .materialize_discussion(&discussion_id)?
+        .ok_or_else(|| anyhow!("discussion {discussion_id} not found"))?;
+    let annotation_kind = args
+        .kind
+        .as_deref()
+        .unwrap_or("rationale")
+        .parse::<AnnotationKind>()
+        .map_err(|error| anyhow!(error))?;
+    let content = args
+        .body
+        .as_deref()
+        .map(str::trim)
+        .filter(|body| !body.is_empty())
+        .ok_or_else(|| anyhow!("--body must not be empty for --into-annotation"))?
+        .to_string();
+    let tags = args.tag.clone();
+    let annotation_id = {
+        let _lock = repo.locker().write().map_err(|error| anyhow!("{error}"))?;
+        if let Some(existing) = super::context::find_annotation_resolved_from_discussion(
+            repo,
+            &discussion_id.to_string(),
+        )? {
+            existing.annotation_id
+        } else if let Some(CollaborationResolution::Annotation { annotation_id }) =
+            &discussion.resolution
+        {
+            annotation_id.clone()
+        } else {
+            let (target, scope) = context_target_from_anchor(&discussion.anchor)?;
+            let written = super::context::append_context_annotation(
+                repo,
+                target,
+                scope,
+                annotation_kind,
+                content,
+                tags,
+                Some(discussion_id.to_string()),
+            )?;
+            emit_locality_notice_once(repo, AnnotationSurface::Context);
+            written.annotation.annotation_id
+        }
+    };
+    Ok(CollaborationResolution::Annotation { annotation_id })
+}
+
+fn context_target_from_anchor(
+    anchor: &CollaborationAnchor,
+) -> Result<(ContextTarget, AnnotationScope)> {
+    match anchor {
+        CollaborationAnchor::Symbol { path, symbol, .. } => Ok((
+            ContextTarget::file(path.clone()).map_err(|error| anyhow!(error))?,
+            AnnotationScope::Symbol {
+                name: symbol.clone(),
+                resolved_lines: None,
+            },
+        )),
+        CollaborationAnchor::Path { path, .. } => Ok((
+            ContextTarget::file(path.clone()).map_err(|error| anyhow!(error))?,
+            AnnotationScope::File,
+        )),
+        CollaborationAnchor::State { state_id } => {
+            Ok((ContextTarget::state(*state_id), AnnotationScope::File))
+        }
+        CollaborationAnchor::Repository | CollaborationAnchor::Change { .. } => Err(anyhow!(
+            "discuss resolve --into-annotation needs a file, symbol, or state anchor"
+        )),
+    }
 }
 
 fn run_reopen(
@@ -866,6 +931,21 @@ fn anchor_label(value: &AnchorOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn symbol_anchor_maps_to_symbol_context_target() {
+        let (target, scope) = context_target_from_anchor(&CollaborationAnchor::Symbol {
+            state_id: StateId::from_bytes([7; 32]),
+            path: "src/lib.rs".to_string(),
+            symbol: "foo".to_string(),
+        })
+        .expect("symbol anchor");
+        assert_eq!(target.path(), Some("src/lib.rs"));
+        assert!(matches!(
+            scope,
+            AnnotationScope::Symbol { ref name, .. } if name == "foo"
+        ));
+    }
 
     #[test]
     fn skipped_wait_line_carries_the_reason() {

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -7907,7 +7907,8 @@ fn discuss_resolve_into_annotation_creates_context_annotation() {
             "security",
         ],
     );
-    assert_eq!(replayed["disposition"], "idempotent_replay");
+    assert_eq!(replayed["replayed"], true);
+    assert_eq!(replayed["idempotency_status"], "replayed");
     assert_eq!(
         replayed["discussion"]["resolution"]["annotation_id"],
         annotation_id

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -7812,7 +7812,7 @@ fn discuss_open_named_flags_records_thread_ref() {
 }
 
 #[test]
-fn discuss_resolve_into_annotation_records_complete_resolution() {
+fn discuss_resolve_into_annotation_creates_context_annotation() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
     std::fs::create_dir_all(temp.path().join("src")).unwrap();
@@ -7832,9 +7832,12 @@ fn discuss_resolve_into_annotation_records_complete_resolution() {
         .as_str()
         .expect("discuss open should return an id");
 
+    let op_id = "11111111-1111-4111-8111-111111111111";
     let resolved = json_value(
         temp.path(),
         &[
+            "--op-id",
+            op_id,
             "discuss",
             "resolve",
             discussion_id,
@@ -7850,21 +7853,76 @@ fn discuss_resolve_into_annotation_records_complete_resolution() {
         ],
     );
     assert_eq!(resolved["output_kind"], "discuss_resolve");
-    assert_eq!(
-        resolved["discussion"]["resolution"]["kind"],
-        "into_annotation"
+    assert_eq!(resolved["discussion"]["resolution"]["kind"], "annotation");
+    let annotation_id = resolved["discussion"]["resolution"]["annotation_id"]
+        .as_str()
+        .expect("resolve --into-annotation must reference a real annotation id");
+    assert!(
+        !annotation_id.is_empty(),
+        "annotation id must not be empty: {resolved}"
     );
+
+    let listed = json_value(temp.path(), &["context", "get", "--path", "src/lib.rs"]);
+    assert_eq!(listed["output_kind"], "context_get");
+    let annotations = listed["annotations"]
+        .as_array()
+        .expect("context get should list annotations");
+    let created = annotations
+        .iter()
+        .find(|annotation| annotation["annotation_id"] == annotation_id)
+        .unwrap_or_else(|| panic!("context get should include {annotation_id}: {listed}"));
+    assert_eq!(created["kind"], "invariant");
+    assert_eq!(created["content"], "The cache key must include visibility");
+    assert_eq!(created["tags"], serde_json::json!(["cache", "security"]));
+    assert_eq!(created["scope"], "symbol:foo");
+
+    let history = json_value(temp.path(), &["context", "history", annotation_id]);
+    assert_eq!(history["output_kind"], "context_history");
+    assert_eq!(history["annotation_id"], annotation_id);
     assert_eq!(
-        resolved["discussion"]["resolution"]["annotation_kind"],
-        "invariant"
-    );
-    assert_eq!(
-        resolved["discussion"]["resolution"]["content"],
+        history["revisions"][0]["content"],
         "The cache key must include visibility"
     );
     assert_eq!(
-        resolved["discussion"]["resolution"]["tags"],
+        history["revisions"][0]["tags"],
         serde_json::json!(["cache", "security"])
+    );
+
+    let replayed = json_value(
+        temp.path(),
+        &[
+            "--op-id",
+            op_id,
+            "discuss",
+            "resolve",
+            discussion_id,
+            "--into-annotation",
+            "--body",
+            "The cache key must include visibility",
+            "--kind",
+            "invariant",
+            "--tag",
+            "cache",
+            "--tag",
+            "security",
+        ],
+    );
+    assert_eq!(replayed["disposition"], "idempotent_replay");
+    assert_eq!(
+        replayed["discussion"]["resolution"]["annotation_id"],
+        annotation_id
+    );
+    let after = json_value(temp.path(), &["context", "get", "--path", "src/lib.rs"]);
+    let ids: Vec<&str> = after["annotations"]
+        .as_array()
+        .expect("context get")
+        .iter()
+        .filter_map(|annotation| annotation["annotation_id"].as_str())
+        .collect();
+    assert_eq!(
+        ids,
+        vec![annotation_id],
+        "replaying resolve --into-annotation must not mint a second context row: {after}"
     );
 }
 

--- a/crates/hosted-client/src/client/discussion_sync.rs
+++ b/crates/hosted-client/src/client/discussion_sync.rs
@@ -58,6 +58,20 @@
 //! key)` (see `resolve_op_key`) and is recorded only after `ResolveDiscussion`
 //! succeeds.
 //!
+//! ## Annotation identity (heddle#1731)
+//!
+//! `discuss resolve --into-annotation` writes a real local context annotation
+//! and records `CollaborationResolution::Annotation { annotation_id }` with
+//! that id. Hosted push still calls weft `ResolveDiscussion.IntoAnnotation`
+//! (kind/content/tags) so the hosted discussion shows as resolved. Weft may
+//! mint a distinct `hc-…` id that is **not** a context-store row. After the
+//! echo we keep the local context id rather than replacing it with that
+//! orphan. The coherent id across push/clone is the context annotation:
+//! local UUID, then the SetContext server id recorded in
+//! `hosted-context-mirror.json`. A weft twin that creates the context row
+//! (or accepts the existing id) would make clone `discuss show` and
+//! `context history` share one id.
+//!
 //! ## Reconciliation is author-aware, never body-alone
 //!
 //! When the mirror map is lost/rebuilt, an unlinked server turn is reconciled
@@ -110,6 +124,7 @@ use repo::{CollaborationStore, Repository};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    attachments::context_root_for_state,
     client::HostedClient,
     hosted_runtime::hosted::{HostedDiscussion, HostedDiscussionTurn, HostedResolution},
 };
@@ -520,8 +535,10 @@ async fn push_one(
         }
     }
 
-    if push_into_annotation_resolution(client, repo_path, mirror, index, &server_id, discussion)
-        .await?
+    if push_into_annotation_resolution(
+        client, repo_path, mirror, index, &server_id, discussion, repo,
+    )
+    .await?
     {
         changed = true;
     }
@@ -535,17 +552,14 @@ async fn push_into_annotation_resolution(
     index: usize,
     server_id: &str,
     discussion: &MaterializedDiscussion,
+    repo: &Repository,
 ) -> Result<bool> {
-    let Some(objects::object::CollaborationResolution::IntoAnnotation {
-        annotation_kind,
-        content,
-        tags,
-    }) = &discussion.resolution
+    let Some((annotation_kind, content, tags)) = resolution_annotation_payload(repo, discussion)?
     else {
         return Ok(false);
     };
     let operation_id =
-        resolve_into_annotation_op_id(repo_path, server_id, *annotation_kind, content, tags)?;
+        resolve_into_annotation_op_id(repo_path, server_id, annotation_kind, &content, &tags)?;
     if mirror.repos[repo_path].discussions[index]
         .resolved_into_annotation_operation_id
         .as_deref()
@@ -557,9 +571,9 @@ async fn push_into_annotation_resolution(
         .resolve_discussion_into_annotation(
             repo_path,
             server_id,
-            *annotation_kind,
-            content,
-            tags.clone(),
+            annotation_kind,
+            &content,
+            tags,
             operation_id.clone(),
         )
         .await
@@ -574,6 +588,53 @@ async fn push_into_annotation_resolution(
         entry.pulled_resolution_key = Some(key);
     }
     Ok(true)
+}
+
+fn resolution_annotation_payload(
+    repo: &Repository,
+    discussion: &MaterializedDiscussion,
+) -> Result<Option<(objects::object::AnnotationKind, String, Vec<String>)>> {
+    match &discussion.resolution {
+        Some(CollaborationResolution::IntoAnnotation {
+            annotation_kind,
+            content,
+            tags,
+        }) => Ok(Some((*annotation_kind, content.clone(), tags.clone()))),
+        Some(CollaborationResolution::Annotation { annotation_id }) => {
+            let Some(head) = repo.head().context("resolve repository head")? else {
+                return Ok(None);
+            };
+            let Some(head_state) = repo
+                .store()
+                .get_state(&head)
+                .context("load head state for resolution annotation")?
+            else {
+                return Ok(None);
+            };
+            let Some(root) = context_root_for_state(repo, &head_state)? else {
+                return Ok(None);
+            };
+            let Some((_, blob, index)) = repo
+                .find_annotation(&root, annotation_id)
+                .context("look up resolution annotation")?
+            else {
+                return Ok(None);
+            };
+            let Some(revision) = blob
+                .annotations
+                .get(index)
+                .and_then(|annotation| annotation.current_revision())
+            else {
+                return Ok(None);
+            };
+            Ok(Some((
+                revision.kind,
+                revision.content.clone(),
+                revision.tags.clone(),
+            )))
+        }
+        _ => Ok(None),
+    }
 }
 
 /// Fetch hosted discussions for `against` (or repository HEAD) and materialize
@@ -1106,11 +1167,12 @@ fn pull_resolution(
     if pushed_echo
         && matches!(
             existing.resolution,
-            Some(CollaborationResolution::Annotation { ref annotation_id })
-                if Some(annotation_id.as_str())
-                    == hosted_annotation_id(&discussion.resolution)
+            Some(CollaborationResolution::Annotation { .. })
         )
     {
+        // Local already bound a real context annotation id. Weft's
+        // ResolveDiscussion.IntoAnnotation mints a distinct hc- that is
+        // not a context row (heddle#1731). Keep the local id.
         mirror
             .repos
             .get_mut(repo_path)
@@ -2339,6 +2401,93 @@ mod tests {
             Some(CollaborationResolution::Annotation {
                 annotation_id: "ann-1".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn pushed_real_annotation_echo_keeps_local_context_id() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").unwrap();
+        repo.snapshot_with_attribution(
+            Some("seed".to_string()),
+            None,
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        )
+        .unwrap();
+
+        assert!(
+            apply_hosted_discussion(
+                &repo,
+                "acme/widgets",
+                None,
+                &hosted("disc-1", "first", "turn-1", HostedResolution::Open),
+            )
+            .unwrap()
+        );
+
+        let store = CollaborationStore::open(repo.heddle_dir()).unwrap();
+        let existing = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        write_local_operation(
+            &store,
+            existing.discussion_id,
+            existing.heads.iter().copied().collect(),
+            Attribution::human(Principal::new("Local", "local@example.com")),
+            1_700_000_100_000,
+            CollaborationOperationBodyV1::Resolve {
+                resolution: CollaborationResolution::Annotation {
+                    annotation_id: "local-context-ann".to_string(),
+                },
+            },
+            test_key("resolve-into-real-annotation"),
+        )
+        .unwrap();
+
+        let path = mirror_path(repo.heddle_dir());
+        let mut mirror: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        mirror["repos"]["acme/widgets"]["discussions"][0]["resolved_into_annotation_operation_id"] =
+            serde_json::json!("pushed-op");
+        std::fs::write(&path, serde_json::to_vec_pretty(&mirror).unwrap()).unwrap();
+
+        apply_hosted_discussion(
+            &repo,
+            "acme/widgets",
+            None,
+            &hosted(
+                "disc-1",
+                "first",
+                "turn-1",
+                HostedResolution::IntoAnnotation {
+                    annotation_id: "hc-orphan-from-weft".to_string(),
+                },
+            ),
+        )
+        .unwrap();
+
+        let echoed = store
+            .materialize()
+            .unwrap()
+            .discussions
+            .into_values()
+            .next()
+            .unwrap();
+        assert!(
+            echoed.conflict_operations.is_empty(),
+            "a pushed Annotation echo must not surface as competing collab state"
+        );
+        assert_eq!(
+            echoed.resolution,
+            Some(CollaborationResolution::Annotation {
+                annotation_id: "local-context-ann".to_string(),
+            }),
+            "weft's minted hc- must not replace the real local context id"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle discuss resolve --into-annotation` now creates a real context annotation through the same write path as `heddle context set` (stable id, kind, body, tags, symbol/file anchor, `resolved_from_discussion` back-pointer).
- The discussion resolution is `Annotation { annotation_id }` pointing at that row, so `context get` / `context list` / `context history <id>` work locally. Same `--op-id` replay reuses the row.
- Hosted push still calls weft `ResolveDiscussion.IntoAnnotation` so the hosted discussion shows resolved. Weft may mint a distinct `hc-…` that is **not** a context row; heddle no longer replaces the local context id with that orphan (heddle#1731 AX).

## Closes

Closes HeddleCo/heddle#1731

## Red commit

`c7aef371` — main tip where `--into-annotation` only stored `CollaborationResolution::IntoAnnotation { kind, content, tags }` and never wrote the context store. Preview AX (2026-09-10) resolved `disc-01a08970-…` then cloned a dangling `hc-jg48er3qzd1m449zyv4wx5rwd0`.

## Test evidence

Proof on tip `07d20b7c`:

```
$ cargo test -p heddle-cli --lib symbol_anchor_maps_to_symbol_context_target
test cli::commands::discuss::tests::symbol_anchor_maps_to_symbol_context_target ... ok

$ cargo test -p heddle-cli --test cli_workflow discuss_resolve
test oss_cli_polish::discuss_resolve_dismiss_requires_reason_with_typed_advice_json ... ok
test oss_cli_polish::discuss_resolve_by_edit_emits_resolved_state_json ... ok
test oss_cli_polish::discuss_resolve_into_annotation_creates_context_annotation ... ok

$ cargo test -p heddle-hosted-client --features client --lib echo
test client::discussion_sync::tests::pushed_real_annotation_echo_keeps_local_context_id ... ok
test client::discussion_sync::tests::pushed_into_annotation_echo_does_not_conflict ... ok

$ cargo test -p heddle-hosted-client --features client --lib push_discussion_opens_appends_and_resolves_into_annotation
test client::discussion_sync::tests::push_discussion_opens_appends_and_resolves_into_annotation ... ok

$ cargo test -p heddle-cli --test cli_output_contracts context_set_get_history
test output_kind_runtime::context_set_get_history_audit_check_emit_output_kind ... ok
```

AX-shaped local proof: resolve `--into-annotation` → resolution `kind=annotation` with a real id → `context get --path` shows body+tags+`symbol:foo` → `context history <id>` works → same `--op-id` sets `replayed=true` and does not mint a second row.

## Manual verification

N/A — covered by tests.

## Hosted id coherence

- **Local / originator:** resolution id = context annotation id (UUID from `Annotation::new`).
- **After push:** context sync publishes that row via `SetContext`; the server id lives in `hosted-context-mirror.json` (`local_id ↔ server_id`). Discussion sync still sends kind/content/tags to weft so the hosted discussion is resolved.
- **Weft `hc-…`:** `ResolveDiscussion.IntoAnnotation` may mint an id that is not a context-store row. Heddle keeps the local context id on the echo instead of remapping to that orphan.
- **Clone:** the annotation arrives via context sync (SetContext / pack id). `context history` works on that id. Clone `discuss show` may still display weft's minted `hc-…` until weft creates the context row or accepts the existing id. No weft twin in this PR — prefer the heddle-side bind; a weft follow-up would make clone discussion.annotation_id == the context row.

## Surfaces

- **Verb:** clap help now says it creates a real `context set` annotation; rust path writes that row and links it.
- **Human and agent:** default resolve line unchanged; JSON resolution kind is `annotation` with `annotation_id` (was `into_annotation` with inline body/tags — those live on the context row).
- **Git interop:** annotations remain native-only (unchanged).
- **Wire:** no proto change. Hosted still uses existing `ResolveDiscussion.IntoAnnotation`.
- **Reverse states:** `context get` / `list` / `history` see the row; same `--op-id` replay does not mint a second row.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76822b8f-fa23-4112-ab85-de65127789b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76822b8f-fa23-4112-ab85-de65127789b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605781&installation_model_id=21489&pr_number=1734&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1734&signature=eba1d706690492335805d1cd0fdc3a83d24cfeb41793c53cf02e126f8cf604ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->