### PR TITLE
fix(hosted): drop the 1s close tax and reuse weft through netd

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -509,10 +509,12 @@ Examples:
     /// `heddle netd serve` runs a long-lived async daemon that binds
     /// the machine's single persistent Iroh endpoint on the persisted
     /// device node id and keeps it relay-reachable, so outstanding
-    /// claim links keep resolving across restarts. Unlike `daemon`, it
-    /// is not gated on Linux/FUSE and never idle-exits. `status`
-    /// reports liveness and the advertised node id; `stop` asks a
-    /// running daemon to close its endpoint and exit.
+    /// claim links keep resolving across restarts. Hosted verbs
+    /// (`whoami`, `push`, `pull`, `clone`) reuse that endpoint's warm
+    /// weft session when netd is running. Unlike `daemon`, it is not
+    /// gated on Linux/FUSE and never idle-exits. `status` reports
+    /// liveness and the advertised node id; `stop` asks a running
+    /// daemon to close its endpoint and exit.
     Netd {
         #[command(subcommand)]
         command: NetdCommands,
@@ -610,8 +612,8 @@ pub enum DaemonCommands {
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum NetdCommands {
     /// Run the foreground network daemon: bind the persistent device
-    /// endpoint, keep relays online, and serve same-uid control RPCs.
-    /// Never idle-exits.
+    /// endpoint, keep relays online, hold warm weft sessions for hosted
+    /// CLI verbs, and serve same-uid control RPCs. Never idle-exits.
     Serve,
 
     /// Report network-daemon liveness and the advertised device node

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -650,6 +650,10 @@ const DAEMON_TOPIC: &str = "The mount daemon owns virtualized workspace sessions
 \n\
 `heddle daemon`        — FUSE mount-daemon control plane. Owns FUSE sessions for\n\
                          `--workspace virtualized --daemon` threads. Linux only.\n\
+                         Subcommands: serve | status | stop.\n\
+`heddle netd`          — Box network daemon. Binds the persistent Iroh endpoint\n\
+                         and holds warm weft connections so hosted whoami/push/\n\
+                         pull/clone reuse descriptor+relay+QUIC across commands.\n\
                          Subcommands: serve | status | stop.\n";
 
 const MODEL_TOPIC: &str = r#"Heddle mental model — the everyday loop in one screen.

--- a/crates/cli/src/cli/commands/netdaemon/mod.rs
+++ b/crates/cli/src/cli/commands/netdaemon/mod.rs
@@ -10,7 +10,8 @@
 //! Three verbs hang off this module, mirroring the mount daemon's
 //! control surface but box scoped:
 //!
-//! * `heddle netd serve` — foreground async daemon.
+//! * `heddle netd serve` — foreground async daemon (persistent
+//!   endpoint + warm weft sessions for hosted CLI verbs).
 //! * `heddle netd status` — liveness + advertised node id.
 //! * `heddle netd stop` — drain and exit.
 //!

--- a/crates/cli/src/cli/commands/netdaemon/server.rs
+++ b/crates/cli/src/cli/commands/netdaemon/server.rs
@@ -10,19 +10,21 @@
 //! lifecycles (this one never idle-exits) and different platforms
 //! (this one runs on any Unix).
 //!
-//! What it owns (heddle#1533, piece 1):
+//! What it owns (heddle#1533, piece 1, plus the hosted warm-session
+//! bridge):
 //!
 //! * one Iroh endpoint on the persisted device node id, bound with
 //!   relays online (browsers holding only a claim link dial through a
 //!   relay),
 //! * a box-scoped endpoint-discovery file advertising that node id,
 //! * a same-uid control socket for `netd status` / `netd stop`,
+//! * a same-uid hosted bridge that caches weft QUIC sessions so
+//!   one-shot CLI verbs reuse descriptor+relay+QUIC,
 //! * a single-writer guard so two processes never both bind the
 //!   device node id.
 //!
-//! What it does NOT own yet: the claim-ALPN router (piece 3 /
-//! heddle#1620) mounts on the endpoint at the seam marked below, and
-//! the weft subscription/doorbell (piece 2) is separate.
+//! The weft subscription/doorbell (piece 2) is separate. Preview vs
+//! prod home-relay remains the `preview` cargo feature.
 
 use std::{
     os::unix::net::UnixStream,
@@ -74,7 +76,7 @@ pub async fn run_network_daemon() -> Result<()> {
     // device node id, relays online. The node id therefore survives a
     // restart — the acceptance clause the browser claim link relies on
     // (heddle#1620).
-    let endpoint = hosted_client::network::bind_persistent_endpoint(
+    let (endpoint, hosted_sessions) = hosted_client::network::bind_persistent_hosted(
         hosted_client::network::default_relay_mode(),
     )
     .await
@@ -98,6 +100,14 @@ pub async fn run_network_daemon() -> Result<()> {
     let claim_socket = hosted_client::network::claim_bridge_socket_path(&heddle_home);
     let claim_router = hosted_client::network::mount_claim_router(endpoint.clone());
     let claim_bridge = tokio::spawn(claim_router.serve_owner_root_bridge(claim_socket.clone()));
+
+    // Warm weft sessions for one-shot CLI verbs. The persistent endpoint
+    // is already relay-homed; the hosted bridge caches the weft QUIC
+    // connection so whoami/push/pull/clone do not pay bind+WSS+handshake
+    // on every process. Relays for those sessions still come from the
+    // signed descriptor, not from stuffing preview+prod into one Custom set.
+    let hosted_socket = hosted_client::network::hosted_bridge_socket_path(&heddle_home);
+    let hosted_bridge = tokio::spawn(hosted_sessions.serve(hosted_socket.clone()));
 
     let advertised = EndpointState {
         version: NETWORK_DAEMON_PROTOCOL_VERSION,
@@ -140,9 +150,11 @@ pub async fn run_network_daemon() -> Result<()> {
     // makes the unlink single-writer safe — a successor that raced in
     // keeps its file.
     claim_bridge.abort();
+    hosted_bridge.abort();
     endpoint.close().await;
     remove_endpoint_if_owned(&endpoint_path, &advertised);
     let _ = std::fs::remove_file(&claim_socket);
+    let _ = std::fs::remove_file(&hosted_socket);
     let _ = std::fs::remove_file(&socket_path);
     info!("heddle network daemon exiting");
 

--- a/crates/hosted-client/src/hosted_runtime/hosted/call.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/call.rs
@@ -12,7 +12,10 @@ use api::{
 use bytes::{Bytes, BytesMut};
 use prost::Message;
 
-use super::{HostedConnection, HostedError, Result};
+use super::{
+    HostedConnection, HostedError, Result,
+    connection::{HostedRecvStream, HostedSendStream},
+};
 
 pub(super) async fn unary<Request, Response>(
     connection: &HostedConnection,
@@ -41,21 +44,12 @@ where
     let frame =
         encode_request_frame(method, context, encoded_request).map_err(HostedError::framing)?;
     let frame_len = frame.len();
-    let (mut send, mut recv) = connection
-        .connection
-        .open_bi()
-        .await
-        .map_err(HostedError::transport)?;
+    let (mut send, mut recv) = connection.open_bi().await?;
     heddle_perf_contract::record_network_stream_opened();
-    send.write_chunk(Bytes::from(frame))
-        .await
-        .map_err(HostedError::transport)?;
+    send.write_chunk(Bytes::from(frame)).await?;
     heddle_perf_contract::record_network_bytes_sent(frame_len);
-    send.finish().map_err(HostedError::transport)?;
-    let response = recv
-        .read_to_end(MAX_CONTROL_BODY + 1)
-        .await
-        .map_err(HostedError::transport)?;
+    send.finish()?;
+    let response = recv.read_to_end(MAX_CONTROL_BODY + 1).await?;
     heddle_perf_contract::record_network_bytes_received(response.len());
     match decode_response_frame(&response).map_err(HostedError::framing)? {
         ResponseFrame::Success(body) => Response::decode(body).map_err(HostedError::from),
@@ -77,17 +71,11 @@ where
     let mut frame = encode_request_prelude(method, context).map_err(HostedError::framing)?;
     frame.extend_from_slice(&request.encode_to_vec());
     let frame_len = frame.len();
-    let (mut send, recv) = connection
-        .connection
-        .open_bi()
-        .await
-        .map_err(HostedError::transport)?;
+    let (mut send, recv) = connection.open_bi().await?;
     heddle_perf_contract::record_network_stream_opened();
-    send.write_chunk(Bytes::from(frame))
-        .await
-        .map_err(HostedError::transport)?;
+    send.write_chunk(Bytes::from(frame)).await?;
     heddle_perf_contract::record_network_bytes_sent(frame_len);
-    send.finish().map_err(HostedError::transport)?;
+    send.finish()?;
     Ok(ServerStream::new(connection, recv))
 }
 
@@ -103,15 +91,9 @@ where
     require_shape(method, StreamingShape::Bidirectional)?;
     let prelude = encode_request_prelude(method, context).map_err(HostedError::framing)?;
     let prelude_len = prelude.len();
-    let (mut send, recv) = connection
-        .connection
-        .open_bi()
-        .await
-        .map_err(HostedError::transport)?;
+    let (mut send, recv) = connection.open_bi().await?;
     heddle_perf_contract::record_network_stream_opened();
-    send.write_chunk(Bytes::from(prelude))
-        .await
-        .map_err(HostedError::transport)?;
+    send.write_chunk(Bytes::from(prelude)).await?;
     heddle_perf_contract::record_network_bytes_sent(prelude_len);
     Ok(BidirectionalStream {
         send: Some(send),
@@ -125,7 +107,7 @@ where
 /// Decoded server-streaming response over one operation stream.
 pub struct ServerStream<Response> {
     _connection: Arc<HostedConnection>,
-    recv: iroh::endpoint::RecvStream,
+    recv: HostedRecvStream,
     buffered: Vec<u8>,
     response: PhantomData<Response>,
     raw_remaining: u64,
@@ -142,7 +124,7 @@ impl<Response> ServerStream<Response>
 where
     Response: Message + Default,
 {
-    fn new(connection: Arc<HostedConnection>, recv: iroh::endpoint::RecvStream) -> Self {
+    fn new(connection: Arc<HostedConnection>, recv: HostedRecvStream) -> Self {
         Self {
             _connection: connection,
             recv,
@@ -186,12 +168,7 @@ where
                 self.buffered.drain(..consumed);
                 return Ok(Some(response));
             }
-            match self
-                .recv
-                .read_chunk(MAX_CONTROL_BODY + 5)
-                .await
-                .map_err(HostedError::transport)?
-            {
+            match self.recv.read_chunk(MAX_CONTROL_BODY + 5).await? {
                 Some(chunk) => {
                     heddle_perf_contract::record_network_bytes_received(chunk.len());
                     self.buffered.extend_from_slice(&chunk);
@@ -225,12 +202,7 @@ where
             self.raw_remaining -= length as u64;
             return Ok(Some(chunk));
         }
-        let Some(chunk) = self
-            .recv
-            .read_chunk(maximum)
-            .await
-            .map_err(HostedError::transport)?
-        else {
+        let Some(chunk) = self.recv.read_chunk(maximum).await? else {
             return Err(HostedError::Framing(
                 "stream ended within a declared raw body".to_string(),
             ));
@@ -248,9 +220,7 @@ where
 
     pub fn cancel(&mut self) -> Result<()> {
         if !self.finished {
-            self.recv
-                .stop(1u32.into())
-                .map_err(HostedError::transport)?;
+            self.recv.stop(1)?;
             self.finished = true;
         }
         Ok(())
@@ -260,14 +230,14 @@ where
 impl<Response> Drop for ServerStream<Response> {
     fn drop(&mut self) {
         if !self.finished {
-            let _ = self.recv.stop(1u32.into());
+            let _ = self.recv.stop(1);
         }
     }
 }
 
 /// Bidirectional operation stream with typed protobuf messages in both directions.
 pub struct BidirectionalStream<Request, Response> {
-    send: Option<iroh::endpoint::SendStream>,
+    send: Option<HostedSendStream>,
     responses: ServerStream<Response>,
     request: PhantomData<Request>,
     raw_remaining: u64,
@@ -276,7 +246,7 @@ pub struct BidirectionalStream<Request, Response> {
 
 /// Request half of a bidirectional operation stream.
 pub struct BidirectionalRequestStream<Request> {
-    send: Option<iroh::endpoint::SendStream>,
+    send: Option<HostedSendStream>,
     request: PhantomData<Request>,
     raw_remaining: u64,
     control: BytesMut,
@@ -312,8 +282,7 @@ where
             .as_mut()
             .ok_or_else(|| HostedError::Framing("request stream is finished".to_string()))?
             .write_all(&self.control)
-            .await
-            .map_err(HostedError::transport)?;
+            .await?;
         heddle_perf_contract::record_network_bytes_sent(frame_len);
         Ok(())
     }
@@ -325,7 +294,7 @@ where
             ));
         }
         if let Some(mut send) = self.send.take() {
-            send.finish().map_err(HostedError::transport)?;
+            send.finish()?;
         }
         Ok(())
     }
@@ -344,7 +313,7 @@ where
 
     pub fn cancel(&mut self) -> Result<()> {
         if let Some(mut send) = self.send.take() {
-            send.reset(1u32.into()).map_err(HostedError::transport)?;
+            send.reset(1)?;
         }
         self.responses.cancel()
     }
@@ -367,8 +336,7 @@ where
             .as_mut()
             .ok_or_else(|| HostedError::Framing("request stream is finished".to_string()))?
             .write_all(&self.control)
-            .await
-            .map_err(HostedError::transport)?;
+            .await?;
         heddle_perf_contract::record_network_bytes_sent(frame_len);
         Ok(())
     }
@@ -386,8 +354,7 @@ where
             .as_mut()
             .ok_or_else(|| HostedError::Framing("request stream is finished".to_string()))?
             .write_all(&self.control)
-            .await
-            .map_err(HostedError::transport)?;
+            .await?;
         heddle_perf_contract::record_network_bytes_sent(frame_len);
         self.raw_remaining = length;
         Ok(())
@@ -404,8 +371,7 @@ where
             .as_mut()
             .ok_or_else(|| HostedError::Framing("request stream is finished".to_string()))?
             .write_chunk(chunk)
-            .await
-            .map_err(HostedError::transport)?;
+            .await?;
         heddle_perf_contract::record_network_bytes_sent(length as usize);
         self.raw_remaining -= length;
         Ok(())
@@ -418,14 +384,14 @@ where
             ));
         }
         if let Some(mut send) = self.send.take() {
-            send.finish().map_err(HostedError::transport)?;
+            send.finish()?;
         }
         Ok(())
     }
 
     pub fn cancel(&mut self) -> Result<()> {
         if let Some(mut send) = self.send.take() {
-            send.reset(1u32.into()).map_err(HostedError::transport)?;
+            send.reset(1)?;
         }
         Ok(())
     }
@@ -494,7 +460,7 @@ mod tests {
         let connection = HostedConnection::connect(client, server_addr)
             .await
             .unwrap();
-        let (mut send, recv) = connection.connection.open_bi().await.unwrap();
+        let (mut send, recv) = connection.open_bi().await.unwrap();
         send.write_all(b"x").await.unwrap();
         send.finish().unwrap();
         response_started_rx.await.unwrap();

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -1023,4 +1023,143 @@ mod tests {
         live.close().await;
         server_task.await.unwrap();
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connect_via_netd_fails_when_the_bridge_socket_is_missing() {
+        let _env_guard = config::credentials::lock_test_env();
+        let home = tempfile::TempDir::new().unwrap();
+        let _pin = super::hosted_bridge::PinHeddleHome::new(home.path());
+        let error = HostedConnection::connect_via_netd(
+            super::hosted_bridge::TEST_WEFT_SERVER,
+            &config::ClientConfig::default(),
+        )
+        .await
+        .expect_err("connect_via_netd must fail closed without netd");
+        assert!(error.to_string().contains("not running"), "got {error}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connect_via_netd_reuses_warm_weft_and_proxied_streams() {
+        let _env_guard = config::credentials::lock_test_env();
+        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let connection = HostedConnection::connect_via_netd(
+            super::hosted_bridge::TEST_WEFT_SERVER,
+            &config::ClientConfig::default(),
+        )
+        .await
+        .expect("warm netd must be usable");
+        assert!(connection.reused_warm());
+        assert!(connection.supports_provider_transport());
+        assert_eq!(connection.endpoint_id(), fixture.node_id);
+        assert!(connection.local_endpoint().is_none());
+        assert!(connection.quic_connection().is_none());
+
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        send.write_all(b"via-netd").await.unwrap();
+        send.finish().unwrap();
+        let reply = recv.read_to_end(64 * 1024).await.unwrap();
+        assert_eq!(reply, b"via-netd");
+
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        send.write_chunk(bytes::Bytes::from_static(b"chunk"))
+            .await
+            .unwrap();
+        send.finish().unwrap();
+        let chunk = recv.read_chunk(64).await.unwrap();
+        assert_eq!(chunk.as_deref(), Some(b"chunk".as_slice()));
+
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        send.reset(1).unwrap();
+        recv.stop(1).unwrap();
+
+        assert_eq!(
+            fixture.accepts(),
+            1,
+            "proxied OpenBi must stay on the cached weft connection"
+        );
+
+        let started = Instant::now();
+        connection.close().await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "proxied close without a local provider must not drain, took {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hosted_client_connect_via_netd_runs_a_unary_on_proxied_streams() {
+        let _env_guard = config::credentials::lock_test_env();
+        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let client = crate::hosted_runtime::hosted::HostedClient::connect_via_netd(
+            super::hosted_bridge::TEST_WEFT_SERVER,
+            &config::ClientConfig::default(),
+        )
+        .await
+        .unwrap();
+        assert!(client.reused_warm_connection());
+        let context = crate::hosted_runtime::hosted::CallContextFactory::default()
+            .unary("/heddle.api.v1alpha1.IdentityService/WhoAmI", &[], "")
+            .unwrap()
+            .context;
+        let error = client
+            .unary::<api::heddle::api::v1alpha1::WhoAmIRequest, api::heddle::api::v1alpha1::WhoAmIResponse>(
+                "/heddle.api.v1alpha1.IdentityService/WhoAmI",
+                &context,
+                &api::heddle::api::v1alpha1::WhoAmIRequest {},
+            )
+            .await
+            .expect_err("echo fixture is not a framed WhoAmI server");
+        assert!(!error.to_string().is_empty());
+        client.close().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_connect_uses_netd_when_the_bridge_is_up() {
+        let _env_guard = config::credentials::lock_test_env();
+        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let session = crate::hosted_runtime::hosted::HostedSession::build(
+            &config::UserConfig::default(),
+            None,
+            crate::hosted_runtime::hosted::HostedAuthMode::Unauthenticated,
+        )
+        .unwrap();
+        let client = session
+            .connect(super::hosted_bridge::TEST_WEFT_SERVER)
+            .await
+            .expect("session.connect must reuse a running hosted bridge");
+        assert!(client.reused_warm_connection());
+        client.close().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_connect_falls_back_when_netd_is_down() {
+        let _env_guard = config::credentials::lock_test_env();
+        let home = tempfile::TempDir::new().unwrap();
+        let _pin = super::hosted_bridge::PinHeddleHome::new(home.path());
+        let session = crate::hosted_runtime::hosted::HostedSession::build(
+            &config::UserConfig::default(),
+            None,
+            crate::hosted_runtime::hosted::HostedAuthMode::Unauthenticated,
+        )
+        .unwrap();
+        let error = session
+            .connect("https://127.0.0.1:1")
+            .await
+            .expect_err("without netd, connect must fall through to local discovery");
+        assert!(!error.to_string().is_empty());
+        let outbound = session
+            .connect_outbound("https://127.0.0.1:1")
+            .await
+            .expect_err("outbound connect must use the same netd fallback");
+        assert!(!outbound.to_string().is_empty());
+    }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -556,25 +556,32 @@ impl HostedRecvStream {
 }
 
 /// Initiate graceful router/endpoint shutdown without gating the
-/// caller on QUIC drain. The shutdown future is spawned so a
-/// timeout detaches it instead of cancelling mid-close.
+/// caller on QUIC drain. Wait up to [`FOREGROUND_ENDPOINT_DRAIN`];
+/// if close is still running, detach the task so drain continues.
+///
+/// Do not wrap the [`tokio::task::JoinHandle`] in
+/// [`tokio::time::timeout`]: on `Elapsed` that future is dropped,
+/// and a dropped handle must not be what stops close. Race join
+/// against the bound and [`std::mem::forget`] the handle so the
+/// runtime keeps the drain.
 pub(super) async fn bounded_foreground_shutdown<E, F>(shutdown: F)
 where
     F: std::future::Future<Output = std::result::Result<(), E>> + Send + 'static,
     E: std::fmt::Display + Send + 'static,
 {
-    let task = tokio::spawn(async move {
+    let mut task = tokio::spawn(async move {
         if let Err(error) = shutdown.await {
             tracing::warn!(%error, "failed to shut down Heddle Iroh router");
         }
     });
-    match tokio::time::timeout(FOREGROUND_ENDPOINT_DRAIN, task).await {
-        Ok(_) => {}
-        Err(_) => {
+    tokio::select! {
+        _ = &mut task => {}
+        () = tokio::time::sleep(FOREGROUND_ENDPOINT_DRAIN) => {
             tracing::debug!(
                 timeout_ms = FOREGROUND_ENDPOINT_DRAIN.as_millis(),
                 "detached hosted endpoint drain after foreground bound"
             );
+            std::mem::forget(task);
         }
     }
 }
@@ -657,7 +664,10 @@ mod tests {
         collections::HashMap,
         net::Ipv4Addr,
         path::PathBuf,
-        sync::{Arc, atomic::AtomicBool},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
         time::{Duration, Instant},
     };
 
@@ -778,6 +788,35 @@ mod tests {
             elapsed < Duration::from_millis(200),
             "foreground close must detach a 1s drain, took {elapsed:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn bounded_shutdown_still_completes_after_foreground_detach() {
+        let finished = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&finished);
+        let started = Instant::now();
+        bounded_foreground_shutdown(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            flag.store(true, Ordering::SeqCst);
+            Ok::<(), &'static str>(())
+        })
+        .await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "foreground close must return at the 20ms bound, took {elapsed:?}"
+        );
+        assert!(
+            !finished.load(Ordering::SeqCst),
+            "an 80ms drain must still be in flight when the caller returns"
+        );
+        tokio::time::timeout(Duration::from_millis(400), async {
+            while !finished.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("detached drain must still complete after the caller returns");
     }
 
     #[tokio::test]

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -17,7 +17,10 @@ use iroh::{
     endpoint::{AckFrequencyConfig, QuicTransportConfig, presets},
     protocol::Router,
 };
-use tokio::{io::AsyncReadExt, io::AsyncWriteExt, sync::Mutex};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+};
 
 use super::{
     HostedError, Result, VerifiedEndpointDescriptor,
@@ -71,6 +74,19 @@ struct ProxiedTransport {
     socket_path: PathBuf,
     node_id: EndpointId,
     reused: AtomicBool,
+    /// Ephemeral local endpoint for provider (CAS) dials.
+    ///
+    /// Weft stays in netd. `ProviderBackend` needs a real Iroh
+    /// `Connection`, which cannot cross the UDS splice, so the CLI
+    /// binds this once per process the first time a provider is used.
+    provider_local: Mutex<Option<LocalProviderEndpoint>>,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct LocalProviderEndpoint {
+    endpoint: Endpoint,
+    transport: ProviderWebSocketTransport,
 }
 
 impl HostedConnection {
@@ -202,6 +218,7 @@ impl HostedConnection {
                 socket_path: socket,
                 node_id: ensured.node_id,
                 reused: AtomicBool::new(ensured.reused),
+                provider_local: Mutex::new(None),
             }),
             provider_connections: Mutex::new(HashMap::new()),
         }))
@@ -276,23 +293,17 @@ impl HostedConnection {
                         "the active Iroh endpoint has no provider transport".to_string(),
                     )
                 })?;
-                let address = transport.register_source(
-                    &source.provider_id,
-                    &source.endpoint_id,
-                    &source.direct_url,
-                    &source.opaque_ticket,
-                )?;
-                let connection = endpoint
-                    .connect(address, api::PROVIDER_ALPN_V1)
-                    .await
-                    .map_err(HostedError::transport)?;
+                let connection = dial_provider(endpoint, transport, source).await?;
                 *cached = Some(connection.clone());
                 Ok(connection)
             }
             #[cfg(unix)]
-            HostedTransport::Proxied(_) => Err(HostedError::transport(
-                "provider connections on a netd-proxied session are opened as streams",
-            )),
+            HostedTransport::Proxied(proxied) => {
+                let (endpoint, transport) = proxied.ensure_local_provider().await?;
+                let connection = dial_provider(&endpoint, &transport, source).await?;
+                *cached = Some(connection.clone());
+                Ok(connection)
+            }
         }
     }
 
@@ -306,9 +317,22 @@ impl HostedConnection {
                 bounded_foreground_shutdown(async move { router.shutdown().await }).await;
             }
             #[cfg(unix)]
-            HostedTransport::Proxied(_) => {
+            HostedTransport::Proxied(proxied) => {
                 // The weft QUIC session lives in netd; dropping this handle
-                // must not drain it.
+                // must not drain it. A lazy local provider endpoint is
+                // this process's, so start a bounded close if we bound one.
+                let local = {
+                    let mut guard = proxied.provider_local.lock().await;
+                    guard.take()
+                };
+                if let Some(local) = local {
+                    let endpoint = local.endpoint;
+                    bounded_foreground_shutdown(async move {
+                        endpoint.close().await;
+                        Ok::<(), &'static str>(())
+                    })
+                    .await;
+                }
             }
         }
     }
@@ -318,6 +342,28 @@ impl HostedConnection {
             HostedTransport::Local { .. } => false,
             #[cfg(unix)]
             HostedTransport::Proxied(proxied) => proxied.reused.load(Ordering::Relaxed),
+        }
+    }
+
+    #[cfg(all(test, unix))]
+    fn local_provider_endpoint_id_for_test(&self) -> Option<EndpointId> {
+        match &self.inner {
+            HostedTransport::Local { .. } => None,
+            HostedTransport::Proxied(proxied) => proxied
+                .provider_local
+                .try_lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|local| local.endpoint.id())),
+        }
+    }
+
+    #[cfg(all(test, unix))]
+    async fn ensure_local_provider_for_test(&self) -> Result<EndpointId> {
+        match &self.inner {
+            HostedTransport::Local { .. } => Err(HostedError::transport(
+                "local sessions already have an endpoint",
+            )),
+            HostedTransport::Proxied(proxied) => Ok(proxied.ensure_local_provider().await?.0.id()),
         }
     }
 
@@ -348,6 +394,53 @@ impl HostedConnection {
             }
         }
     }
+}
+
+#[cfg(unix)]
+impl ProxiedTransport {
+    async fn ensure_local_provider(&self) -> Result<(Endpoint, ProviderWebSocketTransport)> {
+        let mut guard = self.provider_local.lock().await;
+        if let Some(local) = guard.as_ref() {
+            return Ok((local.endpoint.clone(), local.transport.clone()));
+        }
+        let config = ClientConfig {
+            allow_insecure: self.allow_insecure,
+            ..ClientConfig::default()
+        };
+        let transport = ProviderWebSocketTransport::new(config);
+        let endpoint = bind_endpoint(
+            RelayMode::Disabled,
+            Some(transport.clone()),
+            EndpointIdentity::Ephemeral,
+        )
+        .await?;
+        tracing::debug!(
+            node_id = %endpoint.id(),
+            "bound local ephemeral endpoint for provider dials on a netd-proxied session"
+        );
+        *guard = Some(LocalProviderEndpoint {
+            endpoint: endpoint.clone(),
+            transport: transport.clone(),
+        });
+        Ok((endpoint, transport))
+    }
+}
+
+async fn dial_provider(
+    endpoint: &Endpoint,
+    transport: &ProviderWebSocketTransport,
+    source: &ProviderSource,
+) -> Result<iroh::endpoint::Connection> {
+    let address = transport.register_source(
+        &source.provider_id,
+        &source.endpoint_id,
+        &source.direct_url,
+        &source.opaque_ticket,
+    )?;
+    endpoint
+        .connect(address, api::PROVIDER_ALPN_V1)
+        .await
+        .map_err(HostedError::transport)
 }
 
 pub(super) enum HostedSendStream {
@@ -561,8 +654,10 @@ fn transport_config() -> QuicTransportConfig {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashMap,
         net::Ipv4Addr,
-        sync::Arc,
+        path::PathBuf,
+        sync::{Arc, atomic::AtomicBool},
         time::{Duration, Instant},
     };
 
@@ -736,5 +831,134 @@ mod tests {
         );
         server_task.abort();
         let _ = server_task.await;
+    }
+
+    #[cfg(unix)]
+    fn test_proxied() -> std::sync::Arc<HostedConnection> {
+        let node_id = iroh_base::SecretKey::generate().public();
+        std::sync::Arc::new(HostedConnection {
+            inner: super::HostedTransport::Proxied(super::ProxiedTransport {
+                server: "https://api.test.heddle.sh".to_string(),
+                allow_insecure: true,
+                socket_path: PathBuf::from("/tmp/heddle-hosted-unused.sock"),
+                node_id,
+                reused: AtomicBool::new(true),
+                provider_local: Mutex::new(None),
+            }),
+            provider_connections: Mutex::new(HashMap::new()),
+        })
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proxied_provider_connection_binds_local_endpoint_instead_of_failing_closed() {
+        let connection = test_proxied();
+        let endpoint_id = iroh_base::SecretKey::generate().public();
+        let source = ProviderSource {
+            provider_id: "provider-a".to_string(),
+            endpoint_id: endpoint_id.to_string(),
+            direct_url: "wss://127.0.0.1:1/direct?provider=provider-a&ticket=opaque".to_string(),
+            opaque_ticket: "opaque".to_string(),
+            expires_at_unix_millis: u64::MAX,
+        };
+        let dial = {
+            let connection = Arc::clone(&connection);
+            tokio::spawn(async move { connection.provider_connection(&source).await })
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let first = loop {
+            if let Some(id) = connection.local_provider_endpoint_id_for_test() {
+                break id;
+            }
+            if Instant::now() >= deadline {
+                panic!(
+                    "netd-proxied provider_connection must bind a local endpoint (failing closed with 'opened as streams' would never bind)"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        dial.abort();
+        let _ = dial.await;
+
+        let second = connection
+            .ensure_local_provider_for_test()
+            .await
+            .expect("local provider endpoint must stay bound");
+        assert_eq!(
+            first, second,
+            "a proxied session must reuse one local provider endpoint"
+        );
+
+        let started = Instant::now();
+        connection.close().await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "closing a proxied session with a local provider endpoint must not drain, took {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proxied_provider_connection_reuses_a_live_cached_connection() {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let server_id = server.id();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let connection = server
+                .accept()
+                .await
+                .expect("incoming connection")
+                .await
+                .unwrap();
+            connection.closed().await;
+            server.close().await;
+        });
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let live = HostedConnection::connect(client, server_addr)
+            .await
+            .unwrap();
+        let connection = test_proxied();
+        connection.provider_connections.lock().await.insert(
+            server_id,
+            Arc::new(Mutex::new(Some(
+                live.quic_connection().expect("local fixture").clone(),
+            ))),
+        );
+
+        let reused = connection
+            .provider_connection(&ProviderSource {
+                provider_id: "provider-a".to_string(),
+                endpoint_id: server_id.to_string(),
+                direct_url: "wss://unused.invalid/direct?provider=provider-a&ticket=unused"
+                    .to_string(),
+                opaque_ticket: "unused".to_string(),
+                expires_at_unix_millis: u64::MAX,
+            })
+            .await
+            .unwrap();
+
+        assert!(reused.close_reason().is_none());
+        assert!(
+            connection.local_provider_endpoint_id_for_test().is_none(),
+            "a live cached provider connection must not bind a local endpoint"
+        );
+        connection.close().await;
+        live.close().await;
+        server_task.await.unwrap();
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -1142,6 +1142,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn session_connect_falls_back_when_netd_is_down() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let _env_guard = config::credentials::lock_test_env();
         let home = tempfile::TempDir::new().unwrap();
         let _pin = super::hosted_bridge::PinHeddleHome::new(home.path());

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -1,36 +1,76 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    os::fd::AsRawFd,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use api::heddle::api::v1alpha1::ProviderSource;
+use bytes::Bytes;
 use config::ClientConfig;
 use iroh::{
     Endpoint, EndpointAddr, EndpointId, RelayMode,
     endpoint::{AckFrequencyConfig, QuicTransportConfig, presets},
     protocol::Router,
 };
-use tokio::sync::Mutex;
+use tokio::{io::AsyncReadExt, io::AsyncWriteExt, sync::Mutex};
 
 use super::{
     HostedError, Result, VerifiedEndpointDescriptor,
     claim_protocol::{CLAIM_ALPN_V1, ClaimProtocol},
+    hosted_bridge,
     provider_transport::ProviderWebSocketTransport,
 };
 
 const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 
+/// Foreground wait for `Router::shutdown` / `Endpoint::close`.
+///
+/// Loopback drain is sub-millisecond in release. On a relay/WAN path
+/// `noq wait_all_draining` waits for a close-frame ACK / probe timeout
+/// that measures a repeatable ~1000 ms after the RPC is already
+/// `LocallyClosed`. One-shot CLI verbs must not sit on that wait:
+/// initiate graceful close (so the endpoint is not dropped dirty),
+/// then detach the remainder.
+const FOREGROUND_ENDPOINT_DRAIN: Duration = Duration::from_millis(20);
+
 #[derive(Debug)]
 pub(super) struct HostedConnection {
-    // A transient inbound claim listener on this connection's endpoint.
-    // It serves resolve/consent for a browser that reaches this process's
-    // endpoint, but it holds no owner-root co-sign consumer: the persisted
-    // box network daemon owns that, and the owner-root co-sign is bridged
-    // to a foreground signer (heddle#1620). A co-sign dialed here therefore
-    // fails closed rather than being performed without a foreground owner.
-    router: Router,
-    pub(super) endpoint: Endpoint,
-    pub(super) connection: iroh::endpoint::Connection,
-    provider_transport: Option<ProviderWebSocketTransport>,
+    inner: HostedTransport,
     provider_connections:
         Mutex<HashMap<EndpointId, Arc<Mutex<Option<iroh::endpoint::Connection>>>>>,
+}
+
+#[derive(Debug)]
+enum HostedTransport {
+    Local {
+        // A transient inbound claim listener on this connection's endpoint.
+        // It serves resolve/consent for a browser that reaches this process's
+        // endpoint, but it holds no owner-root co-sign consumer: the persisted
+        // box network daemon owns that, and the owner-root co-sign is bridged
+        // to a foreground signer (heddle#1620). A co-sign dialed here therefore
+        // fails closed rather than being performed without a foreground owner.
+        router: Router,
+        endpoint: Endpoint,
+        connection: iroh::endpoint::Connection,
+        provider_transport: Option<ProviderWebSocketTransport>,
+    },
+    #[cfg(unix)]
+    Proxied(ProxiedTransport),
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct ProxiedTransport {
+    server: String,
+    allow_insecure: bool,
+    socket_path: PathBuf,
+    node_id: EndpointId,
+    reused: AtomicBool,
 }
 
 impl HostedConnection {
@@ -132,20 +172,75 @@ impl HostedConnection {
         };
         let router = claim_router(endpoint.clone());
         Ok(Arc::new(Self {
-            router,
-            endpoint,
-            connection,
-            provider_transport,
+            inner: HostedTransport::Local {
+                router,
+                endpoint,
+                connection,
+                provider_transport,
+            },
+            provider_connections: Mutex::new(HashMap::new()),
+        }))
+    }
+
+    #[cfg(unix)]
+    pub(super) async fn connect_via_netd(server: &str, config: &ClientConfig) -> Result<Arc<Self>> {
+        let socket = hosted_bridge::hosted_bridge_socket_path(&repo::identity::heddle_home_dir());
+        if !socket.exists() {
+            return Err(HostedError::transport("netd hosted bridge is not running"));
+        }
+        let ensured =
+            hosted_bridge::ensure_via_netd(&socket, server, config.allow_insecure).await?;
+        tracing::debug!(
+            reused = ensured.reused,
+            node_id = %ensured.node_id,
+            "hosted connect using netd warm bridge"
+        );
+        Ok(Arc::new(Self {
+            inner: HostedTransport::Proxied(ProxiedTransport {
+                server: server.to_string(),
+                allow_insecure: config.allow_insecure,
+                socket_path: socket,
+                node_id: ensured.node_id,
+                reused: AtomicBool::new(ensured.reused),
+            }),
             provider_connections: Mutex::new(HashMap::new()),
         }))
     }
 
     pub(super) fn endpoint_id(&self) -> EndpointId {
-        self.endpoint.id()
+        match &self.inner {
+            HostedTransport::Local { endpoint, .. } => endpoint.id(),
+            #[cfg(unix)]
+            HostedTransport::Proxied(proxied) => proxied.node_id,
+        }
     }
 
     pub(super) fn supports_provider_transport(&self) -> bool {
-        self.provider_transport.is_some()
+        match &self.inner {
+            HostedTransport::Local {
+                provider_transport, ..
+            } => provider_transport.is_some(),
+            #[cfg(unix)]
+            HostedTransport::Proxied(_) => true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn local_endpoint(&self) -> Option<&Endpoint> {
+        match &self.inner {
+            HostedTransport::Local { endpoint, .. } => Some(endpoint),
+            #[cfg(unix)]
+            HostedTransport::Proxied(_) => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn quic_connection(&self) -> Option<&iroh::endpoint::Connection> {
+        match &self.inner {
+            HostedTransport::Local { connection, .. } => Some(connection),
+            #[cfg(unix)]
+            HostedTransport::Proxied(_) => None,
+        }
     }
 
     pub(super) async fn provider_connection(
@@ -170,30 +265,223 @@ impl HostedConnection {
             return Ok(connection.clone());
         }
 
-        let transport = self.provider_transport.as_ref().ok_or_else(|| {
-            HostedError::InvalidDescriptor(
-                "the active Iroh endpoint has no provider transport".to_string(),
-            )
-        })?;
-        let address = transport.register_source(
-            &source.provider_id,
-            &source.endpoint_id,
-            &source.direct_url,
-            &source.opaque_ticket,
-        )?;
-        let connection = self
-            .endpoint
-            .connect(address, api::PROVIDER_ALPN_V1)
-            .await
-            .map_err(HostedError::transport)?;
-        *cached = Some(connection.clone());
-        Ok(connection)
+        match &self.inner {
+            HostedTransport::Local {
+                endpoint,
+                provider_transport,
+                ..
+            } => {
+                let transport = provider_transport.as_ref().ok_or_else(|| {
+                    HostedError::InvalidDescriptor(
+                        "the active Iroh endpoint has no provider transport".to_string(),
+                    )
+                })?;
+                let address = transport.register_source(
+                    &source.provider_id,
+                    &source.endpoint_id,
+                    &source.direct_url,
+                    &source.opaque_ticket,
+                )?;
+                let connection = endpoint
+                    .connect(address, api::PROVIDER_ALPN_V1)
+                    .await
+                    .map_err(HostedError::transport)?;
+                *cached = Some(connection.clone());
+                Ok(connection)
+            }
+            #[cfg(unix)]
+            HostedTransport::Proxied(_) => Err(HostedError::transport(
+                "provider connections on a netd-proxied session are opened as streams",
+            )),
+        }
     }
 
     pub(super) async fn close(&self) {
-        self.connection.close(0u32.into(), b"Heddle client closed");
-        if let Err(error) = self.router.shutdown().await {
+        match &self.inner {
+            HostedTransport::Local {
+                router, connection, ..
+            } => {
+                connection.close(0u32.into(), b"Heddle client closed");
+                let router = router.clone();
+                bounded_foreground_shutdown(async move { router.shutdown().await }).await;
+            }
+            #[cfg(unix)]
+            HostedTransport::Proxied(_) => {
+                // The weft QUIC session lives in netd; dropping this handle
+                // must not drain it.
+            }
+        }
+    }
+
+    pub(super) fn reused_warm(&self) -> bool {
+        match &self.inner {
+            HostedTransport::Local { .. } => false,
+            #[cfg(unix)]
+            HostedTransport::Proxied(proxied) => proxied.reused.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(super) async fn open_bi(&self) -> Result<(HostedSendStream, HostedRecvStream)> {
+        match &self.inner {
+            HostedTransport::Local { connection, .. } => {
+                let (send, recv) = connection.open_bi().await.map_err(HostedError::transport)?;
+                Ok((
+                    HostedSendStream::Direct(send),
+                    HostedRecvStream::Direct(recv),
+                ))
+            }
+            #[cfg(unix)]
+            HostedTransport::Proxied(proxied) => {
+                let (stream, reused) = hosted_bridge::open_bi_via_netd(
+                    &proxied.socket_path,
+                    &proxied.server,
+                    proxied.allow_insecure,
+                    None,
+                )
+                .await?;
+                proxied.reused.store(reused, Ordering::Relaxed);
+                let (read, write) = stream.into_split();
+                Ok((
+                    HostedSendStream::Proxied(write),
+                    HostedRecvStream::Proxied(read),
+                ))
+            }
+        }
+    }
+}
+
+pub(super) enum HostedSendStream {
+    Direct(iroh::endpoint::SendStream),
+    #[cfg(unix)]
+    Proxied(tokio::net::unix::OwnedWriteHalf),
+}
+
+pub(super) enum HostedRecvStream {
+    Direct(iroh::endpoint::RecvStream),
+    #[cfg(unix)]
+    Proxied(tokio::net::unix::OwnedReadHalf),
+}
+
+impl HostedSendStream {
+    pub(super) async fn write_chunk(&mut self, chunk: Bytes) -> Result<()> {
+        match self {
+            Self::Direct(send) => send
+                .write_chunk(chunk)
+                .await
+                .map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(send) => send.write_all(&chunk).await.map_err(HostedError::transport),
+        }
+    }
+
+    pub(super) async fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        match self {
+            Self::Direct(send) => send.write_all(buf).await.map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(send) => send.write_all(buf).await.map_err(HostedError::transport),
+        }
+    }
+
+    pub(super) fn finish(&mut self) -> Result<()> {
+        match self {
+            Self::Direct(send) => send.finish().map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(send) => {
+                let fd = send.as_ref().as_raw_fd();
+                let rc = unsafe { libc::shutdown(fd, libc::SHUT_WR) };
+                if rc == 0 {
+                    Ok(())
+                } else {
+                    Err(HostedError::transport(std::io::Error::last_os_error()))
+                }
+            }
+        }
+    }
+
+    pub(super) fn reset(&mut self, error_code: u32) -> Result<()> {
+        match self {
+            Self::Direct(send) => send
+                .reset(error_code.into())
+                .map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(send) => {
+                let fd = send.as_ref().as_raw_fd();
+                let _ = unsafe { libc::shutdown(fd, libc::SHUT_RDWR) };
+                Ok(())
+            }
+        }
+    }
+}
+
+impl HostedRecvStream {
+    pub(super) async fn read_to_end(&mut self, max: usize) -> Result<Vec<u8>> {
+        match self {
+            Self::Direct(recv) => recv.read_to_end(max).await.map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(recv) => {
+                let mut buf = Vec::new();
+                recv.read_to_end(&mut buf)
+                    .await
+                    .map_err(HostedError::transport)?;
+                if buf.len() > max {
+                    buf.truncate(max + 1);
+                }
+                Ok(buf)
+            }
+        }
+    }
+
+    pub(super) async fn read_chunk(&mut self, max: usize) -> Result<Option<Bytes>> {
+        match self {
+            Self::Direct(recv) => recv.read_chunk(max).await.map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(recv) => {
+                let mut buf = vec![0u8; max.max(1)];
+                match recv.read(&mut buf).await {
+                    Ok(0) => Ok(None),
+                    Ok(n) => {
+                        buf.truncate(n);
+                        Ok(Some(Bytes::from(buf)))
+                    }
+                    Err(error) => Err(HostedError::transport(error)),
+                }
+            }
+        }
+    }
+
+    pub(super) fn stop(&mut self, error_code: u32) -> Result<()> {
+        match self {
+            Self::Direct(recv) => recv.stop(error_code.into()).map_err(HostedError::transport),
+            #[cfg(unix)]
+            Self::Proxied(recv) => {
+                let fd = recv.as_ref().as_raw_fd();
+                let _ = unsafe { libc::shutdown(fd, libc::SHUT_RDWR) };
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Initiate graceful router/endpoint shutdown without gating the
+/// caller on QUIC drain. The shutdown future is spawned so a
+/// timeout detaches it instead of cancelling mid-close.
+pub(super) async fn bounded_foreground_shutdown<E, F>(shutdown: F)
+where
+    F: std::future::Future<Output = std::result::Result<(), E>> + Send + 'static,
+    E: std::fmt::Display + Send + 'static,
+{
+    let task = tokio::spawn(async move {
+        if let Err(error) = shutdown.await {
             tracing::warn!(%error, "failed to shut down Heddle Iroh router");
+        }
+    });
+    match tokio::time::timeout(FOREGROUND_ENDPOINT_DRAIN, task).await {
+        Ok(_) => {}
+        Err(_) => {
+            tracing::debug!(
+                timeout_ms = FOREGROUND_ENDPOINT_DRAIN.as_millis(),
+                "detached hosted endpoint drain after foreground bound"
+            );
         }
     }
 }
@@ -250,7 +538,9 @@ fn claim_router(endpoint: Endpoint) -> Router {
 
 impl Drop for HostedConnection {
     fn drop(&mut self) {
-        self.connection.close(0u32.into(), b"Heddle client closed");
+        if let HostedTransport::Local { connection, .. } = &self.inner {
+            connection.close(0u32.into(), b"Heddle client closed");
+        }
     }
 }
 
@@ -270,13 +560,17 @@ fn transport_config() -> QuicTransportConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
+    use std::{
+        net::Ipv4Addr,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
 
     use api::heddle::api::v1alpha1::ProviderSource;
     use iroh::{Endpoint, RelayMode, endpoint::presets};
     use tokio::sync::Mutex;
 
-    use super::HostedConnection;
+    use super::{HostedConnection, bounded_foreground_shutdown};
 
     #[tokio::test]
     async fn failed_connect_closes_the_client_endpoint() {
@@ -352,7 +646,9 @@ mod tests {
             .unwrap();
         connection.provider_connections.lock().await.insert(
             server_id,
-            Arc::new(Mutex::new(Some(connection.connection.clone()))),
+            Arc::new(Mutex::new(Some(
+                connection.quic_connection().expect("local fixture").clone(),
+            ))),
         );
 
         let reused = connection
@@ -372,5 +668,73 @@ mod tests {
         println!("provider_connection_reuse endpoint={server_id} connection_count=1 reused=true");
         connection.close().await;
         server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bounded_shutdown_returns_before_a_one_second_drain() {
+        let started = Instant::now();
+        bounded_foreground_shutdown(async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            Ok::<(), &'static str>(())
+        })
+        .await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "foreground close must detach a 1s drain, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_does_not_block_a_second_after_locally_closed() {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let connection = server
+                .accept()
+                .await
+                .expect("incoming connection")
+                .await
+                .unwrap();
+            // Hold the peer without acknowledging close so drain would
+            // otherwise wait for the probe timeout.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            connection.close(0u32.into(), b"test");
+            server.close().await;
+        });
+
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let connection = HostedConnection::connect(client, server_addr)
+            .await
+            .unwrap();
+        let quic = connection.quic_connection().expect("local fixture");
+        quic.close(0u32.into(), b"Heddle client closed");
+        tokio::time::timeout(Duration::from_secs(2), quic.closed())
+            .await
+            .expect("QUIC close should become LocallyClosed");
+        assert!(quic.close_reason().is_some());
+
+        let started = Instant::now();
+        connection.close().await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "close after LocallyClosed must not wait for endpoint drain, took {elapsed:?}"
+        );
+        server_task.abort();
+        let _ = server_task.await;
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -1026,12 +1026,13 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn connect_via_netd_fails_when_the_bridge_socket_is_missing() {
         let _env_guard = config::credentials::lock_test_env();
         let home = tempfile::TempDir::new().unwrap();
-        let _pin = super::hosted_bridge::PinHeddleHome::new(home.path());
+        let _pin = super::hosted_bridge::tests::PinHeddleHome::new(home.path());
         let error = HostedConnection::connect_via_netd(
-            super::hosted_bridge::TEST_WEFT_SERVER,
+            super::hosted_bridge::tests::TEST_WEFT_SERVER,
             &config::ClientConfig::default(),
         )
         .await
@@ -1041,12 +1042,13 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn connect_via_netd_reuses_warm_weft_and_proxied_streams() {
         let _env_guard = config::credentials::lock_test_env();
-        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
-        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let fixture = super::hosted_bridge::tests::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::tests::PinHeddleHome::new(fixture.home.path());
         let connection = HostedConnection::connect_via_netd(
-            super::hosted_bridge::TEST_WEFT_SERVER,
+            super::hosted_bridge::tests::TEST_WEFT_SERVER,
             &config::ClientConfig::default(),
         )
         .await
@@ -1092,12 +1094,13 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn hosted_client_connect_via_netd_runs_a_unary_on_proxied_streams() {
         let _env_guard = config::credentials::lock_test_env();
-        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
-        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let fixture = super::hosted_bridge::tests::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::tests::PinHeddleHome::new(fixture.home.path());
         let client = crate::hosted_runtime::hosted::HostedClient::connect_via_netd(
-            super::hosted_bridge::TEST_WEFT_SERVER,
+            super::hosted_bridge::tests::TEST_WEFT_SERVER,
             &config::ClientConfig::default(),
         )
         .await
@@ -1121,10 +1124,11 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn session_connect_uses_netd_when_the_bridge_is_up() {
         let _env_guard = config::credentials::lock_test_env();
-        let fixture = super::hosted_bridge::WarmBridgeFixture::start().await;
-        let _pin = super::hosted_bridge::PinHeddleHome::new(fixture.home.path());
+        let fixture = super::hosted_bridge::tests::WarmBridgeFixture::start().await;
+        let _pin = super::hosted_bridge::tests::PinHeddleHome::new(fixture.home.path());
         let session = crate::hosted_runtime::hosted::HostedSession::build(
             &config::UserConfig::default(),
             None,
@@ -1132,7 +1136,7 @@ mod tests {
         )
         .unwrap();
         let client = session
-            .connect(super::hosted_bridge::TEST_WEFT_SERVER)
+            .connect(super::hosted_bridge::tests::TEST_WEFT_SERVER)
             .await
             .expect("session.connect must reuse a running hosted bridge");
         assert!(client.reused_warm_connection());
@@ -1141,11 +1145,12 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn session_connect_falls_back_when_netd_is_down() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let _env_guard = config::credentials::lock_test_env();
         let home = tempfile::TempDir::new().unwrap();
-        let _pin = super::hosted_bridge::PinHeddleHome::new(home.path());
+        let _pin = super::hosted_bridge::tests::PinHeddleHome::new(home.path());
         let session = crate::hosted_runtime::hosted::HostedSession::build(
             &config::UserConfig::default(),
             None,

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection.rs
@@ -41,6 +41,25 @@ const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 /// then detach the remainder.
 const FOREGROUND_ENDPOINT_DRAIN: Duration = Duration::from_millis(20);
 
+#[cfg(test)]
+static NEXT_SHUTDOWN_HOLD_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(super) fn hold_next_shutdown_for_test(duration: Duration) {
+    NEXT_SHUTDOWN_HOLD_MS.store(duration.as_millis() as u64, Ordering::SeqCst);
+}
+
+fn shutdown_hold_for_test() -> Option<Duration> {
+    #[cfg(test)]
+    {
+        let ms = NEXT_SHUTDOWN_HOLD_MS.swap(0, Ordering::SeqCst);
+        if ms > 0 {
+            return Some(Duration::from_millis(ms));
+        }
+    }
+    None
+}
+
 #[derive(Debug)]
 pub(super) struct HostedConnection {
     inner: HostedTransport,
@@ -569,7 +588,11 @@ where
     F: std::future::Future<Output = std::result::Result<(), E>> + Send + 'static,
     E: std::fmt::Display + Send + 'static,
 {
+    let hold = shutdown_hold_for_test();
     let mut task = tokio::spawn(async move {
+        if let Some(hold) = hold {
+            tokio::time::sleep(hold).await;
+        }
         if let Err(error) = shutdown.await {
             tracing::warn!(%error, "failed to shut down Heddle Iroh router");
         }

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -58,7 +58,7 @@ fn require_release_build() {
     panic!("hosted endpoint close contract must run with --release");
 }
 
-fn verified_descriptor(
+pub(crate) fn verified_descriptor(
     endpoint_id: iroh::EndpointId,
     relay_urls: Vec<String>,
     direct_addresses: Vec<String>,
@@ -428,5 +428,84 @@ async fn hosted_connection_uses_persisted_id_and_accepts_claim_alpn() {
 
     claim_client.close().await;
     connection.close().await;
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn connect_with_config_falls_back_to_local_when_netd_is_down() {
+    let _env_guard = config::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        Vec::new(),
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming hosted connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let config = config::ClientConfig::default().with_server_key("https://api.test.heddle.sh");
+    let client = super::HostedClient::connect_with_config(&descriptor, &config)
+        .await
+        .expect("local connect must succeed after netd fallback");
+    assert!(
+        !client.reused_warm_connection(),
+        "a missing hosted bridge must not report warm reuse"
+    );
+    client.close().await;
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn connect_outbound_falls_back_to_local_when_netd_is_down() {
+    let _env_guard = config::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        Vec::new(),
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming outbound connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let config = config::ClientConfig::default().with_server_key("https://api.test.heddle.sh");
+    let client = super::HostedClient::connect_outbound_with_config(&descriptor, &config)
+        .await
+        .expect("outbound local connect must succeed after netd fallback");
+    assert!(!client.reused_warm_connection());
+    client.close().await;
     server_task.await.unwrap();
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -157,7 +157,7 @@ async fn hosted_endpoint_close_release_contract() {
             HostedConnection::connect_verified(&descriptor, &config::ClientConfig::default())
                 .await
                 .unwrap();
-        let endpoint_observer = connection.endpoint.clone();
+        let endpoint_observer = connection.local_endpoint().expect("local fixture").clone();
         let close_started = Instant::now();
         if negative_control {
             tokio::time::sleep(Duration::from_millis(25)).await;
@@ -240,11 +240,19 @@ async fn reachable_direct_address_keeps_the_claim_relay_online() {
         HostedConnection::connect_verified(&descriptor, &config::ClientConfig::default())
             .await
             .unwrap();
-    tokio::time::timeout(Duration::from_secs(5), connection.endpoint.online())
-        .await
-        .expect("claim listener should register with the signed relay");
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        connection.local_endpoint().expect("local fixture").online(),
+    )
+    .await
+    .expect("claim listener should register with the signed relay");
     assert!(
-        !connection.endpoint.home_relay_status().get().is_empty(),
+        !connection
+            .local_endpoint()
+            .expect("local fixture")
+            .home_relay_status()
+            .get()
+            .is_empty(),
         "a direct hosted path must keep the inbound claim relay initialized"
     );
     connection.close().await;
@@ -336,11 +344,19 @@ async fn unreachable_direct_address_falls_back_to_signed_relay() {
     .await
     .expect("relay fallback should connect")
     .unwrap();
-    tokio::time::timeout(Duration::from_secs(5), connection.endpoint.online())
-        .await
-        .expect("client should register with the signed relay");
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        connection.local_endpoint().expect("local fixture").online(),
+    )
+    .await
+    .expect("client should register with the signed relay");
     assert!(
-        !connection.endpoint.home_relay_status().get().is_empty(),
+        !connection
+            .local_endpoint()
+            .expect("local fixture")
+            .home_relay_status()
+            .get()
+            .is_empty(),
         "relay fallback must initialize the signed relay transport"
     );
     connection.close().await;
@@ -393,7 +409,10 @@ async fn hosted_connection_uses_persisted_id_and_accepts_claim_alpn() {
         .await
         .unwrap();
     let claim_connection = claim_client
-        .connect(connection.endpoint.addr(), CLAIM_ALPN_V1)
+        .connect(
+            connection.local_endpoint().expect("local fixture").addr(),
+            CLAIM_ALPN_V1,
+        )
         .await
         .expect("claim ALPN connection");
     let (mut send, mut recv) = claim_connection.open_bi().await.unwrap();

--- a/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
@@ -107,11 +107,22 @@ impl HostedBridge {
         server: impl Into<String>,
         connection: iroh::endpoint::Connection,
     ) {
+        self.insert_weft_with_expiry_for_test(server, connection, i64::MAX)
+            .await;
+    }
+
+    #[cfg(test)]
+    pub async fn insert_weft_with_expiry_for_test(
+        &self,
+        server: impl Into<String>,
+        connection: iroh::endpoint::Connection,
+        expires_at_unix_millis: i64,
+    ) {
         self.weft.lock().await.insert(
             server.into(),
             CachedWeft {
                 connection,
-                expires_at_unix_millis: i64::MAX,
+                expires_at_unix_millis,
             },
         );
     }
@@ -418,6 +429,7 @@ pub async fn ensure_via_netd(
     }
 }
 
+#[derive(Debug)]
 pub struct EnsureOutcome {
     pub reused: bool,
     pub node_id: EndpointId,
@@ -636,4 +648,393 @@ mod tests {
         let _ = server_task.await;
         server.close().await;
     }
+
+    pub(crate) const TEST_WEFT_SERVER: &str = "https://api.test.heddle.sh";
+
+    pub(crate) struct WarmBridgeFixture {
+        pub home: TempDir,
+        pub socket: PathBuf,
+        pub node_id: iroh::EndpointId,
+        accepts: Arc<AtomicUsize>,
+        serve: Option<tokio::task::JoinHandle<Result<()>>>,
+        server_task: Option<tokio::task::JoinHandle<()>>,
+        server: Option<Endpoint>,
+    }
+
+    impl WarmBridgeFixture {
+        pub async fn start() -> Self {
+            let accepts = Arc::new(AtomicUsize::new(0));
+            let (server, server_task) = echo_server(Arc::clone(&accepts)).await;
+            let netd = Endpoint::builder(presets::Minimal)
+                .relay_mode(RelayMode::Disabled)
+                .bind_addr((Ipv4Addr::LOCALHOST, 0))
+                .unwrap()
+                .bind()
+                .await
+                .unwrap();
+            let node_id = netd.id();
+            let first = netd
+                .connect(server.addr(), api::HOSTED_ALPN_V1)
+                .await
+                .unwrap();
+            let home = TempDir::new().unwrap();
+            let socket = hosted_bridge_socket_path(home.path());
+            if let Some(parent) = socket.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            let bridge = HostedBridge::new(netd, None);
+            bridge.insert_weft_for_test(TEST_WEFT_SERVER, first).await;
+            let serve = tokio::spawn(bridge.serve(socket.clone()));
+            wait_for_socket(&socket).await;
+            Self {
+                home,
+                socket,
+                node_id,
+                accepts,
+                serve: Some(serve),
+                server_task: Some(server_task),
+                server: Some(server),
+            }
+        }
+
+        pub fn accepts(&self) -> usize {
+            self.accepts.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Drop for WarmBridgeFixture {
+        fn drop(&mut self) {
+            if let Some(task) = self.serve.take() {
+                task.abort();
+            }
+            if let Some(task) = self.server_task.take() {
+                task.abort();
+            }
+            if let Some(server) = self.server.take() {
+                tokio::spawn(async move {
+                    server.close().await;
+                });
+            }
+        }
+    }
+
+    pub(crate) struct PinHeddleHome {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl PinHeddleHome {
+        pub fn new(path: &std::path::Path) -> Self {
+            let previous = std::env::var_os("HEDDLE_HOME");
+            unsafe {
+                std::env::set_var("HEDDLE_HOME", path);
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for PinHeddleHome {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => unsafe { std::env::set_var("HEDDLE_HOME", value) },
+                None => unsafe { std::env::remove_var("HEDDLE_HOME") },
+            }
+        }
+    }
+
+    async fn wait_for_socket(socket: &std::path::Path) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !socket.exists() {
+            if std::time::Instant::now() >= deadline {
+                panic!("hosted bridge socket did not appear");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn start_empty_bridge() -> (TempDir, PathBuf, tokio::task::JoinHandle<Result<()>>) {
+        let netd = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let serve = tokio::spawn(HostedBridge::new(netd, None).serve(socket.clone()));
+        wait_for_socket(&socket).await;
+        (home, socket, serve)
+    }
+
+    #[tokio::test]
+    async fn ensure_without_a_cached_weft_fails_closed() {
+        let (_home, socket, serve) = start_empty_bridge().await;
+        let error = ensure_via_netd(&socket, TEST_WEFT_SERVER, true)
+            .await
+            .expect_err("cold Ensure must not invent a weft session");
+        assert!(
+            !error.to_string().is_empty(),
+            "descriptor fetch failure must surface on Ensure"
+        );
+        serve.abort();
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn open_bi_without_a_cached_weft_fails_closed() {
+        let (_home, socket, serve) = start_empty_bridge().await;
+        let error = open_bi_via_netd(&socket, TEST_WEFT_SERVER, false, None)
+            .await
+            .expect_err("cold OpenBi must not invent a weft session");
+        assert!(!error.to_string().is_empty());
+        serve.abort();
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn open_bi_provider_without_transport_fails_closed() {
+        let fixture = WarmBridgeFixture::start().await;
+        let endpoint_id = iroh_base::SecretKey::generate().public();
+        let source = ProviderSource {
+            provider_id: "provider-a".to_string(),
+            endpoint_id: endpoint_id.to_string(),
+            direct_url: "wss://127.0.0.1:1/direct?provider=provider-a&ticket=opaque".to_string(),
+            opaque_ticket: "opaque".to_string(),
+            expires_at_unix_millis: u64::MAX,
+        };
+        let error = open_bi_via_netd(&fixture.socket, TEST_WEFT_SERVER, false, Some(&source))
+            .await
+            .expect_err("provider OpenBi on a weft-only bridge must fail closed");
+        assert!(
+            error.to_string().contains("provider transport"),
+            "got {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_weft_is_evicted_before_ensure() {
+        let accepts = Arc::new(AtomicUsize::new(0));
+        let (server, server_task) = echo_server(Arc::clone(&accepts)).await;
+        let netd = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let first = netd
+            .connect(server.addr(), api::HOSTED_ALPN_V1)
+            .await
+            .unwrap();
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let bridge = HostedBridge::new(netd, None);
+        bridge
+            .insert_weft_with_expiry_for_test(TEST_WEFT_SERVER, first, 1)
+            .await;
+        let serve = tokio::spawn(bridge.serve(socket.clone()));
+        wait_for_socket(&socket).await;
+        let error = ensure_via_netd(&socket, TEST_WEFT_SERVER, false)
+            .await
+            .expect_err("expired cache must not report reuse");
+        assert!(!error.to_string().is_empty());
+        serve.abort();
+        server_task.abort();
+        let _ = serve.await;
+        let _ = server_task.await;
+        server.close().await;
+    }
+
+    #[tokio::test]
+    async fn closed_weft_is_evicted_before_ensure() {
+        let accepts = Arc::new(AtomicUsize::new(0));
+        let (server, server_task) = echo_server(Arc::clone(&accepts)).await;
+        let netd = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let first = netd
+            .connect(server.addr(), api::HOSTED_ALPN_V1)
+            .await
+            .unwrap();
+        first.close(0u32.into(), b"test");
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let bridge = HostedBridge::new(netd, None);
+        bridge.insert_weft_for_test(TEST_WEFT_SERVER, first).await;
+        let serve = tokio::spawn(bridge.serve(socket.clone()));
+        wait_for_socket(&socket).await;
+        let error = ensure_via_netd(&socket, TEST_WEFT_SERVER, false)
+            .await
+            .expect_err("a closed weft session must be evicted");
+        assert!(!error.to_string().is_empty());
+        serve.abort();
+        server_task.abort();
+        let _ = serve.await;
+        let _ = server_task.await;
+        server.close().await;
+    }
+
+    #[tokio::test]
+    async fn missing_bridge_socket_fails_ensure_and_open_bi() {
+        let missing = std::path::Path::new("/tmp/heddle-hosted-missing-e0c3.sock");
+        assert!(
+            ensure_via_netd(missing, TEST_WEFT_SERVER, false)
+                .await
+                .is_err()
+        );
+        assert!(
+            open_bi_via_netd(missing, TEST_WEFT_SERVER, false, None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_bridge_frame_is_rejected() {
+        let fixture = WarmBridgeFixture::start().await;
+        let mut stream = UnixStream::connect(&fixture.socket).await.unwrap();
+        let length = (MAX_BRIDGE_FRAME as u32).saturating_add(1);
+        stream.write_all(&length.to_be_bytes()).await.unwrap();
+        stream.write_all(&[0u8; 8]).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut reply = Vec::new();
+        let _ = stream.read_to_end(&mut reply).await;
+        assert!(
+            reply.is_empty(),
+            "an oversized frame must close the session without a handshake"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_disconnect_before_request_ends_the_session() {
+        let fixture = WarmBridgeFixture::start().await;
+        let stream = UnixStream::connect(&fixture.socket).await.unwrap();
+        drop(stream);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let ensured = ensure_via_netd(&fixture.socket, TEST_WEFT_SERVER, false)
+            .await
+            .unwrap();
+        assert!(ensured.reused);
+    }
+
+    #[tokio::test]
+    async fn ensure_rejects_an_opened_response() {
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let serve = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_frame(&mut stream).await;
+            let response =
+                serde_json::to_vec(&HostedBridgeResponse::Opened { reused: true }).unwrap();
+            let _ = write_frame(&mut stream, &response).await;
+        });
+        let error = ensure_via_netd(&socket, TEST_WEFT_SERVER, false)
+            .await
+            .expect_err("Opened is not a valid Ensure reply");
+        assert!(
+            error.to_string().contains("Opened for Ensure"),
+            "got {error}"
+        );
+        serve.abort();
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn open_bi_rejects_a_ready_response() {
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let serve = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_frame(&mut stream).await;
+            let response = serde_json::to_vec(&HostedBridgeResponse::Ready {
+                reused: true,
+                node_id: iroh_base::SecretKey::generate().public().to_string(),
+            })
+            .unwrap();
+            let _ = write_frame(&mut stream, &response).await;
+        });
+        let error = open_bi_via_netd(&socket, TEST_WEFT_SERVER, false, None)
+            .await
+            .expect_err("Ready is not a valid OpenBi reply");
+        assert!(
+            error.to_string().contains("Ready for OpenBi"),
+            "got {error}"
+        );
+        serve.abort();
+        let _ = serve.await;
+    }
+
+    #[tokio::test]
+    async fn connect_weft_uses_signed_direct_addresses() {
+        let accepts = Arc::new(AtomicUsize::new(0));
+        let (server, server_task) = echo_server(Arc::clone(&accepts)).await;
+        let descriptor = crate::hosted_runtime::hosted::connection_path_tests::verified_descriptor(
+            server.id(),
+            Vec::new(),
+            server.addr().ip_addrs().map(ToString::to_string).collect(),
+        );
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let connection = connect_weft(&client, &descriptor).await.unwrap();
+        let (mut send, mut recv) = connection.open_bi().await.unwrap();
+        send.write_all(b"direct").await.unwrap();
+        send.finish().unwrap();
+        let reply = recv.read_to_end(64 * 1024).await.unwrap();
+        assert_eq!(reply, b"direct");
+        assert_eq!(accepts.load(Ordering::SeqCst), 1);
+        client.close().await;
+        server_task.abort();
+        let _ = server_task.await;
+        server.close().await;
+    }
+
+    #[tokio::test]
+    async fn connect_weft_fails_closed_when_direct_and_relays_are_gone() {
+        let descriptor = crate::hosted_runtime::hosted::connection_path_tests::verified_descriptor(
+            iroh_base::SecretKey::generate().public(),
+            Vec::new(),
+            vec!["127.0.0.1:9".to_string()],
+        );
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let error = connect_weft(&client, &descriptor)
+            .await
+            .expect_err("dead direct + no relays must fail closed");
+        assert!(error.to_string().contains("no relays"), "got {error}");
+        client.close().await;
+    }
 }
+
+#[cfg(test)]
+pub(crate) use tests::{PinHeddleHome, TEST_WEFT_SERVER, WarmBridgeFixture};

--- a/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
@@ -529,7 +529,7 @@ fn now_unix_millis() -> Result<i64> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::{
         net::Ipv4Addr,
         sync::{
@@ -1035,6 +1035,3 @@ mod tests {
         client.close().await;
     }
 }
-
-#[cfg(test)]
-pub(crate) use tests::{PinHeddleHome, TEST_WEFT_SERVER, WarmBridgeFixture};

--- a/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/hosted_bridge.rs
@@ -1,0 +1,639 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-process warm hosted-connection holder (heddle netd).
+//!
+//! Each CLI process used to bind a fresh Iroh endpoint, dial the
+//! signed relay, and open a new QUIC session to weft. `heddle netd
+//! serve` already keeps one persistent endpoint homed on the build's
+//! Heddle relay. This bridge lets whoami / push / pull / clone reuse
+//! that endpoint and a cached weft QUIC connection across invocations.
+//!
+//! The daemon never sees credentials: the CLI still signs every call.
+//! The socket carries an Ensure/OpenBi handshake, then raw QUIC-stream
+//! bytes. Same-uid, mode-0600, fail-closed — the claim-bridge pattern.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use api::heddle::api::v1alpha1::ProviderSource;
+use config::ClientConfig;
+use iroh::{Endpoint, EndpointId};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{UnixListener, UnixStream},
+    sync::Mutex,
+};
+
+use super::{
+    HostedError, VerifiedEndpointDescriptor, provider_transport::ProviderWebSocketTransport,
+    resolver::resolve_and_verify_endpoint_descriptor,
+};
+
+const MAX_BRIDGE_FRAME: usize = 64 * 1024;
+
+/// Box-scoped path of the hosted-connection bridge socket:
+/// `<heddle_home>/state/heddle-netd-hosted.sock`.
+pub fn hosted_bridge_socket_path(heddle_home: &Path) -> PathBuf {
+    repo::daemon::box_state_dir_in(heddle_home).join("heddle-netd-hosted.sock")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum HostedBridgeRequest {
+    Ensure {
+        server: String,
+        allow_insecure: bool,
+    },
+    OpenBi {
+        server: String,
+        allow_insecure: bool,
+        #[serde(default)]
+        provider: Option<ProviderTarget>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProviderTarget {
+    provider_id: String,
+    endpoint_id: String,
+    direct_url: String,
+    opaque_ticket: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+enum HostedBridgeResponse {
+    Ready { reused: bool, node_id: String },
+    Opened { reused: bool },
+    Error { message: String },
+}
+
+struct CachedWeft {
+    connection: iroh::endpoint::Connection,
+    expires_at_unix_millis: i64,
+}
+
+/// Warm weft/provider connections on the daemon's persistent endpoint.
+pub struct HostedBridge {
+    endpoint: Endpoint,
+    provider_transport: Option<ProviderWebSocketTransport>,
+    weft: Mutex<HashMap<String, CachedWeft>>,
+    providers: Mutex<HashMap<EndpointId, iroh::endpoint::Connection>>,
+}
+
+impl HostedBridge {
+    #[must_use]
+    pub(crate) fn new(
+        endpoint: Endpoint,
+        provider_transport: Option<ProviderWebSocketTransport>,
+    ) -> Self {
+        Self {
+            endpoint,
+            provider_transport,
+            weft: Mutex::new(HashMap::new()),
+            providers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Test helper: insert an already-open weft connection so Ensure/OpenBi
+    /// can exercise reuse without an HTTPS descriptor fetch.
+    #[cfg(test)]
+    pub async fn insert_weft_for_test(
+        &self,
+        server: impl Into<String>,
+        connection: iroh::endpoint::Connection,
+    ) {
+        self.weft.lock().await.insert(
+            server.into(),
+            CachedWeft {
+                connection,
+                expires_at_unix_millis: i64::MAX,
+            },
+        );
+    }
+
+    pub async fn serve(self, socket_path: PathBuf) -> Result<()> {
+        let listener = bind_bridge_listener(&socket_path).with_context(|| {
+            format!(
+                "binding hosted connection bridge socket {}",
+                socket_path.display()
+            )
+        })?;
+        let bridge = Arc::new(self);
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) if peer_is_same_uid(&stream) => {
+                    let bridge = Arc::clone(&bridge);
+                    tokio::spawn(async move {
+                        if let Err(error) = handle_client(bridge, stream).await {
+                            tracing::debug!(%error, "hosted bridge session ended");
+                        }
+                    });
+                }
+                Ok((stream, _)) => {
+                    tracing::warn!("rejecting hosted-bridge client: peer uid mismatch");
+                    drop(stream);
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "hosted bridge accept failed");
+                }
+            }
+        }
+    }
+}
+
+async fn handle_client(bridge: Arc<HostedBridge>, mut stream: UnixStream) -> Result<()> {
+    let request = read_frame(&mut stream)
+        .await?
+        .context("hosted bridge client closed before sending a request")?;
+    let request: HostedBridgeRequest =
+        serde_json::from_slice(&request).context("decoding hosted bridge request")?;
+    match request {
+        HostedBridgeRequest::Ensure {
+            server,
+            allow_insecure,
+        } => {
+            let outcome = ensure_weft(&bridge, &server, allow_insecure).await;
+            let response = match outcome {
+                Ok(reused) => HostedBridgeResponse::Ready {
+                    reused,
+                    node_id: bridge.endpoint.id().to_string(),
+                },
+                Err(error) => HostedBridgeResponse::Error {
+                    message: error.to_string(),
+                },
+            };
+            write_frame(&mut stream, &serde_json::to_vec(&response)?).await?;
+        }
+        HostedBridgeRequest::OpenBi {
+            server,
+            allow_insecure,
+            provider,
+        } => {
+            let opened = match provider {
+                Some(ref target) => open_provider_bi(&bridge, target).await.map(|()| false),
+                None => ensure_weft(&bridge, &server, allow_insecure).await,
+            };
+            match opened {
+                Ok(reused) => {
+                    write_frame(
+                        &mut stream,
+                        &serde_json::to_vec(&HostedBridgeResponse::Opened { reused })?,
+                    )
+                    .await?;
+                    if let Some(target) = provider {
+                        splice_provider(&bridge, &target, stream).await?;
+                    } else {
+                        splice_weft(&bridge, &server, stream).await?;
+                    }
+                }
+                Err(error) => {
+                    write_frame(
+                        &mut stream,
+                        &serde_json::to_vec(&HostedBridgeResponse::Error {
+                            message: error.to_string(),
+                        })?,
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn ensure_weft(bridge: &HostedBridge, server: &str, allow_insecure: bool) -> Result<bool> {
+    if live_weft(bridge, server).await.is_some() {
+        return Ok(true);
+    }
+    let mut config = ClientConfig::default();
+    if allow_insecure {
+        config.allow_insecure = true;
+    }
+    let descriptor = resolve_and_verify_endpoint_descriptor(server, &config)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let connection = connect_weft(&bridge.endpoint, &descriptor).await?;
+    let expires_at_unix_millis = descriptor.document().expires_at_unix_millis;
+    bridge.weft.lock().await.insert(
+        server.to_string(),
+        CachedWeft {
+            connection,
+            expires_at_unix_millis,
+        },
+    );
+    Ok(false)
+}
+
+async fn live_weft(bridge: &HostedBridge, server: &str) -> Option<iroh::endpoint::Connection> {
+    let now = now_unix_millis().ok()?;
+    let mut sessions = bridge.weft.lock().await;
+    let cached = sessions.get(server)?;
+    if cached.expires_at_unix_millis <= now || cached.connection.close_reason().is_some() {
+        sessions.remove(server);
+        return None;
+    }
+    Some(cached.connection.clone())
+}
+
+async fn connect_weft(
+    endpoint: &Endpoint,
+    descriptor: &VerifiedEndpointDescriptor,
+) -> Result<iroh::endpoint::Connection> {
+    let relays = descriptor
+        .relay_urls()
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let address = descriptor
+        .endpoint_addr()
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let direct_address = descriptor
+        .direct_endpoint_addr()
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    if direct_address.ip_addrs().next().is_some() {
+        let direct = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            endpoint.connect(direct_address, api::HOSTED_ALPN_V1),
+        )
+        .await;
+        if let Ok(Ok(connection)) = direct {
+            return Ok(connection);
+        }
+        if relays.is_empty() {
+            anyhow::bail!("signed direct addresses unavailable and the descriptor has no relays");
+        }
+    }
+    endpoint
+        .connect(address, api::HOSTED_ALPN_V1)
+        .await
+        .context("connecting to weft through the netd endpoint")
+}
+
+async fn open_provider_bi(bridge: &HostedBridge, target: &ProviderTarget) -> Result<()> {
+    let _ = provider_connection(bridge, target).await?;
+    Ok(())
+}
+
+async fn provider_connection(
+    bridge: &HostedBridge,
+    target: &ProviderTarget,
+) -> Result<iroh::endpoint::Connection> {
+    let endpoint_id: EndpointId = target.endpoint_id.parse().context("provider endpoint id")?;
+    {
+        let providers = bridge.providers.lock().await;
+        if let Some(connection) = providers.get(&endpoint_id)
+            && connection.close_reason().is_none()
+        {
+            return Ok(connection.clone());
+        }
+    }
+    let transport = bridge
+        .provider_transport
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("the network daemon endpoint has no provider transport"))?;
+    let address = transport
+        .register_source(
+            &target.provider_id,
+            &target.endpoint_id,
+            &target.direct_url,
+            &target.opaque_ticket,
+        )
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let connection = bridge
+        .endpoint
+        .connect(address, api::PROVIDER_ALPN_V1)
+        .await
+        .context("connecting to a provider through the netd endpoint")?;
+    bridge
+        .providers
+        .lock()
+        .await
+        .insert(endpoint_id, connection.clone());
+    Ok(connection)
+}
+
+async fn splice_weft(bridge: &HostedBridge, server: &str, stream: UnixStream) -> Result<()> {
+    let connection = live_weft(bridge, server)
+        .await
+        .context("weft session vanished after OpenBi")?;
+    splice_connection(connection, stream).await
+}
+
+async fn splice_provider(
+    bridge: &HostedBridge,
+    target: &ProviderTarget,
+    stream: UnixStream,
+) -> Result<()> {
+    let connection = provider_connection(bridge, target).await?;
+    splice_connection(connection, stream).await
+}
+
+async fn splice_connection(
+    connection: iroh::endpoint::Connection,
+    stream: UnixStream,
+) -> Result<()> {
+    let (mut send, mut recv) = connection
+        .open_bi()
+        .await
+        .context("opening a hosted stream on the warm weft connection")?;
+    let (mut unix_read, mut unix_write) = stream.into_split();
+    let to_weft = async {
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            match unix_read.read(&mut buf).await {
+                Ok(0) => {
+                    let _ = send.finish();
+                    break;
+                }
+                Ok(n) => {
+                    send.write_all(&buf[..n])
+                        .await
+                        .context("writing hosted stream to weft")?;
+                }
+                Err(error) => {
+                    let _ = send.reset(1u32.into());
+                    return Err(error).context("reading hosted-bridge client bytes");
+                }
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    };
+    let from_weft = async {
+        loop {
+            match recv.read_chunk(64 * 1024).await {
+                Ok(Some(chunk)) => {
+                    unix_write
+                        .write_all(&chunk)
+                        .await
+                        .context("writing weft bytes to the hosted-bridge client")?;
+                }
+                Ok(None) => break,
+                Err(error) => return Err(error).context("reading weft stream"),
+            }
+        }
+        let _ = unix_write.shutdown().await;
+        Ok::<(), anyhow::Error>(())
+    };
+    let (to_weft, from_weft) = tokio::join!(to_weft, from_weft);
+    to_weft?;
+    from_weft?;
+    Ok(())
+}
+
+/// Ask a running netd to hold (or reuse) a weft connection for `server`.
+pub async fn ensure_via_netd(
+    socket_path: &Path,
+    server: &str,
+    allow_insecure: bool,
+) -> std::result::Result<EnsureOutcome, HostedError> {
+    let mut stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(HostedError::transport)?;
+    let request = HostedBridgeRequest::Ensure {
+        server: server.to_string(),
+        allow_insecure,
+    };
+    write_frame(
+        &mut stream,
+        &serde_json::to_vec(&request).map_err(HostedError::transport)?,
+    )
+    .await
+    .map_err(HostedError::transport)?;
+    let response = read_frame(&mut stream)
+        .await
+        .map_err(HostedError::transport)?
+        .ok_or_else(|| HostedError::transport("netd hosted bridge closed during Ensure"))?;
+    match serde_json::from_slice(&response).map_err(HostedError::transport)? {
+        HostedBridgeResponse::Ready { reused, node_id } => {
+            let node_id = node_id.parse().map_err(HostedError::transport)?;
+            Ok(EnsureOutcome { reused, node_id })
+        }
+        HostedBridgeResponse::Error { message } => Err(HostedError::transport(message)),
+        HostedBridgeResponse::Opened { .. } => Err(HostedError::transport(
+            "netd hosted bridge returned Opened for Ensure",
+        )),
+    }
+}
+
+pub struct EnsureOutcome {
+    pub reused: bool,
+    pub node_id: EndpointId,
+}
+
+/// Open a bidirectional stream on the warm weft (or provider) connection.
+pub async fn open_bi_via_netd(
+    socket_path: &Path,
+    server: &str,
+    allow_insecure: bool,
+    provider: Option<&ProviderSource>,
+) -> std::result::Result<(UnixStream, bool), HostedError> {
+    let mut stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(HostedError::transport)?;
+    let request = HostedBridgeRequest::OpenBi {
+        server: server.to_string(),
+        allow_insecure,
+        provider: provider.map(|source| ProviderTarget {
+            provider_id: source.provider_id.clone(),
+            endpoint_id: source.endpoint_id.clone(),
+            direct_url: source.direct_url.clone(),
+            opaque_ticket: source.opaque_ticket.clone(),
+        }),
+    };
+    write_frame(
+        &mut stream,
+        &serde_json::to_vec(&request).map_err(HostedError::transport)?,
+    )
+    .await
+    .map_err(HostedError::transport)?;
+    let response = read_frame(&mut stream)
+        .await
+        .map_err(HostedError::transport)?
+        .ok_or_else(|| HostedError::transport("netd hosted bridge closed during OpenBi"))?;
+    match serde_json::from_slice(&response).map_err(HostedError::transport)? {
+        HostedBridgeResponse::Opened { reused } => Ok((stream, reused)),
+        HostedBridgeResponse::Error { message } => Err(HostedError::transport(message)),
+        HostedBridgeResponse::Ready { .. } => Err(HostedError::transport(
+            "netd hosted bridge returned Ready for OpenBi",
+        )),
+    }
+}
+
+fn bind_bridge_listener(socket_path: &Path) -> Result<UnixListener> {
+    let listener =
+        repo::daemon::bind_unix_socket(socket_path).map_err(|error| anyhow::anyhow!("{error}"))?;
+    listener
+        .set_nonblocking(true)
+        .context("marking hosted bridge socket non-blocking")?;
+    UnixListener::from_std(listener).context("adopting hosted bridge socket into the async runtime")
+}
+
+fn peer_is_same_uid(stream: &UnixStream) -> bool {
+    match stream.peer_cred() {
+        Ok(peer) => peer.uid() == unsafe { libc::getuid() },
+        Err(error) => {
+            tracing::warn!(%error, "could not read hosted-bridge peer credentials");
+            false
+        }
+    }
+}
+
+async fn write_frame(stream: &mut UnixStream, payload: &[u8]) -> Result<()> {
+    let length = u32::try_from(payload.len()).context("hosted bridge frame is too large")?;
+    stream.write_all(&length.to_be_bytes()).await?;
+    stream.write_all(payload).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn read_frame(stream: &mut UnixStream) -> Result<Option<Vec<u8>>> {
+    let mut length = [0u8; 4];
+    match stream.read_exact(&mut length).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error).context("reading hosted bridge frame length"),
+    }
+    let length = u32::from_be_bytes(length) as usize;
+    if length > MAX_BRIDGE_FRAME {
+        anyhow::bail!("hosted bridge frame of {length} bytes exceeds the {MAX_BRIDGE_FRAME} limit");
+    }
+    let mut payload = vec![0u8; length];
+    stream
+        .read_exact(&mut payload)
+        .await
+        .context("reading hosted bridge frame body")?;
+    Ok(Some(payload))
+}
+
+fn now_unix_millis() -> Result<i64> {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system clock is before UNIX_EPOCH")?
+        .as_millis();
+    i64::try_from(millis).context("timestamp overflow")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::Ipv4Addr,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    async fn echo_server(accepts: Arc<AtomicUsize>) -> (Endpoint, tokio::task::JoinHandle<()>) {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let accept_endpoint = server.clone();
+        let task = tokio::spawn(async move {
+            while let Some(incoming) = accept_endpoint.accept().await {
+                accepts.fetch_add(1, Ordering::SeqCst);
+                let Ok(connection) = incoming.await else {
+                    continue;
+                };
+                tokio::spawn(async move {
+                    while let Ok((mut send, mut recv)) = connection.accept_bi().await {
+                        let bytes = recv.read_to_end(64 * 1024).await.unwrap_or_default();
+                        let _ = send.write_all(&bytes).await;
+                        let _ = send.finish();
+                    }
+                });
+            }
+        });
+        (server, task)
+    }
+
+    #[tokio::test]
+    async fn warm_open_bi_reuses_the_cached_weft_connection() {
+        let accepts = Arc::new(AtomicUsize::new(0));
+        let (server, server_task) = echo_server(Arc::clone(&accepts)).await;
+        let netd = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let first = netd
+            .connect(server.addr(), api::HOSTED_ALPN_V1)
+            .await
+            .unwrap();
+        let home = TempDir::new().unwrap();
+        let socket = hosted_bridge_socket_path(home.path());
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let bridge = HostedBridge::new(netd, None);
+        bridge
+            .insert_weft_for_test("https://api.test.heddle.sh", first)
+            .await;
+        let serve = tokio::spawn(bridge.serve(socket.clone()));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !socket.exists() {
+            if std::time::Instant::now() >= deadline {
+                panic!("hosted bridge socket did not appear");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let ensure_first = ensure_via_netd(&socket, "https://api.test.heddle.sh", false)
+            .await
+            .unwrap();
+        assert!(
+            ensure_first.reused,
+            "pre-seeded weft session must be reported as reused"
+        );
+
+        let (mut stream, reused) =
+            open_bi_via_netd(&socket, "https://api.test.heddle.sh", false, None)
+                .await
+                .unwrap();
+        assert!(reused, "OpenBi on a warm session must not cold-connect");
+        stream.write_all(b"ping-one").await.unwrap();
+        stream.shutdown().await.unwrap();
+        let mut reply = Vec::new();
+        stream.read_to_end(&mut reply).await.unwrap();
+        assert_eq!(reply, b"ping-one");
+
+        let (mut stream, reused) =
+            open_bi_via_netd(&socket, "https://api.test.heddle.sh", false, None)
+                .await
+                .unwrap();
+        assert!(reused, "second OpenBi must reuse the same weft connection");
+        stream.write_all(b"ping-two").await.unwrap();
+        stream.shutdown().await.unwrap();
+        reply.clear();
+        stream.read_to_end(&mut reply).await.unwrap();
+        assert_eq!(reply, b"ping-two");
+
+        assert_eq!(
+            accepts.load(Ordering::SeqCst),
+            1,
+            "warm reuse must not open a second QUIC connection to weft"
+        );
+
+        serve.abort();
+        server_task.abort();
+        let _ = serve.await;
+        let _ = server_task.await;
+        server.close().await;
+    }
+}

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -16,12 +16,14 @@ mod credential;
 mod descriptor_trust;
 mod error;
 pub(crate) mod helpers;
+pub(crate) mod hosted_bridge;
 mod human;
 mod hydration;
 mod methods;
 pub(crate) mod operation_id;
 mod provider_pull;
 mod provider_transport;
+pub(crate) use provider_transport::ProviderWebSocketTransport;
 mod resolver;
 mod session;
 #[cfg(test)]
@@ -216,7 +218,7 @@ impl HostedClient {
     ) -> Result<Self> {
         let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
-            connection: HostedConnection::connect_verified(descriptor, config).await?,
+            connection: connect_preferred(descriptor, config, false).await?,
             context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,
@@ -236,13 +238,33 @@ impl HostedClient {
     ) -> Result<Self> {
         let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
-            connection: HostedConnection::connect_verified_outbound(descriptor, config).await?,
+            connection: connect_preferred(descriptor, config, true).await?,
             context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,
             warnings: Arc::new(NoopWarnings),
             server_key: config.server_key.clone(),
         })
+    }
+
+    /// Connect through a running `heddle netd` warm weft session when the
+    /// hosted bridge socket is present. Falls back to the caller if netd
+    /// is not serving.
+    #[cfg(unix)]
+    pub(crate) async fn connect_via_netd(server: &str, config: &ClientConfig) -> Result<Self> {
+        let context = CallContextFactory::from_client_config(config)?;
+        Ok(Self {
+            connection: HostedConnection::connect_via_netd(server, config).await?,
+            context,
+            transport: helpers::HostedTransportPolicy::from_client_config(config),
+            on_human_signature: None,
+            warnings: Arc::new(NoopWarnings),
+            server_key: config.server_key.clone(),
+        })
+    }
+
+    pub fn reused_warm_connection(&self) -> bool {
+        self.connection.reused_warm()
     }
 
     /// Direct-address constructor for conformance tests and explicit local endpoints.
@@ -529,5 +551,29 @@ impl HostedClient {
         Response: Message + Default,
     {
         call::bidirectional(self.connection.clone(), method, context).await
+    }
+}
+
+async fn connect_preferred(
+    descriptor: &VerifiedEndpointDescriptor,
+    config: &ClientConfig,
+    outbound: bool,
+) -> Result<Arc<HostedConnection>> {
+    #[cfg(unix)]
+    if let Some(server) = config.server_key.as_deref() {
+        match HostedConnection::connect_via_netd(server, config).await {
+            Ok(connection) => return Ok(connection),
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    "netd hosted bridge unavailable; connecting locally"
+                );
+            }
+        }
+    }
+    if outbound {
+        HostedConnection::connect_verified_outbound(descriptor, config).await
+    } else {
+        HostedConnection::connect_verified(descriptor, config).await
     }
 }

--- a/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/mod.rs
@@ -334,6 +334,14 @@ impl HostedClient {
         self.connection.close().await;
     }
 
+    /// Hold the next spawned shutdown future so close hits the 20ms
+    /// detach bound. Test-only: proves content already received is
+    /// still durable after the caller returns.
+    #[cfg(test)]
+    pub(crate) fn hold_next_close_for_test(duration: std::time::Duration) {
+        connection::hold_next_shutdown_for_test(duration);
+    }
+
     pub(super) async fn auto_rotate_if_needed(
         &mut self,
         renewable: Option<&RenewableAuthorityCredential>,

--- a/crates/hosted-client/src/hosted_runtime/hosted/provider_transport.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/provider_transport.rs
@@ -23,7 +23,7 @@ const WEBSOCKET_TRANSPORT_ID: u64 = 0x6864_646c_6577_7301;
 const LANE_QUEUE_DEPTH: usize = 64;
 
 #[derive(Clone)]
-pub(super) struct ProviderWebSocketTransport {
+pub(crate) struct ProviderWebSocketTransport {
     inner: Arc<TransportState>,
 }
 
@@ -56,7 +56,7 @@ impl std::fmt::Debug for ProviderWebSocketTransport {
 }
 
 impl ProviderWebSocketTransport {
-    pub(super) fn new(config: ClientConfig) -> Self {
+    pub(crate) fn new(config: ClientConfig) -> Self {
         Self {
             inner: Arc::new(TransportState {
                 config,

--- a/crates/hosted-client/src/hosted_runtime/hosted/session.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/session.rs
@@ -131,6 +131,21 @@ impl HostedSession {
     }
 
     pub async fn connect(&self, server: &str) -> Result<HostedClient, ProtocolError> {
+        #[cfg(unix)]
+        match HostedClient::connect_via_netd(server, &self.config).await {
+            Ok(mut client) => {
+                client
+                    .auto_rotate_if_needed(self.renewable_authority_credential.as_ref())
+                    .await;
+                return Ok(client);
+            }
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    "netd hosted bridge unavailable; discovering the endpoint locally"
+                );
+            }
+        }
         let descriptor = self
             .discover_endpoint(server)
             .await
@@ -150,6 +165,21 @@ impl HostedSession {
     /// the device node id the box network daemon serves the claim router
     /// on (heddle#1620).
     pub async fn connect_outbound(&self, server: &str) -> Result<HostedClient, ProtocolError> {
+        #[cfg(unix)]
+        match HostedClient::connect_via_netd(server, &self.config).await {
+            Ok(mut client) => {
+                client
+                    .auto_rotate_if_needed(self.renewable_authority_credential.as_ref())
+                    .await;
+                return Ok(client);
+            }
+            Err(error) => {
+                tracing::debug!(
+                    %error,
+                    "netd hosted bridge unavailable; discovering the endpoint locally"
+                );
+            }
+        }
         let descriptor = self
             .discover_endpoint(server)
             .await

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -4920,6 +4920,13 @@ mod native_exchange_tests {
             .id();
         save_thread_record(&repo, state, "thread-stable-main", "main");
         let expected = objects::object::Blob::from(PAYLOAD);
+        let objects = wire::enumerate_state_closure(repo.store(), state).unwrap();
+        let pack = wire::build_native_pack(repo.store(), &objects).unwrap();
+        store.stage(
+            super::super::helpers::proto_state_id(state).expect("state id"),
+            pack.pack_data,
+            pack.index_data,
+        );
 
         let pushed = client
             .push_with_expected_head_profiled(
@@ -4936,17 +4943,6 @@ mod native_exchange_tests {
             .0;
         assert!(pushed.success, "durable fixture must accept the push");
         assert_eq!(pushed.new_state, Some(state));
-
-        // Weft fetches the advertised objects before PushComplete.
-        // The fixture records that receipt as the native pack the
-        // next client will clone — after this process's bounded close.
-        let objects = wire::enumerate_state_closure(repo.store(), state).unwrap();
-        let pack = wire::build_native_pack(repo.store(), &objects).unwrap();
-        store.install(
-            super::super::helpers::proto_state_id(state).expect("state id"),
-            pack.pack_data,
-            pack.index_data,
-        );
 
         HostedClient::hold_next_close_for_test(Duration::from_millis(80));
         let started = Instant::now();

--- a/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/sync.rs
@@ -4901,6 +4901,92 @@ mod native_exchange_tests {
         client.close().await;
         server.await.unwrap();
     }
+
+    #[tokio::test]
+    async fn push_content_survives_bounded_close_and_clones_byte_for_byte() {
+        const PAYLOAD: &[u8] = b"durable-across-bounded-close-e0c3\n";
+        let (mut client, server_addr, server, store) =
+            crate::hosted_runtime::hosted::test_server::start_durable_push_clone().await;
+        let source = TempDir::new().unwrap();
+        let repo = Repository::init_default(source.path()).unwrap();
+        std::fs::write(source.path().join("payload.bin"), PAYLOAD).unwrap();
+        let state = repo
+            .snapshot_with_attribution(
+                Some("durable close fixture".to_string()),
+                None,
+                Attribution::human(Principal::new("Test", "test@example.com")),
+            )
+            .unwrap()
+            .id();
+        save_thread_record(&repo, state, "thread-stable-main", "main");
+        let expected = objects::object::Blob::from(PAYLOAD);
+
+        let pushed = client
+            .push_with_expected_head_profiled(
+                &repo,
+                "acme/widgets",
+                state,
+                "main",
+                false,
+                ExpectedRemoteHead::Missing,
+                "durable-close-push-op".to_string(),
+            )
+            .await
+            .unwrap()
+            .0;
+        assert!(pushed.success, "durable fixture must accept the push");
+        assert_eq!(pushed.new_state, Some(state));
+
+        // Weft fetches the advertised objects before PushComplete.
+        // The fixture records that receipt as the native pack the
+        // next client will clone — after this process's bounded close.
+        let objects = wire::enumerate_state_closure(repo.store(), state).unwrap();
+        let pack = wire::build_native_pack(repo.store(), &objects).unwrap();
+        store.install(
+            super::super::helpers::proto_state_id(state).expect("state id"),
+            pack.pack_data,
+            pack.index_data,
+        );
+
+        HostedClient::hold_next_close_for_test(Duration::from_millis(80));
+        let started = Instant::now();
+        client.close().await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "close must detach an 80ms drain, took {elapsed:?}"
+        );
+
+        let mut clone_client =
+            crate::hosted_runtime::hosted::test_server::connect_test_client(server_addr).await;
+        let clone = TempDir::new().unwrap();
+        let (pulled, cloned_repo) = clone_client
+            .clone_pull_with_depth_and_materialization(
+                "acme/widgets",
+                Some("main"),
+                None,
+                PullMaterialization::Full,
+                |_, _| Repository::init_default(clone.path()).map_err(ProtocolError::from),
+            )
+            .await
+            .unwrap();
+        assert!(pulled.success, "clone after bounded close must succeed");
+        assert_eq!(pulled.final_state, Some(state));
+        let got = cloned_repo
+            .store()
+            .get_blob(&expected.hash())
+            .unwrap()
+            .expect("pushed blob must be durable after bounded close");
+        assert_eq!(
+            got.content(),
+            PAYLOAD,
+            "clone from a fresh endpoint must match the pushed bytes"
+        );
+
+        clone_client.close().await;
+        server.abort();
+        let _ = server.await;
+    }
 }
 
 #[cfg(test)]

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -325,14 +325,15 @@ struct PullFixture {
 
 /// In-memory weft stand-in: a staged pack is unpublished until Push
 /// finishes draining the client stream, then it becomes cloneable.
+#[cfg(test)]
 #[derive(Clone, Default)]
 pub(crate) struct DurableSyncStore {
     staged: Arc<Mutex<Option<PullFixture>>>,
     published: Arc<Mutex<Option<PullFixture>>>,
 }
 
+#[cfg(test)]
 impl DurableSyncStore {
-    #[cfg(test)]
     fn pull_fixture(&self) -> Option<PullFixture> {
         self.published
             .lock()
@@ -340,7 +341,6 @@ impl DurableSyncStore {
             .clone()
     }
 
-    #[cfg(test)]
     pub(crate) fn stage(&self, remote_state: StateId, pack_data: Vec<u8>, index_data: Vec<u8>) {
         *self
             .staged
@@ -420,6 +420,7 @@ async fn start_inner(
                 collaboration.clone(),
                 registry.clone(),
                 grants.clone(),
+                #[cfg(test)]
                 None,
             ));
         }
@@ -542,7 +543,7 @@ async fn serve_call(
     collaboration: Option<CollaborationFixture>,
     registry: Option<RegistryFixture>,
     grants: GrantStore,
-    durable: Option<DurableSyncStore>,
+    #[cfg(test)] durable: Option<DurableSyncStore>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -645,6 +646,7 @@ async fn serve_call(
                     recv,
                     request.split_off(prelude_len),
                     push_requests,
+                    #[cfg(test)]
                     durable,
                 )
                 .await;
@@ -672,7 +674,7 @@ async fn serve_push(
     mut recv: iroh::endpoint::RecvStream,
     mut buffered: Vec<u8>,
     captured: Option<Arc<Mutex<Vec<PushRequest>>>>,
-    durable: Option<DurableSyncStore>,
+    #[cfg(test)] durable: Option<DurableSyncStore>,
 ) {
     let request = loop {
         if let Some((frame, consumed)) = decode_stream_frame(&buffered).unwrap() {
@@ -718,8 +720,16 @@ async fn serve_push(
         .await
         .is_ok_and(|chunk| chunk.is_some())
     {}
-    let accept =
-        durable.as_ref().is_some_and(|store| store.publish_staged()) && local_state.is_some();
+    let accept = {
+        #[cfg(test)]
+        {
+            durable.as_ref().is_some_and(|store| store.publish_staged()) && local_state.is_some()
+        }
+        #[cfg(not(test))]
+        {
+            false
+        }
+    };
     let complete = PushServerFrame {
         frame: Some(push_server_frame::Frame::Complete(PushComplete {
             success: accept,

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -332,6 +332,7 @@ pub(crate) struct DurableSyncStore {
 }
 
 impl DurableSyncStore {
+    #[cfg(test)]
     fn pull_fixture(&self) -> Option<PullFixture> {
         self.published
             .lock()
@@ -339,6 +340,7 @@ impl DurableSyncStore {
             .clone()
     }
 
+    #[cfg(test)]
     pub(crate) fn stage(&self, remote_state: StateId, pack_data: Vec<u8>, index_data: Vec<u8>) {
         *self
             .staged

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -323,28 +323,46 @@ struct PullFixture {
     pack: Option<(Vec<u8>, Vec<u8>)>,
 }
 
-/// In-memory weft stand-in: accept a push pack, then serve it on clone.
+/// In-memory weft stand-in: a staged pack is unpublished until Push
+/// finishes draining the client stream, then it becomes cloneable.
 #[derive(Clone, Default)]
 pub(crate) struct DurableSyncStore {
-    stored: Arc<Mutex<Option<PullFixture>>>,
+    staged: Arc<Mutex<Option<PullFixture>>>,
+    published: Arc<Mutex<Option<PullFixture>>>,
 }
 
 impl DurableSyncStore {
     fn pull_fixture(&self) -> Option<PullFixture> {
-        self.stored
+        self.published
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
             .clone()
     }
 
-    pub(crate) fn install(&self, remote_state: StateId, pack_data: Vec<u8>, index_data: Vec<u8>) {
+    pub(crate) fn stage(&self, remote_state: StateId, pack_data: Vec<u8>, index_data: Vec<u8>) {
         *self
-            .stored
+            .staged
             .lock()
             .unwrap_or_else(|poison| poison.into_inner()) = Some(PullFixture {
             remote_state,
             pack: Some((pack_data, index_data)),
         });
+    }
+
+    fn publish_staged(&self) -> bool {
+        let staged = self
+            .staged
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .take();
+        let Some(fixture) = staged else {
+            return false;
+        };
+        *self
+            .published
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(fixture);
+        true
     }
 }
 
@@ -698,7 +716,8 @@ async fn serve_push(
         .await
         .is_ok_and(|chunk| chunk.is_some())
     {}
-    let accept = durable.is_some() && local_state.is_some();
+    let accept =
+        durable.as_ref().is_some_and(|store| store.publish_staged()) && local_state.is_some();
     let complete = PushServerFrame {
         frame: Some(push_server_frame::Frame::Complete(PushComplete {
             success: accept,

--- a/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/hosted-client/src/hosted_runtime/hosted/test_server.rs
@@ -323,6 +323,31 @@ struct PullFixture {
     pack: Option<(Vec<u8>, Vec<u8>)>,
 }
 
+/// In-memory weft stand-in: accept a push pack, then serve it on clone.
+#[derive(Clone, Default)]
+pub(crate) struct DurableSyncStore {
+    stored: Arc<Mutex<Option<PullFixture>>>,
+}
+
+impl DurableSyncStore {
+    fn pull_fixture(&self) -> Option<PullFixture> {
+        self.stored
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone()
+    }
+
+    pub(crate) fn install(&self, remote_state: StateId, pack_data: Vec<u8>, index_data: Vec<u8>) {
+        *self
+            .stored
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(PullFixture {
+            remote_state,
+            pack: Some((pack_data, index_data)),
+        });
+    }
+}
+
 #[derive(Clone, Default)]
 struct BlobFixture {
     contents: HashMap<String, Vec<u8>>,
@@ -375,6 +400,7 @@ async fn start_inner(
                 collaboration.clone(),
                 registry.clone(),
                 grants.clone(),
+                None,
             ));
         }
         server.close().await;
@@ -396,6 +422,93 @@ async fn start_inner(
     (client, server_task)
 }
 
+/// Multi-accept fixture: first client pushes; after bounded close a
+/// fresh client clones the stored pack from the same endpoint address.
+#[cfg(test)]
+pub(crate) async fn start_durable_push_clone() -> (
+    HostedClient,
+    iroh::EndpointAddr,
+    JoinHandle<()>,
+    DurableSyncStore,
+) {
+    let store = DurableSyncStore::default();
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let server_addr = server.addr();
+    let grants = GrantStore::default();
+    let store_for_server = store.clone();
+    let server_task = tokio::spawn(async move {
+        loop {
+            let Some(incoming) = server.accept().await else {
+                break;
+            };
+            let Ok(connection) = incoming.await else {
+                continue;
+            };
+            let store = store_for_server.clone();
+            let grants = grants.clone();
+            tokio::spawn(async move {
+                while let Ok((send, recv)) = connection.accept_bi().await {
+                    tokio::spawn(serve_call(
+                        send,
+                        recv,
+                        store.pull_fixture(),
+                        BlobFixture::default(),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        grants.clone(),
+                        Some(store.clone()),
+                    ));
+                }
+            });
+        }
+        server.close().await;
+    });
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let signer = Ed25519Signer::generate().unwrap();
+    let context = CallContextFactory::default()
+        .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:test")
+        .unwrap();
+    let client = HostedClient::connect_addr_with_context(endpoint, server_addr.clone(), context)
+        .await
+        .unwrap();
+    (client, server_addr, server_task, store)
+}
+
+#[cfg(test)]
+pub(crate) async fn connect_test_client(server_addr: iroh::EndpointAddr) -> HostedClient {
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let signer = Ed25519Signer::generate().unwrap();
+    let context = CallContextFactory::default()
+        .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:test")
+        .unwrap();
+    HostedClient::connect_addr_with_context(endpoint, server_addr, context)
+        .await
+        .unwrap()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn serve_call(
     mut send: iroh::endpoint::SendStream,
@@ -409,6 +522,7 @@ async fn serve_call(
     collaboration: Option<CollaborationFixture>,
     registry: Option<RegistryFixture>,
     grants: GrantStore,
+    durable: Option<DurableSyncStore>,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -506,7 +620,14 @@ async fn serve_call(
         }
         StreamingShape::Bidirectional => {
             if method == "/heddle.api.v1alpha1.RepoSyncService/Push" {
-                serve_push(send, recv, request.split_off(prelude_len), push_requests).await;
+                serve_push(
+                    send,
+                    recv,
+                    request.split_off(prelude_len),
+                    push_requests,
+                    durable,
+                )
+                .await;
                 return;
             }
             tokio::spawn(async move {
@@ -531,6 +652,7 @@ async fn serve_push(
     mut recv: iroh::endpoint::RecvStream,
     mut buffered: Vec<u8>,
     captured: Option<Arc<Mutex<Vec<PushRequest>>>>,
+    durable: Option<DurableSyncStore>,
 ) {
     let request = loop {
         if let Some((frame, consumed)) = decode_stream_frame(&buffered).unwrap() {
@@ -552,6 +674,7 @@ async fn serve_push(
         buffered.extend_from_slice(&chunk);
     };
     let advertised = request.objects.clone();
+    let local_state = request.local_state.clone();
     if let Some(captured) = captured {
         captured
             .lock()
@@ -575,10 +698,16 @@ async fn serve_push(
         .await
         .is_ok_and(|chunk| chunk.is_some())
     {}
+    let accept = durable.is_some() && local_state.is_some();
     let complete = PushServerFrame {
         frame: Some(push_server_frame::Frame::Complete(PushComplete {
-            success: false,
-            error: "test rejection".to_string(),
+            success: accept,
+            new_state: if accept { local_state } else { None },
+            error: if accept {
+                String::new()
+            } else {
+                "test rejection".to_string()
+            },
             ..PushComplete::default()
         })),
     }

--- a/crates/hosted-client/src/hosted_runtime/net_endpoint.rs
+++ b/crates/hosted-client/src/hosted_runtime/net_endpoint.rs
@@ -12,24 +12,40 @@
 //! invalidate every outstanding claim URL.
 
 use anyhow::{Context, Result};
+use config::ClientConfig;
 use iroh::{Endpoint, EndpointId, RelayMode, endpoint::presets};
 
-use super::agent_node_identity;
+use super::{agent_node_identity, hosted::ProviderWebSocketTransport};
 
 /// Bind an endpoint on the persisted device node id, reachable
 /// through `relay_mode`. The identity is loaded-or-minted exactly
 /// once (serialized by the identity write lock); every subsequent
 /// bind — including after a restart — reuses the same secret key and
 /// therefore the same node id.
+pub(crate) struct PersistentEndpoint {
+    pub endpoint: Endpoint,
+    pub provider_transport: ProviderWebSocketTransport,
+}
+
 pub(crate) async fn bind(relay_mode: RelayMode) -> Result<Endpoint> {
+    Ok(bind_with_provider(relay_mode).await?.endpoint)
+}
+
+pub(crate) async fn bind_with_provider(relay_mode: RelayMode) -> Result<PersistentEndpoint> {
     let identity =
         agent_node_identity::load_or_create().context("loading persisted device node identity")?;
-    Endpoint::builder(presets::Minimal)
+    let provider_transport = ProviderWebSocketTransport::new(ClientConfig::default());
+    let endpoint = Endpoint::builder(presets::Minimal)
         .relay_mode(relay_mode)
         .secret_key(identity.secret_key())
+        .add_custom_transport(std::sync::Arc::new(provider_transport.clone()))
         .bind()
         .await
-        .context("binding persistent device iroh endpoint")
+        .context("binding persistent device iroh endpoint")?;
+    Ok(PersistentEndpoint {
+        endpoint,
+        provider_transport,
+    })
 }
 
 /// The persisted device node id, or `None` when the identity has

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -168,4 +168,26 @@ mod tests {
             assert_eq!(host, "relay.heddle.sh");
         }
     }
+
+    #[tokio::test]
+    async fn bind_persistent_hosted_uses_the_device_endpoint() {
+        let _env_guard = config::credentials::lock_test_env();
+        let home = tempfile::TempDir::new().expect("temp Heddle home");
+        let previous = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", home.path());
+        }
+        let (endpoint, _bridge) = bind_persistent_hosted(RelayMode::Disabled)
+            .await
+            .expect("persistent hosted bind");
+        let node_id = persisted_node_id()
+            .expect("read persisted node id")
+            .expect("bind must mint a device identity");
+        assert_eq!(endpoint.id(), node_id);
+        endpoint.close().await;
+        match previous {
+            Some(value) => unsafe { std::env::set_var("HEDDLE_HOME", value) },
+            None => unsafe { std::env::remove_var("HEDDLE_HOME") },
+        }
+    }
 }

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -41,6 +41,8 @@ pub use iroh::{Endpoint, EndpointId, RelayMode};
 pub use crate::hosted_runtime::claim_bridge::{
     DaemonClaimRouter, claim_bridge_socket_path, mount_claim_router,
 };
+#[cfg(feature = "client")]
+pub use crate::hosted_runtime::hosted::hosted_bridge::{HostedBridge, hosted_bridge_socket_path};
 
 /// Home relay for this build flavor. Trailing slash matches the
 /// signed endpoint-descriptor encoding.
@@ -91,6 +93,23 @@ pub fn default_relay_mode() -> RelayMode {
 #[cfg(feature = "client")]
 pub async fn bind_persistent_endpoint(relay_mode: RelayMode) -> anyhow::Result<Endpoint> {
     crate::hosted_runtime::net_endpoint::bind(relay_mode).await
+}
+
+/// Bind the persistent device endpoint together with the hosted-session
+/// bridge that reuses it for CLI weft calls.
+#[cfg(feature = "client")]
+pub async fn bind_persistent_hosted(
+    relay_mode: RelayMode,
+) -> anyhow::Result<(
+    Endpoint,
+    crate::hosted_runtime::hosted::hosted_bridge::HostedBridge,
+)> {
+    let persistent = crate::hosted_runtime::net_endpoint::bind_with_provider(relay_mode).await?;
+    let bridge = crate::hosted_runtime::hosted::hosted_bridge::HostedBridge::new(
+        persistent.endpoint.clone(),
+        Some(persistent.provider_transport),
+    );
+    Ok((persistent.endpoint, bridge))
 }
 
 /// The persisted device node id, or `None` when the identity has

--- a/crates/hosted-client/src/network.rs
+++ b/crates/hosted-client/src/network.rs
@@ -170,6 +170,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn bind_persistent_hosted_uses_the_device_endpoint() {
         let _env_guard = config::credentials::lock_test_env();
         let home = tempfile::TempDir::new().expect("temp Heddle home");

--- a/docs/perf/hosted-endpoint-close.md
+++ b/docs/perf/hosted-endpoint-close.md
@@ -21,8 +21,10 @@ not describe the relay path.
 
 `HostedConnection::close` still *starts* graceful shutdown so the
 endpoint is not dropped dirty. The foreground wait is bounded at
-**20 ms** (`FOREGROUND_ENDPOINT_DRAIN`). The remainder is detached.
-Process exit is no longer gated on `wait_all_draining`.
+**20 ms** (`FOREGROUND_ENDPOINT_DRAIN`). On timeout the `JoinHandle`
+is forgotten so drain keeps running (wrapping the handle in
+`tokio::time::timeout` would drop it on `Elapsed` and cancel
+mid-close). Process exit is no longer gated on `wait_all_draining`.
 
 When `heddle netd serve` is running, hosted verbs reuse the daemon's
 persistent endpoint and a cached weft QUIC connection. Close of a
@@ -67,8 +69,9 @@ error logs and fails if the literal #1143
 test refuses to run as a debug-build gate.
 
 Unit tests in `connection.rs` fail closed if close again blocks ≥~1 s
-on a local fixture after the QUIC session is already LocallyClosed, and
-if a 1 s injected drain is not detached.
+on a local fixture after the QUIC session is already LocallyClosed, if
+a 1 s injected drain is not returned from early, and if a drain that
+outlives the 20 ms bound is aborted instead of completing after detach.
 
 ```sh
 TMPDIR=/home/scratch HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL=latency \

--- a/docs/perf/hosted-endpoint-close.md
+++ b/docs/perf/hosted-endpoint-close.md
@@ -1,69 +1,75 @@
 # Hosted Endpoint Close Performance
 
-Hosted operations explicitly close their QUIC connection and then await
-`Endpoint::close()` at their shared teardown boundary. The await is required:
-skipping it reproduces `Endpoint dropped without calling Endpoint::close` and
-an ungraceful abort. This document records the release-mode cost and its
-executable budget so the earlier debug-build number is not treated as shipped
-latency.
+Hosted operations initiate a graceful QUIC/endpoint close at their shared
+teardown boundary. Calling `Endpoint::close` is required: skipping it
+reproduces `Endpoint dropped without calling Endpoint::close` and an
+ungraceful abort (#1143/#1151). Awaiting the full drain is not required
+on the one-shot CLI path.
 
-## Release measurement
+## The WAN tax
 
-Measured on 2026-08-04 at `fb5d4b7c` using rustc 1.97.0's optimized release
-profile on Linux x86_64 (AMD Ryzen 7 7700, 8 cores/16 threads). Each sample
-established a loopback connection over the hosted ALPN through
-`HostedConnection::connect_verified`; endpoint setup and compilation were
-outside the timed window. The timer covered only the shared hosted-operation
-teardown. Twenty control samples closed the QUIC connection but temporarily
-skipped the endpoint-close await, with each sample isolated in a fresh test
-process so its intentional ungraceful abort could not contaminate the next
-connection.
+On a relay/WAN path (preview AX), `Router::shutdown` → `Endpoint::close`
+→ `noq wait_all_draining` waits for a close-frame ACK / probe timeout.
+After the RPC is already `LocallyClosed`, that wait is a repeatable
+**~1000 ms**. It turned a finished ~1 s `whoami` into a ~2 s CLI.
+
+Loopback release measurements from 2026-08-04 (`fb5d4b7c`) remain true
+for isolated local fixtures: median 0.3965 ms, p95 0.694 ms. They do
+not describe the relay path.
+
+## Decision
+
+`HostedConnection::close` still *starts* graceful shutdown so the
+endpoint is not dropped dirty. The foreground wait is bounded at
+**20 ms** (`FOREGROUND_ENDPOINT_DRAIN`). The remainder is detached.
+Process exit is no longer gated on `wait_all_draining`.
+
+When `heddle netd serve` is running, hosted verbs reuse the daemon's
+persistent endpoint and a cached weft QUIC connection. Close of a
+proxied handle is a no-op: the session stays warm in netd.
+
+Preview vs prod relays stay the `preview` cargo feature. Hosted
+connections still take their relay list from the signed descriptor.
+
+## Release measurement (loopback)
+
+Measured on 2026-08-04 at `fb5d4b7c` using rustc 1.97.0's optimized
+release profile on Linux x86_64 (AMD Ryzen 7 7700, 8 cores/16 threads).
+Each sample established a loopback connection over the hosted ALPN
+through `HostedConnection::connect_verified`; endpoint setup and
+compilation were outside the timed window. The timer covered only the
+shared hosted-operation teardown.
 
 | teardown | samples | median | p95 | min-max |
 | --- | ---: | ---: | ---: | ---: |
 | graceful `Endpoint::close().await` | 20 | 0.3965 ms | 0.694 ms | 0.354-0.779 ms |
 | control: skip endpoint-close await | 20 | 0.0020 ms | 0.003 ms | 0.002-0.003 ms |
 
-The median release drain attributable to the await was approximately 0.3945
-ms, not the 0.87 seconds observed in the historical debug build. All 20 control
-runs emitted the #1143 ungraceful-abort error. A non-isolated control also made
-the following connection time out, further confirming that skipping the await
-is not a viable optimization.
-
-## Budget and decision
-
-The release contract is **p95 <= 20 ms** for the isolated endpoint close. Law 7
-in #1218 requires an executable latency gate; its smallest fixed-work product
-band is the 20 ms p95 budget for cold metadata commands. Hosted completion is
-otherwise expressed relative to RTT plus fixed server work, so client endpoint
-drain is gated as fixed local work rather than folded into an unstable total
-push, pull, or clone duration.
-
-The measured p95 has about 29x headroom under that budget. The graceful close
-therefore stays unchanged: adding a timeout or another teardown path would add
-complexity to save less than one millisecond while risking the real leak and
-spurious error fixed by #1143/#1151.
+The 20 ms foreground bound has large headroom on loopback. The bound
+exists for the WAN drain, not to shave the 0.4 ms local case.
 
 ## Executable contract
 
 The dedicated release workflow runs:
 
 ```sh
-TMPDIR=/home/scratch cargo test --locked --release -p heddle-cli --lib \
+TMPDIR=/home/scratch cargo test --locked --release -p heddle-hosted-client --lib \
   hosted_endpoint_close_release_contract -- --ignored --nocapture
 ```
 
-The test takes 20 samples, prints median/p95/min/max, asserts p95 is within 20
-ms, and asserts that the endpoint is closed before each successful hosted
-connection is dropped. The workflow also enables Iroh error logs and fails if
-the literal #1143 `Endpoint dropped without calling Endpoint::close` message
-appears. The test refuses to run as a debug-build gate.
+The test takes 20 samples, prints median/p95/min/max, asserts p95 is
+within 20 ms, and asserts that the endpoint is closed before each
+successful hosted connection is dropped. The workflow also enables Iroh
+error logs and fails if the literal #1143
+`Endpoint dropped without calling Endpoint::close` message appears. The
+test refuses to run as a debug-build gate.
 
-The repeatable negative control adds 25 ms inside the measured close window and
-must fail with `HOSTED CLOSE GATE RED`:
+Unit tests in `connection.rs` fail closed if close again blocks ≥~1 s
+on a local fixture after the QUIC session is already LocallyClosed, and
+if a 1 s injected drain is not detached.
 
 ```sh
 TMPDIR=/home/scratch HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL=latency \
-  cargo test --locked --release -p heddle-cli --lib \
+  cargo test --locked --release -p heddle-hosted-client --lib \
   hosted_endpoint_close_release_contract -- --ignored --nocapture
 ```

--- a/docs/perf/hosted-endpoint-close.md
+++ b/docs/perf/hosted-endpoint-close.md
@@ -26,7 +26,9 @@ Process exit is no longer gated on `wait_all_draining`.
 
 When `heddle netd serve` is running, hosted verbs reuse the daemon's
 persistent endpoint and a cached weft QUIC connection. Close of a
-proxied handle is a no-op: the session stays warm in netd.
+proxied handle does not drain weft. If that process opened a provider
+(CAS) connection, it bound a local ephemeral endpoint; close starts a
+bounded drain of that endpoint only.
 
 Preview vs prod relays stay the `preview` cargo feature. Hosted
 connections still take their relay list from the signed descriptor.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Preview `whoami` / push / pull / clone sat at **~2.0s wall even when warm-repeated**. The last **~1000ms** was `HostedConnection::close` awaiting `Router::shutdown` → `Endpoint::close` → `noq wait_all_draining` after the RPC was already `LocallyClosed`.
- One-shot CLI close now **starts** graceful shutdown (so we do not drop the endpoint dirty) and **bounds the foreground wait at 20ms**. On timeout the `JoinHandle` is **`mem::forget`’d** so drain keeps running. Wrapping the handle in `tokio::time::timeout` dropped it on `Elapsed` and cancelled mid-close — the opposite of detach.
- When `heddle netd serve` is running, hosted verbs reuse netd’s persistent endpoint and a **cached weft QUIC connection** over a same-uid UDS bridge. The CLI still signs every call; netd never sees credentials. Relays for those sessions still come from the **signed descriptor**. Preview vs prod home-relay stays the `preview` cargo feature from #1746 — this does not stuff both maps into one `Custom` set.
- Provider (CAS) dials on a netd-proxied session no longer fail closed. `ProviderBackend` still needs a real Iroh `Connection`, which cannot cross the UDS splice, so the CLI binds **one ephemeral local endpoint per process** the first time a provider is used. Weft stays in netd. Close of that local endpoint is the same 20ms-bounded drain.

## Closes

Refs HeddleCo/heddle#1746

## Measured 2s split (preview, warm-repeated whoami)

| Phase | ~ms |
|------|----:|
| HTTPS well-known descriptor | 130 |
| Cold relay WSS/TLS | 420 |
| Connection established (relay path) | 661 |
| whoami RPC until LocallyClosed | +330 → ~993 |
| **Idle until relay Shutdown / command exit** | **+1000 → ~1993** |

Local capture/context/discuss stay ~8–23ms. Target for warm networked ops is tens of ms once netd is up.

## Before / after

**Without netd (still the default one-shot path):**
- Teardown gap should collapse from ~1000ms to ≤20ms foreground.
- Residual floor is still cold bind + descriptor + relay + QUIC + RPC (~0.7–1.1s on preview). That is honest: a new process cannot reuse a connection it does not have.

**With `heddle netd serve` already running (warm reuse):**
- Second `whoami` should skip HTTPS descriptor fetch, relay WSS, and a new QUIC session.
- Residual floor: CLI process start + UDS Ensure/OpenBi + WhoAmI on the cached connection + bounded close (no-op on the proxied weft handle). Target: tens of ms once warm. Descriptor refetch only happens if the cached session expired or the QUIC connection died.
- `pull` / `clone` that need providers still pay a **per-process** local bind + provider WSS on the first CAS dial. Subsequent extents in that process reuse the cached provider connection. Cross-process provider reuse is not in this change (weft is).

## How teardown changed

`HostedConnection::close` still sends `CONNECTION_CLOSE`, then `tokio::spawn`s the shutdown. Foreground `select!` races the join against `FOREGROUND_ENDPOINT_DRAIN` (20ms). If the bound wins, `std::mem::forget(task)` detaches the handle so close is not cancelled. A proxied/netd handle does not close the daemon weft session. If that process bound a local provider endpoint, close starts the same bounded drain on it.

## How reuse works (netd, not a second daemon)

`heddle netd serve` already held the persistent device endpoint. It now also binds `<heddle_home>/state/heddle-netd-hosted.sock`. `HostedSession::connect` tries that bridge first (`Ensure` then per-RPC `OpenBi` spliced as raw stream bytes). Cache key is the server authority; a live, unexpired weft connection is reused. If the socket is missing, the CLI falls back to the local bind path with the new bounded close.

No auto-start: warm reuse is available when netd is running. Claim-bridge and preview/prod feature split are unchanged.

## Content durability across bounded close

`push_content_survives_bounded_close_and_clones_byte_for_byte` pins the weft-fetches-synchronously assumption:

1. Stage the native pack for the pushed closure (unpublished).
2. Complete the framed Push; the fixture publishes that pack only after the client stream has drained (`PushComplete.success`).
3. Hold shutdown 80ms so `close()` hits the 20ms bound and `mem::forget`s the drain.
4. Drop that client/endpoint. Connect a **fresh** client to the same server address.
5. Full clone; assert the payload blob is byte-for-byte `durable-across-bounded-close-e0c3\n`.

If Push never completes, the pack stays unpublished and the clone has nothing.

## Patch coverage (this revision)

codecov/patch was 75.89% with the gaps on the new netd/proxied paths. New tests drive those production paths instead of `#[allow]` or deleting code:

**`hosted_bridge.rs`**
- Cold Ensure / OpenBi fail closed (no cached weft → descriptor fetch, no invented session)
- Expired and closed weft cache eviction
- Provider OpenBi without a provider transport fails closed
- Missing socket, oversized frame, client disconnect before handshake
- Protocol mismatch: Opened-for-Ensure and Ready-for-OpenBi
- `connect_weft` on signed direct addresses, and fail-closed when direct + relays are gone

**`connection.rs` / `session.rs` / `mod.rs`**
- `connect_via_netd` missing-socket fail-closed
- Warm `connect_via_netd` + proxied `open_bi` (`write_all` / `write_chunk` / `finish` / `read_to_end` / `read_chunk` / `reset` / `stop`) and proxied close without a local provider
- `HostedClient::connect_via_netd` unary on proxied streams
- `HostedSession::connect` reuse when the bridge is up; fallback to local discovery when it is not (`connect` and `connect_outbound`)
- `connect_preferred` local fallback for `connect_with_config` and `connect_outbound_with_config` when netd is down

**`network.rs` / `net_endpoint.rs`**
- `bind_persistent_hosted` binds the persisted device endpoint

## Live verification (not CI proof)

On a preview-featured binary, against `https://api.preview.heddle.sh`:

```sh
# Cold / no netd — teardown gap should collapse
RUST_LOG=debug time heddle whoami --server api.preview.heddle.sh
# Repeat. Expect command_body_ms ~1s not ~2s; no 1s gap after LocallyClosed.

# Warm reuse
heddle netd serve   # leave running
RUST_LOG=debug time heddle whoami --server api.preview.heddle.sh   # first may still cold-fill netd
RUST_LOG=debug time heddle whoami --server api.preview.heddle.sh   # should drop far below ~2s
```

Look for `hosted connect using netd warm bridge reused=true` and the absence of a ~1s LocallyClosed → Shutdown gap. A `pull`/`clone` through netd should succeed (providers dial the local ephemeral endpoint) rather than fail with “opened as streams”.

## Red commit

N/A — fail-closed tests landed with the fix. They fail if close again blocks ≥~1s after LocallyClosed, if a second OpenBi on a warm netd session opens another QUIC connection, if a proxied session refuses provider dials instead of binding a local endpoint, if a drain that outlives the 20ms bound is aborted instead of completing after detach (`bounded_shutdown_still_completes_after_foreground_detach`), or if pushed blob bytes are missing after bounded close + a fresh clone (`push_content_survives_bounded_close_and_clones_byte_for_byte`).

## Test evidence

HEAD `8f32ed581cd1debcf489d30f2e43dc68c5efa908`

```
cargo clippy --locked -p heddle-hosted-client --lib --features client,test-utils -- -D warnings -D dead-code
Finished `dev` profile

cargo clippy --locked -p heddle-hosted-client --lib --bins --tests --examples --features client -- -D warnings -D dead-code
Finished `dev` profile

cargo test --locked -p heddle-hosted-client --lib --features client
test result: ok. 490 passed; 0 failed; 1 ignored
```

`full-ci` is on the PR. Leaving draft. Do not treat live preview AX or `pr-to-status` as CI proof.

## Manual verification

N/A — covered by tests. Live preview timing is documented above for a human/agent with preview credentials.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e642ca4e-aab6-4696-8502-a288cc12e0c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e642ca4e-aab6-4696-8502-a288cc12e0c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791862216&installation_model_id=21489&pr_number=1747&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1747&signature=8869b6eb2cb6df8c655a0f534a27bf6919f671439e2742d948c1bd19592d90b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->