### PR TITLE
Agent-driven grant create at writer or below; refuse maintainer/admin/owner

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -51,7 +51,10 @@ heddle auth derive-agent \
 ```
 
 Without `--allow`, the command installs the curated safe set: push/pull,
-repository reads, context operations, discussions, and `WhoAmI`. Repeating
+repository reads, context operations, discussions, `WhoAmI`, and collaborator
+grants at writer or below (`ListGrants` / `CreateGrant` / `DeleteGrant`).
+Admin and owner grants stay human-verified even when those RPCs are allowed.
+Repeating
 `--allow` selects a subset; it cannot opt into an unsafe method. Every derived
 block independently applies the mandatory deny policy in
 [`device_flow.rs`](../crates/client/src/device_flow.rs). That policy rejects

--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -53,7 +53,8 @@ heddle auth derive-agent \
 Without `--allow`, the command installs the curated safe set: push/pull,
 repository reads, context operations, discussions, `WhoAmI`, and collaborator
 grants at writer or below (`ListGrants` / `CreateGrant` / `DeleteGrant`).
-Admin and owner grants stay human-verified even when those RPCs are allowed.
+Maintainer, admin, and owner grants stay human-verified even when those RPCs
+are allowed.
 Repeating
 `--allow` selects a subset; it cannot opt into an unsafe method. Every derived
 block independently applies the mandatory deny policy in

--- a/.agents/skills/heddle/SKILL.md
+++ b/.agents/skills/heddle/SKILL.md
@@ -218,10 +218,11 @@ heddle auth derive-agent \
 ```
 
 - Without `--allow`, a curated safe set is installed (push/pull, repo reads,
-  context, discussions, `WhoAmI`). Repeating `--allow` selects a **subset**; it
-  cannot opt into an unsafe method. A mandatory deny policy always rejects
-  credential issuance, auth-trust mutation, recovery enrollment, and repo/
-  namespace deletion.
+  context, discussions, `WhoAmI`, and writer-or-below collaborator grants).
+  Repeating `--allow` selects a **subset**; it cannot opt into an unsafe method.
+  A mandatory deny policy always rejects credential issuance, auth-trust
+  mutation, recovery enrollment, and repo/namespace deletion. Admin and owner
+  grants stay human-verified even when `CreateGrant` is allowed.
 - By default the child **replaces** the active stored credential for `--server`.
   Use `--out <DIR>` to write a portable 0600 bundle (`token`, `device-key.pem`,
   `metadata.json`) for handing to another process. Token-only `--stdout` export

--- a/.agents/skills/heddle/SKILL.md
+++ b/.agents/skills/heddle/SKILL.md
@@ -221,8 +221,8 @@ heddle auth derive-agent \
   context, discussions, `WhoAmI`, and writer-or-below collaborator grants).
   Repeating `--allow` selects a **subset**; it cannot opt into an unsafe method.
   A mandatory deny policy always rejects credential issuance, auth-trust
-  mutation, recovery enrollment, and repo/namespace deletion. Admin and owner
-  grants stay human-verified even when `CreateGrant` is allowed.
+  mutation, recovery enrollment, and repo/namespace deletion. Maintainer, admin,
+  and owner grants stay human-verified even when `CreateGrant` is allowed.
 - By default the child **replaces** the active stored credential for `--server`.
   Use `--out <DIR>` to write a portable 0600 bundle (`token`, `device-key.pem`,
   `metadata.json`) for handing to another process. Token-only `--stdout` export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 ### Changed
 
 - **Agent-driven `heddle grant` at writer or below.** Attenuated / derive-agent
-  sessions may create and delete `reader`, `contributor` (developer), and
-  `maintainer` grants without WebAuthn. Admin and owner still require human
+  sessions may create and delete `reader` and `contributor` (developer) grants
+  without WebAuthn. Maintainer, admin, and owner still require human
   verification; the CLI refuses those roles locally when the bearer is a
-  detectable agent session (heddle#1738). Help states the ceiling. Derive-agent
-  children now include `ListGrants` / `CreateGrant` / `DeleteGrant` in the safe
-  operation set.
+  detectable agent session (heddle#1738 / weft#2119). Help states the ceiling.
+  Derive-agent children now include `ListGrants` / `CreateGrant` / `DeleteGrant`
+  in the safe operation set.
 
 - **heddle 0.23.0 on heddle-api 0.30.0 and capability-verifier 0.19.0.**
   Native bootstrap consumes the canonical `heddle_api::descriptor_trust`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Changed
 
+- **Agent-driven `heddle grant` at writer or below.** Attenuated / derive-agent
+  sessions may create and delete `reader`, `contributor` (developer), and
+  `maintainer` grants without WebAuthn. Admin and owner still require human
+  verification; the CLI refuses those roles locally when the bearer is a
+  detectable agent session (heddle#1738). Help states the ceiling. Derive-agent
+  children now include `ListGrants` / `CreateGrant` / `DeleteGrant` in the safe
+  operation set.
+
 - **heddle 0.23.0 on heddle-api 0.30.0 and capability-verifier 0.19.0.**
   Native bootstrap consumes the canonical `heddle_api::descriptor_trust`
   contract (set version 1, two-layer root attestation + signed

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -269,6 +269,17 @@ impl GrantRoleArg {
             Self::Owner => "owner",
         }
     }
+
+    /// Hosted role ordinal used for the agent grant ceiling.
+    pub fn as_grant_role(self) -> repo::GrantRole {
+        match self {
+            Self::Reader => repo::GrantRole::Reader,
+            Self::Contributor | Self::Developer => repo::GrantRole::Developer,
+            Self::Maintainer => repo::GrantRole::Maintainer,
+            Self::Admin => repo::GrantRole::Admin,
+            Self::Owner => repo::GrantRole::Owner,
+        }
+    }
 }
 
 /// Grant another principal access to a hosted spool.
@@ -282,6 +293,10 @@ Adds a collaborator to an existing hosted spool. This is not a signup
 invite — `heddle auth invite` only creates an account-creation code.
 
 Roles: reader, contributor (developer), maintainer, admin, owner.
+
+Agent sessions may grant writer or below (reader, contributor,
+maintainer) without human verification. Admin and owner stay
+human-verified and are refused for derive-agent / attenuated sessions.
 
 Examples:
   heddle grant create --spool spool/willow-ibis-8e7264/notes --principal alice --role contributor
@@ -299,6 +314,9 @@ Examples:
 
     /// Remove a grant. `ID` is the principal shown by `heddle grant list`.
     #[command(after_help = "\
+Agents may delete writer-or-below grants without human verification.
+Deleting an admin or owner grant still requires a human-verified session.
+
 Examples:
   heddle grant delete alice --spool spool/willow-ibis-8e7264/notes
 ")]
@@ -746,6 +764,11 @@ mod tests {
         assert_eq!(args.principal, "alice");
         assert_eq!(args.role, GrantRoleArg::Contributor);
         assert_eq!(args.role.as_hosted_role_name(), "developer");
+        assert!(args.role.as_grant_role().agent_may_grant());
+        assert!(GrantRoleArg::Reader.as_grant_role().agent_may_grant());
+        assert!(GrantRoleArg::Maintainer.as_grant_role().agent_may_grant());
+        assert!(!GrantRoleArg::Admin.as_grant_role().agent_may_grant());
+        assert!(!GrantRoleArg::Owner.as_grant_role().agent_may_grant());
         assert_eq!(args.server.as_deref(), Some("api.preview.heddle.sh"));
     }
 

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -294,8 +294,8 @@ invite — `heddle auth invite` only creates an account-creation code.
 
 Roles: reader, contributor (developer), maintainer, admin, owner.
 
-Agent sessions may grant writer or below (reader, contributor,
-maintainer) without human verification. Admin and owner stay
+Agent sessions may grant writer or below (reader, contributor)
+without human verification. Maintainer, admin, and owner stay
 human-verified and are refused for derive-agent / attenuated sessions.
 
 Examples:
@@ -315,7 +315,7 @@ Examples:
     /// Remove a grant. `ID` is the principal shown by `heddle grant list`.
     #[command(after_help = "\
 Agents may delete writer-or-below grants without human verification.
-Deleting an admin or owner grant still requires a human-verified session.
+Deleting a maintainer, admin, or owner grant still requires a human-verified session.
 
 Examples:
   heddle grant delete alice --spool spool/willow-ibis-8e7264/notes
@@ -766,7 +766,7 @@ mod tests {
         assert_eq!(args.role.as_hosted_role_name(), "developer");
         assert!(args.role.as_grant_role().agent_may_grant());
         assert!(GrantRoleArg::Reader.as_grant_role().agent_may_grant());
-        assert!(GrantRoleArg::Maintainer.as_grant_role().agent_may_grant());
+        assert!(!GrantRoleArg::Maintainer.as_grant_role().agent_may_grant());
         assert!(!GrantRoleArg::Admin.as_grant_role().agent_may_grant());
         assert!(!GrantRoleArg::Owner.as_grant_role().agent_may_grant());
         assert_eq!(args.server.as_deref(), Some("api.preview.heddle.sh"));

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -397,6 +397,7 @@ secrets. `heddle visibility` embargoes a state and its descendants;
     ///
     /// Separate from `heddle auth invite`, which is signup-only. Create,
     /// list, and delete collaborator grants on a spool you can administer.
+    /// Agents may grant writer or below; admin and owner stay human-verified.
     #[cfg(feature = "client")]
     Grant {
         #[command(subcommand)]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -397,7 +397,7 @@ secrets. `heddle visibility` embargoes a state and its descendants;
     ///
     /// Separate from `heddle auth invite`, which is signup-only. Create,
     /// list, and delete collaborator grants on a spool you can administer.
-    /// Agents may grant writer or below; admin and owner stay human-verified.
+    /// Agents may grant writer or below; maintainer, admin, and owner stay human-verified.
     #[cfg(feature = "client")]
     Grant {
         #[command(subcommand)]

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1273,6 +1273,41 @@ impl RecoveryAdvice {
     }
 
     #[cfg(feature = "client")]
+    pub fn grant_agent_ceiling(spool: &str, role: &str) -> Self {
+        Self::safety_refusal(
+            "grant_agent_ceiling",
+            format!(
+                "Cannot grant '{role}' on '{spool}': agent sessions cannot grant admin or owner"
+            ),
+            "Grant reader, contributor, or maintainer from this session. Admin and owner require a human-verified session (Tapestry or an unattenuated owner credential).",
+            "the active credential is an attenuated agent session and the requested role is above writer",
+            "no collaborator grant was created",
+            "hosted grants and local checkouts were left unchanged",
+            format!("heddle grant create --spool {spool} --principal <handle> --role contributor"),
+            vec![
+                format!(
+                    "heddle grant create --spool {spool} --principal <handle> --role contributor"
+                ),
+                "heddle whoami".to_string(),
+            ],
+        )
+    }
+
+    #[cfg(feature = "client")]
+    pub fn grant_needs_human(spool: &str) -> Self {
+        Self::safety_refusal(
+            "grant_needs_human",
+            format!("Cannot manage grants on '{spool}': human verification required"),
+            "Admin and owner grants require a human-verified session. Agent sessions may grant writer or below (reader, contributor, maintainer) without WebAuthn.",
+            "the server demanded human verification for this grant write",
+            "no collaborator grant was created or removed",
+            "hosted grants and local checkouts were left unchanged",
+            "heddle whoami".to_string(),
+            vec!["heddle whoami".to_string()],
+        )
+    }
+
+    #[cfg(feature = "client")]
     pub fn grant_not_found(spool: &str) -> Self {
         Self::safety_refusal(
             "grant_not_found",

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1277,9 +1277,9 @@ impl RecoveryAdvice {
         Self::safety_refusal(
             "grant_agent_ceiling",
             format!(
-                "Cannot grant '{role}' on '{spool}': agent sessions cannot grant admin or owner"
+                "Cannot grant '{role}' on '{spool}': agent sessions cannot grant maintainer, admin, or owner"
             ),
-            "Grant reader, contributor, or maintainer from this session. Admin and owner require a human-verified session (Tapestry or an unattenuated owner credential).",
+            "Grant reader or contributor from this session. Maintainer, admin, and owner require a human-verified session (Tapestry or an unattenuated owner credential).",
             "the active credential is an attenuated agent session and the requested role is above writer",
             "no collaborator grant was created",
             "hosted grants and local checkouts were left unchanged",
@@ -1298,7 +1298,7 @@ impl RecoveryAdvice {
         Self::safety_refusal(
             "grant_needs_human",
             format!("Cannot manage grants on '{spool}': human verification required"),
-            "Admin and owner grants require a human-verified session. Agent sessions may grant writer or below (reader, contributor, maintainer) without WebAuthn.",
+            "Maintainer, admin, and owner grants require a human-verified session. Agent sessions may grant writer or below (reader, contributor) without WebAuthn.",
             "the server demanded human verification for this grant write",
             "no collaborator grant was created or removed",
             "hosted grants and local checkouts were left unchanged",

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1259,6 +1259,16 @@ impl RecoveryAdvice {
     }
 
     #[cfg(feature = "client")]
+    pub fn grant_spool_required() -> Self {
+        Self::invalid_usage(
+            "grant_spool_required",
+            "hosted grant URL must include a spool path, e.g. https://api.heddle.sh/spool/<handle>/<name>",
+            "Pass `--spool spool/<handle>/<name>` or a hosted URL that includes the spool path.",
+            "heddle grant list --spool spool/<handle>/<name>",
+        )
+    }
+
+    #[cfg(feature = "client")]
     pub fn grant_denied(spool: &str) -> Self {
         Self::safety_refusal(
             "grant_denied",

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1638,7 +1638,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
                     ),
                     (
                         77,
-                        "not permitted to grant on this spool, or agent cannot grant admin/owner",
+                        "not permitted to grant on this spool, or agent cannot grant maintainer/admin/owner",
                     ),
                     (78, "not authenticated or spool path missing"),
                 ],

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1636,7 +1636,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
                         76,
                         "server rejected the grant; do not retry without changing inputs",
                     ),
-                    (77, "not permitted to grant on this spool"),
+                    (
+                        77,
+                        "not permitted to grant on this spool, or agent cannot grant admin/owner",
+                    ),
                     (78, "not authenticated or spool path missing"),
                 ],
             ),

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -250,9 +250,7 @@ fn resolve_grant_spool(spool: &str, server: Option<&str>) -> Result<(String, Str
                 return Ok((authority, full_path));
             }
             Ok(_) | Err(_) => {
-                return Err(anyhow!(
-                    "hosted grant URL must include a spool path, e.g. https://api.heddle.sh/spool/<handle>/<name>"
-                ));
+                return Err(anyhow!(RecoveryAdvice::grant_spool_required()));
             }
         }
     }
@@ -321,6 +319,16 @@ mod tests {
         .expect("parse url");
         assert_eq!(server, "api.preview.heddle.sh");
         assert_eq!(path, "spool/willow-ibis-8e7264/notes");
+    }
+
+    #[test]
+    fn hosted_url_without_spool_path_is_typed_usage() {
+        let err = resolve_grant_spool("https://api.preview.heddle.sh/", None)
+            .expect_err("URL without a spool path");
+        let advice = err
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "grant_spool_required");
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -273,10 +273,10 @@ fn map_grant_error(spool: &str, err: &ProtocolError) -> anyhow::Error {
         _ => "",
     };
     let lower = message.to_ascii_lowercase();
-    let advice = if is_human_verification_required(&lower) {
-        RecoveryAdvice::grant_needs_human(spool)
-    } else if lower.contains("cannot grant admin or owner") {
+    let advice = if lower.contains("cannot grant admin or owner") {
         RecoveryAdvice::grant_agent_ceiling(spool, "admin or owner")
+    } else if is_human_verification_required(&lower) {
+        RecoveryAdvice::grant_needs_human(spool)
     } else if matches!(
         err,
         ProtocolError::AuthorizationFailed(_) | ProtocolError::AuthenticationFailed(_)

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -273,8 +273,10 @@ fn map_grant_error(spool: &str, err: &ProtocolError) -> anyhow::Error {
         _ => "",
     };
     let lower = message.to_ascii_lowercase();
-    let advice = if lower.contains("cannot grant admin or owner") {
-        RecoveryAdvice::grant_agent_ceiling(spool, "admin or owner")
+    let advice = if lower.contains("cannot grant maintainer, admin, or owner")
+        || lower.contains("cannot grant admin or owner")
+    {
+        RecoveryAdvice::grant_agent_ceiling(spool, "maintainer, admin, or owner")
     } else if is_human_verification_required(&lower) {
         RecoveryAdvice::grant_needs_human(spool)
     } else if matches!(
@@ -376,7 +378,7 @@ mod tests {
     #[test]
     fn agent_admin_refuse_from_the_hosted_client_is_the_ceiling() {
         let err = ProtocolError::AuthorizationFailed(
-            "agent sessions cannot grant admin or owner; those roles require human verification"
+            "agent sessions cannot grant maintainer, admin, or owner; those roles require human verification"
                 .into(),
         );
         let mapped = map_grant_error("spool/alice/notes", &err);

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -7,8 +7,13 @@ use heddle_cli_contract::cli::commands::wire::auth::{
 };
 use hosted_client::hosted_runtime::{
     auth::resolve_server,
-    hosted::{HostedAuthMode, HostedClient, HostedSession, canonicalize_spool_path},
+    hosted::{
+        HostedAuthMode, HostedClient, HostedSession, canonicalize_spool_path,
+        resolve_hosted_credential,
+    },
+    refuse_agent_privileged_grant,
 };
+use repo::GrantRole;
 use wire::{HostedGrantInfo, ProtocolError};
 
 use super::{
@@ -34,6 +39,7 @@ pub async fn cmd_grant(cli: &Cli, command: GrantCommands) -> Result<()> {
 
 async fn cmd_grant_create(cli: &Cli, args: GrantCreateArgs) -> Result<()> {
     let (server, spool) = resolve_grant_spool(&args.spool, args.server.as_deref())?;
+    refuse_privileged_agent_grant(&server, &spool, args.role.as_grant_role())?;
     let mut session = hosted_connect(&server).await?;
     let result = create_connected(
         cli,
@@ -74,7 +80,37 @@ async fn hosted_connect(server: &str) -> Result<HostedClient> {
     session
         .connect(server)
         .await
+        .map(|client| {
+            client.with_human_signature_callback(
+                hosted_client::client::headless_human_signature_callback(),
+            )
+        })
         .map_err(|err| map_grant_error("", &err))
+}
+
+fn refuse_privileged_agent_grant(server: &str, spool: &str, role: GrantRole) -> Result<()> {
+    let resolved = resolve_hosted_credential(Some(server))?;
+    let Some(token) = resolved.token.as_ref() else {
+        return Ok(());
+    };
+    if refuse_agent_privileged_grant(&token.id, role) {
+        return Err(anyhow!(RecoveryAdvice::grant_agent_ceiling(
+            spool,
+            role_display_name(role)
+        )));
+    }
+    Ok(())
+}
+
+fn role_display_name(role: GrantRole) -> &'static str {
+    match role {
+        GrantRole::Reader => "reader",
+        GrantRole::Developer => "contributor",
+        GrantRole::Maintainer => "maintainer",
+        GrantRole::Admin => "admin",
+        GrantRole::Owner => "owner",
+        GrantRole::Unspecified => "unspecified",
+    }
 }
 
 async fn create_connected(
@@ -237,7 +273,11 @@ fn map_grant_error(spool: &str, err: &ProtocolError) -> anyhow::Error {
         _ => "",
     };
     let lower = message.to_ascii_lowercase();
-    let advice = if matches!(
+    let advice = if is_human_verification_required(&lower) {
+        RecoveryAdvice::grant_needs_human(spool)
+    } else if lower.contains("cannot grant admin or owner") {
+        RecoveryAdvice::grant_agent_ceiling(spool, "admin or owner")
+    } else if matches!(
         err,
         ProtocolError::AuthorizationFailed(_) | ProtocolError::AuthenticationFailed(_)
     ) || lower.contains("permission")
@@ -258,11 +298,17 @@ fn map_grant_error(spool: &str, err: &ProtocolError) -> anyhow::Error {
     anyhow!(advice)
 }
 
+fn is_human_verification_required(lowered_message: &str) -> bool {
+    lowered_message.contains("user verification required")
+        || lowered_message.contains("human verification")
+        || lowered_message.contains("webauthn")
+}
+
 #[cfg(test)]
 mod tests {
     use wire::ProtocolError;
 
-    use super::{grant_row, map_grant_error, resolve_grant_spool};
+    use super::{grant_row, is_human_verification_required, map_grant_error, resolve_grant_spool};
 
     #[test]
     fn url_target_takes_host_and_canonical_path() {
@@ -309,6 +355,35 @@ mod tests {
             .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
             .expect("advice");
         assert_eq!(advice.kind, "grant_denied");
+    }
+
+    #[test]
+    fn human_verification_is_not_swallowed_as_a_generic_failure() {
+        assert!(is_human_verification_required(
+            "user verification required for /heddle.api.v1alpha1.RegistryService/CreateGrant"
+        ));
+        let err = ProtocolError::AuthorizationFailed(
+            "user verification required for CreateGrant: use a client with a WebAuthn authenticator"
+                .into(),
+        );
+        let mapped = map_grant_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "grant_needs_human");
+    }
+
+    #[test]
+    fn agent_admin_refuse_from_the_hosted_client_is_the_ceiling() {
+        let err = ProtocolError::AuthorizationFailed(
+            "agent sessions cannot grant admin or owner; those roles require human verification"
+                .into(),
+        );
+        let mapped = map_grant_error("spool/alice/notes", &err);
+        let advice = mapped
+            .downcast_ref::<crate::cli::commands::RecoveryAdvice>()
+            .expect("advice");
+        assert_eq!(advice.kind, "grant_agent_ceiling");
     }
 
     #[test]

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -138,10 +138,11 @@ impl HeddleExitCode {
             | "env_store_not_found"
             | "env_store_slot_not_found" => Some(Self::DataErr),
             "env_store_denied" | "env_store_expired" => Some(Self::NoPerm),
-            "promote_not_owner" | "promote_account_standing" | "grant_denied" => {
-                Some(Self::NoPerm)
+            "promote_not_owner" | "promote_account_standing" | "grant_denied"
+            | "grant_agent_ceiling" => Some(Self::NoPerm),
+            "promote_slug_taken" | "promote_failed" | "grant_failed" | "grant_needs_human" => {
+                Some(Self::Protocol)
             }
-            "promote_slug_taken" | "promote_failed" | "grant_failed" => Some(Self::Protocol),
             "promote_already_root" => Some(Self::DataErr),
             "grant_not_found" => Some(Self::Config),
             // Capture aborted on ENOSPC; working tree is intact. Classifies
@@ -549,7 +550,9 @@ mod tests {
             ("promote_failed", HeddleExitCode::Protocol),
             ("promote_already_root", HeddleExitCode::DataErr),
             ("grant_denied", HeddleExitCode::NoPerm),
+            ("grant_agent_ceiling", HeddleExitCode::NoPerm),
             ("grant_failed", HeddleExitCode::Protocol),
+            ("grant_needs_human", HeddleExitCode::Protocol),
             ("grant_not_found", HeddleExitCode::Config),
         ] {
             assert_eq!(

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -145,6 +145,7 @@ impl HeddleExitCode {
             }
             "promote_already_root" => Some(Self::DataErr),
             "grant_not_found" => Some(Self::Config),
+            "grant_spool_required" => Some(Self::Usage),
             // Capture aborted on ENOSPC; working tree is intact. Classifies
             // as IO rather than a distinct raw-28 OS code so agents stay on
             // the documented sysexits taxonomy.
@@ -554,6 +555,7 @@ mod tests {
             ("grant_failed", HeddleExitCode::Protocol),
             ("grant_needs_human", HeddleExitCode::Protocol),
             ("grant_not_found", HeddleExitCode::Config),
+            ("grant_spool_required", HeddleExitCode::Usage),
         ] {
             assert_eq!(
                 HeddleExitCode::from_error(&advice_with_kind(kind)),

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -26,8 +26,7 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
     );
     assert!(
         parent_out.contains("writer or below")
-            && (parent_out.contains("admin and owner")
-                || parent_out.contains("Admin and owner")),
+            && (parent_out.contains("admin and owner") || parent_out.contains("Admin and owner")),
         "grant help must state the agent grant ceiling:\n{parent_out}"
     );
     assert!(

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -26,7 +26,8 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
     );
     assert!(
         parent_out.contains("writer or below")
-            && (parent_out.contains("admin and owner") || parent_out.contains("Admin and owner")),
+            && (parent_out.contains("maintainer, admin, and owner")
+                || parent_out.contains("Maintainer, admin, and owner")),
         "grant help must state the agent grant ceiling:\n{parent_out}"
     );
     assert!(
@@ -47,7 +48,9 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
     );
     assert!(
         create_out.contains("writer or below")
-            && create_out.contains("Admin and owner")
+            && create_out.contains("(reader, contributor)")
+            && !create_out.contains("(reader, contributor, maintainer)")
+            && create_out.contains("Maintainer, admin, and owner")
             && (create_out.contains("human-verified") || create_out.contains("human verification")),
         "grant create help must state the agent grant ceiling:\n{create_out}"
     );

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -25,6 +25,12 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
         "grant help must separate itself from signup invite:\n{parent_out}"
     );
     assert!(
+        parent_out.contains("writer or below")
+            && (parent_out.contains("admin and owner")
+                || parent_out.contains("Admin and owner")),
+        "grant help must state the agent grant ceiling:\n{parent_out}"
+    );
+    assert!(
         !parent_out.contains("auth invite --email"),
         "grant help must not overload auth invite:\n{parent_out}"
     );
@@ -40,6 +46,12 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
         create_out.contains("signup") || create_out.contains("auth invite"),
         "grant create help must say this is not a signup invite:\n{create_out}"
     );
+    assert!(
+        create_out.contains("writer or below")
+            && create_out.contains("Admin and owner")
+            && (create_out.contains("human-verified") || create_out.contains("human verification")),
+        "grant create help must state the agent grant ceiling:\n{create_out}"
+    );
 
     let list = heddle(&["grant", "list", "--help"]);
     assert_eq!(list.status.code(), Some(0));
@@ -51,6 +63,10 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
     let delete_out = String::from_utf8_lossy(&delete.stdout);
     assert!(delete_out.contains("<ID>"));
     assert!(delete_out.contains("--spool"));
+    assert!(
+        delete_out.contains("writer-or-below") || delete_out.contains("writer or below"),
+        "grant delete help must state the agent grant ceiling:\n{delete_out}"
+    );
 }
 
 #[test]

--- a/crates/hosted-client/src/client/mod.rs
+++ b/crates/hosted-client/src/client/mod.rs
@@ -25,6 +25,6 @@ pub use local_sync::LocalSync;
 
 #[cfg(feature = "client")]
 pub use crate::hosted_runtime::{
-    HostedAuthMode, HostedClient, HostedSession, connect_websocket, resolve_active_bearer,
-    resolve_hosted_credential,
+    HostedAuthMode, HostedClient, HostedSession, connect_websocket, credential_is_agent_attenuated,
+    refuse_agent_privileged_grant, resolve_active_bearer, resolve_hosted_credential,
 };

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -14,6 +14,7 @@
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use crypto::{Ed25519Signer, Signer};
+use repo::GrantRole;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AgentAuthOperationDisposition {
@@ -284,6 +285,11 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     "GetDiscussion",
     // Session identity.
     "WhoAmI",
+    // Collaborator grants at writer or below (heddle#1738). Admin/owner
+    // CreateGrant stays human-gated even when these RPCs are in the ceiling.
+    "ListGrants",
+    "CreateGrant",
+    "DeleteGrant",
 ];
 
 /// Read-only RPCs shared by every derived-agent template. Every entry is a
@@ -315,6 +321,7 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
     "WhoAmI",
     // Read of the installed owner keyring after BootstrapOwnerRoot (heddle#1600).
     "GetCurrentOwnerKeyring",
+    "ListGrants",
 ];
 
 /// Collaboration writes a `contributor` adds on top of the read set.
@@ -330,6 +337,10 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
     "ResolveDiscussion",
     // Provision the caller's own child spool (host-only auto-provision push).
     "CreateSpool",
+    // Everyday collaborator invites at writer or below. Admin/owner remain
+    // human-gated by role, not by omitting the RPC from the ceiling.
+    "CreateGrant",
+    "DeleteGrant",
 ];
 
 /// The push/pull/ref-move set a CI lander needs to run `ready`/`land`.
@@ -348,7 +359,8 @@ pub enum AgentTemplate {
     /// Read + review: every read RPC plus `Pull`. No writes, no ref moves.
     Reviewer,
     /// Read + collaboration writes: reviewer plus `Push`/`UpdateRef`, context
-    /// writes, and discussion writes. No repo/namespace admin.
+    /// writes, discussion writes, and writer-or-below collaborator grants.
+    /// No repo/namespace admin. Admin/owner CreateGrant stays human-gated.
     ///
     /// This is intentionally the **full safe agent ceiling** — its operation
     /// set equals [`SAFE_AGENT_OPERATIONS`], so `--template contributor` is
@@ -509,6 +521,21 @@ pub(crate) fn restrict_agent_account_root(
 /// chains off the parent's keys, and the server validates the full
 /// chain against its trust list when the agent presents the token.
 /// The CLI never holds the server's signing key.
+/// True when the bearer has an attenuation block (derive-agent or a
+/// restricted agent-account root). Human browser login stores a
+/// single-block independent root and is not attenuated.
+pub fn credential_is_agent_attenuated(token: &str) -> bool {
+    biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
+        .map(|biscuit| biscuit.block_count() > 1)
+        .unwrap_or(false)
+}
+
+/// Refuse admin/owner (and any role above writer) on a detectable
+/// agent/attenuated session before a CreateGrant / UpdateGrant round-trip.
+pub fn refuse_agent_privileged_grant(token: &str, role: GrantRole) -> bool {
+    credential_is_agent_attenuated(token) && !role.agent_may_grant()
+}
+
 pub fn attenuate_for_agent(
     parent_token_b64: &str,
     restrictions: AgentAttenuation,
@@ -1274,6 +1301,26 @@ mod tests {
         // the integration tests where a real server's keypair is
         // available.
         assert!(attenuated.len() > parent.len());
+        assert!(
+            !credential_is_agent_attenuated(&parent),
+            "a single-block parent root is not an attenuated agent session"
+        );
+        assert!(
+            credential_is_agent_attenuated(&attenuated),
+            "derive-agent children must be detectable before a grant round-trip"
+        );
+        assert!(
+            !refuse_agent_privileged_grant(&attenuated, GrantRole::Reader)
+                && !refuse_agent_privileged_grant(&attenuated, GrantRole::Developer)
+                && !refuse_agent_privileged_grant(&attenuated, GrantRole::Maintainer),
+            "writer and below stay allowed on an attenuated session"
+        );
+        assert!(refuse_agent_privileged_grant(&attenuated, GrantRole::Admin));
+        assert!(refuse_agent_privileged_grant(&attenuated, GrantRole::Owner));
+        assert!(
+            !refuse_agent_privileged_grant(&parent, GrantRole::Admin),
+            "an unattenuated root is not refused locally; the server still human-gates admin"
+        );
     }
 
     #[test]

--- a/crates/hosted-client/src/hosted_runtime/device_flow.rs
+++ b/crates/hosted-client/src/hosted_runtime/device_flow.rs
@@ -285,8 +285,9 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     "GetDiscussion",
     // Session identity.
     "WhoAmI",
-    // Collaborator grants at writer or below (heddle#1738). Admin/owner
-    // CreateGrant stays human-gated even when these RPCs are in the ceiling.
+    // Collaborator grants at writer or below (heddle#1738 / weft#2119).
+    // Maintainer/admin/owner CreateGrant stays human-gated even when
+    // these RPCs are in the ceiling.
     "ListGrants",
     "CreateGrant",
     "DeleteGrant",
@@ -337,8 +338,8 @@ const TEMPLATE_CONTRIBUTOR_WRITES: &[&str] = &[
     "ResolveDiscussion",
     // Provision the caller's own child spool (host-only auto-provision push).
     "CreateSpool",
-    // Everyday collaborator invites at writer or below. Admin/owner remain
-    // human-gated by role, not by omitting the RPC from the ceiling.
+    // Everyday collaborator invites at writer or below. Maintainer/admin/owner
+    // remain human-gated by role, not by omitting the RPC from the ceiling.
     "CreateGrant",
     "DeleteGrant",
 ];
@@ -360,7 +361,8 @@ pub enum AgentTemplate {
     Reviewer,
     /// Read + collaboration writes: reviewer plus `Push`/`UpdateRef`, context
     /// writes, discussion writes, and writer-or-below collaborator grants.
-    /// No repo/namespace admin. Admin/owner CreateGrant stays human-gated.
+    /// No repo/namespace admin. Maintainer/admin/owner CreateGrant stays
+    /// human-gated.
     ///
     /// This is intentionally the **full safe agent ceiling** — its operation
     /// set equals [`SAFE_AGENT_OPERATIONS`], so `--template contributor` is
@@ -530,7 +532,7 @@ pub fn credential_is_agent_attenuated(token: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Refuse admin/owner (and any role above writer) on a detectable
+/// Refuse maintainer/admin/owner (roles above writer) on a detectable
 /// agent/attenuated session before a CreateGrant / UpdateGrant round-trip.
 pub fn refuse_agent_privileged_grant(token: &str, role: GrantRole) -> bool {
     credential_is_agent_attenuated(token) && !role.agent_may_grant()
@@ -1311,10 +1313,13 @@ mod tests {
         );
         assert!(
             !refuse_agent_privileged_grant(&attenuated, GrantRole::Reader)
-                && !refuse_agent_privileged_grant(&attenuated, GrantRole::Developer)
-                && !refuse_agent_privileged_grant(&attenuated, GrantRole::Maintainer),
+                && !refuse_agent_privileged_grant(&attenuated, GrantRole::Developer),
             "writer and below stay allowed on an attenuated session"
         );
+        assert!(refuse_agent_privileged_grant(
+            &attenuated,
+            GrantRole::Maintainer
+        ));
         assert!(refuse_agent_privileged_grant(&attenuated, GrantRole::Admin));
         assert!(refuse_agent_privileged_grant(&attenuated, GrantRole::Owner));
         assert!(

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -721,7 +721,7 @@ fn refuse_privileged_grant_for_agent_bearer(
     let grant_role = GrantRole::from_hosted_role_i32(role as i32);
     if refuse_agent_privileged_grant(token, grant_role) {
         return Err(ProtocolError::AuthorizationFailed(
-            "agent sessions cannot grant admin or owner; those roles require human verification"
+            "agent sessions cannot grant maintainer, admin, or owner; those roles require human verification"
                 .into(),
         ));
     }
@@ -1027,7 +1027,7 @@ mod tests {
         assert_eq!(parse_hosted_role_arg("owner").unwrap(), HostedRole::Owner);
         assert!(GrantRole::from_hosted_role_i32(HostedRole::Reader as i32).agent_may_grant());
         assert!(GrantRole::from_hosted_role_i32(HostedRole::Developer as i32).agent_may_grant());
-        assert!(GrantRole::from_hosted_role_i32(HostedRole::Maintainer as i32).agent_may_grant());
+        assert!(!GrantRole::from_hosted_role_i32(HostedRole::Maintainer as i32).agent_may_grant());
         assert!(!GrantRole::from_hosted_role_i32(HostedRole::Admin as i32).agent_may_grant());
         assert!(!GrantRole::from_hosted_role_i32(HostedRole::Owner as i32).agent_may_grant());
         let err = parse_hosted_role_arg("root").unwrap_err();

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -13,7 +13,10 @@ use api::heddle::api::v1alpha1::{
     ServiceAccountResponse, SpoolSummary, SupportAccessGrant, ThreadApproval, UpdateGrantRequest,
     UpdateSpoolRequest, Visibility, grant_target_ref::Target as GrantTargetKind,
 };
+use repo::GrantRole;
 use wire::ProtocolError;
+
+use crate::hosted_runtime::refuse_agent_privileged_grant;
 
 use super::{
     HostedClient,
@@ -379,6 +382,8 @@ impl HostedClient {
             "heddle.api.v1alpha1.RegistryService/CreateGrant",
             client_operation_id,
         );
+        let parsed_role = parse_hosted_role_arg(role)?;
+        refuse_privileged_grant_for_agent_bearer(self, parsed_role)?;
         let target = build_target_ref(namespace_path, repo_path)?;
         let grant = authed_call!(
             self,
@@ -386,7 +391,7 @@ impl HostedClient {
             "CreateGrant",
             CreateGrantRequest {
                 subject: subject.to_string(),
-                role: parse_hosted_role_arg(role)? as i32,
+                role: parsed_role as i32,
                 target,
                 client_operation_id: operation_id.to_wire(),
             }
@@ -421,6 +426,8 @@ impl HostedClient {
             "heddle.api.v1alpha1.RegistryService/UpdateGrant",
             client_operation_id,
         );
+        let parsed_role = parse_hosted_role_arg(role)?;
+        refuse_privileged_grant_for_agent_bearer(self, parsed_role)?;
         let target = build_target_ref(namespace_path, repo_path)?;
         let grant = authed_call!(
             self,
@@ -428,7 +435,7 @@ impl HostedClient {
             "UpdateGrant",
             UpdateGrantRequest {
                 subject: subject.to_string(),
-                role: parse_hosted_role_arg(role)? as i32,
+                role: parsed_role as i32,
                 target,
                 client_operation_id: operation_id.to_wire(),
             }
@@ -699,6 +706,26 @@ fn build_target_ref(
             "exactly one of namespace_path or repo_path must be set".into(),
         )),
     }
+}
+
+fn refuse_privileged_grant_for_agent_bearer(
+    client: &HostedClient,
+    role: api::heddle::api::v1alpha1::HostedRole,
+) -> Result<(), ProtocolError> {
+    let Ok(token) = std::str::from_utf8(client.context.bearer_capability()) else {
+        return Ok(());
+    };
+    if token.is_empty() {
+        return Ok(());
+    }
+    let grant_role = GrantRole::from_hosted_role_i32(role as i32);
+    if refuse_agent_privileged_grant(token, grant_role) {
+        return Err(ProtocolError::AuthorizationFailed(
+            "agent sessions cannot grant admin or owner; those roles require human verification"
+                .into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Parse a CLI-supplied role name into the proto `HostedRole` enum.
@@ -998,6 +1025,11 @@ mod tests {
         );
         assert_eq!(parse_hosted_role_arg("admin").unwrap(), HostedRole::Admin);
         assert_eq!(parse_hosted_role_arg("owner").unwrap(), HostedRole::Owner);
+        assert!(GrantRole::from_hosted_role_i32(HostedRole::Reader as i32).agent_may_grant());
+        assert!(GrantRole::from_hosted_role_i32(HostedRole::Developer as i32).agent_may_grant());
+        assert!(GrantRole::from_hosted_role_i32(HostedRole::Maintainer as i32).agent_may_grant());
+        assert!(!GrantRole::from_hosted_role_i32(HostedRole::Admin as i32).agent_may_grant());
+        assert!(!GrantRole::from_hosted_role_i32(HostedRole::Owner as i32).agent_may_grant());
         let err = parse_hosted_role_arg("root").unwrap_err();
         assert!(err.to_string().contains("invalid role"));
     }

--- a/crates/hosted-client/src/hosted_runtime/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/mod.rs
@@ -33,7 +33,9 @@ mod root_mint_tests;
 pub mod websocket;
 pub mod whoami;
 
-pub use device_flow::AgentTemplate;
+pub use device_flow::{
+    AgentTemplate, credential_is_agent_attenuated, refuse_agent_privileged_grant,
+};
 pub use hosted::{
     HostedAuthMode, HostedClient, HostedSession, ServerStream, resolve_active_bearer,
     resolve_hosted_credential,

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -317,7 +317,7 @@ fn authorize_restricted_root(
 
 /// heddle#1738: derive-agent children must be able to call the grant RPCs
 /// so everyday collaborator invites do not fail at the Biscuit layer.
-/// Admin/owner stay human-gated by role, not by omitting CreateGrant.
+/// Maintainer/admin/owner stay human-gated by role, not by omitting CreateGrant.
 #[test]
 fn safe_ceiling_allows_collaborator_grants_at_writer_or_below() {
     for op in ["ListGrants", "CreateGrant", "DeleteGrant"] {

--- a/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/root_mint_tests.rs
@@ -315,6 +315,30 @@ fn authorize_restricted_root(
     authorizer.authorize().map(|_| ())
 }
 
+/// heddle#1738: derive-agent children must be able to call the grant RPCs
+/// so everyday collaborator invites do not fail at the Biscuit layer.
+/// Admin/owner stay human-gated by role, not by omitting CreateGrant.
+#[test]
+fn safe_ceiling_allows_collaborator_grants_at_writer_or_below() {
+    for op in ["ListGrants", "CreateGrant", "DeleteGrant"] {
+        assert!(
+            SAFE_AGENT_OPERATIONS.contains(&op),
+            "agent ceiling missing {op}: derive-agent cannot invite writer-or-below collaborators"
+        );
+        assert!(
+            AgentTemplate::Contributor
+                .operations()
+                .iter()
+                .any(|operation| operation == op),
+            "contributor template must include {op}"
+        );
+    }
+    assert!(
+        !SAFE_AGENT_OPERATIONS.contains(&"UpdateGrant"),
+        "UpdateGrant stays out of the agent ceiling so a child cannot raise a grant to admin"
+    );
+}
+
 /// Regression: the agent ceiling must carry the personal-spool discovery +
 /// provisioning ops. Without them, an unclaimed agent-rooted account's
 /// `heddle push <host>` aborts client-side inside `auto_provision_hosted_repo`

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -25,12 +25,12 @@ pub enum GrantRole {
 
 impl GrantRole {
     /// Highest role an agent or attenuated session may grant without
-    /// human verification. Admin and owner stay human-gated (heddle#1738).
+    /// human verification. Writer is Developer (`contributor` in the CLI).
+    /// Maintainer, admin, and owner stay human-gated (heddle#1738 / weft#2119).
     ///
-    /// HostedRole has no `writer` token. Maintainer is the last rung below
-    /// admin; everyday collaborator invites use reader / contributor
-    /// (`developer`).
-    pub const AGENT_GRANT_CEILING: Self = Self::Maintainer;
+    /// HostedRole has no `writer` token. Everyday collaborator invites
+    /// use reader / contributor (`developer`).
+    pub const AGENT_GRANT_CEILING: Self = Self::Developer;
 
     /// Parse a proto `HostedRole` i32. Unknown values fail closed to
     /// [`GrantRole::Unspecified`].
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_may_grant_writer_and_below_but_not_admin_or_owner() {
+    fn agent_may_grant_writer_and_below_but_not_maintainer_admin_or_owner() {
         assert!(GrantRole::Reader.agent_may_grant());
         assert!(GrantRole::Developer.agent_may_grant());
         assert!(
@@ -216,12 +216,13 @@ mod tests {
                 .expect("contributor alias")
                 .agent_may_grant()
         );
-        assert!(GrantRole::Maintainer.agent_may_grant());
+        assert!(!GrantRole::Maintainer.agent_may_grant());
         assert!(!GrantRole::Admin.agent_may_grant());
         assert!(!GrantRole::Owner.agent_may_grant());
         assert!(!GrantRole::Unspecified.agent_may_grant());
         assert!(!GrantRole::from_hosted_role_i32(99).agent_may_grant());
-        assert!(GrantRole::Maintainer <= GrantRole::AGENT_GRANT_CEILING);
+        assert!(GrantRole::Developer <= GrantRole::AGENT_GRANT_CEILING);
+        assert!(GrantRole::Maintainer > GrantRole::AGENT_GRANT_CEILING);
         assert!(GrantRole::Admin > GrantRole::AGENT_GRANT_CEILING);
     }
 

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -24,6 +24,14 @@ pub enum GrantRole {
 }
 
 impl GrantRole {
+    /// Highest role an agent or attenuated session may grant without
+    /// human verification. Admin and owner stay human-gated (heddle#1738).
+    ///
+    /// HostedRole has no `writer` token. Maintainer is the last rung below
+    /// admin; everyday collaborator invites use reader / contributor
+    /// (`developer`).
+    pub const AGENT_GRANT_CEILING: Self = Self::Maintainer;
+
     /// Parse a proto `HostedRole` i32. Unknown values fail closed to
     /// [`GrantRole::Unspecified`].
     pub fn from_hosted_role_i32(role: i32) -> Self {
@@ -35,6 +43,25 @@ impl GrantRole {
             5 => GrantRole::Owner,
             _ => GrantRole::Unspecified,
         }
+    }
+
+    /// Parse a CLI or wire role name. `contributor` is the everyday name
+    /// for [`GrantRole::Developer`].
+    pub fn from_hosted_role_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "reader" => Some(Self::Reader),
+            "contributor" | "developer" => Some(Self::Developer),
+            "maintainer" => Some(Self::Maintainer),
+            "admin" => Some(Self::Admin),
+            "owner" => Some(Self::Owner),
+            _ => None,
+        }
+    }
+
+    /// Agent-driven `CreateGrant` may mint this role without WebAuthn.
+    /// Unspecified and anything above [`Self::AGENT_GRANT_CEILING`] fail closed.
+    pub fn agent_may_grant(self) -> bool {
+        !matches!(self, Self::Unspecified) && self <= Self::AGENT_GRANT_CEILING
     }
 }
 
@@ -178,6 +205,22 @@ mod tests {
             None,
             &private
         ));
+    }
+
+    #[test]
+    fn agent_may_grant_writer_and_below_but_not_admin_or_owner() {
+        assert!(GrantRole::Reader.agent_may_grant());
+        assert!(GrantRole::Developer.agent_may_grant());
+        assert!(GrantRole::from_hosted_role_name("contributor")
+            .expect("contributor alias")
+            .agent_may_grant());
+        assert!(GrantRole::Maintainer.agent_may_grant());
+        assert!(!GrantRole::Admin.agent_may_grant());
+        assert!(!GrantRole::Owner.agent_may_grant());
+        assert!(!GrantRole::Unspecified.agent_may_grant());
+        assert!(!GrantRole::from_hosted_role_i32(99).agent_may_grant());
+        assert!(GrantRole::Maintainer <= GrantRole::AGENT_GRANT_CEILING);
+        assert!(GrantRole::Admin > GrantRole::AGENT_GRANT_CEILING);
     }
 
     #[test]

--- a/crates/repo/src/grant_audience.rs
+++ b/crates/repo/src/grant_audience.rs
@@ -211,9 +211,11 @@ mod tests {
     fn agent_may_grant_writer_and_below_but_not_admin_or_owner() {
         assert!(GrantRole::Reader.agent_may_grant());
         assert!(GrantRole::Developer.agent_may_grant());
-        assert!(GrantRole::from_hosted_role_name("contributor")
-            .expect("contributor alias")
-            .agent_may_grant());
+        assert!(
+            GrantRole::from_hosted_role_name("contributor")
+                .expect("contributor alias")
+                .agent_may_grant()
+        );
         assert!(GrantRole::Maintainer.agent_may_grant());
         assert!(!GrantRole::Admin.agent_may_grant());
         assert!(!GrantRole::Owner.agent_may_grant());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Agent / attenuated sessions may `heddle grant create|delete` for **writer or below** (`reader`, `contributor`≡developer) without WebAuthn.
- **Maintainer, admin, and owner** stay human-gated. The CLI refuses those roles locally when the bearer is a detectable derive-agent or restricted agent-account session (before a weft round-trip).
- Help text states the ceiling. Derive-agent's safe set includes `ListGrants` / `CreateGrant` / `DeleteGrant` so the Biscuit layer does not block everyday collaborator invites.
- Human-verification failures map to `grant_needs_human` (rc 76). Local privileged-role refuse is `grant_agent_ceiling` (rc 77). A hosted grant URL without a spool path is `grant_spool_required` (rc 64).

Preview AX treated every grant write as human-gated (rc 76). The product lock is: agents may grant, but only to writer or lower; they must not grant maintainer, admin, or owner.

HostedRole has no `writer` token. Writer is Developer (`contributor` in the CLI). The client ceiling is `<= Developer`, matching weft#2119.

**Weft twin:** weft#2119 already caps `CreateGrant`/`DeleteGrant` at Reader|Developer without human PoP. This PR lands the matching client ceiling, UX, and derive-agent ops so the CLI fails closed on maintainer/admin/owner.

**Rebase (2026-09-11):** Rebased onto `origin/main` (`16cfe711`, includes #1743 runtime `--schema`). Dropped two obsolete follow-ups that only refreshed deleted apparatus (`docs/json-schemas.md` / `clients/npm/generated`):
- `e40e39c2` doctor-schemas coverage refresh
- `dd406bc3` npm schema regen

Kept the typed `grant_spool_required` refuse. Left `typed_error_lint` at main's 149 ratchet (#1742 already migrated the drifted sites; do not re-pin to 157).

## Closes

Closes HeddleCo/heddle#1738

## Surfaces

- **The verb.** Help, clap, and the grant path agree: agents may grant reader/contributor; maintainer/admin/owner stay human-verified. A URL without a spool path has a typed way out.
- **Human and agent.** Default text states the ceiling; JSON kinds `grant_agent_ceiling` (77), `grant_needs_human` (76), and `grant_spool_required` (64) are additive.
- **Git interop.** Not applicable.
- **The wire.** No new RPC. Client ceiling matches weft#2119 (Reader|Developer).
- **Reverse states.** Create (in) / list (see) / delete (out) unchanged; maintainer/admin/owner remain the gated way in.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15e5e608-72c8-4cd2-a827-11418265bc0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15e5e608-72c8-4cd2-a827-11418265bc0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791646382&installation_model_id=21489&pr_number=1740&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1740&signature=1be01f372f7a5589ca187b8897211a860b2997b94266e03b1c6bd7be07f0e653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->