### PR TITLE
fix(netd): Heddle home relay via `preview` feature, never n0 Default

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -185,6 +185,11 @@ client = [
     "heddle-cli-contract/client",
     "heddle-cli-render/client",
 ]
+# Preview AX / preview.heddle.sh home relay for `heddle netd serve`.
+# Off by default: stock and crates.io installs home on production
+# (`https://relay.heddle.sh/`). Enable for preview-environment
+# binaries: `cargo build --release -p heddle-cli --features client,preview`.
+preview = ["hosted-client/preview"]
 # Deep git import + AI-session reasoning extraction now backs every Git
 # overlay import path. Kept as a feature name for existing feature sets,
 # but the dependency is always present so no legacy bridge importer is

--- a/crates/hosted-client/Cargo.toml
+++ b/crates/hosted-client/Cargo.toml
@@ -96,6 +96,13 @@ client = [
     "dep:tokio-tungstenite",
     "dep:webpki-roots",
 ]
+# Preview AX home relay for `heddle netd serve`
+# (`https://relay.preview.heddle.sh/`). Off by default so stock and
+# `--release` installs home on production (`https://relay.heddle.sh/`).
+# Does not change hosted CLI connections, which still take relays
+# from the signed descriptor. Enable via `heddle-cli`'s `preview`
+# forward: `cargo build --release -p heddle-cli --features client,preview`.
+preview = []
 # In-process hosted fixture for crate tests and CLI grant integration.
 # Production client builds do not enable this.
 test-utils = []

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -42,19 +42,39 @@ pub use crate::hosted_runtime::claim_bridge::{
     DaemonClaimRouter, claim_bridge_socket_path, mount_claim_router,
 };
 
-/// Relay mode that keeps the endpoint reachable through the default
-/// (number-0) relay servers.
+/// Production and preview Heddle relays. Trailing slashes match the
+/// signed endpoint-descriptor encoding.
+///
+/// `heddle netd serve` binds this pair so a claim link can reach the
+/// machine from either environment. Hosted CLI connections still take
+/// their relay list from the signed descriptor (`RelayMode::custom`);
+/// this is only the daemon's home-relay map when no descriptor is in
+/// hand. Never fall through to iroh's [`RelayMode::Default`]: that
+/// map is n0's `*.relay.n0.iroh.link` and is not a Heddle relay.
+#[cfg(feature = "client")]
+const HEDDLE_RELAY_URLS: [&str; 2] = [
+    "https://relay.heddle.sh/",
+    "https://relay.preview.heddle.sh/",
+];
+
+/// Relay mode that keeps the endpoint reachable through Heddle's
+/// relays only.
 ///
 /// The persistent endpoint must stay relay-reachable: a browser
 /// holding only a claim link has no direct path to the machine, so it
 /// dials the advertised node id through a relay. Binding with
-/// [`RelayMode::Disabled`] would strand exactly that caller. Piece 2
-/// (weft subscription) will be able to pass a signed
-/// [`RelayMode::Custom`] set instead; the daemon keeps whatever relay
-/// mode it was bound with online for its whole lifetime.
+/// [`RelayMode::Disabled`] would strand exactly that caller. The
+/// daemon keeps this custom map online for its whole lifetime.
 #[cfg(feature = "client")]
 pub fn default_relay_mode() -> RelayMode {
-    RelayMode::Default
+    RelayMode::custom(HEDDLE_RELAY_URLS.iter().map(|url| {
+        url.parse().unwrap_or_else(|error| {
+            // Crate constants. A parse failure is a programming error,
+            // not a runtime condition; falling through to Default
+            // would put netd on n0's map.
+            panic!("HEDDLE_RELAY_URLS entry {url:?} must parse as RelayUrl: {error}")
+        })
+    }))
 }
 
 /// Bind the machine's single persistent Iroh endpoint on the device

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -45,21 +45,20 @@ pub use crate::hosted_runtime::claim_bridge::{
 /// Home relay for this build flavor. Trailing slash matches the
 /// signed endpoint-descriptor encoding.
 ///
-/// Split on `debug_assertions` — the existing cargo profile gate
-/// (`cargo test` / `cargo build` vs `cargo build --release`). Dev and
-/// preview-shaped debug binaries hardcode preview only; shipped
-/// `--release` binaries hardcode production only. The unused URL is
-/// cfg'd out, so a release binary cannot embed preview and a debug
-/// binary cannot embed prod.
+/// Split on the `preview` cargo feature (forwarded from `heddle-cli`):
+/// stock / `--release` without the feature hardcodes production only;
+/// `--features preview` hardcodes preview only. The unused URL is
+/// cfg'd out, so a production binary cannot embed preview and a
+/// preview binary cannot embed prod.
 ///
 /// Hosted CLI connections still take their relay list from the signed
 /// descriptor (`RelayMode::custom`). This constant is only the netd
 /// home-relay map when no descriptor is in hand. Never
 /// [`RelayMode::Default`]: that map is n0's `*.relay.n0.iroh.link`.
-#[cfg(all(feature = "client", debug_assertions))]
+#[cfg(all(feature = "client", feature = "preview"))]
 const HEDDLE_HOME_RELAY_URL: &str = "https://relay.preview.heddle.sh/";
 
-#[cfg(all(feature = "client", not(debug_assertions)))]
+#[cfg(all(feature = "client", not(feature = "preview")))]
 const HEDDLE_HOME_RELAY_URL: &str = "https://relay.heddle.sh/";
 
 /// Relay mode that keeps the endpoint reachable through this build's
@@ -131,21 +130,21 @@ mod tests {
             "n0 default relay leaked into netd bind: {host}"
         );
 
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "preview")]
         {
             assert_eq!(HEDDLE_HOME_RELAY_URL, "https://relay.preview.heddle.sh/");
             assert!(
                 !HEDDLE_HOME_RELAY_URL.contains("://relay.heddle.sh"),
-                "debug/dev build must not embed the production relay"
+                "preview feature must not embed the production relay"
             );
             assert_eq!(host, "relay.preview.heddle.sh");
         }
-        #[cfg(not(debug_assertions))]
+        #[cfg(not(feature = "preview"))]
         {
             assert_eq!(HEDDLE_HOME_RELAY_URL, "https://relay.heddle.sh/");
             assert!(
                 !HEDDLE_HOME_RELAY_URL.contains("preview"),
-                "release build must not embed the preview relay"
+                "default/release build must not embed the preview relay"
             );
             assert_eq!(host, "relay.heddle.sh");
         }

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -42,23 +42,28 @@ pub use crate::hosted_runtime::claim_bridge::{
     DaemonClaimRouter, claim_bridge_socket_path, mount_claim_router,
 };
 
-/// Production and preview Heddle relays. Trailing slashes match the
+/// Home relay for this build flavor. Trailing slash matches the
 /// signed endpoint-descriptor encoding.
 ///
-/// `heddle netd serve` binds this pair so a claim link can reach the
-/// machine from either environment. Hosted CLI connections still take
-/// their relay list from the signed descriptor (`RelayMode::custom`);
-/// this is only the daemon's home-relay map when no descriptor is in
-/// hand. Never fall through to iroh's [`RelayMode::Default`]: that
-/// map is n0's `*.relay.n0.iroh.link` and is not a Heddle relay.
-#[cfg(feature = "client")]
-const HEDDLE_RELAY_URLS: [&str; 2] = [
-    "https://relay.heddle.sh/",
-    "https://relay.preview.heddle.sh/",
-];
+/// Split on `debug_assertions` — the existing cargo profile gate
+/// (`cargo test` / `cargo build` vs `cargo build --release`). Dev and
+/// preview-shaped debug binaries hardcode preview only; shipped
+/// `--release` binaries hardcode production only. The unused URL is
+/// cfg'd out, so a release binary cannot embed preview and a debug
+/// binary cannot embed prod.
+///
+/// Hosted CLI connections still take their relay list from the signed
+/// descriptor (`RelayMode::custom`). This constant is only the netd
+/// home-relay map when no descriptor is in hand. Never
+/// [`RelayMode::Default`]: that map is n0's `*.relay.n0.iroh.link`.
+#[cfg(all(feature = "client", debug_assertions))]
+const HEDDLE_HOME_RELAY_URL: &str = "https://relay.preview.heddle.sh/";
 
-/// Relay mode that keeps the endpoint reachable through Heddle's
-/// relays only.
+#[cfg(all(feature = "client", not(debug_assertions)))]
+const HEDDLE_HOME_RELAY_URL: &str = "https://relay.heddle.sh/";
+
+/// Relay mode that keeps the endpoint reachable through this build's
+/// Heddle home relay.
 ///
 /// The persistent endpoint must stay relay-reachable: a browser
 /// holding only a claim link has no direct path to the machine, so it
@@ -67,14 +72,13 @@ const HEDDLE_RELAY_URLS: [&str; 2] = [
 /// daemon keeps this custom map online for its whole lifetime.
 #[cfg(feature = "client")]
 pub fn default_relay_mode() -> RelayMode {
-    RelayMode::custom(HEDDLE_RELAY_URLS.iter().map(|url| {
-        url.parse().unwrap_or_else(|error| {
-            // Crate constants. A parse failure is a programming error,
-            // not a runtime condition; falling through to Default
-            // would put netd on n0's map.
-            panic!("HEDDLE_RELAY_URLS entry {url:?} must parse as RelayUrl: {error}")
-        })
-    }))
+    let url = HEDDLE_HOME_RELAY_URL.parse().unwrap_or_else(|error| {
+        // Crate constant. A parse failure is a programming error, not
+        // a runtime condition; falling through to Default would put
+        // netd on n0's map.
+        panic!("HEDDLE_HOME_RELAY_URL {HEDDLE_HOME_RELAY_URL:?} must parse as RelayUrl: {error}")
+    });
+    RelayMode::custom([url])
 }
 
 /// Bind the machine's single persistent Iroh endpoint on the device
@@ -103,7 +107,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_relay_mode_is_heddle_custom_not_n0_default() {
+    fn default_relay_mode_is_heddle_custom_for_this_build_flavor() {
         let mode = default_relay_mode();
         assert!(
             matches!(mode, RelayMode::Custom(_)),
@@ -111,34 +115,39 @@ mod tests {
         );
 
         let urls: Vec<iroh::RelayUrl> = mode.relay_map().urls();
-        assert!(
-            !urls.is_empty(),
-            "netd must stay relay-reachable for claim links"
-        );
-
-        let mut hosts: Vec<String> = urls
-            .iter()
-            .map(|url| {
-                url.host_str()
-                    .unwrap_or("")
-                    .trim_end_matches('.')
-                    .to_string()
-            })
-            .collect();
-        hosts.sort();
-        hosts.dedup();
-
-        for host in &hosts {
-            assert!(
-                !host.ends_with("n0.iroh.link") && host != "n0.iroh.link",
-                "n0 default relay leaked into netd bind: {host}"
-            );
-        }
-
         assert_eq!(
-            hosts,
-            ["relay.heddle.sh", "relay.preview.heddle.sh"],
-            "netd home relays must be Heddle's only"
+            urls.len(),
+            1,
+            "this build flavor must hardcode exactly one home relay, got {urls:?}"
         );
+
+        let host = urls[0]
+            .host_str()
+            .unwrap_or("")
+            .trim_end_matches('.')
+            .to_string();
+        assert!(
+            !host.ends_with("n0.iroh.link") && host != "n0.iroh.link",
+            "n0 default relay leaked into netd bind: {host}"
+        );
+
+        #[cfg(debug_assertions)]
+        {
+            assert_eq!(HEDDLE_HOME_RELAY_URL, "https://relay.preview.heddle.sh/");
+            assert!(
+                !HEDDLE_HOME_RELAY_URL.contains("://relay.heddle.sh"),
+                "debug/dev build must not embed the production relay"
+            );
+            assert_eq!(host, "relay.preview.heddle.sh");
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            assert_eq!(HEDDLE_HOME_RELAY_URL, "https://relay.heddle.sh/");
+            assert!(
+                !HEDDLE_HOME_RELAY_URL.contains("preview"),
+                "release build must not embed the preview relay"
+            );
+            assert_eq!(host, "relay.heddle.sh");
+        }
     }
 }

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -77,3 +77,48 @@ pub async fn bind_persistent_endpoint(relay_mode: RelayMode) -> anyhow::Result<E
 pub fn persisted_node_id() -> anyhow::Result<Option<EndpointId>> {
     crate::hosted_runtime::net_endpoint::persisted_node_id()
 }
+
+#[cfg(all(test, feature = "client"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_relay_mode_is_heddle_custom_not_n0_default() {
+        let mode = default_relay_mode();
+        assert!(
+            matches!(mode, RelayMode::Custom(_)),
+            "netd must bind RelayMode::Custom, got {mode:?}"
+        );
+
+        let urls: Vec<iroh::RelayUrl> = mode.relay_map().urls();
+        assert!(
+            !urls.is_empty(),
+            "netd must stay relay-reachable for claim links"
+        );
+
+        let mut hosts: Vec<String> = urls
+            .iter()
+            .map(|url| {
+                url.host_str()
+                    .unwrap_or("")
+                    .trim_end_matches('.')
+                    .to_string()
+            })
+            .collect();
+        hosts.sort();
+        hosts.dedup();
+
+        for host in &hosts {
+            assert!(
+                !host.ends_with("n0.iroh.link") && host != "n0.iroh.link",
+                "n0 default relay leaked into netd bind: {host}"
+            );
+        }
+
+        assert_eq!(
+            hosts,
+            ["relay.heddle.sh", "relay.preview.heddle.sh"],
+            "netd home relays must be Heddle's only"
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle netd serve` bound the persistent endpoint with `RelayMode::Default`, so iroh homed on n0 (`*.relay.n0.iroh.link`). Live log: `home is now relay https://usw1-1.relay.n0.iroh.link./`.
- Hosted CLI connections stay as-is: they use `RelayMode::custom(relays)` from the signed endpoint descriptor (source of truth for hosted).
- Netd `default_relay_mode()` is now `RelayMode::custom` with **exactly one** Heddle home relay, selected at compile time by the **`preview` cargo feature** (not `debug_assertions`):
  - Default / `--release` (feature off) → `https://relay.heddle.sh/` only
  - `--features preview` → `https://relay.preview.heddle.sh/` only
- `heddle-cli` forwards `preview = ["hosted-client/preview"]`. The unused URL is cfg'd out, so a production binary cannot embed preview and a preview binary cannot embed prod. Never `RelayMode::Default`.

## Preview AX build

```
cargo build --release -p heddle-cli --features client,preview
```

Stock / crates.io / tagged release (prod home relay):

```
cargo build --release -p heddle-cli --features client
```

(`client` is already in the CLI default feature set; listing it is explicit.)

## Closes

Refs HeddleCo/heddle#1533
Refs HeddleCo/heddle#1620

## Red commit
`cd6cd652e78e50b1376d40bf524c17c355037d59`

## Test evidence

Debug, feature off (prod only):

```
$ cargo test --locked -p heddle-hosted-client --features client --lib default_relay_mode -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 10.37s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-31b582925b429dc4)

running 1 test
test network::tests::default_relay_mode_is_heddle_custom_for_this_build_flavor ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out; finished in 0.00s
```

Debug, `--features client,preview` (preview only):

```
$ cargo test --locked -p heddle-hosted-client --features client,preview --lib default_relay_mode -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 15.90s
     Running unittests src/lib.rs (target/debug/deps/hosted_client-bb9e7d743b4f10c0)

running 1 test
test network::tests::default_relay_mode_is_heddle_custom_for_this_build_flavor ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out; finished in 0.00s
```

Release, feature off (prod only):

```
$ cargo test --locked --release -p heddle-hosted-client --features client --lib default_relay_mode -- --nocapture
    Finished `release` profile [optimized] target(s) in 5m 28s
     Running unittests src/lib.rs (target/release/deps/hosted_client-a4ebec7cac5956b1)

running 1 test
test network::tests::default_relay_mode_is_heddle_custom_for_this_build_flavor ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out; finished in 0.00s
```

Release, `--features client,preview` (preview only):

```
$ cargo test --locked --release -p heddle-hosted-client --features client,preview --lib default_relay_mode -- --nocapture
    Finished `release` profile [optimized] target(s) in 5m 20s
     Running unittests src/lib.rs (target/release/deps/hosted_client-e271ee0fd6c15a3e)

running 1 test
test network::tests::default_relay_mode_is_heddle_custom_for_this_build_flavor ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 463 filtered out; finished in 0.00s
```

String isolation of exact `https://relay.*.heddle.sh/` literals:

```
debug client:            https://relay.heddle.sh/           (preview absent)
debug client,preview:    https://relay.preview.heddle.sh/   (prod absent)
release client:          https://relay.heddle.sh/           (preview absent)
release client,preview:  https://relay.preview.heddle.sh/   (prod absent)
```

Fast Lane `fast-check` green on this head.

## Manual verification

N/A — covered by tests.

How to verify on a live box:
- Stock/release `heddle netd serve` log must show `relay.heddle.sh`, never `relay.preview.heddle.sh` or `relay.n0.iroh.link`.
- Preview AX (`--features client,preview`) `heddle netd serve` log must show `relay.preview.heddle.sh`, never `relay.heddle.sh` or `relay.n0.iroh.link`.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a1d119b-4751-495b-ac27-2da18115097d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a1d119b-4751-495b-ac27-2da18115097d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791852940&installation_model_id=21489&pr_number=1746&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1746&signature=5b444503c9742e914f0d054ee6bf87682fef9776f4180c82c92376f08820fc0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->