### PR TITLE
feat(cli): heddle grant for spool collaborator access

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -149,7 +149,17 @@ pub enum AuthCommands {
     },
 
     /// Create or list signup invites owned by the signed-in account.
+    ///
+    /// Signup-only: this mints an account-creation code. It does not grant
+    /// another principal access to a spool. Use `heddle grant` to add a
+    /// collaborator.
     #[command(args_conflicts_with_subcommands = true)]
+    #[command(after_help = "\
+Signup-only. `heddle auth invite` creates an account-creation code.
+It does not grant spool access. Add a collaborator with:
+
+  heddle grant create --spool <path|url> --principal <handle> --role contributor
+")]
     Invite {
         /// Bind the new invite to an email address.
         #[arg(long)]
@@ -235,6 +245,114 @@ pub enum AuthInviteCommands {
     List,
 }
 
+/// Hosted role granted on a spool.
+///
+/// `contributor` is the everyday name for the `developer` role.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GrantRoleArg {
+    Reader,
+    Contributor,
+    Developer,
+    Maintainer,
+    Admin,
+    Owner,
+}
+
+impl GrantRoleArg {
+    /// Wire token `CreateGrant` / `UpdateGrant` accept.
+    pub fn as_hosted_role_name(self) -> &'static str {
+        match self {
+            Self::Reader => "reader",
+            Self::Contributor | Self::Developer => "developer",
+            Self::Maintainer => "maintainer",
+            Self::Admin => "admin",
+            Self::Owner => "owner",
+        }
+    }
+}
+
+/// Grant another principal access to a hosted spool.
+///
+/// Separate from `heddle auth invite`, which is signup-only.
+#[derive(Subcommand, Clone, Debug)]
+pub enum GrantCommands {
+    /// Grant a principal a role on a hosted spool.
+    #[command(after_help = "\
+Adds a collaborator to an existing hosted spool. This is not a signup
+invite — `heddle auth invite` only creates an account-creation code.
+
+Roles: reader, contributor (developer), maintainer, admin, owner.
+
+Examples:
+  heddle grant create --spool spool/willow-ibis-8e7264/notes --principal alice --role contributor
+  heddle grant create --spool https://api.preview.heddle.sh/notes --principal alice --role reader
+")]
+    Create(GrantCreateArgs),
+
+    /// List grants on a hosted spool.
+    #[command(after_help = "\
+Examples:
+  heddle grant list --spool spool/willow-ibis-8e7264/notes
+  heddle grant list --spool notes --server api.preview.heddle.sh
+")]
+    List(GrantListArgs),
+
+    /// Remove a grant. `ID` is the principal shown by `heddle grant list`.
+    #[command(after_help = "\
+Examples:
+  heddle grant delete alice --spool spool/willow-ibis-8e7264/notes
+")]
+    Delete(GrantDeleteArgs),
+}
+
+/// Arguments for `heddle grant create`.
+#[derive(Args, Clone, Debug)]
+pub struct GrantCreateArgs {
+    /// Spool to grant on (`spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL).
+    #[arg(long, value_name = "PATH|URL")]
+    pub spool: String,
+
+    /// Principal to grant (handle or account).
+    #[arg(long, value_name = "HANDLE|ACCOUNT")]
+    pub principal: String,
+
+    /// Role to grant.
+    #[arg(long, value_enum)]
+    pub role: GrantRoleArg,
+
+    /// Hosted Heddle server. Omit when `--spool` is a URL, or to use the configured default.
+    #[arg(long)]
+    pub server: Option<String>,
+}
+
+/// Arguments for `heddle grant list`.
+#[derive(Args, Clone, Debug)]
+pub struct GrantListArgs {
+    /// Spool whose grants to list (`spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL).
+    #[arg(long, value_name = "PATH|URL")]
+    pub spool: String,
+
+    /// Hosted Heddle server. Omit when `--spool` is a URL, or to use the configured default.
+    #[arg(long)]
+    pub server: Option<String>,
+}
+
+/// Arguments for `heddle grant delete`.
+#[derive(Args, Clone, Debug)]
+pub struct GrantDeleteArgs {
+    /// Principal shown as `ID` by `heddle grant list`.
+    #[arg(value_name = "ID")]
+    pub id: String,
+
+    /// Spool the grant is on (`spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL).
+    #[arg(long, value_name = "PATH|URL")]
+    pub spool: String,
+
+    /// Hosted Heddle server. Omit when `--spool` is a URL, or to use the configured default.
+    #[arg(long)]
+    pub server: Option<String>,
+}
+
 #[derive(Subcommand, Clone, Debug)]
 pub enum AuthTrustCommands {
     /// Show the descriptor root pin controlling a server connection
@@ -270,7 +388,10 @@ pub struct AuthTrustReplaceArgs {
 mod tests {
     use clap::Parser;
 
-    use crate::cli::{AuthCommands, AuthInviteCommands, AuthTrustCommands, Cli, Commands};
+    use crate::cli::{
+        AuthCommands, AuthInviteCommands, AuthTrustCommands, Cli, Commands, GrantCommands,
+        GrantRoleArg,
+    };
 
     #[test]
     fn trust_replace_parses_compare_and_swap_inputs() {
@@ -597,5 +718,75 @@ mod tests {
                 "runner persona must reject authority-changing overrides"
             );
         }
+    }
+
+    #[test]
+    fn grant_create_parses_spool_principal_and_contributor_role() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "grant",
+            "create",
+            "--spool",
+            "spool/willow-ibis-8e7264/notes",
+            "--principal",
+            "alice",
+            "--role",
+            "contributor",
+            "--server",
+            "api.preview.heddle.sh",
+        ])
+        .expect("grant create flags parse");
+        let Commands::Grant {
+            command: GrantCommands::Create(args),
+        } = cli.command
+        else {
+            panic!("expected grant create");
+        };
+        assert_eq!(args.spool, "spool/willow-ibis-8e7264/notes");
+        assert_eq!(args.principal, "alice");
+        assert_eq!(args.role, GrantRoleArg::Contributor);
+        assert_eq!(args.role.as_hosted_role_name(), "developer");
+        assert_eq!(args.server.as_deref(), Some("api.preview.heddle.sh"));
+    }
+
+    #[test]
+    fn grant_list_and_delete_parse() {
+        let list = Cli::try_parse_from([
+            "heddle",
+            "grant",
+            "list",
+            "--spool",
+            "notes",
+            "--server",
+            "api.preview.heddle.sh",
+        ])
+        .expect("grant list flags parse");
+        let Commands::Grant {
+            command: GrantCommands::List(args),
+        } = list.command
+        else {
+            panic!("expected grant list");
+        };
+        assert_eq!(args.spool, "notes");
+        assert_eq!(args.server.as_deref(), Some("api.preview.heddle.sh"));
+
+        let delete = Cli::try_parse_from([
+            "heddle",
+            "grant",
+            "delete",
+            "alice",
+            "--spool",
+            "spool/willow-ibis-8e7264/notes",
+        ])
+        .expect("grant delete flags parse");
+        let Commands::Grant {
+            command: GrantCommands::Delete(args),
+        } = delete.command
+        else {
+            panic!("expected grant delete");
+        };
+        assert_eq!(args.id, "alice");
+        assert_eq!(args.spool, "spool/willow-ibis-8e7264/notes");
+        assert!(Cli::try_parse_from(["heddle", "grant", "delete", "alice"]).is_err());
     }
 }

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -18,7 +18,7 @@ use super::{
     },
 };
 #[cfg(feature = "client")]
-use super::{AuthCommands, ClaimArgs, PromoteArgs};
+use super::{AuthCommands, ClaimArgs, GrantCommands, PromoteArgs};
 
 #[derive(Clone, Debug, Args)]
 pub struct FsckArgs {
@@ -371,6 +371,16 @@ Examples:
     Auth {
         #[command(subcommand)]
         command: AuthCommands,
+    },
+
+    /// Grant a principal access to a hosted spool.
+    ///
+    /// Separate from `heddle auth invite`, which is signup-only. Create,
+    /// list, and delete collaborator grants on a spool you can administer.
+    #[cfg(feature = "client")]
+    Grant {
+        #[command(subcommand)]
+        command: GrantCommands,
     },
 
     /// Promote a personal hosted spool to a root-level spool.

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -57,7 +57,8 @@ pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
 pub use commands_client::{
     AgentTemplateArg, AuthCommands, AuthInviteCommands, AuthTrustCommands, AuthTrustReplaceArgs,
-    AuthTrustShowArgs, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN, PromoteArgs,
+    AuthTrustShowArgs, ClaimArgs, DEFAULT_CLAIM_WEB_ORIGIN, GrantCommands, GrantCreateArgs,
+    GrantDeleteArgs, GrantListArgs, GrantRoleArg, PromoteArgs,
 };
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1228,6 +1228,53 @@ impl RecoveryAdvice {
     }
 
     #[cfg(feature = "client")]
+    pub fn grant_denied(spool: &str) -> Self {
+        Self::safety_refusal(
+            "grant_denied",
+            format!("Cannot manage grants on '{spool}': permission denied"),
+            "Only an owner or admin of this spool can create or delete grants. Check roles with `heddle whoami`.",
+            "the caller does not hold GrantWrite on the spool",
+            "no collaborator grant was created or removed",
+            "hosted grants and local checkouts were left unchanged",
+            "heddle whoami".to_string(),
+            vec!["heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn grant_not_found(spool: &str) -> Self {
+        Self::safety_refusal(
+            "grant_not_found",
+            format!("Cannot manage grants: spool '{spool}' was not found"),
+            format!("Check the path with `heddle whoami`, then retry with `--spool {spool}`."),
+            format!("the server has no spool at '{spool}'"),
+            "no collaborator grant was created or removed",
+            "hosted grants and local checkouts were left unchanged",
+            "heddle whoami".to_string(),
+            vec!["heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn grant_failed(spool: &str, error: &str) -> Self {
+        let primary = if spool.is_empty() {
+            "heddle whoami".to_string()
+        } else {
+            format!("heddle grant list --spool {spool}")
+        };
+        Self::safety_refusal(
+            "grant_failed",
+            format!("Cannot manage grants on '{spool}': {error}"),
+            "Fix the reported condition, then retry `heddle grant`. Check identity with `heddle whoami`.",
+            format!("the server refused a grant RPC for '{spool}': {error}"),
+            "no collaborator grant was created or removed",
+            "hosted grants and local checkouts were left unchanged",
+            primary.clone(),
+            vec![primary, "heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
     pub fn promote_failed(full_path: &str, error: &str) -> Self {
         Self::safety_refusal(
             "promote_failed",

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1601,7 +1601,16 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "client",
         ),
     ),
-    entry(&["grant"], feature_gated(user_scoped(GROUP), "client")),
+    entry(
+        &["grant"],
+        feature_gated(
+            CommandContract {
+                help_rank: 193,
+                ..user_scoped(GROUP)
+            },
+            "client",
+        ),
+    ),
     entry(
         &["grant", "create"],
         feature_gated(

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -12,8 +12,6 @@ use verbs::{
     ResolveReport, StatusReport, VerifyReport,
 };
 
-#[cfg(feature = "client")]
-use crate::cli::AuthCommands;
 #[cfg(feature = "semantic")]
 use crate::cli::SemanticCommands;
 #[cfg(feature = "git-overlay")]
@@ -29,6 +27,8 @@ use crate::cli::{
     },
     render::shell_quote,
 };
+#[cfg(feature = "client")]
+use crate::cli::{AuthCommands, GrantCommands};
 #[cfg(feature = "git-overlay")]
 use crate::cli::{BridgeCommands, BridgeGitCommands};
 
@@ -1595,6 +1595,99 @@ const CONTRACTS: &[CommandContractEntry] = &[
                         "target slug taken or request rejected; do not retry without changing inputs",
                     ),
                     (77, "not the owner, or account is not claimed/verified"),
+                    (78, "not authenticated or spool path missing"),
+                ],
+            ),
+            "client",
+        ),
+    ),
+    entry(&["grant"], feature_gated(user_scoped(GROUP), "client")),
+    entry(
+        &["grant", "create"],
+        feature_gated(
+            exits(
+                json_discriminators(
+                    documented_schemas(
+                        CommandContract {
+                            help_rank: 193,
+                            ..user_scoped(NETWORK_METADATA_MUTATION)
+                        },
+                        &["grant create"],
+                    ),
+                    &[json_discriminator(
+                        Some("grant create"),
+                        "output_kind",
+                        "grant_create",
+                    )],
+                ),
+                &[
+                    (0, "ok"),
+                    (75, "server unreachable; safe to retry"),
+                    (
+                        76,
+                        "server rejected the grant; do not retry without changing inputs",
+                    ),
+                    (77, "not permitted to grant on this spool"),
+                    (78, "not authenticated or spool path missing"),
+                ],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["grant", "list"],
+        feature_gated(
+            exits(
+                json_discriminators(
+                    documented_schemas(
+                        CommandContract {
+                            help_rank: 194,
+                            ..user_scoped(READ_JSON)
+                        },
+                        &["grant list"],
+                    ),
+                    &[json_discriminator(
+                        Some("grant list"),
+                        "output_kind",
+                        "grant_list",
+                    )],
+                ),
+                &[
+                    (0, "ok"),
+                    (75, "server unreachable; safe to retry"),
+                    (77, "not permitted to list grants on this spool"),
+                    (78, "not authenticated or spool path missing"),
+                ],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["grant", "delete"],
+        feature_gated(
+            exits(
+                json_discriminators(
+                    documented_schemas(
+                        CommandContract {
+                            help_rank: 195,
+                            ..user_scoped(NETWORK_METADATA_MUTATION)
+                        },
+                        &["grant delete"],
+                    ),
+                    &[json_discriminator(
+                        Some("grant delete"),
+                        "output_kind",
+                        "grant_delete",
+                    )],
+                ),
+                &[
+                    (0, "ok"),
+                    (75, "server unreachable; safe to retry"),
+                    (
+                        76,
+                        "server rejected the delete; do not retry without changing inputs",
+                    ),
+                    (77, "not permitted to delete grants on this spool"),
                     (78, "not authenticated or spool path missing"),
                 ],
             ),
@@ -4647,6 +4740,12 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         Commands::Whoami { .. } => vec!["whoami"],
         #[cfg(feature = "client")]
         Commands::Claim(_) => vec!["claim"],
+        #[cfg(feature = "client")]
+        Commands::Grant { command } => match command {
+            GrantCommands::Create(_) => vec!["grant", "create"],
+            GrantCommands::List(_) => vec!["grant", "list"],
+            GrantCommands::Delete(_) => vec!["grant", "delete"],
+        },
         #[cfg(feature = "client")]
         Commands::Promote(_) => vec!["promote"],
         Commands::Context { command } => match command {

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -185,6 +185,36 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["claim"], &["claim"]),
     #[cfg(feature = "client")]
     sample(&["promote"], &["promote", "spool/willow-ibis-8e7264/notes"]),
+    #[cfg(feature = "client")]
+    sample(
+        &["grant", "create"],
+        &[
+            "grant",
+            "create",
+            "--spool",
+            "spool/willow-ibis-8e7264/notes",
+            "--principal",
+            "alice",
+            "--role",
+            "contributor",
+        ],
+    ),
+    #[cfg(feature = "client")]
+    sample(
+        &["grant", "list"],
+        &["grant", "list", "--spool", "spool/willow-ibis-8e7264/notes"],
+    ),
+    #[cfg(feature = "client")]
+    sample(
+        &["grant", "delete"],
+        &[
+            "grant",
+            "delete",
+            "alice",
+            "--spool",
+            "spool/willow-ibis-8e7264/notes",
+        ],
+    ),
     #[cfg(feature = "git-overlay")]
     sample(&["bridge", "git", "import"], &["bridge", "git", "import"]),
     #[cfg(feature = "git-overlay")]
@@ -1523,6 +1553,9 @@ fn auth_commands_are_user_scoped() {
         &["auth", "derive-agent"],
         &["auth", "create-service-token"],
         &["claim"],
+        &["grant", "create"],
+        &["grant", "list"],
+        &["grant", "delete"],
     ] {
         let contract = raw_command_contract_for_path(path.iter().copied())
             .unwrap_or_else(|| panic!("missing command contract for `{}`", path.join(" ")));
@@ -1785,6 +1818,9 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             // client-gated hosted verbs.
             "whoami",
             "promote",
+            "grant create",
+            "grant list",
+            "grant delete",
             "bridge git import",
             "bridge git export",
             "sync git",
@@ -2490,6 +2526,6 @@ fn feature_gated_command_roots_are_catalog_owned() {
     // listed here.
     assert_eq!(
         feature_gated_command_roots(),
-        &["auth", "ci", "claim", "promote", "whoami"]
+        &["auth", "ci", "claim", "grant", "promote", "whoami"]
     );
 }

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -46,8 +46,8 @@ use super::{
         },
         auth::{
             AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput,
-            PromoteOutput, ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput,
-            WhoamiOutput,
+            GrantCreateOutput, GrantDeleteOutput, GrantListOutput, PromoteOutput,
+            ServiceTokenOutput, SignupInviteCreatedOutput, SignupInviteListOutput, WhoamiOutput,
         },
         thread::{
             ApprovalOutput, ApprovalRevokeOutput, EligibilityOutput, ThreadAbsorbOutput,
@@ -178,6 +178,9 @@ schema_registry! {
     (&["auth trust show", "auth trust replace"], AuthTrustOutput),
     (&["whoami"], WhoamiOutput),
     (&["promote"], PromoteOutput),
+    (&["grant create"], GrantCreateOutput),
+    (&["grant list"], GrantListOutput),
+    (&["grant delete"], GrantDeleteOutput),
     (&["auth create-service-token"], ServiceTokenOutput),
     (&["auth invite"], SignupInviteCreatedOutput),
     (&["auth invite list"], SignupInviteListOutput),

--- a/crates/cli-contract/src/cli/commands/surface_conformance.rs
+++ b/crates/cli-contract/src/cli/commands/surface_conformance.rs
@@ -69,6 +69,7 @@ pub const APPROVED_NON_EVERYDAY_ROOT_COMMANDS: &[&str] = &[
     "env",
     "hook",
     "netd",
+    "grant",
     "promote",
     "revert",
     "semantic",

--- a/crates/cli-contract/src/cli/commands/wire/auth.rs
+++ b/crates/cli-contract/src/cli/commands/wire/auth.rs
@@ -22,6 +22,53 @@ pub struct PromoteOutput {
     pub recommended_action: Option<String>,
 }
 
+/// JSON payload for `heddle grant create`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "GrantCreateSchema")]
+pub struct GrantCreateOutput {
+    pub output_kind: &'static str,
+    pub id: String,
+    pub principal: String,
+    pub role: String,
+    pub spool: String,
+    pub server: String,
+    pub recommended_action: Option<String>,
+}
+
+/// One row from `heddle grant list`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "GrantRowSchema")]
+pub struct GrantRowOutput {
+    pub id: String,
+    pub principal: String,
+    pub role: String,
+    pub spool: String,
+}
+
+/// JSON payload for `heddle grant list`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "GrantListSchema")]
+pub struct GrantListOutput {
+    pub output_kind: &'static str,
+    pub spool: String,
+    pub server: String,
+    pub grants: Vec<GrantRowOutput>,
+    pub recommended_action: Option<String>,
+}
+
+/// JSON payload for `heddle grant delete`.
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(rename = "GrantDeleteSchema")]
+pub struct GrantDeleteOutput {
+    pub output_kind: &'static str,
+    pub id: String,
+    pub principal: String,
+    pub spool: String,
+    pub server: String,
+    pub deleted: bool,
+    pub recommended_action: Option<String>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 #[schemars(rename = "AgentAccountCreatedSchema")]
 pub struct AgentAccountCreatedOutput {

--- a/crates/cli-contract/src/cli/commands/wire/mod.rs
+++ b/crates/cli-contract/src/cli/commands/wire/mod.rs
@@ -36,7 +36,8 @@ pub use agent::{
 };
 pub use auth::{
     AgentAccountCreatedOutput, AuthLogoutOutput, AuthStatusOutput, AuthTrustOutput, CaptureActor,
-    HumanPromotionDirective, PromoteOutput, ServiceTokenOutput, SignupInviteCreatedOutput,
+    GrantCreateOutput, GrantDeleteOutput, GrantListOutput, GrantRowOutput, HumanPromotionDirective,
+    PromoteOutput, ServiceTokenOutput, SignupInviteCreatedOutput,
     SignupInviteListOutput, SignupInviteOutput, WhoamiIdentity, WhoamiOutput, WhoamiRole,
 };
 pub use bridge::{

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -17,8 +17,8 @@ use super::{
 };
 use crate::{
     cli::{
-        Cli, GrantCommands, GrantCreateArgs, GrantDeleteArgs, GrantListArgs, should_output_json,
-        style,
+        Cli, CliContext, GrantCommands, GrantCreateArgs, GrantDeleteArgs, GrantListArgs,
+        should_output_json, style,
     },
     config::UserConfig,
     remote::RemoteTarget,

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `heddle grant` — create, list, and delete spool collaborator grants.
+
+use anyhow::{Context, Result, anyhow};
+use heddle_cli_contract::cli::commands::wire::auth::{
+    GrantCreateOutput, GrantDeleteOutput, GrantListOutput, GrantRowOutput,
+};
+use hosted_client::hosted_runtime::{
+    auth::resolve_server,
+    hosted::{HostedAuthMode, HostedClient, HostedSession, canonicalize_spool_path},
+};
+use wire::{HostedGrantInfo, ProtocolError};
+
+use super::{
+    advice::RecoveryAdvice,
+    next_action::{NextActionValidationContext, write_full_command_json},
+};
+use crate::{
+    cli::{
+        Cli, GrantCommands, GrantCreateArgs, GrantDeleteArgs, GrantListArgs, should_output_json,
+        style,
+    },
+    config::UserConfig,
+    remote::RemoteTarget,
+};
+
+pub async fn cmd_grant(cli: &Cli, command: GrantCommands) -> Result<()> {
+    match command {
+        GrantCommands::Create(args) => cmd_grant_create(cli, args).await,
+        GrantCommands::List(args) => cmd_grant_list(cli, args).await,
+        GrantCommands::Delete(args) => cmd_grant_delete(cli, args).await,
+    }
+}
+
+async fn cmd_grant_create(cli: &Cli, args: GrantCreateArgs) -> Result<()> {
+    let (server, spool) = resolve_grant_spool(&args.spool, args.server.as_deref())?;
+    let mut session = hosted_connect(&server).await?;
+    let result = create_connected(
+        cli,
+        &mut session,
+        &server,
+        &spool,
+        &args.principal,
+        args.role.as_hosted_role_name(),
+    )
+    .await;
+    session.close().await;
+    result
+}
+
+async fn cmd_grant_list(cli: &Cli, args: GrantListArgs) -> Result<()> {
+    let (server, spool) = resolve_grant_spool(&args.spool, args.server.as_deref())?;
+    let mut session = hosted_connect(&server).await?;
+    let result = list_connected(cli, &mut session, &server, &spool).await;
+    session.close().await;
+    result
+}
+
+async fn cmd_grant_delete(cli: &Cli, args: GrantDeleteArgs) -> Result<()> {
+    let (server, spool) = resolve_grant_spool(&args.spool, args.server.as_deref())?;
+    let mut session = hosted_connect(&server).await?;
+    let result = delete_connected(cli, &mut session, &server, &spool, &args.id).await;
+    session.close().await;
+    result
+}
+
+async fn hosted_connect(server: &str) -> Result<HostedClient> {
+    let user_config = UserConfig::load_default()?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.to_string()),
+        HostedAuthMode::CredentialFallback,
+    )?;
+    session
+        .connect(server)
+        .await
+        .map_err(|err| map_grant_error("", &err))
+}
+
+async fn create_connected(
+    cli: &Cli,
+    client: &mut HostedClient,
+    server: &str,
+    spool: &str,
+    principal: &str,
+    role: &str,
+) -> Result<()> {
+    let created = client
+        .create_grant(principal, role, None, Some(spool), cli.operation_id_wire())
+        .await
+        .map_err(|err| map_grant_error(spool, &err))?;
+    let row = grant_row(&created, spool);
+    if should_output_json(cli, None) {
+        write_full_command_json(
+            &GrantCreateOutput {
+                output_kind: "grant_create",
+                id: row.id.clone(),
+                principal: row.principal.clone(),
+                role: row.role.clone(),
+                spool: row.spool.clone(),
+                server: server.to_string(),
+                recommended_action: Some(format!("heddle grant list --spool {spool}")),
+            },
+            NextActionValidationContext::without_repo(&["grant", "create"]),
+        )?;
+    } else {
+        println!(
+            "{} granted {} {} on {}",
+            style::ok_marker(),
+            style::bold(&row.principal),
+            style::bold(&row.role),
+            style::bold(&row.spool)
+        );
+        super::action_line::print_next(&format!("heddle grant list --spool {spool}"));
+    }
+    Ok(())
+}
+
+async fn list_connected(
+    cli: &Cli,
+    client: &mut HostedClient,
+    server: &str,
+    spool: &str,
+) -> Result<()> {
+    let grants = client
+        .list_grants(Some(&format!("repo:{spool}")))
+        .await
+        .map_err(|err| map_grant_error(spool, &err))?;
+    let rows: Vec<GrantRowOutput> = grants.iter().map(|grant| grant_row(grant, spool)).collect();
+    if should_output_json(cli, None) {
+        write_full_command_json(
+            &GrantListOutput {
+                output_kind: "grant_list",
+                spool: spool.to_string(),
+                server: server.to_string(),
+                grants: rows,
+                recommended_action: None,
+            },
+            NextActionValidationContext::without_repo(&["grant", "list"]),
+        )?;
+    } else if rows.is_empty() {
+        println!("No grants on {}.", style::bold(spool));
+        super::action_line::print_next(&format!(
+            "heddle grant create --spool {spool} --principal <handle> --role contributor"
+        ));
+    } else {
+        println!("ID\tROLE\tSPOOL");
+        for row in rows {
+            println!("{}\t{}\t{}", row.id, row.role, row.spool);
+        }
+    }
+    Ok(())
+}
+
+async fn delete_connected(
+    cli: &Cli,
+    client: &mut HostedClient,
+    server: &str,
+    spool: &str,
+    principal: &str,
+) -> Result<()> {
+    client
+        .delete_grant(principal, None, Some(spool), cli.operation_id_wire())
+        .await
+        .map_err(|err| map_grant_error(spool, &err))?;
+    if should_output_json(cli, None) {
+        write_full_command_json(
+            &GrantDeleteOutput {
+                output_kind: "grant_delete",
+                id: principal.to_string(),
+                principal: principal.to_string(),
+                spool: spool.to_string(),
+                server: server.to_string(),
+                deleted: true,
+                recommended_action: Some(format!("heddle grant list --spool {spool}")),
+            },
+            NextActionValidationContext::without_repo(&["grant", "delete"]),
+        )?;
+    } else {
+        println!(
+            "{} removed {} from {}",
+            style::ok_marker(),
+            style::bold(principal),
+            style::bold(spool)
+        );
+        super::action_line::print_next(&format!("heddle grant list --spool {spool}"));
+    }
+    Ok(())
+}
+
+fn grant_row(grant: &HostedGrantInfo, fallback_spool: &str) -> GrantRowOutput {
+    let spool = grant
+        .repo_path
+        .as_deref()
+        .or(grant.namespace_path.as_deref())
+        .unwrap_or(fallback_spool)
+        .to_string();
+    GrantRowOutput {
+        id: grant.subject.clone(),
+        principal: grant.subject.clone(),
+        role: grant.role.clone(),
+        spool,
+    }
+}
+
+fn resolve_grant_spool(spool: &str, server: Option<&str>) -> Result<(String, String)> {
+    if spool.starts_with("https://") {
+        match RemoteTarget::parse(spool) {
+            Ok(RemoteTarget::Network {
+                authority,
+                repo_path: Some(repo_path),
+            }) => {
+                let full_path = canonicalize_spool_path(&repo_path).map_err(anyhow::Error::new)?;
+                return Ok((authority, full_path));
+            }
+            Ok(_) | Err(_) => {
+                return Err(anyhow!(
+                    "hosted grant URL must include a spool path, e.g. https://api.heddle.sh/spool/<handle>/<name>"
+                ));
+            }
+        }
+    }
+    let server = resolve_server(server).context("resolve hosted server for grant")?;
+    let full_path = canonicalize_spool_path(spool).map_err(anyhow::Error::new)?;
+    Ok((server, full_path))
+}
+
+fn map_grant_error(spool: &str, err: &ProtocolError) -> anyhow::Error {
+    let message = match err {
+        ProtocolError::RemoteFailure { message, .. } => message.as_str(),
+        ProtocolError::AlreadyExists(message)
+        | ProtocolError::AuthorizationFailed(message)
+        | ProtocolError::AuthenticationFailed(message)
+        | ProtocolError::InvalidState(message)
+        | ProtocolError::ObjectNotFound(message)
+        | ProtocolError::Remote(message) => message.as_str(),
+        _ => "",
+    };
+    let lower = message.to_ascii_lowercase();
+    let advice = if matches!(
+        err,
+        ProtocolError::AuthorizationFailed(_) | ProtocolError::AuthenticationFailed(_)
+    ) || lower.contains("permission")
+        || lower.contains("not authorized")
+        || lower.contains("forbidden")
+    {
+        RecoveryAdvice::grant_denied(spool)
+    } else if matches!(err, ProtocolError::ObjectNotFound(_)) || lower.contains("not found") {
+        RecoveryAdvice::grant_not_found(spool)
+    } else {
+        let display = if message.is_empty() {
+            err.to_string()
+        } else {
+            message.to_string()
+        };
+        RecoveryAdvice::grant_failed(spool, &display)
+    };
+    anyhow!(advice)
+}
+
+#[cfg(test)]
+mod tests {
+    use wire::ProtocolError;
+
+    use super::{grant_row, map_grant_error, resolve_grant_spool};
+
+    #[test]
+    fn url_target_takes_host_and_canonical_path() {
+        let (server, path) = resolve_grant_spool(
+            "https://api.preview.heddle.sh/willow-ibis-8e7264/notes",
+            None,
+        )
+        .expect("parse url");
+        assert_eq!(server, "api.preview.heddle.sh");
+        assert_eq!(path, "spool/willow-ibis-8e7264/notes");
+    }
+
+    #[test]
+    fn canonical_spool_path_is_not_a_hostname() {
+        let (server, path) =
+            resolve_grant_spool("spool/pine-yak-87fa33/repo", Some("api.preview.heddle.sh"))
+                .expect("canonical path");
+        assert_eq!(server, "api.preview.heddle.sh");
+        assert_eq!(path, "spool/pine-yak-87fa33/repo");
+    }
+
+    #[test]
+    fn grant_row_uses_subject_as_delete_id() {
+        let row = grant_row(
+            &wire::HostedGrantInfo {
+                subject: "alice".into(),
+                role: "developer".into(),
+                namespace_path: None,
+                repo_path: Some("spool/me/notes".into()),
+            },
+            "fallback",
+        );
+        assert_eq!(row.id, "alice");
+        assert_eq!(row.principal, "alice");
+        assert_eq!(row.role, "developer");
+        assert_eq!(row.spool, "spool/me/notes");
+    }
+
+    #[test]
+    fn permission_denial_is_not_swallowed() {
+        let err = ProtocolError::AuthorizationFailed("missing grant:write".into());
+        let mapped = map_grant_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "grant_denied");
+    }
+
+    #[test]
+    fn missing_spool_is_not_swallowed() {
+        let err = ProtocolError::ObjectNotFound("unknown spool".into());
+        let mapped = map_grant_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "grant_not_found");
+    }
+}

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -36,6 +36,8 @@ pub(crate) mod heddleignore_defaults;
 mod history_target;
 mod hook;
 #[cfg(feature = "client")]
+mod grant;
+#[cfg(feature = "client")]
 mod hosted_identity;
 mod import_progress;
 mod init;
@@ -144,6 +146,8 @@ pub use heddle_cli_contract::cli::commands::{
     verification_health,
 };
 pub use hook::cmd_hook;
+#[cfg(feature = "client")]
+pub use grant::cmd_grant;
 #[cfg(feature = "client")]
 pub use hosted_identity::{cmd_hosted_auth, cmd_hosted_claim, cmd_hosted_whoami};
 pub use init::cmd_init;

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -138,9 +138,12 @@ impl HeddleExitCode {
             | "env_store_not_found"
             | "env_store_slot_not_found" => Some(Self::DataErr),
             "env_store_denied" | "env_store_expired" => Some(Self::NoPerm),
-            "promote_not_owner" | "promote_account_standing" => Some(Self::NoPerm),
-            "promote_slug_taken" | "promote_failed" => Some(Self::Protocol),
+            "promote_not_owner" | "promote_account_standing" | "grant_denied" => {
+                Some(Self::NoPerm)
+            }
+            "promote_slug_taken" | "promote_failed" | "grant_failed" => Some(Self::Protocol),
             "promote_already_root" => Some(Self::DataErr),
+            "grant_not_found" => Some(Self::Config),
             // Capture aborted on ENOSPC; working tree is intact. Classifies
             // as IO rather than a distinct raw-28 OS code so agents stay on
             // the documented sysexits taxonomy.
@@ -545,6 +548,9 @@ mod tests {
             ("promote_slug_taken", HeddleExitCode::Protocol),
             ("promote_failed", HeddleExitCode::Protocol),
             ("promote_already_root", HeddleExitCode::DataErr),
+            ("grant_denied", HeddleExitCode::NoPerm),
+            ("grant_failed", HeddleExitCode::Protocol),
+            ("grant_not_found", HeddleExitCode::Config),
         ] {
             assert_eq!(
                 HeddleExitCode::from_error(&advice_with_kind(kind)),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,7 +14,9 @@ use cli::cli::commands::cmd_context_reason_git;
 #[cfg(feature = "semantic")]
 use cli::cli::commands::cmd_semantic;
 #[cfg(feature = "client")]
-use cli::cli::commands::{cmd_hosted_auth, cmd_hosted_claim, cmd_hosted_whoami, cmd_promote};
+use cli::cli::commands::{
+    cmd_grant, cmd_hosted_auth, cmd_hosted_claim, cmd_hosted_whoami, cmd_promote,
+};
 #[cfg(feature = "git-overlay")]
 use cli::cli::{
     BridgeCommands, BridgeGitCommands,
@@ -638,6 +640,9 @@ async fn async_main() -> Result<()> {
 
         #[cfg(feature = "client")]
         Commands::Claim(args) => cmd_hosted_claim(args.clone()).await,
+
+        #[cfg(feature = "client")]
+        Commands::Grant { command } => cmd_grant(&cli, command.clone()).await,
 
         #[cfg(feature = "client")]
         Commands::Promote(args) => cmd_promote(&cli, args.clone()).await,

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -66,6 +66,9 @@ const SWEPT: &[&str] = &[
     // no override needed).
     "whoami",
     "promote",
+    "grant create",
+    "grant list",
+    "grant delete",
     // heddle#272 — output_kind sweep on the named-by-persona verbs.
     "agent presence list",
     "agent presence show",

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -68,7 +68,10 @@ fn auth_invite_help_stays_signup_only() {
         "auth invite help should point collaborators at grant:\n{stdout}"
     );
     assert!(
-        !stdout.contains("--spool"),
-        "auth invite must not grow spool-grant flags:\n{stdout}"
+        !stdout.lines().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("--spool") && !trimmed.contains("heddle grant")
+        }),
+        "auth invite must not grow a --spool flag of its own:\n{stdout}"
     );
 }

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "client")]
+
+use std::process::Command;
+
+fn heddle(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .output()
+        .expect("run built heddle binary")
+}
+
+#[test]
+fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
+    let parent = heddle(&["grant", "--help"]);
+    assert_eq!(parent.status.code(), Some(0));
+    let parent_out = String::from_utf8_lossy(&parent.stdout);
+    assert!(parent_out.contains("Usage: heddle grant"));
+    assert!(parent_out.contains("create"));
+    assert!(parent_out.contains("list"));
+    assert!(parent_out.contains("delete"));
+    assert!(
+        parent_out.contains("signup-only") || parent_out.contains("signup"),
+        "grant help must separate itself from signup invite:\n{parent_out}"
+    );
+    assert!(
+        !parent_out.contains("auth invite --email"),
+        "grant help must not overload auth invite:\n{parent_out}"
+    );
+
+    let create = heddle(&["grant", "create", "--help"]);
+    assert_eq!(create.status.code(), Some(0));
+    let create_out = String::from_utf8_lossy(&create.stdout);
+    assert!(create_out.contains("--spool"));
+    assert!(create_out.contains("--principal"));
+    assert!(create_out.contains("--role"));
+    assert!(create_out.contains("contributor"));
+    assert!(
+        create_out.contains("signup") || create_out.contains("auth invite"),
+        "grant create help must say this is not a signup invite:\n{create_out}"
+    );
+
+    let list = heddle(&["grant", "list", "--help"]);
+    assert_eq!(list.status.code(), Some(0));
+    let list_out = String::from_utf8_lossy(&list.stdout);
+    assert!(list_out.contains("--spool"));
+
+    let delete = heddle(&["grant", "delete", "--help"]);
+    assert_eq!(delete.status.code(), Some(0));
+    let delete_out = String::from_utf8_lossy(&delete.stdout);
+    assert!(delete_out.contains("<ID>"));
+    assert!(delete_out.contains("--spool"));
+}
+
+#[test]
+fn auth_invite_help_stays_signup_only() {
+    let output = heddle(&["auth", "invite", "--help"]);
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: heddle auth invite"));
+    assert!(
+        stdout.to_ascii_lowercase().contains("signup"),
+        "auth invite help must stay signup-only:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("heddle grant"),
+        "auth invite help should point collaborators at grant:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("--spool"),
+        "auth invite must not grow spool-grant flags:\n{stdout}"
+    );
+}

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -763,7 +763,6 @@ async fn serve_create_grant(
         subject: body.subject,
         role: body.role,
         target: body.target,
-        ..HostedGrant::default()
     };
     upsert_grant(grants, grant.clone());
     send.write_chunk(Bytes::from(
@@ -794,10 +793,7 @@ async fn serve_list_grants(
         .into_iter()
         .filter(|grant| grant_matches_resource(grant, &resource))
         .collect();
-    let response = ListGrantsResponse {
-        grants: listed,
-        ..ListGrantsResponse::default()
-    };
+    let response = ListGrantsResponse { grants: listed };
     send.write_chunk(Bytes::from(
         encode_success_response(&response.encode_to_vec()).unwrap(),
     ))
@@ -825,7 +821,6 @@ async fn serve_update_grant(
         subject: body.subject,
         role: body.role,
         target: body.target,
-        ..HostedGrant::default()
     };
     upsert_grant(grants, grant.clone());
     send.write_chunk(Bytes::from(

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -15,18 +15,20 @@ use api::{
     },
     heddle::api::v1alpha1::{
         AnnotatedFile, BlobResponse, CallFailure, CallFailureCode, ContextRevision,
-        CreateSpoolRequest, DeleteSpoolRequest, Discussion, GetBlobRequest,
-        GetContextHistoryPageEnd, GetContextHistoryRequest, GetContextHistoryResponse,
-        GetCurrentUserSpoolRequest, GetDiscussionRequest, GetSpoolRequest, HostedSpool,
-        ListContextPageEnd, ListContextRequest, ListContextResponse, ListDiscussionsByStateRequest,
-        ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd, ListRefsResponse,
-        ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind, PromoteSpoolRequest,
-        PromoteSpoolResponse, PullComplete, PullReady, PullServerFrame, PushClientFrame,
-        PushComplete, PushReady, PushRequest, PushServerFrame, RepoEvent, SignedSpoolOwnerGenesis,
-        StateContextEntry, StateId, SubscribeRepoEventsRequest, TransferCheckpoint, TransportMode,
-        UpdateSpoolRequest, get_context_history_response, list_context_response,
-        list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
-        push_client_frame, push_server_frame,
+        CreateGrantRequest, CreateSpoolRequest, DeleteGrantRequest, DeleteSpoolRequest, Discussion,
+        GetBlobRequest, GetContextHistoryPageEnd, GetContextHistoryRequest,
+        GetContextHistoryResponse, GetCurrentUserSpoolRequest, GetDiscussionRequest,
+        GetSpoolRequest, GrantTargetRef, HostedGrant, HostedSpool, ListContextPageEnd,
+        ListContextRequest, ListContextResponse, ListDiscussionsByStateRequest,
+        ListDiscussionsPageEnd, ListDiscussionsResponse, ListGrantsRequest, ListGrantsResponse,
+        ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk,
+        PackStreamKind, PromoteSpoolRequest, PromoteSpoolResponse, PullComplete, PullReady,
+        PullServerFrame, PushClientFrame, PushComplete, PushReady, PushRequest, PushServerFrame,
+        RepoEvent, SignedSpoolOwnerGenesis, StateContextEntry, StateId, SubscribeRepoEventsRequest,
+        TransferCheckpoint, TransportMode, UpdateGrantRequest, UpdateSpoolRequest,
+        get_context_history_response, list_context_response, list_discussions_response,
+        list_refs_response, list_threads_response, pull_server_frame, push_client_frame,
+        push_server_frame,
     },
     method_descriptor,
 };
@@ -48,6 +50,10 @@ const GET_CURRENT_USER_SPOOL_METHOD: &str =
     "/heddle.api.v1alpha1.RegistryService/GetCurrentUserSpool";
 const GET_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/GetSpool";
 const PROMOTE_SPOOL_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/PromoteSpool";
+const CREATE_GRANT_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/CreateGrant";
+const LIST_GRANTS_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/ListGrants";
+const UPDATE_GRANT_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/UpdateGrant";
+const DELETE_GRANT_METHOD: &str = "/heddle.api.v1alpha1.RegistryService/DeleteGrant";
 const GET_DISCUSSION_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/GetDiscussion";
 const LIST_BY_STATE_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/ListByState";
 const LIST_CONTEXT_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/ListContext";
@@ -312,6 +318,11 @@ struct BlobFixture {
     requested: Arc<Mutex<Vec<String>>>,
 }
 
+#[derive(Clone, Default)]
+struct GrantStore {
+    grants: Arc<Mutex<Vec<HostedGrant>>>,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn start_inner(
     pull: Option<PullFixture>,
@@ -332,6 +343,7 @@ async fn start_inner(
         .await
         .unwrap();
     let server_addr = server.addr();
+    let grants = GrantStore::default();
     let server_task = tokio::spawn(async move {
         let connection = server
             .accept()
@@ -351,6 +363,7 @@ async fn start_inner(
                 context.clone(),
                 collaboration.clone(),
                 registry.clone(),
+                grants.clone(),
             ));
         }
         server.close().await;
@@ -384,6 +397,7 @@ async fn serve_call(
     context: Option<ContextFixture>,
     collaboration: Option<CollaborationFixture>,
     registry: Option<RegistryFixture>,
+    grants: GrantStore,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -412,6 +426,14 @@ async fn serve_call(
                 serve_get_spool(&mut send, &mut recv, &mut request, registry).await;
             } else if method == PROMOTE_SPOOL_METHOD {
                 serve_promote_spool(&mut send, &mut recv, &mut request, registry).await;
+            } else if method == CREATE_GRANT_METHOD {
+                serve_create_grant(&mut send, &mut recv, &mut request, &grants).await;
+            } else if method == LIST_GRANTS_METHOD {
+                serve_list_grants(&mut send, &mut recv, &mut request, &grants).await;
+            } else if method == UPDATE_GRANT_METHOD {
+                serve_update_grant(&mut send, &mut recv, &mut request, &grants).await;
+            } else if method == DELETE_GRANT_METHOD {
+                serve_delete_grant(&mut send, &mut recv, &mut request, &grants).await;
             } else if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
                 serve_get_blob(&mut send, &mut recv, &mut request, blobs).await;
             } else if method == GET_DISCUSSION_METHOD {
@@ -719,6 +741,170 @@ async fn serve_get_spool(
     ))
     .await
     .unwrap();
+}
+
+async fn serve_create_grant(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    grants: &GrantStore,
+) {
+    read_request_body(recv, request).await;
+    let body = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| CreateGrantRequest::decode(frame.body).ok());
+    let Some(body) = body else {
+        send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+            .await
+            .unwrap();
+        return;
+    };
+    let grant = HostedGrant {
+        subject: body.subject,
+        role: body.role,
+        target: body.target,
+        ..HostedGrant::default()
+    };
+    upsert_grant(grants, grant.clone());
+    send.write_chunk(Bytes::from(
+        encode_success_response(&grant.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_list_grants(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    grants: &GrantStore,
+) {
+    read_request_body(recv, request).await;
+    let resource = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| ListGrantsRequest::decode(frame.body).ok())
+        .map(|body| body.resource)
+        .unwrap_or_default();
+    let stored = grants
+        .grants
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .clone();
+    let listed: Vec<HostedGrant> = stored
+        .into_iter()
+        .filter(|grant| grant_matches_resource(grant, &resource))
+        .collect();
+    let response = ListGrantsResponse {
+        grants: listed,
+        ..ListGrantsResponse::default()
+    };
+    send.write_chunk(Bytes::from(
+        encode_success_response(&response.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_update_grant(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    grants: &GrantStore,
+) {
+    read_request_body(recv, request).await;
+    let body = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| UpdateGrantRequest::decode(frame.body).ok());
+    let Some(body) = body else {
+        send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+            .await
+            .unwrap();
+        return;
+    };
+    let grant = HostedGrant {
+        subject: body.subject,
+        role: body.role,
+        target: body.target,
+        ..HostedGrant::default()
+    };
+    upsert_grant(grants, grant.clone());
+    send.write_chunk(Bytes::from(
+        encode_success_response(&grant.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
+}
+
+async fn serve_delete_grant(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    grants: &GrantStore,
+) {
+    read_request_body(recv, request).await;
+    let body = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| DeleteGrantRequest::decode(frame.body).ok());
+    if let Some(body) = body {
+        let key = grant_identity_key(&body.subject, body.target.as_ref());
+        grants
+            .grants
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .retain(|grant| grant_identity_key(&grant.subject, grant.target.as_ref()) != key);
+    }
+    send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+        .await
+        .unwrap();
+}
+
+fn upsert_grant(store: &GrantStore, grant: HostedGrant) {
+    let key = grant_identity_key(&grant.subject, grant.target.as_ref());
+    let mut grants = store
+        .grants
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    if let Some(existing) = grants
+        .iter_mut()
+        .find(|row| grant_identity_key(&row.subject, row.target.as_ref()) == key)
+    {
+        *existing = grant;
+    } else {
+        grants.push(grant);
+    }
+}
+
+fn grant_identity_key(subject: &str, target: Option<&GrantTargetRef>) -> (String, String, String) {
+    let (namespace, repo) = grant_target_paths(target);
+    (
+        subject.to_string(),
+        namespace.unwrap_or_default(),
+        repo.unwrap_or_default(),
+    )
+}
+
+fn grant_target_paths(target: Option<&GrantTargetRef>) -> (Option<String>, Option<String>) {
+    use api::heddle::api::v1alpha1::grant_target_ref::Target;
+    match target.and_then(|target| target.target.clone()) {
+        Some(Target::NamespacePath(path)) if !path.is_empty() => (Some(path), None),
+        Some(Target::RepoPath(repository)) => (
+            None,
+            super::helpers::repository_ref_path(&repository).map(ToOwned::to_owned),
+        ),
+        _ => (None, None),
+    }
+}
+
+fn grant_matches_resource(grant: &HostedGrant, resource: &str) -> bool {
+    if resource.is_empty() {
+        return true;
+    }
+    let (namespace, repo) = grant_target_paths(grant.target.as_ref());
+    let path = resource
+        .strip_prefix("repo:")
+        .or_else(|| resource.strip_prefix("ns:"))
+        .unwrap_or(resource);
+    repo.as_deref() == Some(path) || namespace.as_deref() == Some(path)
 }
 
 async fn serve_promote_spool(

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -373,9 +373,12 @@ impl HostedClient {
         role: &str,
         namespace_path: Option<&str>,
         repo_path: Option<&str>,
+        client_operation_id: impl Into<String>,
     ) -> Result<wire::HostedGrantInfo, ProtocolError> {
-        let operation_id =
-            ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/CreateGrant");
+        let operation_id = ClientOperationId::caller_or_fresh(
+            "heddle.api.v1alpha1.RegistryService/CreateGrant",
+            client_operation_id,
+        );
         let target = build_target_ref(namespace_path, repo_path)?;
         let grant = authed_call!(
             self,
@@ -412,9 +415,12 @@ impl HostedClient {
         role: &str,
         namespace_path: Option<&str>,
         repo_path: Option<&str>,
+        client_operation_id: impl Into<String>,
     ) -> Result<wire::HostedGrantInfo, ProtocolError> {
-        let operation_id =
-            ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/UpdateGrant");
+        let operation_id = ClientOperationId::caller_or_fresh(
+            "heddle.api.v1alpha1.RegistryService/UpdateGrant",
+            client_operation_id,
+        );
         let target = build_target_ref(namespace_path, repo_path)?;
         let grant = authed_call!(
             self,
@@ -435,9 +441,12 @@ impl HostedClient {
         subject: &str,
         namespace_path: Option<&str>,
         repo_path: Option<&str>,
+        client_operation_id: impl Into<String>,
     ) -> Result<(), ProtocolError> {
-        let operation_id =
-            ClientOperationId::fresh("heddle.api.v1alpha1.RegistryService/DeleteGrant");
+        let operation_id = ClientOperationId::caller_or_fresh(
+            "heddle.api.v1alpha1.RegistryService/DeleteGrant",
+            client_operation_id,
+        );
         let target = build_target_ref(namespace_path, repo_path)?;
         authed_call!(
             self,
@@ -699,12 +708,12 @@ fn parse_hosted_role_arg(
     use api::heddle::api::v1alpha1::HostedRole;
     match value.trim().to_ascii_lowercase().as_str() {
         "reader" => Ok(HostedRole::Reader),
-        "developer" => Ok(HostedRole::Developer),
+        "contributor" | "developer" => Ok(HostedRole::Developer),
         "maintainer" => Ok(HostedRole::Maintainer),
         "admin" => Ok(HostedRole::Admin),
         "owner" => Ok(HostedRole::Owner),
         other => Err(ProtocolError::InvalidState(format!(
-            "invalid role '{other}': expected reader|developer|maintainer|admin|owner"
+            "invalid role '{other}': expected reader|contributor|developer|maintainer|admin|owner"
         ))),
     }
 }
@@ -792,20 +801,17 @@ mod tests {
             .await;
         client.delete_repository("acme/widgets-new").await.unwrap();
         let _ = client
-            .create_grant("principal:alice", "reader", None, Some("acme/widgets"))
+            .create_grant("principal:alice", "reader", None, Some("acme/widgets"), "")
             .await;
-        assert!(
-            client
-                .list_grants(Some("repo:acme/widgets"))
-                .await
-                .unwrap()
-                .is_empty()
-        );
+        let listed = client.list_grants(Some("repo:acme/widgets")).await.unwrap();
+        assert!(listed.iter().any(|grant| grant.subject == "principal:alice"
+            && grant.role == "reader"
+            && grant.repo_path.as_deref() == Some("acme/widgets")));
         let _ = client
-            .update_grant("principal:alice", "maintainer", Some("acme"), None)
+            .update_grant("principal:alice", "maintainer", Some("acme"), None, "")
             .await;
         client
-            .delete_grant("principal:alice", Some("acme"), None)
+            .delete_grant("principal:alice", Some("acme"), None, "")
             .await
             .unwrap();
         client
@@ -876,6 +882,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn spool_grant_create_list_delete_round_trip() {
+        let _home = IsolatedHeddleHome::new();
+        let (mut client, server) = crate::hosted_runtime::hosted::test_server::start().await;
+
+        let created = client
+            .create_grant(
+                "alice",
+                "contributor",
+                None,
+                Some("spool/willow-ibis-8e7264/notes"),
+                "grant-create-op",
+            )
+            .await
+            .expect("CreateGrant should persist the collaborator");
+        assert_eq!(created.subject, "alice");
+        assert_eq!(created.role, "developer");
+        assert_eq!(
+            created.repo_path.as_deref(),
+            Some("spool/willow-ibis-8e7264/notes")
+        );
+
+        let listed = client
+            .list_grants(Some("repo:spool/willow-ibis-8e7264/notes"))
+            .await
+            .expect("ListGrants should show the created grant");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].subject, "alice");
+        assert_eq!(listed[0].role, "developer");
+        assert_eq!(
+            listed[0].repo_path.as_deref(),
+            Some("spool/willow-ibis-8e7264/notes")
+        );
+
+        client
+            .delete_grant(
+                "alice",
+                None,
+                Some("spool/willow-ibis-8e7264/notes"),
+                "grant-delete-op",
+            )
+            .await
+            .expect("DeleteGrant should remove the collaborator");
+
+        let after_delete = client
+            .list_grants(Some("repo:spool/willow-ibis-8e7264/notes"))
+            .await
+            .expect("ListGrants after delete");
+        assert!(
+            after_delete.is_empty(),
+            "deleted grant must not remain in ListGrants: {after_delete:?}"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn namespace_and_repository_mutations_use_spool_requests() {
         let (mut client, server, captured) =
             crate::hosted_runtime::hosted::test_server::start_recording_spool_mutations().await;
@@ -921,6 +984,10 @@ mod tests {
     #[test]
     fn parse_hosted_role_arg_accepts_every_role_and_rejects_unknown() {
         assert_eq!(parse_hosted_role_arg("reader").unwrap(), HostedRole::Reader);
+        assert_eq!(
+            parse_hosted_role_arg("contributor").unwrap(),
+            HostedRole::Developer
+        );
         assert_eq!(
             parse_hosted_role_arg(" Developer ").unwrap(),
             HostedRole::Developer

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2078,6 +2078,65 @@ before this root.
 
 ---
 
+## `heddle grant create --output json`
+
+Grant a principal a role on a hosted spool. Separate from `heddle auth invite`,
+which is signup-only.
+
+```json
+{
+  "output_kind": "grant_create",
+  "id": "alice",
+  "principal": "alice",
+  "role": "developer",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "recommended_action": "heddle grant list --spool spool/willow-ibis-8e7264/notes"
+}
+```
+
+`id` is the principal, the same token `heddle grant delete <id> --spool …`
+accepts. `contributor` on the CLI is stored as the `developer` role.
+
+---
+
+## `heddle grant list --output json`
+
+```json
+{
+  "output_kind": "grant_list",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "grants": [
+    {
+      "id": "alice",
+      "principal": "alice",
+      "role": "developer",
+      "spool": "spool/willow-ibis-8e7264/notes"
+    }
+  ],
+  "recommended_action": null
+}
+```
+
+---
+
+## `heddle grant delete --output json`
+
+```json
+{
+  "output_kind": "grant_delete",
+  "id": "alice",
+  "principal": "alice",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "deleted": true,
+  "recommended_action": "heddle grant list --spool spool/willow-ibis-8e7264/notes"
+}
+```
+
+---
+
 ## `heddle auth create-service-token --output json`
 
 ```json

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6044,6 +6044,65 @@ before this root.
 
 ---
 
+## `heddle grant create --output json`
+
+Grant a principal a role on a hosted spool. Separate from `heddle auth invite`,
+which is signup-only.
+
+```json
+{
+  "output_kind": "grant_create",
+  "id": "alice",
+  "principal": "alice",
+  "role": "developer",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "recommended_action": "heddle grant list --spool spool/willow-ibis-8e7264/notes"
+}
+```
+
+`id` is the principal, the same token `heddle grant delete <id> --spool …`
+accepts. `contributor` on the CLI is stored as the `developer` role.
+
+---
+
+## `heddle grant list --output json`
+
+```json
+{
+  "output_kind": "grant_list",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "grants": [
+    {
+      "id": "alice",
+      "principal": "alice",
+      "role": "developer",
+      "spool": "spool/willow-ibis-8e7264/notes"
+    }
+  ],
+  "recommended_action": null
+}
+```
+
+---
+
+## `heddle grant delete --output json`
+
+```json
+{
+  "output_kind": "grant_delete",
+  "id": "alice",
+  "principal": "alice",
+  "spool": "spool/willow-ibis-8e7264/notes",
+  "server": "api.preview.heddle.sh",
+  "deleted": true,
+  "recommended_action": "heddle grant list --spool spool/willow-ibis-8e7264/notes"
+}
+```
+
+---
+
 ## `heddle auth create-service-token --output json`
 
 ```json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `heddle grant create|list|delete` so a spool owner can grant another principal access from the everyday CLI.
- Wire through existing RegistryService `CreateGrant` / `ListGrants` / `DeleteGrant` RPCs in hosted-client. No new RPCs.
- Keep `heddle auth invite` signup-only; its help now points collaborators at `heddle grant`.

`--spool` accepts `spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL. `--role contributor` is the everyday alias for proto `developer`. Delete `ID` is the principal shown by `grant list` (HostedGrant has no server id), so `--spool` is required.

## Closes

Closes HeddleCo/heddle#1732

## Red commit

N/A — clap, CLI, catalog, and the hosted-client create→list→delete contract test landed together. The mock previously dropped grants; `GrantStore` is what makes the round-trip assertible.

## Test evidence

Tip `f8b9910c` (rebased on current `main` / `c7aef371`).

`fast-check` on `d4c0d1ee` failed because `docs/llms-full.txt` was stale after the grant JSON samples. Regenerated with `cargo run -p heddle-docsgen`; `committed_corpus_is_fresh` now passes.

```
cargo test -p heddle-cli-args --features client --lib grant_
test grant_create_parses_spool_principal_and_contributor_role ... ok
test grant_list_and_delete_parse ... ok

cargo test -p heddle-hosted-client --features client --lib -- spool_grant_create_list_delete parse_hosted_role_arg administration_facade_builds
test parse_hosted_role_arg_accepts_every_role_and_rejects_unknown ... ok
test spool_grant_create_list_delete_round_trip ... ok
test administration_facade_builds_and_dispatches_every_native_request ... ok

cargo test -p heddle-cli --lib cli::commands::grant
test result: ok. 5 passed

cargo test -p heddle-cli --test grant
test auth_invite_help_stays_signup_only ... ok
test grant_help_exposes_create_list_delete_and_stays_off_signup_invite ... ok

cargo test -p heddle-docsgen --lib committed_corpus_is_fresh
test tests::committed_corpus_is_fresh ... ok
```

## Manual verification

N/A — covered by clap parse tests, help integration tests (`crates/cli/tests/grant.rs`), and the hosted-client grant round-trip.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75319102-cc27-4b28-afb1-5c3645fe4fc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75319102-cc27-4b28-afb1-5c3645fe4fc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606019&installation_model_id=21489&pr_number=1736&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1736&signature=63b733d857f69dd71e9e5ac6fde488d43a0d90adeb159825aec12223fabd92da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->