### PR TITLE
fix(grant): list with the bare spool path so ListGrants matches

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -306,6 +306,10 @@ Examples:
 
     /// List grants on a hosted spool.
     #[command(after_help = "\
+`--spool` is the same bare path create and delete use
+(`spool/<handle>/<name>`, `<handle>/<name>`, or a hosted URL).
+Do not prefix `repo:`.
+
 Examples:
   heddle grant list --spool spool/willow-ibis-8e7264/notes
   heddle grant list --spool notes --server api.preview.heddle.sh

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -249,6 +249,7 @@ mount = [
 [dev-dependencies]
 # Test-only: hosted fixtures mint biscuits and stand up Iroh endpoints
 # directly; the production CLI gets both through `hosted-client`.
+hosted-client = { workspace = true, features = ["client", "test-utils"] }
 biscuit-auth.workspace = true
 iroh.workspace = true
 criterion = "0.8"

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -156,7 +156,7 @@ async fn list_grant_rows(client: &mut HostedClient, spool: &str) -> Result<Vec<G
     // Same bare `spool/<handle>/<name>` CreateGrant/DeleteGrant send.
     // weft exact-matches that visible path; a `repo:` prefix never hits.
     let grants = client
-        .list_grants(Some(&format!("repo:{spool}")))
+        .list_grants(Some(spool))
         .await
         .map_err(|err| map_grant_error(spool, &err))?;
     Ok(grants.iter().map(|grant| grant_row(grant, spool)).collect())

--- a/crates/cli/src/cli/commands/grant.rs
+++ b/crates/cli/src/cli/commands/grant.rs
@@ -152,17 +152,23 @@ async fn create_connected(
     Ok(())
 }
 
+async fn list_grant_rows(client: &mut HostedClient, spool: &str) -> Result<Vec<GrantRowOutput>> {
+    // Same bare `spool/<handle>/<name>` CreateGrant/DeleteGrant send.
+    // weft exact-matches that visible path; a `repo:` prefix never hits.
+    let grants = client
+        .list_grants(Some(&format!("repo:{spool}")))
+        .await
+        .map_err(|err| map_grant_error(spool, &err))?;
+    Ok(grants.iter().map(|grant| grant_row(grant, spool)).collect())
+}
+
 async fn list_connected(
     cli: &Cli,
     client: &mut HostedClient,
     server: &str,
     spool: &str,
 ) -> Result<()> {
-    let grants = client
-        .list_grants(Some(&format!("repo:{spool}")))
-        .await
-        .map_err(|err| map_grant_error(spool, &err))?;
-    let rows: Vec<GrantRowOutput> = grants.iter().map(|grant| grant_row(grant, spool)).collect();
+    let rows = list_grant_rows(client, spool).await?;
     if should_output_json(cli, None) {
         write_full_command_json(
             &GrantListOutput {
@@ -306,9 +312,94 @@ fn is_human_verification_required(lowered_message: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::{ffi::OsString, sync::MutexGuard};
+
+    use clap::Parser;
     use wire::ProtocolError;
 
-    use super::{grant_row, is_human_verification_required, map_grant_error, resolve_grant_spool};
+    use super::{
+        create_connected, grant_row, is_human_verification_required, list_grant_rows,
+        map_grant_error, resolve_grant_spool,
+    };
+    use crate::cli::Cli;
+
+    struct IsolatedHeddleHome {
+        _guard: MutexGuard<'static, ()>,
+        _temp: tempfile::TempDir,
+        previous_home: Option<OsString>,
+    }
+
+    impl IsolatedHeddleHome {
+        fn new() -> Self {
+            let guard = ::config::credentials::lock_test_env();
+            let temp = tempfile::TempDir::new().expect("temporary Heddle home");
+            let previous_home = std::env::var_os("HEDDLE_HOME");
+            unsafe { std::env::set_var("HEDDLE_HOME", temp.path()) };
+            Self {
+                _guard: guard,
+                _temp: temp,
+                previous_home,
+            }
+        }
+    }
+
+    impl Drop for IsolatedHeddleHome {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous_home {
+                    Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                    None => std::env::remove_var("HEDDLE_HOME"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn create_then_list_returns_the_grant_row() {
+        let _home = IsolatedHeddleHome::new();
+        let (mut client, server) =
+            hosted_client::hosted_runtime::hosted::test_server::start().await;
+        let spool = "spool/willow-ibis-8e7264/notes";
+        let cli = Cli::parse_from([
+            "heddle",
+            "--quiet",
+            "grant",
+            "create",
+            "--spool",
+            spool,
+            "--principal",
+            "alice",
+            "--role",
+            "contributor",
+        ]);
+
+        create_connected(
+            &cli,
+            &mut client,
+            "test.invalid",
+            spool,
+            "alice",
+            "contributor",
+        )
+        .await
+        .expect("create grant on the production path");
+
+        let rows = list_grant_rows(&mut client, spool)
+            .await
+            .expect("list grants on the production path");
+        assert_eq!(
+            rows.len(),
+            1,
+            "owner list must return the created grant: {rows:?}"
+        );
+        assert_eq!(rows[0].id, "alice");
+        assert_eq!(rows[0].principal, "alice");
+        assert_eq!(rows[0].role, "developer");
+        assert_eq!(rows[0].spool, spool);
+
+        client.close().await;
+        server.await.unwrap();
+    }
 
     #[test]
     fn url_target_takes_host_and_canonical_path() {

--- a/crates/cli/tests/grant.rs
+++ b/crates/cli/tests/grant.rs
@@ -59,6 +59,14 @@ fn grant_help_exposes_create_list_delete_and_stays_off_signup_invite() {
     assert_eq!(list.status.code(), Some(0));
     let list_out = String::from_utf8_lossy(&list.stdout);
     assert!(list_out.contains("--spool"));
+    assert!(
+        list_out.contains("same bare path") && list_out.contains("Do not prefix `repo:`"),
+        "grant list help must use the create/delete spool path, not repo::\n{list_out}"
+    );
+    assert!(
+        !list_out.contains("repo:spool/") && !list_out.contains("--resource repo:"),
+        "grant list help must not require a repo: filter:\n{list_out}"
+    );
 
     let delete = heddle(&["grant", "delete", "--help"]);
     assert_eq!(delete.status.code(), Some(0));

--- a/crates/hosted-client/Cargo.toml
+++ b/crates/hosted-client/Cargo.toml
@@ -96,6 +96,9 @@ client = [
     "dep:tokio-tungstenite",
     "dep:webpki-roots",
 ]
+# In-process hosted fixture for crate tests and CLI grant integration.
+# Production client builds do not enable this.
+test-utils = []
 # Forwarded from the CLI's `telemetry` feature: trace-context propagation on
 # hosted calls.
 telemetry = [

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -32,6 +32,7 @@ mod sync;
 #[cfg(test)]
 mod test_https;
 #[cfg(any(test, feature = "test-utils"))]
+#[allow(dead_code)]
 pub mod test_server;
 mod thread_identity;
 mod thread_metadata;

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -32,7 +32,6 @@ mod sync;
 #[cfg(test)]
 mod test_https;
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(dead_code)]
 pub mod test_server;
 mod thread_identity;
 mod thread_metadata;

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -31,8 +31,8 @@ mod state_review;
 mod sync;
 #[cfg(test)]
 mod test_https;
-#[cfg(test)]
-pub(crate) mod test_server;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_server;
 mod thread_identity;
 mod thread_metadata;
 mod user;

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -106,7 +106,7 @@ pub(crate) struct ContextFixture {
     pub history_requests: Arc<Mutex<Vec<String>>>,
 }
 
-pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
+pub async fn start() -> (HostedClient, JoinHandle<()>) {
     start_inner(
         None,
         BlobFixture::default(),
@@ -894,12 +894,11 @@ fn grant_matches_resource(grant: &HostedGrant, resource: &str) -> bool {
     if resource.is_empty() {
         return true;
     }
+    // weft `list_manageable_grants` exact-matches the visible path
+    // (`spool/<handle>/<name>`). Stripping `repo:` here hid the CLI sending
+    // `repo:{spool}` while create/delete send the bare path (heddle#1744).
     let (namespace, repo) = grant_target_paths(grant.target.as_ref());
-    let path = resource
-        .strip_prefix("repo:")
-        .or_else(|| resource.strip_prefix("ns:"))
-        .unwrap_or(resource);
-    repo.as_deref() == Some(path) || namespace.as_deref() == Some(path)
+    repo.as_deref() == Some(resource) || namespace.as_deref() == Some(resource)
 }
 
 async fn serve_promote_spool(
@@ -1331,6 +1330,45 @@ async fn serve_subscribe_repo_events(
             .await
             .unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod grant_filter_tests {
+    use api::heddle::api::v1alpha1::{
+        GrantTargetRef, HostedGrant, RepositoryRef, grant_target_ref::Target,
+        repository_ref::Reference,
+    };
+
+    use super::{grant_matches_resource, grant_target_paths};
+
+    fn repo_grant(path: &str) -> HostedGrant {
+        HostedGrant {
+            subject: "alice".into(),
+            role: 2,
+            target: Some(GrantTargetRef {
+                target: Some(Target::RepoPath(RepositoryRef {
+                    reference: Some(Reference::CanonicalPath(path.to_string())),
+                })),
+            }),
+        }
+    }
+
+    #[test]
+    fn list_filter_matches_bare_spool_path_only() {
+        let grant = repo_grant("spool/willow-ibis-8e7264/notes");
+        let (namespace, repo) = grant_target_paths(grant.target.as_ref());
+        assert_eq!(namespace, None);
+        assert_eq!(repo.as_deref(), Some("spool/willow-ibis-8e7264/notes"));
+        assert!(grant_matches_resource(
+            &grant,
+            "spool/willow-ibis-8e7264/notes"
+        ));
+        assert!(
+            !grant_matches_resource(&grant, "repo:spool/willow-ibis-8e7264/notes"),
+            "weft exact-matches the visible path; repo: prefix must not match"
+        );
+        assert!(grant_matches_resource(&grant, ""));
     }
 }
 

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -1333,6 +1333,24 @@ async fn serve_subscribe_repo_events(
     }
 }
 
+fn pack_frame(stream_kind: PackStreamKind, data: Vec<u8>) -> Vec<u8> {
+    PullServerFrame {
+        frame: Some(pull_server_frame::Frame::Pack(PackChunk {
+            stream_kind: stream_kind as i32,
+            chunk_length: data.len() as u32,
+            data,
+            transfer: Some(TransferCheckpoint {
+                transfer_id: "pull-pack-test".to_string(),
+                transport_mode: TransportMode::NativePack as i32,
+                is_complete: true,
+                ..TransferCheckpoint::default()
+            }),
+            is_final_chunk: true,
+        })),
+    }
+    .encode_to_vec()
+}
+
 #[cfg(test)]
 mod grant_filter_tests {
     use api::heddle::api::v1alpha1::{
@@ -1370,22 +1388,4 @@ mod grant_filter_tests {
         );
         assert!(grant_matches_resource(&grant, ""));
     }
-}
-
-fn pack_frame(stream_kind: PackStreamKind, data: Vec<u8>) -> Vec<u8> {
-    PullServerFrame {
-        frame: Some(pull_server_frame::Frame::Pack(PackChunk {
-            stream_kind: stream_kind as i32,
-            chunk_length: data.len() as u32,
-            data,
-            transfer: Some(TransferCheckpoint {
-                transfer_id: "pull-pack-test".to_string(),
-                transport_mode: TransportMode::NativePack as i32,
-                is_complete: true,
-                ..TransferCheckpoint::default()
-            }),
-            is_final_chunk: true,
-        })),
-    }
-    .encode_to_vec()
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -120,6 +120,7 @@ pub async fn start() -> (HostedClient, JoinHandle<()>) {
     .await
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_registry(
     fixture: RegistryFixture,
 ) -> (HostedClient, JoinHandle<()>, RegistryFixture) {
@@ -138,6 +139,7 @@ pub(crate) async fn start_with_registry(
     (client, server, fixture_clone)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_collaboration(
     fixture: CollaborationFixture,
 ) -> (HostedClient, JoinHandle<()>, CollaborationFixture) {
@@ -156,6 +158,7 @@ pub(crate) async fn start_with_collaboration(
     (client, server, fixture_clone)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_context(
     fixture: ContextFixture,
 ) -> (HostedClient, JoinHandle<()>, ContextFixture) {
@@ -174,6 +177,7 @@ pub(crate) async fn start_with_context(
     (client, server, fixture_clone)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_recording_push()
 -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<PushRequest>>>) {
     let captured = Arc::new(Mutex::new(Vec::new()));
@@ -191,6 +195,7 @@ pub(crate) async fn start_recording_push()
     (client, server, captured)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_recording_create_spool() -> (
     HostedClient,
     JoinHandle<()>,
@@ -211,6 +216,7 @@ pub(crate) async fn start_recording_create_spool() -> (
     (client, server, captured)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_recording_spool_mutations() -> (
     HostedClient,
     JoinHandle<()>,
@@ -231,6 +237,7 @@ pub(crate) async fn start_recording_spool_mutations() -> (
     (client, server, captured)
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_remote_state(
     remote_state: StateId,
 ) -> (HostedClient, JoinHandle<()>) {
@@ -250,6 +257,7 @@ pub(crate) async fn start_with_remote_state(
     .await
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_pull_pack(
     remote_state: StateId,
     pack_data: Vec<u8>,
@@ -271,12 +279,14 @@ pub(crate) async fn start_with_pull_pack(
     .await
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_get_blob_contents(
     blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
 ) -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
     start_with_get_blob_contents_and_pull(blobs, None).await
 }
 
+#[cfg(test)]
 pub(crate) async fn start_with_get_blob_contents_and_pull_pack(
     blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
     remote_state: StateId,
@@ -293,6 +303,7 @@ pub(crate) async fn start_with_get_blob_contents_and_pull_pack(
     .await
 }
 
+#[cfg(test)]
 async fn start_with_get_blob_contents_and_pull(
     blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
     pull: Option<PullFixture>,

--- a/crates/hosted-client/src/hosted_runtime/hosted/user.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/user.rs
@@ -16,13 +16,12 @@ use api::heddle::api::v1alpha1::{
 use repo::GrantRole;
 use wire::ProtocolError;
 
-use crate::hosted_runtime::refuse_agent_privileged_grant;
-
 use super::{
     HostedClient,
     helpers::{hosted_to_protocol_error, to_protocol_grant, to_protocol_spool},
     operation_id::ClientOperationId,
 };
+use crate::hosted_runtime::refuse_agent_privileged_grant;
 
 macro_rules! signed_call {
     ($self:ident, $client:ident, $rpc:ident, $path:expr, $msg:expr) => {{
@@ -830,7 +829,7 @@ mod tests {
         let _ = client
             .create_grant("principal:alice", "reader", None, Some("acme/widgets"), "")
             .await;
-        let listed = client.list_grants(Some("repo:acme/widgets")).await.unwrap();
+        let listed = client.list_grants(Some("acme/widgets")).await.unwrap();
         assert!(listed.iter().any(|grant| grant.subject == "principal:alice"
             && grant.role == "reader"
             && grant.repo_path.as_deref() == Some("acme/widgets")));
@@ -931,7 +930,7 @@ mod tests {
         );
 
         let listed = client
-            .list_grants(Some("repo:spool/willow-ibis-8e7264/notes"))
+            .list_grants(Some("spool/willow-ibis-8e7264/notes"))
             .await
             .expect("ListGrants should show the created grant");
         assert_eq!(listed.len(), 1);
@@ -953,7 +952,7 @@ mod tests {
             .expect("DeleteGrant should remove the collaborator");
 
         let after_delete = client
-            .list_grants(Some("repo:spool/willow-ibis-8e7264/notes"))
+            .list_grants(Some("spool/willow-ibis-8e7264/notes"))
             .await
             .expect("ListGrants after delete");
         assert!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle grant list` sent `repo:{spool}` to `ListGrants`. weft exact-matches the visible path `spool/<handle>/<name>`, so owner list returned `grants=[]` after create/clone already proved the grant existed (AX 2026-09-11 after weft#2123).
- Create and delete already pass the bare spool path. List now does the same.
- The hosted test fixture no longer strips a `repo:` prefix (that seam kept create-then-list green while production weft stayed empty). Help states list uses the same bare path as create/delete.
- weft#2132 / weft#2133 will also accept a `repo:`-prefixed filter; this CLI still sends the canonical bare path so create/list/delete agree.

## Closes

Closes HeddleCo/heddle#1744

Twin: HeddleCo/weft#2132 (server-side `repo:` normalize; out of scope here).

## Red commit
`1d676894`

## Test evidence
```
$ cargo test -p heddle-cli --lib grant:: -- --nocapture
running 9 tests
test cli::commands::grant::tests::create_then_list_returns_the_grant_row ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 453 filtered out; finished in 0.04s

$ cargo test -p heddle-cli --test grant -- --nocapture
test grant_help_exposes_create_list_delete_and_stays_off_signup_invite ... ok

$ cargo test -p heddle-hosted-client --features client --lib \
    spool_grant_create_list_delete_round_trip \
    list_filter_matches_bare_spool_path_only
... ok

$ cargo run --locked -p heddle-devtools -- check-rust-source-reachability
Rust source guard clean: all 932 source file(s) across 32 crate(s) are reachable; no blanket dead_code allows
```

Fast Lane on `6285697f` failed the source-reachability guard on a blanket `#[allow(dead_code)]` for the hosted fixture. `e2ea7227` removes that blanket and `cfg(test)`-gates the unused `start_*` helpers.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Surfaces

- **The verb.** `grant list` clap help now says `--spool` is the same bare path as create/delete (`Do not prefix repo:`). Rust path, help, and create/delete agree.
- **Human and agent.** Text and `--output json` still list rows; the filter change is what makes `grants` non-empty.
- **Git interop.** Not touched.
- **The wire.** No proto change. ListGrants.resource is the existing string; CLI now sends the canonical visible path.
- **Reverse states.** Create already wrote the grant; list now sees it; delete already used the bare path.

Out of scope: tip half-clone, agent grant ceiling (#1740), weft server normalize (#2132/#2133).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00a3b1c8-1c4b-4471-a487-d070a80078cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00a3b1c8-1c4b-4471-a487-d070a80078cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791746079&installation_model_id=21489&pr_number=1745&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1745&signature=cdd02487526334c501f4ec90349d926782942b95a21864134f1f51e58db7e235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->