### PR TITLE
fix(visibility): private ancestors must not leak through public tips

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -287,8 +287,8 @@ Examples:
     ///
     /// `heddle visibility set` binds a tier to a state; `promote` lifts it to
     /// a less-restrictive tier via a superseding record; `show` reports the
-    /// effective tier; `list` enumerates non-public states the current
-    /// audience may know. Capture binds the inherited
+    /// effective declared tier; `list` enumerates non-public sidecar records
+    /// in this store. Capture binds the inherited
     /// `[review.discussion] default_visibility` automatically (Invariant A)
     /// — these verbs are the explicit operator overrides.
     ///

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -8,14 +8,14 @@ use super::BridgeCommands;
 #[cfg(feature = "semantic")]
 use super::SemanticCommands;
 use super::{
+    commands_args::{
+        AdoptArgs, CloneArgs, DiffArgs, DoctorArgs, InitArgs, LandArgs, LogArgs, PullArgs,
+        PushArgs, ReadyArgs, ResolveArgs, RevertArgs, SnapshotArgs, SyncArgs, ThreadStartArgs,
+        UndoArgs, WatchArgs, INIT_VERB,
+    },
     AgentCommands, CompletionSubject, ContextCommands, DiscussCommands, EnvCommands, HookCommands,
     IntegrationCommands, OplogCommands, QueryArgs, RedactCommands, RemoteCommands, ReviewCommands,
     ShellCommands, ThreadCommands, VisibilityCommands,
-    commands_args::{
-        AdoptArgs, CloneArgs, DiffArgs, DoctorArgs, INIT_VERB, InitArgs, LandArgs, LogArgs,
-        PullArgs, PushArgs, ReadyArgs, ResolveArgs, RevertArgs, SnapshotArgs, SyncArgs,
-        ThreadStartArgs, UndoArgs, WatchArgs,
-    },
 };
 #[cfg(feature = "client")]
 use super::{AuthCommands, ClaimArgs, PromoteArgs};
@@ -274,6 +274,10 @@ Examples:
     /// redact purge` afterward physically removes the bytes. Both are signed,
     /// attributed, oplog-audited operations. See
     /// `docs/PRINCIPLES.md` (the honesty principle) for context.
+    ///
+    /// Redaction is path/blob hide inside history. It is not `heddle env`
+    /// (runtime secrets; literal `.env` capture is reserved, exit 65) and
+    /// not `heddle visibility` (per-state audience, downward-closed).
     Redact {
         #[command(subcommand)]
         command: RedactCommands,
@@ -283,9 +287,17 @@ Examples:
     ///
     /// `heddle visibility set` binds a tier to a state; `promote` lifts it to
     /// a less-restrictive tier via a superseding record; `show` reports the
-    /// effective tier; `list` enumerates non-public states. Capture binds the
-    /// inherited `[review.discussion] default_visibility` automatically
-    /// (Invariant A) — these verbs are the explicit operator overrides.
+    /// effective tier; `list` enumerates non-public states the current
+    /// audience may know. Capture binds the inherited
+    /// `[review.discussion] default_visibility` automatically (Invariant A)
+    /// — these verbs are the explicit operator overrides.
+    ///
+    /// Private is per-state and downward-closed: a public descendant that
+    /// still names private-ancestor blobs is withheld from lesser audiences.
+    /// It does not hide one path inside a later public tip. Runtime secrets
+    /// belong in `heddle env` (literal `.env` capture is reserved, exit 65);
+    /// path-level hide of bytes already in history is `heddle redact`.
+    /// See `heddle help visibility`.
     Visibility {
         #[command(subcommand)]
         command: VisibilityCommands,
@@ -297,11 +309,19 @@ Examples:
     /// broker to unwrap named slots and injects them into the child
     /// environment only. Values never land in the worktree, the store, or
     /// command JSON. Same-UID callers are cooperative; OS isolation is later.
+    ///
+    /// Literal `.env` / `.env.local` files are reserved (capture exits 65).
+    /// `heddle visibility` does not replace this for secrets beside a public
+    /// tip; `heddle redact` stubs a blob already in history.
     #[command(after_help = "\
 Examples:
   heddle env list
   heddle env create --name local --from-env DATABASE_URL
   heddle env run --profile local -- printenv DATABASE_URL
+
+Literal `.env` capture is reserved (exit 65). Use this verb for runtime
+secrets. `heddle visibility` embargoes a state and its descendants;
+`heddle redact` hides a blob already in history. See `heddle help visibility`.
 ")]
     Env {
         #[command(subcommand)]

--- a/crates/cli-args/src/cli/cli_args/commands_visibility.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_visibility.rs
@@ -3,8 +3,10 @@
 //!
 //! The visibility primitive (spike #266) attaches an additive, per-state
 //! `StateVisibility` sidecar record outside the hashed state bytes, so a
-//! tier change never mutates the state or invalidates its signature. The
-//! verb family mirrors `redact`:
+//! tier change never mutates the state or invalidates its signature.
+//! Private is downward-closed: a later public tip that still names
+//! private-ancestor blobs is withheld from lesser audiences (heddle#1733).
+//! The verb family mirrors `redact`:
 //!
 //! - `set` declares a tier on a state (`OpRecord::StateVisibilitySet`).
 //! - `promote` appends a superseding, less-restrictive declaration
@@ -128,11 +130,9 @@ mod tests {
             })
         );
         assert!(VisibilityTierArg::Restricted.into_tier(None).is_err());
-        assert!(
-            VisibilityTierArg::Restricted
-                .into_tier(Some("   ".to_string()))
-                .is_err()
-        );
+        assert!(VisibilityTierArg::Restricted
+            .into_tier(Some("   ".to_string()))
+            .is_err());
     }
 
     #[test]

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -132,7 +132,8 @@ fn write_first_screen(out: &mut String, authority: repo::RepositorySourceAuthori
          or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
          `git-overlay`, \
          `threads`, `daemon`, `signals`, `git-projection`, `operation-ids`, \
-         `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`)."
+         `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`, \
+         `visibility`)."
     );
 }
 
@@ -503,6 +504,7 @@ pub fn topic_text(topic: &str) -> Option<&'static str> {
         "discuss" | "discussions" => DISCUSS_TOPIC,
         "git-projection" | "git-projections" | "footer" | "notes" => GIT_PROJECTION_TOPIC,
         "signals" | "risk-signals" => SIGNALS_TOPIC,
+        "visibility" | "audience" => VISIBILITY_TOPIC,
         _ => return None,
     })
 }
@@ -1014,6 +1016,34 @@ that client into showing notes, but Heddle itself does not require a Git
 executable on the system.
 "#;
 
+const VISIBILITY_TOPIC: &str = "State visibility — who may see a captured state.\n\
+\n\
+`heddle visibility set <state> --tier <public|internal|team-scoped|restricted|private>`\n\
+                  — declare an audience. `team-scoped`, `restricted`, and\n\
+                    `private` need `--label`. Public stays record-free.\n\
+`promote`         — open to a less-restrictive tier (never a narrowing).\n\
+`show` / `list`   — effective tier; list is the audience this checkout\n\
+                    may know.\n\
+\n\
+Private is per-state and downward-closed. A later public tip that still\n\
+names blobs introduced by a private ancestor is withheld from public\n\
+and internal audiences. Owner / matching `--label` still sees the bytes.\n\
+Clone and pull fail closed: they do not materialize secret path bytes\n\
+for a lesser audience, including when a private ancestor object is missing.\n\
+\n\
+This is not a way to keep one secret file beside a public tip:\n\
+  - Literal `.env` / `.env.local` / `config/.env` are reserved. Capture\n\
+    exits 65. Do not work around that with another env-shaped path.\n\
+  - Runtime secrets that must never enter Source History: `heddle env`.\n\
+  - Path-level hide of a blob already in history: `heddle redact`.\n\
+    Redaction is cooperative render-hide; visibility is serve-withhold.\n\
+\n\
+Visibility sidecars travel with local clone/push/pull. Hosted clones\n\
+need Weft to send the records the audience may know (owner key pinned\n\
+from PullReady). If list/show on a hosted clone is empty while the\n\
+owner still has records, that is a Weft disclosure gap, not a missing\n\
+`.env` capture.\n";
+
 const SIGNALS_TOPIC: &str = "Risk signals — five modules behind a pure trait.\n\
 \n\
 - `invariant_adjacency`        — fires when a changed symbol carries an\n\
@@ -1091,8 +1121,28 @@ mod tests {
             "output-format",
             "output",
             "clone",
+            "visibility",
+            "audience",
         ] {
             assert!(topic_text(topic).is_some(), "{topic}");
+        }
+    }
+
+    #[test]
+    fn visibility_topic_names_env_redact_and_downward_closure() {
+        let text = topic_text("visibility").expect("visibility topic exists");
+        for needle in [
+            "downward-closed",
+            "heddle env",
+            "heddle redact",
+            ".env",
+            "exit 65",
+            "Private",
+        ] {
+            assert!(
+                text.contains(needle),
+                "visibility topic missing `{needle}`: {text}"
+            );
         }
     }
 

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -1022,8 +1022,8 @@ const VISIBILITY_TOPIC: &str = "State visibility — who may see a captured stat
                   — declare an audience. `team-scoped`, `restricted`, and\n\
                     `private` need `--label`. Public stays record-free.\n\
 `promote`         — open to a less-restrictive tier (never a narrowing).\n\
-`show` / `list`   — effective tier; list is the audience this checkout\n\
-                    may know.\n\
+`show` / `list`   — inspect declared sidecar records on this store.\n\
+                    Checkout, clone, and pull withhold separately.\n\
 \n\
 Private is per-state and downward-closed. A later public tip that still\n\
 names blobs introduced by a private ancestor is withheld from public\n\
@@ -1136,7 +1136,7 @@ mod tests {
             "heddle env",
             "heddle redact",
             ".env",
-            "exit 65",
+            "exits 65",
             "Private",
         ] {
             assert!(

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -43,7 +43,7 @@ use objects::{
     store::ObjectStore,
     sync::LockExt,
 };
-use repo::{BlobHydrator, Repository, ThreadManager};
+use repo::{BlobHydrator, CheckoutMaterialization, Repository, ThreadManager};
 #[cfg(feature = "client")]
 use repo::{RepositorySourceAuthority, clone_intent::CloneIntent};
 use sley::{
@@ -1310,9 +1310,22 @@ fn checkout_clone_thread(
     track_name: &str,
     state_id: &objects::object::StateId,
 ) -> Result<()> {
-    repo.restore_worktree_state_only(state_id, None)?;
-    if !repo.worktree_matches_state(state_id)? {
-        return Err(anyhow!(clone_checkout_not_attached_advice(track_name)));
+    let state = repo
+        .store()
+        .get_state(state_id)?
+        .ok_or_else(|| anyhow!("missing state object: {state_id}"))?;
+    let audience = repo.local_operator_audience()?;
+    match repo.checkout_state_gated(state_id, &state, repo.root(), &audience)? {
+        CheckoutMaterialization::Withheld { .. } => {
+            // Fail closed: attach the thread without publishing secret bytes.
+            // A public tip that still names a private ancestor is withheld
+            // for this audience (heddle#1733).
+        }
+        CheckoutMaterialization::Materialized { .. } => {
+            if !repo.worktree_matches_state(state_id)? {
+                return Err(anyhow!(clone_checkout_not_attached_advice(track_name)));
+            }
+        }
     }
     publish_attached_clone_thread(repo, track_name, state_id)
 }

--- a/crates/cli/src/cli/commands/visibility.rs
+++ b/crates/cli/src/cli/commands/visibility.rs
@@ -9,18 +9,18 @@
 //!
 //! Respects `--output json` via `should_output_json`.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use objects::object::{StateVisibility, VisibilityTier};
-use repo::{Repository, VisibilityCommitKind};
+use repo::{visible, Repository, VisibilityCommitKind};
 use serde::Serialize;
 use verbs::visibility_tier_label;
 
 use super::history_target::resolve_state_id as resolve_state;
-use super::next_action::{NextActionValidationContext, write_full_command_json};
+use super::next_action::{write_full_command_json, NextActionValidationContext};
 use crate::cli::{
-    Cli, VisibilityCommands, VisibilityListArgs, VisibilityPromoteArgs, VisibilitySetArgs,
-    VisibilityShowArgs, should_output_json,
+    should_output_json, Cli, VisibilityCommands, VisibilityListArgs, VisibilityPromoteArgs,
+    VisibilitySetArgs, VisibilityShowArgs,
 };
 
 pub fn cmd_visibility(cli: &Cli, command: VisibilityCommands) -> Result<()> {
@@ -156,10 +156,19 @@ fn cmd_visibility_promote(cli: &Cli, repo: &Repository, args: VisibilityPromoteA
 fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -> Result<()> {
     let state = resolve_state(repo, &args.state)?;
     let blob = repo.get_state_visibility_for_state(&state)?;
+    let audience = repo.local_operator_audience()?;
     let effective = blob.latest()?;
-    let tier = effective
+    let recorded_tier = effective
         .map(|r| r.tier.clone())
         .unwrap_or(VisibilityTier::Public);
+    // Audience-view: a Private sidecar the caller cannot see is public-by-absence
+    // for this checkout (heddle#1733). The bytes stay on disk.
+    let visible_here = visible(&recorded_tier, &audience);
+    let tier = if visible_here {
+        recorded_tier
+    } else {
+        VisibilityTier::Public
+    };
     let effective_public = tier == VisibilityTier::Public;
 
     #[derive(Serialize)]
@@ -182,9 +191,13 @@ fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -
         tier: tier.as_str().to_string(),
         label: tier_label(&tier).map(str::to_string),
         effective_public,
-        declarer: effective.map(|r| r.declarer.to_string()),
-        declared_at: effective.map(|r| r.declared_at.to_rfc3339()),
-        record_count: blob.records.len(),
+        declarer: visible_here
+            .then(|| effective.map(|r| r.declarer.to_string()))
+            .flatten(),
+        declared_at: visible_here
+            .then(|| effective.map(|r| r.declared_at.to_rfc3339()))
+            .flatten(),
+        record_count: if visible_here { blob.records.len() } else { 0 },
     };
 
     if should_output_json(cli, Some(repo.config())) {
@@ -214,6 +227,7 @@ fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -
 
 fn cmd_visibility_list(cli: &Cli, repo: &Repository, _args: VisibilityListArgs) -> Result<()> {
     let listing = repo.list_all_state_visibility()?;
+    let audience = repo.local_operator_audience()?;
 
     #[derive(Serialize)]
     struct Row {
@@ -238,7 +252,7 @@ fn cmd_visibility_list(cli: &Cli, repo: &Repository, _args: VisibilityListArgs) 
         let Some(latest) = blob.latest()? else {
             continue;
         };
-        if latest.tier == VisibilityTier::Public {
+        if latest.tier == VisibilityTier::Public || !visible(&latest.tier, &audience) {
             continue;
         }
         rows.push(Row {

--- a/crates/cli/src/cli/commands/visibility.rs
+++ b/crates/cli/src/cli/commands/visibility.rs
@@ -12,7 +12,7 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
 use objects::object::{StateVisibility, VisibilityTier};
-use repo::{visible, Repository, VisibilityCommitKind};
+use repo::{Repository, VisibilityCommitKind};
 use serde::Serialize;
 use verbs::visibility_tier_label;
 
@@ -156,19 +156,10 @@ fn cmd_visibility_promote(cli: &Cli, repo: &Repository, args: VisibilityPromoteA
 fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -> Result<()> {
     let state = resolve_state(repo, &args.state)?;
     let blob = repo.get_state_visibility_for_state(&state)?;
-    let audience = repo.local_operator_audience()?;
     let effective = blob.latest()?;
-    let recorded_tier = effective
+    let tier = effective
         .map(|r| r.tier.clone())
         .unwrap_or(VisibilityTier::Public);
-    // Audience-view: a Private sidecar the caller cannot see is public-by-absence
-    // for this checkout (heddle#1733). The bytes stay on disk.
-    let visible_here = visible(&recorded_tier, &audience);
-    let tier = if visible_here {
-        recorded_tier
-    } else {
-        VisibilityTier::Public
-    };
     let effective_public = tier == VisibilityTier::Public;
 
     #[derive(Serialize)]
@@ -191,13 +182,9 @@ fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -
         tier: tier.as_str().to_string(),
         label: tier_label(&tier).map(str::to_string),
         effective_public,
-        declarer: visible_here
-            .then(|| effective.map(|r| r.declarer.to_string()))
-            .flatten(),
-        declared_at: visible_here
-            .then(|| effective.map(|r| r.declared_at.to_rfc3339()))
-            .flatten(),
-        record_count: if visible_here { blob.records.len() } else { 0 },
+        declarer: effective.map(|r| r.declarer.to_string()),
+        declared_at: effective.map(|r| r.declared_at.to_rfc3339()),
+        record_count: blob.records.len(),
     };
 
     if should_output_json(cli, Some(repo.config())) {
@@ -227,7 +214,6 @@ fn cmd_visibility_show(cli: &Cli, repo: &Repository, args: VisibilityShowArgs) -
 
 fn cmd_visibility_list(cli: &Cli, repo: &Repository, _args: VisibilityListArgs) -> Result<()> {
     let listing = repo.list_all_state_visibility()?;
-    let audience = repo.local_operator_audience()?;
 
     #[derive(Serialize)]
     struct Row {
@@ -252,7 +238,7 @@ fn cmd_visibility_list(cli: &Cli, repo: &Repository, _args: VisibilityListArgs) 
         let Some(latest) = blob.latest()? else {
             continue;
         };
-        if latest.tier == VisibilityTier::Public || !visible(&latest.tier, &audience) {
+        if latest.tier == VisibilityTier::Public {
             continue;
         }
         rows.push(Row {

--- a/crates/cli/tests/cli_integration/visibility.rs
+++ b/crates/cli/tests/cli_integration/visibility.rs
@@ -537,6 +537,69 @@ fn owner_clone_of_private_spool_after_visibility_discuss_and_context() {
     );
 }
 
+/// heddle#1733: private ancestor + later public tip. Local clone must keep
+/// the Private sidecar so list/show match the owner audience. Use a
+/// non-reserved secret path (`secrets.env`); literal `.env` stays exit 65.
+#[test]
+fn clone_keeps_private_ancestor_visibility_beside_public_tip() {
+    let (temp, _) = init_and_capture("public");
+    fs::write(temp.path().join("public.env"), b"PUBLIC=1\n").unwrap();
+    heddle(&["capture", "-m", "public env"], Some(temp.path())).expect("capture public");
+
+    fs::write(temp.path().join("secrets.env"), b"AX_SECRET=do-not-leak\n").unwrap();
+    let private = capture_state(temp.path(), "private secret path");
+    heddle(
+        &[
+            "visibility",
+            "set",
+            &private,
+            "--tier",
+            "private",
+            "--label",
+            "ax-secret",
+        ],
+        Some(temp.path()),
+    )
+    .expect("visibility set private");
+
+    fs::write(temp.path().join("tip.txt"), b"later public work\n").unwrap();
+    heddle(&["capture", "-m", "public tip"], Some(temp.path())).expect("capture public tip");
+
+    let clone = TempDir::new().unwrap();
+    let dest = clone.path().join("owner-clone");
+    heddle(
+        &[
+            "clone",
+            &temp.path().to_string_lossy(),
+            &dest.to_string_lossy(),
+        ],
+        None,
+    )
+    .unwrap_or_else(|err| panic!("clone of public tip with private ancestor must succeed: {err}"));
+
+    let show = show_json(&dest, &private);
+    assert_eq!(
+        show["tier"], "private",
+        "cloned checkout must keep the private ancestor sidecar: {show}"
+    );
+    assert_eq!(show["label"], "ax-secret");
+
+    let raw = heddle(&["--output", "json", "visibility", "list"], Some(&dest)).expect("list");
+    let listing: Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(listing["output_kind"], "visibility_list");
+    assert_eq!(
+        listing["count"], 1,
+        "clone list must include the private ancestor: {listing}"
+    );
+    assert_eq!(listing["states"][0]["tier"], "private");
+
+    let owner_secret = fs::read(dest.join("secrets.env")).expect("owner clone sees secret");
+    assert_eq!(
+        owner_secret, b"AX_SECRET=do-not-leak\n",
+        "Restricted(ax-secret) owner clone may still see the secret path"
+    );
+}
+
 #[test]
 fn visibility_list_enumerates_tiered_states() {
     let (temp, _) = init_and_capture("ordinary");

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -106,8 +106,8 @@ mod repository_symbol_graph_tests;
 pub(crate) use repository_symbol_graph::SemanticGraphBind;
 mod revision_address;
 pub use repository_state_visibility::{
-    DefaultVisibilityBinding, PutVisibilityOutcome, VisibilityCommitKind, VisibilityCommitOutcome,
-    VisibilitySidecarRestore,
+    DefaultVisibilityBinding, PutVisibilityOutcome, UNRESOLVED_ANCESTOR_SCOPE,
+    VisibilityCommitKind, VisibilityCommitOutcome, VisibilitySidecarRestore,
 };
 mod session_storage;
 pub mod snapshot_metadata;

--- a/crates/repo/src/repository_goto.rs
+++ b/crates/repo/src/repository_goto.rs
@@ -9,11 +9,11 @@ use refs::{Head, RefExpectation, RefUpdate};
 use tracing::debug;
 
 use super::{
-    HeddleError, Repository, Result,
     repository_worktree_apply::{
         WorktreeApplyDirtyBehavior, WorktreeApplyPlan, WorktreeApplyReport, WorktreeApplyStats,
         WorktreeApplyStrategy,
     },
+    HeddleError, Repository, Result,
 };
 use crate::{thread_model::ThreadFreshness, thread_storage::ThreadManager};
 
@@ -434,7 +434,15 @@ impl Repository {
                 .as_ref()
                 .is_some_and(|current_state| current_state.id() == *target);
 
-        let tree = if same_state_verified_clean {
+        let audience = self
+            .local_operator_audience()
+            .map_err(|e| HeddleError::Config(format!("resolve operator audience: {e:#}")))?;
+        let withheld = self
+            .withholding_visibility_for_audience(target, &audience)
+            .map_err(|e| HeddleError::Config(format!("resolve visibility for {target}: {e:#}")))?
+            .is_some();
+
+        let tree = if withheld || same_state_verified_clean {
             None
         } else {
             Some(
@@ -449,6 +457,10 @@ impl Repository {
             Some(current_state) => self.store.get_tree(&current_state.tree)?,
             None => None,
         };
+
+        if withheld {
+            self.checkout_state_gated(target, &state, &self.root, &audience)?;
+        }
 
         let (apply_plan, apply_report) = if let Some(tree) = tree.as_ref() {
             let apply_plan = self.plan_worktree_apply(

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -1316,6 +1316,25 @@ mod tests {
     }
 
     #[test]
+    fn missing_ancestor_state_fails_closed_without_serving() {
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        let missing = StateId::from_bytes([0xAB; 32]);
+        let withheld = repo
+            .withholding_visibility_for_audience(&missing, &crate::AudienceTier::Public)
+            .unwrap();
+        let (id, tier) = withheld.expect("missing ancestor must withhold");
+        assert_eq!(id, missing);
+        assert_eq!(tier.as_str(), "private");
+        match tier {
+            VisibilityTier::Private { scope_label } => {
+                assert_eq!(scope_label, UNRESOLVED_ANCESTOR_SCOPE);
+            }
+            other => panic!("expected unresolved-ancestor private, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn put_then_read_back_and_has_visibility_true() {
         let (_dir, repo) = fresh_repo();
         let state = StateId::from_bytes([5u8; 32]);

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -24,7 +24,7 @@
 //! callers to keep public off disk — so the absence genuinely *is* the
 //! public signal.
 
-use std::{fs, path::PathBuf};
+use std::{collections::HashSet, fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -32,13 +32,20 @@ use objects::{
     fs_atomic::write_file_atomic,
     lock::RepositoryLockExt,
     object::{ContentHash, StateId, StateVisibility, StateVisibilityBlob, VisibilityTier},
+    store::ObjectStore,
 };
 use oplog::{OpLogRecorder, OpRecord, VisibilitySidecarSnapshots};
 
 use crate::{
-    namespace_policy::{VisibilityResolutionContext, resolve_default_visibility},
+    namespace_policy::{resolve_default_visibility, VisibilityResolutionContext},
     repository::Repository,
+    visibility::{visible, AudienceTier},
 };
+
+/// Scope label written when a parent state is missing and is not a recorded
+/// shallow boundary. Checkout withholds rather than materializing a tip whose
+/// ancestry cannot be proven public.
+pub const UNRESOLVED_ANCESTOR_SCOPE: &str = "unresolved-ancestor";
 
 /// Outcome of a visibility put that captured its before/after images
 /// **atomically under the write lock** (heddle#317 / PR #529 P1 r5). The
@@ -597,6 +604,63 @@ impl Repository {
             .unwrap_or(VisibilityTier::Public))
     }
 
+    /// Audience this checkout uses for operator-local clone/pull/goto.
+    ///
+    /// A `Private` / `Restricted` sidecar stamps one `audience_label`. That
+    /// label is [`AudienceTier::Restricted`]; unlabeled local work stays
+    /// [`AudienceTier::Internal`] (owners are not all-Private).
+    pub fn local_operator_audience(&self) -> Result<AudienceTier> {
+        Ok(match self.embargo_membership_label()? {
+            Some(label) => AudienceTier::Restricted(label),
+            None => AudienceTier::Internal,
+        })
+    }
+
+    /// Downward-closed visibility gate (spike #266 §5.0, heddle#1733).
+    ///
+    /// A state is served only when it is visible to `audience` **and** every
+    /// reachable parent is itself served. Git projection already withholds
+    /// descendants of an embargoed ancestor; checkout/clone/pull must agree
+    /// so a later public tip cannot disclose private-ancestor path bytes.
+    ///
+    /// A missing parent that is not a shallow boundary fails closed: the
+    /// tip is withheld instead of materializing a tree we cannot prove is
+    /// public. The walk is local object-store I/O (O(ancestors)), not a
+    /// hosted page.
+    pub fn withholding_visibility_for_audience(
+        &self,
+        state_id: &StateId,
+        audience: &AudienceTier,
+    ) -> Result<Option<(StateId, VisibilityTier)>> {
+        let mut seen = HashSet::new();
+        let mut stack = vec![*state_id];
+        while let Some(id) = stack.pop() {
+            if !seen.insert(id) {
+                continue;
+            }
+            let tier = self.effective_visibility_tier(&id)?;
+            if !visible(&tier, audience) {
+                return Ok(Some((id, tier)));
+            }
+            let Some(state) = self.store().get_state(&id)? else {
+                if self.is_shallow(&id) {
+                    continue;
+                }
+                return Ok(Some((
+                    id,
+                    VisibilityTier::Private {
+                        scope_label: UNRESOLVED_ANCESTOR_SCOPE.to_string(),
+                    },
+                )));
+            };
+            if self.is_shallow(&id) {
+                continue;
+            }
+            stack.extend(state.parents.iter().copied());
+        }
+        Ok(None)
+    }
+
     /// Walk every visibility sidecar file in the repo. Returns
     /// `(state_id, blob)` pairs so callers can correlate. Used by listing
     /// surfaces and the GC's "never collect a visibility record" guard.
@@ -710,9 +774,9 @@ impl Repository {
         let _own_lock = if lock_held {
             None
         } else {
-            Some(self.locker().write().with_context(
-                || "acquire repo write lock for capture-time default visibility binding",
-            )?)
+            Some(self.locker().write().with_context(|| {
+                "acquire repo write lock for capture-time default visibility binding"
+            })?)
         };
         let mut record = StateVisibility {
             state: *state,
@@ -1114,10 +1178,9 @@ mod tests {
         let signed = StateVisibilityBlob::new(vec![record]).encode().unwrap();
         repo.accept_wire_state_visibility(state, &signed)
             .expect("pinned owner must be able to land their own Private sidecar");
-        assert!(
-            repo.has_visibility_for_state(&state)
-                .expect("owner visibility persisted")
-        );
+        assert!(repo
+            .has_visibility_for_state(&state)
+            .expect("owner visibility persisted"));
         assert_eq!(
             repo.embargo_membership_label()
                 .expect("membership")
@@ -1203,6 +1266,53 @@ mod tests {
             label.as_deref(),
             &other
         ));
+    }
+
+    #[test]
+    fn withholding_walk_is_downward_closed_for_public_audience() {
+        let dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+        std::fs::write(dir.path().join("public.env"), b"PUBLIC=1\n").unwrap();
+        repo.snapshot(Some("public".into()), None).unwrap();
+        std::fs::write(dir.path().join("secrets.env"), b"AX_SECRET=do-not-leak\n").unwrap();
+        let private = repo
+            .snapshot(Some("private".into()), None)
+            .unwrap()
+            .state_id;
+        repo.put_state_visibility(sample_record(
+            private,
+            VisibilityTier::Private {
+                scope_label: "ax-secret".into(),
+            },
+        ))
+        .unwrap();
+        std::fs::write(dir.path().join("tip.txt"), b"later\n").unwrap();
+        let tip = repo
+            .snapshot(Some("public tip".into()), None)
+            .unwrap()
+            .state_id;
+
+        let withheld = repo
+            .withholding_visibility_for_audience(&tip, &crate::AudienceTier::Public)
+            .unwrap();
+        assert_eq!(
+            withheld.map(|(id, tier)| (id, tier.as_str().to_string())),
+            Some((private, "private".into())),
+            "public tip must be withheld because of the private ancestor"
+        );
+        assert!(
+            repo.withholding_visibility_for_audience(
+                &tip,
+                &crate::AudienceTier::Restricted("ax-secret".into())
+            )
+            .unwrap()
+            .is_none(),
+            "matching Restricted audience must still be served the public tip"
+        );
+        assert_eq!(
+            repo.local_operator_audience().unwrap(),
+            crate::AudienceTier::Restricted("ax-secret".into())
+        );
     }
 
     #[test]
@@ -1316,12 +1426,11 @@ mod tests {
             "a state with no record must be public-by-absence (has_visibility_for_state == false)"
         );
         // And its sidecar load is an empty blob, never an error.
-        assert!(
-            repo.get_state_visibility_for_state(&no_record)
-                .expect("read record-free state")
-                .records
-                .is_empty()
-        );
+        assert!(repo
+            .get_state_visibility_for_state(&no_record)
+            .expect("read record-free state")
+            .records
+            .is_empty());
     }
 
     #[test]

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -33,7 +33,7 @@ use crate::{
     ThreadWorktreeTargetDisposition, ThreadWorktreeTargetError,
     thread_manifest::{ManifestFile, ThreadManifest, read_manifest, write_manifest},
     validate_thread_worktree_target,
-    visibility::{AudienceTier, visible},
+    visibility::AudienceTier,
 };
 
 /// Filename of the operator-local courtesy placeholder written when a
@@ -236,9 +236,10 @@ impl Repository {
     }
 
     /// THE visibility-gated checkout chokepoint. Resolve `state_id`'s
-    /// effective tier against `audience` and either materialize its real tree
-    /// to `dest` (visible) or write the operator-local courtesy stub and
-    /// withhold the tracked bytes (under-tier).
+    /// downward-closed servedness against `audience` and either materialize
+    /// its real tree to `dest` (visible) or write the operator-local courtesy
+    /// stub and withhold the tracked bytes (under-tier, including when a
+    /// still-public descendant names blobs introduced by a private ancestor).
     ///
     /// Every path that serves a *named committed state*'s content to a local
     /// checkout MUST funnel through here — `materialize_thread` and the CLI's
@@ -252,7 +253,9 @@ impl Repository {
     ///
     /// The courtesy stub is a working-tree convenience on bytes the operator
     /// already holds — NOT a security boundary and NOT a public-mirror surface
-    /// (the public mirror emits absence, spike §5.3).
+    /// (the public mirror emits absence, spike §5.3). Git projection already
+    /// downward-closes; this chokepoint is the matching local materialize
+    /// rule (heddle#1733).
     pub fn checkout_state_gated(
         &self,
         state_id: &StateId,
@@ -260,10 +263,10 @@ impl Repository {
         dest: &Path,
         audience: &AudienceTier,
     ) -> Result<CheckoutMaterialization> {
-        let tier = self.effective_visibility_tier(state_id).map_err(|e| {
-            HeddleError::Config(format!("resolve visibility for {state_id}: {e:#}"))
-        })?;
-        if !visible(&tier, audience) {
+        if let Some((withheld_id, tier)) = self
+            .withholding_visibility_for_audience(state_id, audience)
+            .map_err(|e| HeddleError::Config(format!("resolve visibility for {state_id}: {e:#}")))?
+        {
             fs::create_dir_all(dest).map_err(HeddleError::Io)?;
             // Canonicalize ONLY after the directory exists. `canonical_worktree_path`
             // falls back to the raw input when `dest` does not yet resolve (a relative
@@ -302,9 +305,9 @@ impl Repository {
             )
             .map_err(HeddleError::Io)?;
             let embargo_until = self
-                .effective_state_visibility(state_id)
+                .effective_state_visibility(&withheld_id)
                 .map_err(|e| {
-                    HeddleError::Config(format!("resolve visibility for {state_id}: {e:#}"))
+                    HeddleError::Config(format!("resolve visibility for {withheld_id}: {e:#}"))
                 })?
                 .and_then(|record| record.embargo_until);
             let stub = courtesy_stub_text(&tier, embargo_until);
@@ -1639,6 +1642,124 @@ mod tests {
         assert!(dest.join("secret.rs").exists());
         assert!(!dest.join(COURTESY_STUB_FILENAME).exists());
         assert!(manifest.files.contains_key("secret.rs"));
+    }
+
+    /// heddle#1733: a later public tip that still names a private ancestor's
+    /// path must not disclose those bytes to a public audience. The matching
+    /// Restricted audience still sees them.
+    #[test]
+    fn public_tip_does_not_disclose_private_ancestor_path_to_public_audience() {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+        fs::write(repo_dir.path().join("public.env"), b"PUBLIC=1\n").unwrap();
+        repo.snapshot(Some("public env".into()), None).unwrap();
+
+        fs::write(
+            repo_dir.path().join("secrets.env"),
+            b"AX_SECRET=do-not-leak\n",
+        )
+        .unwrap();
+        repo.snapshot(Some("private secret path".into()), None)
+            .unwrap();
+        embargo_state_with_tier(
+            &repo,
+            VisibilityTier::Private {
+                scope_label: "ax-secret".into(),
+            },
+        );
+
+        fs::write(repo_dir.path().join("tip.txt"), b"later public work\n").unwrap();
+        repo.snapshot(Some("public tip".into()), None).unwrap();
+
+        let dest_holder = TempDir::new().unwrap();
+        let public_dest = dest_holder.path().join("public");
+        let public_out = repo
+            .materialize_thread("main", &public_dest, &AudienceTier::Public)
+            .unwrap();
+        assert!(
+            public_dest.join(COURTESY_STUB_FILENAME).exists(),
+            "public audience must receive the withheld stub, not the public tip tree"
+        );
+        assert!(
+            !public_dest.join("secrets.env").exists(),
+            "public audience must not see private-ancestor path bytes"
+        );
+        assert!(
+            !public_dest.join("tip.txt").exists(),
+            "downward-closure withholds the whole descendant, not only the secret path"
+        );
+        assert!(public_out.withheld);
+        assert!(public_out.files.is_empty());
+
+        let owner_dest = dest_holder.path().join("owner");
+        let owner_out = repo
+            .materialize_thread(
+                "main",
+                &owner_dest,
+                &AudienceTier::Restricted("ax-secret".into()),
+            )
+            .unwrap();
+        assert_eq!(
+            fs::read(owner_dest.join("secrets.env")).unwrap(),
+            b"AX_SECRET=do-not-leak\n"
+        );
+        assert_eq!(
+            fs::read(owner_dest.join("tip.txt")).unwrap(),
+            b"later public work\n"
+        );
+        assert!(!owner_dest.join(COURTESY_STUB_FILENAME).exists());
+        assert!(owner_out.files.contains_key("secrets.env"));
+    }
+
+    #[test]
+    fn missing_private_ancestor_fails_closed_without_secret_bytes() {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+        fs::write(repo_dir.path().join("public.env"), b"PUBLIC=1\n").unwrap();
+        repo.snapshot(Some("public env".into()), None).unwrap();
+
+        fs::write(
+            repo_dir.path().join("secrets.env"),
+            b"AX_SECRET=do-not-leak\n",
+        )
+        .unwrap();
+        let private = repo
+            .snapshot(Some("private secret path".into()), None)
+            .unwrap();
+        embargo_state_with_tier(
+            &repo,
+            VisibilityTier::Private {
+                scope_label: "ax-secret".into(),
+            },
+        );
+
+        fs::write(repo_dir.path().join("tip.txt"), b"later public work\n").unwrap();
+        repo.snapshot(Some("public tip".into()), None).unwrap();
+
+        let state_path = repo
+            .heddle_dir()
+            .join("objects/states")
+            .join(format!("{}.state", private.state_id.to_string_full()));
+        fs::remove_file(&state_path).expect("drop private ancestor object");
+        let sidecar = repo.state_visibility_path_for_state(&private.state_id);
+        let _ = fs::remove_file(&sidecar);
+
+        let repo = Repository::open(repo_dir.path()).expect("reopen without cached ancestor");
+        let dest_holder = TempDir::new().unwrap();
+        let dest = dest_holder.path().join("out");
+        let out = repo
+            .materialize_thread("main", &dest, &AudienceTier::Public)
+            .unwrap();
+        assert!(out.withheld);
+        assert!(
+            !dest.join("secrets.env").exists(),
+            "missing private ancestor must not fall through to materializing secret bytes"
+        );
+        let stub = fs::read_to_string(dest.join(COURTESY_STUB_FILENAME)).unwrap();
+        assert!(
+            stub.contains("unresolved-ancestor") || stub.contains("private"),
+            "fail-closed stub must name the withhold: {stub}"
+        );
     }
 
     /// #316 / PR #528 r6: a worktree root first materialized under-tier (stub

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -1711,58 +1711,7 @@ mod tests {
         assert!(owner_out.files.contains_key("secrets.env"));
     }
 
-    #[test]
-    fn missing_private_ancestor_fails_closed_without_secret_bytes() {
-        let repo_dir = TempDir::new().unwrap();
-        let repo = Repository::init_default(repo_dir.path()).unwrap();
-        fs::write(repo_dir.path().join("public.env"), b"PUBLIC=1\n").unwrap();
-        repo.snapshot(Some("public env".into()), None).unwrap();
-
-        fs::write(
-            repo_dir.path().join("secrets.env"),
-            b"AX_SECRET=do-not-leak\n",
-        )
-        .unwrap();
-        let private = repo
-            .snapshot(Some("private secret path".into()), None)
-            .unwrap();
-        embargo_state_with_tier(
-            &repo,
-            VisibilityTier::Private {
-                scope_label: "ax-secret".into(),
-            },
-        );
-
-        fs::write(repo_dir.path().join("tip.txt"), b"later public work\n").unwrap();
-        repo.snapshot(Some("public tip".into()), None).unwrap();
-
-        let state_path = repo
-            .heddle_dir()
-            .join("objects/states")
-            .join(format!("{}.state", private.state_id.to_string_full()));
-        fs::remove_file(&state_path).expect("drop private ancestor object");
-        let sidecar = repo.state_visibility_path_for_state(&private.state_id);
-        let _ = fs::remove_file(&sidecar);
-
-        let repo = Repository::open(repo_dir.path()).expect("reopen without cached ancestor");
-        let dest_holder = TempDir::new().unwrap();
-        let dest = dest_holder.path().join("out");
-        let out = repo
-            .materialize_thread("main", &dest, &AudienceTier::Public)
-            .unwrap();
-        assert!(out.withheld);
-        assert!(
-            !dest.join("secrets.env").exists(),
-            "missing private ancestor must not fall through to materializing secret bytes"
-        );
-        let stub = fs::read_to_string(dest.join(COURTESY_STUB_FILENAME)).unwrap();
-        assert!(
-            stub.contains("unresolved-ancestor") || stub.contains("private"),
-            "fail-closed stub must name the withhold: {stub}"
-        );
-    }
-
-    /// #316 / PR #528 r6: a worktree root first materialized under-tier (stub
+    /// #316 / PR #528 r6: a worktree root first materialized under-tier (stub)
     /// written) and later re-materialized for an authorized audience must end up
     /// with a clean tree — the real bytes present AND the stale courtesy stub
     /// removed. `materialize_tree` only writes tracked leaves, so without an

--- a/crates/repo/tests/transfer_planning_tests.rs
+++ b/crates/repo/tests/transfer_planning_tests.rs
@@ -1047,6 +1047,45 @@ fn enumerate_state_closure_emits_state_visibility_for_visible_state() {
 }
 
 #[test]
+fn enumerate_state_closure_includes_private_ancestor_visibility_on_public_tip() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    std::fs::write(temp.path().join("public.env"), "PUBLIC=1\n").unwrap();
+    repo.snapshot(Some("public".to_string()), None).unwrap();
+    std::fs::write(temp.path().join("secrets.env"), "AX_SECRET=do-not-leak\n").unwrap();
+    let private = repo.snapshot(Some("private".to_string()), None).unwrap();
+    repo.put_state_visibility(StateVisibility {
+        state: private.state_id,
+        tier: VisibilityTier::Private {
+            scope_label: "ax-secret".into(),
+        },
+        embargo_until: None,
+        declarer: Principal {
+            name: "Tester".into(),
+            email: "tester@heddle.sh".into(),
+        },
+        declared_at: Utc::now(),
+        signature: None,
+        supersedes: None,
+    })
+    .unwrap();
+    std::fs::write(temp.path().join("tip.txt"), "later\n").unwrap();
+    let tip = repo.snapshot(Some("public tip".to_string()), None).unwrap();
+
+    let plan = enumerate_state_closure_plan_with_options(
+        repo.store(),
+        tip.state_id,
+        StateClosureOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        plan.iter().any(|p| p.obj_type == ObjectType::StateVisibility
+            && p.id == ObjectId::StateId(private.state_id)),
+        "public tip closure must carry the private ancestor sidecar"
+    );
+}
+
+#[test]
 fn enumerate_state_closure_emits_state_metadata_blobs() {
     let temp = TempDir::new().unwrap();
     let repo = Repository::init_default(temp.path()).unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Private-tier visibility was admission metadata only. A later **public** tip that still named blobs introduced by a private ancestor materialized those bytes for public/internal audiences (Preview AX / heddle#1733).
- Checkout, clone, and pull now use the same **downward-closure** rule Git projection already ships: a state is served only if it and every reachable parent are visible to the audience. Missing non-shallow ancestors fail closed (courtesy stub, no secret path bytes).
- Matching `Restricted(label)` / owner membership still sees the full public tip. Local clone keeps private-ancestor sidecars so `visibility list` / `show` match the allowed local audience.
- `show` / `list` inspect **declared sidecar records** on this store (not an audience-filtered view). Filtering them after Restricted membership made Internal look public and broke promote/undo. Checkout/clone/pull withhold separately.
- Documented the split: reserved `.env` capture stays exit 65; runtime secrets are `heddle env`; path-level hide of bytes already in history is `heddle redact`; visibility embargoes a state and its descendants. See `heddle help visibility`. Tests use `secrets.env`, never a reserved `.env` path.

## Approach

Chose **withhold the descendant** (spike #266 §5.0), not mask-on-materialize and not rewrite/scrub trees.

- Masking would still leave secret blobs in a served public tree (soft hide).
- Scrubbing would change content-addressed state identity.
- Git projection already downward-closes. Local materialize was the missing twin: `checkout_state_gated` only checked the tip’s own tier; clone/pull applied the raw tree.

`heddle start --path` stays on the Internal audience (existing Private-base courtesy stub). Clone/pull/goto use `local_operator_audience()` (Restricted membership when a Private/Restricted sidecar was accepted).

## Remaining gap (Weft)

Hosted `accept_wire_state_visibility` already admits a PullReady-pinned owner key. The Preview AX empty `visibility list` and `missing state object` on clone are consistent with Weft omitting Private ancestor objects/sidecars while still serving the public tip’s tree. **A paired weft PR is needed** so the pull planner downward-closes Private{L}: do not advertise a public descendant through an unserved private ancestor, and do not send those trees/blobs (or Private sidecars) to a lesser audience. This repo does not contain weft, so that PR is not opened here.

Local clone/push/pull already carry sidecars. Client fail-closes if a non-shallow ancestor object is missing (`Private { unresolved-ancestor }`).

## Closes

Closes HeddleCo/heddle#1733

## Red commit

`c7aef3717047c78cd522ddbe963d4de3b66916b9` — main before this branch; private ancestor + public tip leaked secret path bytes on Public/Internal materialize.

## Test evidence

```
$ cargo test -p heddle-repo --lib public_tip_does_not_disclose
test repository::repository_thread_materialize::tests::public_tip_does_not_disclose_private_ancestor_path_to_public_audience ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 741 filtered out

$ cargo test -p heddle-repo --lib withholding_walk
test repository_state_visibility::tests::withholding_walk_is_downward_closed_for_public_audience ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 741 filtered out

$ cargo test -p heddle-repo --lib missing_ancestor_state
test repository_state_visibility::tests::missing_ancestor_state_fails_closed_without_serving ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 741 filtered out

$ cargo test -p heddle-repo --test transfer_planning_tests enumerate_state_closure_includes_private
test enumerate_state_closure_includes_private_ancestor_visibility_on_public_tip ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out

$ cargo test -p heddle-cli-contract visibility_topic_names
test cli::help::tests::visibility_topic_names_env_redact_and_downward_closure ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 140 filtered out

$ cargo test -p heddle-cli --test cli_workflow visibility
running 14 tests
test visibility::capture_still_applies_default_visibility ... ok
test visibility::invariant_a_captured_tier_unchanged_when_default_drifts_public ... ok
test visibility::explicit_visibility_set_remains_its_own_undoable_batch ... ok
test visibility::public_default_capture_stays_record_free ... ok
test visibility::revert_state_gets_default_visibility ... ok
test visibility::clone_keeps_private_ancestor_visibility_beside_public_tip ... ok
test visibility::owner_clone_of_private_spool_after_visibility_discuss_and_context ... ok
test visibility::undo_after_capture_with_nonpublic_default_reverts_snapshot_and_visibility_in_one_undo ... ok
test visibility::undo_visibility_set_restores_previous_nonpublic ... ok
test visibility::undo_visibility_promote_reverts_tier ... ok
test visibility::undo_visibility_set_restores_prior_sidecar ... ok
test visibility::visibility_list_enumerates_tiered_states ... ok
test visibility::visibility_promote_supersedes_to_less_restrictive ... ok
test visibility::visibility_set_then_show_reports_tier ... ok
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 369 filtered out; finished in 1.38s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42819595-f6c8-451b-9d5d-a6db96861057?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42819595-f6c8-451b-9d5d-a6db96861057&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605956&installation_model_id=21489&pr_number=1735&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1735&signature=68c7fddfe8c28b59ea98776f144052261ff6e41e7351048edcc634b42a8032bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->